### PR TITLE
fix: fix check of type of enum values

### DIFF
--- a/src/utils/__tests__/index.js
+++ b/src/utils/__tests__/index.js
@@ -1,0 +1,47 @@
+import { matchesJsonSchemaType } from '../index';
+
+describe('matchesJsonSchemaType', () => {
+  test('string', () => {
+    expect(matchesJsonSchemaType('test', 'string')).toEqual(true);
+    expect(matchesJsonSchemaType(35, 'string')).toEqual(false);
+  });
+
+  test('', () => {
+    expect(matchesJsonSchemaType(1, 'integer')).toEqual(true);
+    expect(matchesJsonSchemaType(1.5, 'integer')).toEqual(false);
+    expect(matchesJsonSchemaType('string', 'integer')).toEqual(false);
+  });
+
+  test('', () => {
+    expect(matchesJsonSchemaType(1, 'number')).toEqual(true);
+    expect(matchesJsonSchemaType(1.5, 'number')).toEqual(true);
+    expect(matchesJsonSchemaType({}, 'number')).toEqual(false);
+  });
+
+  test('', () => {
+    expect(matchesJsonSchemaType(true, 'boolean')).toEqual(true);
+    expect(matchesJsonSchemaType(false, 'boolean')).toEqual(true);
+    expect(matchesJsonSchemaType(25, 'boolean')).toEqual(false);
+  });
+
+  test('', () => {
+    expect(matchesJsonSchemaType(null, 'null')).toEqual(true);
+    expect(matchesJsonSchemaType(0, 'null')).toEqual(false);
+    expect(matchesJsonSchemaType('', 'null')).toEqual(false);
+    expect(matchesJsonSchemaType({}, 'null')).toEqual(false);
+  });
+
+  test('', () => {
+    expect(matchesJsonSchemaType({}, 'object')).toEqual(true);
+    expect(matchesJsonSchemaType([], 'object')).toEqual(false);
+    expect(matchesJsonSchemaType(null, 'object')).toEqual(false);
+    expect(matchesJsonSchemaType('string', 'object')).toEqual(false);
+  });
+
+  test('', () => {
+    expect(matchesJsonSchemaType([], 'array')).toEqual(true);
+    expect(matchesJsonSchemaType({}, 'array')).toEqual(false);
+    expect(matchesJsonSchemaType(null, 'array')).toEqual(false);
+    expect(matchesJsonSchemaType('string', 'array')).toEqual(false);
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,6 @@
+// @ts-check
+/** @typedef {'string'|'number'|'integer'|'boolean'|'null'|'object'|'array'} JSONSchemaType */
+
 /* eslint-disable import/prefer-default-export */
 const urlPattern = new RegExp('^(https?:\\/\\/)?' // protocol
 + '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' // domain name
@@ -23,3 +26,25 @@ export const getLineNumberFromId = (source, charId) => {
     posNum,
   };
 };
+
+/**
+ * Checks if value matches specified JSON schema type
+ *
+ * @param {*} value - value to check
+ * @param {JSONSchemaType} type - JSON Schema type
+ * @returns string
+ */
+export function matchesJsonSchemaType(value, type) {
+  switch(type) {
+    case 'array':
+      return Array.isArray(value)
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value)
+    case 'null':
+      return value === null
+    case 'integer':
+      return Number.isInteger(value)
+    default:
+      return typeof value === type
+  }
+}

--- a/src/validators/OpenAPISchema.js
+++ b/src/validators/OpenAPISchema.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable import/no-cycle */
 import createError from '../error';
 
@@ -5,6 +6,7 @@ import OpenAPIExternalDocumentation from './OpenAPIExternalDocumentation';
 import OpenAPISchemaMap from './OpenAPISchemaMap';
 import OpenAPIDiscriminator from './OpenAPIDiscriminator';
 import OpenAPIXML from './OpenAPIXML';
+import { matchesJsonSchemaType } from '../utils';
 
 const OpenAPISchemaObject = {
   validators: {
@@ -136,7 +138,7 @@ const OpenAPISchemaObject = {
           if (node.type
               && typeof node.type === 'string'
               // eslint-disable-next-line valid-typeof
-              && node.enum.filter((item) => typeof item !== node.type).length !== 0) {
+              && node.enum.some((item) => !matchesJsonSchemaType(item, node.type))) {
             return createError('All values of "enum" field must be of the same type as the "type" field', node, ctx);
           }
         }


### PR DESCRIPTION
Example of wrong behaviour without this fix:

```yaml
type: integer
enum: [1, 2, 3] # fails here
```