### PR TITLE
refactor: changed error generation & added error templates

### DIFF
--- a/src/error/default.js
+++ b/src/error/default.js
@@ -1,4 +1,4 @@
-import { getLocationByPath, getCodeFrameForLocation } from './yaml';
+import { getLocationByPath, getCodeFrameForLocation } from '../yaml';
 
 const prettyPrintError = (error, enableCodeframe) => {
   const message = `${error.location.startLine}:${error.location.startCol}`
@@ -6,7 +6,7 @@ const prettyPrintError = (error, enableCodeframe) => {
   + `${error.message} by path ${error.path}\n`
   + `${enableCodeframe ? `${error.codeFrame}\n` : ''}`
   + `${error.pathStack.length ? '\nError traced by following path:\n' : ''}`
-  + `${error.pathStack.length ? error.pathStack.join('\n') : ''}\n`;
+  + `${error.pathStack.length ? error.pathStack.join('\n') : ''}`;
   return message;
 };
 

--- a/src/error/index.js
+++ b/src/error/index.js
@@ -1,0 +1,19 @@
+import createError from './default';
+
+export const createErrorFieldNotAllowed = (fieldName, node, ctx) => createError(
+  `${fieldName} is not allowed here. Use "x-" prefix to override this behavior`, node, ctx, 'key',
+);
+
+export const createErrorMissingRequiredField = (fieldName, node, ctx) => createError(
+  `${fieldName} must be present on this level`, node, ctx,
+);
+
+export const createErrrorFieldTypeMismatch = (desiredType, node, ctx) => createError(
+  `This field must be of ${desiredType} type`, node, ctx, 'key',
+);
+
+export const createErrorMutuallyExclusiveFields = (fieldNames, node, ctx) => createError(
+  `${fieldNames.join(', ')} are mutually exclusive`, node, ctx, 'key',
+);
+
+export default createError;

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -1,5 +1,5 @@
 import resolveNode from './resolver';
-import createError from './error';
+import { createErrorFieldNotAllowed } from './error';
 
 const validateNode = (node, definition, ctx) => {
   if (node && definition && definition.validators) {
@@ -12,7 +12,7 @@ const validateNode = (node, definition, ctx) => {
       ctx.path.push(field);
 
       if (!allowedChildren.includes(field) && field.indexOf('x-') !== 0) {
-        ctx.result.push(createError('This field is not permitted here', node, ctx, 'key'));
+        ctx.result.push(createErrorFieldNotAllowed(field, node, ctx));
       }
 
       ctx.path.pop();

--- a/src/validators/OpenAPI3Root.js
+++ b/src/validators/OpenAPI3Root.js
@@ -1,4 +1,4 @@
-import createError from '../error';
+import { createErrorMissingRequiredField } from '../error';
 
 import { OpenAPIInfo } from './OpenAPIInfo';
 import { OpenAPIPaths } from './OpenAPIPaths';
@@ -12,19 +12,19 @@ export default {
   validators: {
     openapi() {
       return (node, ctx) => {
-        if (node && !node.openapi) return createError('The openapi field must be included to the root.', node, ctx);
+        if (node && !node.openapi) return createErrorMissingRequiredField('openapi', node, ctx);
         return null;
       };
     },
     info() {
       return (node, ctx) => {
-        if (node && !node.info) return createError('The info field must be included to the root.', node, ctx);
+        if (node && !node.info) return createErrorMissingRequiredField('info', node, ctx);
         return null;
       };
     },
     paths() {
       return (node, ctx) => {
-        if (node && !node.paths) return createError('The paths field must be included to the root.', node, ctx);
+        if (node && !node.paths) return createErrorMissingRequiredField('paths', node, ctx);
         return null;
       };
     },

--- a/src/validators/OpenAPIDiscriminator.js
+++ b/src/validators/OpenAPIDiscriminator.js
@@ -1,21 +1,20 @@
-import createError from '../error';
+import { createErrorMissingRequiredField, createErrrorFieldTypeMismatch } from '../error';
 
 export default {
   validators: {
     propertyName() {
       return (node, ctx) => {
-        if (!(node && node.propertyName)) return createError('propertyName field is required for Discriminator object', node, ctx, 'key');
-        if (typeof node.propertyName !== 'string') return createError('propertyName of the Discriminator must be a string', node, ctx);
+        if (!(node && node.propertyName)) return createErrorMissingRequiredField('propertyName', node, ctx);
+        if (typeof node.propertyName !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     mapping() {
       return (node, ctx) => {
-        if (node && node.mapping && typeof node.mapping !== 'object') return createError('mapping must be a [string, string] object', node, ctx);
-        if (node && node.mapping && Object.keys(node.mapping).filter((key) => typeof node.mapping[key] !== 'string').length !== 0) return createError('mapping must be a [string, string] object', node, ctx);
+        if (node && node.mapping && typeof node.mapping !== 'object') return createErrrorFieldTypeMismatch('Map[string, string]', node, ctx);
+        if (node && node.mapping && Object.keys(node.mapping).filter((key) => typeof node.mapping[key] !== 'string').length !== 0) return createErrrorFieldTypeMismatch('Map[string, string]', node, ctx);
         return null;
       };
     },
   },
-
 };

--- a/src/validators/OpenAPIEncoding.js
+++ b/src/validators/OpenAPIEncoding.js
@@ -1,13 +1,13 @@
 // eslint-disable-next-line import/no-cycle
 import { OpenAPIHeaderMap } from './OpenAPIHeader';
-import createError from '../error';
+import { createErrrorFieldTypeMismatch } from '../error';
 
 export default {
   validators: {
     contentType() {
       return (node, ctx) => {
         if (node && node.contentType && typeof node.contentType !== 'string') {
-          return createError('The contentType field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };
@@ -15,7 +15,7 @@ export default {
     style() {
       return (node, ctx) => {
         if (node && node.style && typeof node.style !== 'string') {
-          return createError('The style field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };
@@ -23,7 +23,7 @@ export default {
     explode() {
       return (node, ctx) => {
         if (node && node.explode && typeof node.explode !== 'boolean') {
-          return createError('The explode field must be a boolean', node, ctx);
+          return createErrrorFieldTypeMismatch('boolean', node, ctx);
         }
         return null;
       };
@@ -31,7 +31,7 @@ export default {
     allowReserved() {
       return (node, ctx) => {
         if (node && node.allowReserved && typeof node.allowReserved !== 'boolean') {
-          return createError('The allowReserved field must be a boolean', node, ctx);
+          return createErrrorFieldTypeMismatch('boolean', node, ctx);
         }
         return null;
       };

--- a/src/validators/OpenAPIExample.js
+++ b/src/validators/OpenAPIExample.js
@@ -1,11 +1,11 @@
-import createError from '../error';
+import { createErrrorFieldTypeMismatch, createErrorMutuallyExclusiveFields } from '../error';
 
 export const OpenAPIExample = {
   validators: {
     value() {
       return (node, ctx) => {
         if (node.value && node.externalValue) {
-          return createError('The value field and externalValue field are mutually exclusive.', node, ctx, 'key');
+          return createErrorMutuallyExclusiveFields(['value', 'externalValue'], node, ctx);
         }
         return null;
       };
@@ -13,10 +13,10 @@ export const OpenAPIExample = {
     externalValue() {
       return (node, ctx) => {
         if (node.externalValue && typeof node.externalValue !== 'string') {
-          return createError('The externalValue field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         if (node.value && node.externalValue) {
-          return createError('The value field and externalValue field are mutually exclusive.', node, ctx, 'key');
+          return createErrorMutuallyExclusiveFields(['value', 'externalValue'], node, ctx);
         }
         return null;
       };
@@ -24,7 +24,7 @@ export const OpenAPIExample = {
     description() {
       return (node, ctx) => {
         if (node.description && typeof node.description !== 'string') {
-          return createError('The description field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };
@@ -32,7 +32,7 @@ export const OpenAPIExample = {
     summary() {
       return (node, ctx) => {
         if (node.summary && typeof node.summary !== 'string') {
-          return createError('The summary field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };

--- a/src/validators/OpenAPIExternalDocumentation.js
+++ b/src/validators/OpenAPIExternalDocumentation.js
@@ -1,15 +1,15 @@
-import createError from '../error';
+import createError, { createErrrorFieldTypeMismatch, createErrorMissingRequiredField } from '../error';
 
 import { isUrl } from '../utils';
 
 const OpenAPIExternalDocumentation = {
   validators: {
     description() {
-      return (node, ctx) => (node && node.description && typeof node.description !== 'string' ? createError('description of the ExternalDocumentation object must be a string', node, ctx) : null);
+      return (node, ctx) => (node && node.description && typeof node.description !== 'string' ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
     url() {
       return (node, ctx) => {
-        if (node && !node.url) return createError('url is a required field for an ExternalDocumentation object', node, ctx, 'key');
+        if (node && !node.url) return createErrorMissingRequiredField('url', node, ctx, 'key');
         if (!isUrl(node.url)) return createError('url must be a valid URL', node, ctx);
         return null;
       };

--- a/src/validators/OpenAPIHeader.js
+++ b/src/validators/OpenAPIHeader.js
@@ -1,4 +1,4 @@
-import createError from '../error';
+import createError, { createErrrorFieldTypeMismatch, createErrorMutuallyExclusiveFields } from '../error';
 import { OpenAPIExampleMap } from './OpenAPIExample';
 // eslint-disable-next-line import/no-cycle
 import { OpenAPIMediaTypeObject } from './OpenAPIMediaObject';
@@ -8,13 +8,13 @@ export const OpenAPIHeader = {
   validators: {
     description() {
       return (node, ctx) => {
-        if (node && node.description && typeof node.description !== 'string') return createError('description field must be a string', node, ctx);
+        if (node && node.description && typeof node.description !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     required() {
       return (node, ctx) => {
-        if (node && node.required && typeof node.required !== 'boolean') return createError('required field must be a boolean', node, ctx);
+        if (node && node.required && typeof node.required !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         if (node && node.in && node.in === 'path' && !(node.required || node.required !== true)) {
           return createError('If the parameter location is "path", this property is REQUIRED and its value MUST be true.', node, ctx);
         }
@@ -23,37 +23,37 @@ export const OpenAPIHeader = {
     },
     deprecated() {
       return (node, ctx) => {
-        if (node && node.deprecated && typeof node.deprecated !== 'boolean') return createError('deprecated field must be a boolean', node, ctx);
+        if (node && node.deprecated && typeof node.deprecated !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     allowEmptyValue() {
       return (node, ctx) => {
-        if (node && node.allowEmptyValue && typeof node.allowEmptyValue !== 'boolean') return createError('allowEmptyValue field must be a boolean', node, ctx);
+        if (node && node.allowEmptyValue && typeof node.allowEmptyValue !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     explode() {
       return (node, ctx) => {
-        if (node && node.explode && typeof node.explode !== 'boolean') return createError('explode field must be a boolean', node, ctx);
+        if (node && node.explode && typeof node.explode !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     allowReserved() {
       return (node, ctx) => {
-        if (node && node.allowReserved && typeof node.allowReserved !== 'boolean') return createError('allowReserved field must be a boolean', node, ctx);
+        if (node && node.allowReserved && typeof node.allowReserved !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     example() {
       return (node, ctx) => {
-        if (node.example && node.examples) return createError('The example field is mutually exclusive of the examples field.', node, ctx, 'key');
+        if (node.example && node.examples) return createErrorMutuallyExclusiveFields(['example', 'examples'], node, ctx);
         return null;
       };
     },
     examples() {
       return (node, ctx) => {
-        if (node.example && node.examples) return createError('The examples field is mutually exclusive of the example field.', node, ctx, 'key');
+        if (node.example && node.examples) return createErrorMutuallyExclusiveFields(['examples', 'example'], node, ctx);
         return null;
       };
     },

--- a/src/validators/OpenAPIInfo.js
+++ b/src/validators/OpenAPIInfo.js
@@ -1,9 +1,9 @@
-import createError from '../error';
+import { createErrorMissingRequiredField, createErrrorFieldTypeMismatch } from '../error';
 
 export const OpenAPILicense = {
   validators: {
     name() {
-      return (node, ctx) => (!node || !node.name ? createError('Name is required for the license object', node, ctx, 'key') : null);
+      return (node, ctx) => (!node || !node.name ? createErrorMissingRequiredField('name', node, ctx) : null);
     },
     url() {
       return () => null;
@@ -14,13 +14,13 @@ export const OpenAPILicense = {
 export const OpenAPIContact = {
   validators: {
     name() {
-      return (node, ctx) => ((node && node.name) && typeof node.name !== 'string' ? createError('Name must be a string', node, ctx) : null);
+      return (node, ctx) => ((node && node.name) && typeof node.name !== 'string' ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
     url() {
-      return (node, ctx) => ((node && node.url) && typeof node.url !== 'string' ? createError('Url must be a string', node, ctx) : null);
+      return (node, ctx) => ((node && node.url) && typeof node.url !== 'string' ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
     email() {
-      return (node, ctx) => ((node && node.url) && typeof node.url !== 'string' ? createError('Email must be a string', node, ctx) : null);
+      return (node, ctx) => ((node && node.url) && typeof node.url !== 'string' ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
   },
 };
@@ -28,10 +28,10 @@ export const OpenAPIContact = {
 export const OpenAPIInfo = {
   validators: {
     title() {
-      return (node, ctx) => (!node || !node.title ? createError('Info section must include title', node, ctx, 'key') : null);
+      return (node, ctx) => (!node || !node.title ? createErrorMissingRequiredField('title', node, ctx) : null);
     },
     version() {
-      return (node, ctx) => (!node || !node.version ? createError('Version is required for the info section', node, ctx, 'key') : null);
+      return (node, ctx) => (!node || !node.version ? createErrorMissingRequiredField('version', node, ctx) : null);
     },
     description() {
       return () => null;

--- a/src/validators/OpenAPILink.js
+++ b/src/validators/OpenAPILink.js
@@ -1,4 +1,4 @@
-import createError from '../error';
+import { createErrorMutuallyExclusiveFields, createErrrorFieldTypeMismatch } from '../error';
 import OpenAPIServer from './OpenAPIServer';
 
 export const OpenAPILink = {
@@ -6,16 +6,16 @@ export const OpenAPILink = {
     operationRef() {
       return (node, ctx) => {
         if (!node || !node.operationRef) return null;
-        if (node.operationRef && node.operationId) return createError('Fields operationRef and operationId are mutually exclusive', node, ctx, 'key');
-        if (typeof node.operationRef !== 'string') return createError('The operationRef field must be a string in the Open API Link', node, ctx);
+        if (node.operationRef && node.operationId) return createErrorMutuallyExclusiveFields(['operationRef', 'operationId'], node, ctx);
+        if (typeof node.operationRef !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     operationId() {
       return (node, ctx) => {
         if (!node || !node.operationId) return null;
-        if (node.operationRef && node.operationId) return createError('Fields operationId and operationRef are mutually exclusive', node, ctx, 'key');
-        if (typeof node.operationId !== 'string') return createError('The operationId field must be a string in the Open API Link', node, ctx);
+        if (node.operationRef && node.operationId) return createErrorMutuallyExclusiveFields(['operationId', 'operationRef'], node, ctx);
+        if (typeof node.operationId !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
@@ -23,7 +23,7 @@ export const OpenAPILink = {
       return (node, ctx) => {
         if (!node || !node.parameters) return null;
         if (Object.keys(node.parameters).filter((key) => typeof key !== 'string').length > 0) {
-          return createError('The parameters field must be a Map with string keys', node, ctx);
+          return createErrrorFieldTypeMismatch('Map[string, any]', node, ctx);
         }
         return null;
       };
@@ -32,7 +32,7 @@ export const OpenAPILink = {
       return (node, ctx) => {
         if (!node || !node.description) return null;
         if (typeof node.description !== 'string') {
-          return createError('The description field must be a string in the Open API Link', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };

--- a/src/validators/OpenAPIMediaObject.js
+++ b/src/validators/OpenAPIMediaObject.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-cycle */
 import OpenAPISchema from './OpenAPISchema';
-import createError from '../error';
+import { createErrorMutuallyExclusiveFields } from '../error';
 import { OpenAPIExampleMap } from './OpenAPIExample';
 import OpenAPIEncoding from './OpenAPIEncoding';
 
@@ -8,10 +8,10 @@ import OpenAPIEncoding from './OpenAPIEncoding';
 export const OpenAPIMediaObject = {
   validators: {
     example() {
-      return (node, ctx) => (node.example && node.examples ? createError('The example and examples fields are mutually exclusive', node, ctx, 'key') : null);
+      return (node, ctx) => (node.example && node.examples ? createErrorMutuallyExclusiveFields(['example', 'examples'], node, ctx) : null);
     },
     examples() {
-      return (node, ctx) => (node.example && node.examples ? createError('The examples and example fields are mutually exclusive', node, ctx, 'key') : null);
+      return (node, ctx) => (node.example && node.examples ? createErrorMutuallyExclusiveFields(['example', 'examples'], node, ctx) : null);
     },
   },
   properties: {

--- a/src/validators/OpenAPIPaths.js
+++ b/src/validators/OpenAPIPaths.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-cycle */
-import createError from '../error';
+import createError, { createErrrorFieldTypeMismatch } from '../error';
 
 import OpenAPIServer from './OpenAPIServer';
 import OpenAPIOperation from './OpenAPIOperation';
@@ -9,21 +9,21 @@ export const OpenAPIPathItem = {
   validators: {
     summary() {
       return (node, ctx) => (node && node.summary && typeof node.summary !== 'string'
-        ? createError('summary of the Path Item must be a string', node, ctx) : null);
+        ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
     description() {
       return (node, ctx) => (node && node.description && typeof node.description !== 'string'
-        ? createError('description of the Path Item must be a string', node, ctx) : null);
+        ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
     servers() {
       return (node, ctx) => (node && node.servers && !Array.isArray(node.servers)
-        ? createError('servers of the Path Item must be an array', node, ctx) : null);
+        ? createErrrorFieldTypeMismatch('array', node, ctx) : null);
     },
     parameters() {
       return (node, ctx) => {
         if (!node || !node.parameters) return null;
         if (!Array.isArray(node.parameters)) {
-          return createError('parameters of the Path Item must be an array', node, ctx);
+          return createErrrorFieldTypeMismatch('array', node, ctx);
         }
         if ((new Set(node.parameters)).size !== node.parameters.length) {
           return createError('parameters must be unique in the Path Item object', node, ctx);

--- a/src/validators/OpenAPIRequestBody.js
+++ b/src/validators/OpenAPIRequestBody.js
@@ -1,4 +1,4 @@
-import createError from '../error';
+import { createErrrorFieldTypeMismatch, createErrorMissingRequiredField } from '../error';
 import { OpenAPIMediaTypeObject } from './OpenAPIMediaObject';
 
 export const OpenAPIRequestBody = {
@@ -6,7 +6,7 @@ export const OpenAPIRequestBody = {
     description() {
       return (node, ctx) => {
         if (node && node.description && typeof node.description !== 'string') {
-          return createError('The required field must be a string.', node, ctx);
+          return createErrrorFieldTypeMismatch('string.', node, ctx);
         }
         return null;
       };
@@ -14,7 +14,7 @@ export const OpenAPIRequestBody = {
     content() {
       return (node, ctx) => {
         if (node && !node.content) {
-          return createError('The content field is required for the Open API RequestBody object.', node, ctx, 'key');
+          return createErrorMissingRequiredField('content', node, ctx);
         }
         return null;
       };
@@ -22,7 +22,7 @@ export const OpenAPIRequestBody = {
     required() {
       return (node, ctx) => {
         if (node && node.required && typeof node.required !== 'boolean') {
-          return createError('The required field must be a boolean.', node, ctx);
+          return createErrrorFieldTypeMismatch('boolean.', node, ctx);
         }
         return null;
       };

--- a/src/validators/OpenAPIResponse.js
+++ b/src/validators/OpenAPIResponse.js
@@ -1,4 +1,4 @@
-import createError from '../error';
+import { createErrorMissingRequiredField } from '../error';
 
 import { OpenAPIMediaTypeObject } from './OpenAPIMediaObject';
 import { OpenAPIHeaderMap } from './OpenAPIHeader';
@@ -7,7 +7,7 @@ import { OpenAPILinkMap } from './OpenAPILink';
 export const OpenAPIResponse = {
   validators: {
     description() {
-      return (node, ctx) => (!node.description ? createError('Description is required part of a Response definition.', node, ctx, 'key') : null);
+      return (node, ctx) => (!node.description ? createErrorMissingRequiredField('description', node, ctx) : null);
     },
   },
   properties: {

--- a/src/validators/OpenAPISchema.js
+++ b/src/validators/OpenAPISchema.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* eslint-disable import/no-cycle */
-import createError from '../error';
+import createError, { createErrrorFieldTypeMismatch } from '../error';
 
 import OpenAPIExternalDocumentation from './OpenAPIExternalDocumentation';
 import OpenAPISchemaMap from './OpenAPISchemaMap';
@@ -13,7 +13,7 @@ const OpenAPISchemaObject = {
     title() {
       return (node, ctx) => {
         if (node && node.title) {
-          if (!(typeof node.title === 'string')) return createError('Title of the schema must be a string', node, ctx);
+          if (!(typeof node.title === 'string')) return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };
@@ -21,7 +21,7 @@ const OpenAPISchemaObject = {
     multipleOf() {
       return (node, ctx) => {
         if (node && node.multipleOf) {
-          if (typeof node.multipleOf !== 'number') return createError('Value of multipleOf must be a number', node, ctx);
+          if (typeof node.multipleOf !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.multipleOf < 0) return createError('Value of multipleOf must be greater or equal to zero', node, ctx);
         }
         return null;
@@ -29,32 +29,32 @@ const OpenAPISchemaObject = {
     },
     maximum() {
       return (node, ctx) => {
-        if (node && node.maximum && typeof node.maximum !== 'number') return createError('Value of maximum must be a number', node, ctx);
+        if (node && node.maximum && typeof node.maximum !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
         return null;
       };
     },
     exclusiveMaximum() {
       return (node, ctx) => {
-        if (node && node.exclusiveMaximum && typeof node.exclusiveMaximum !== 'boolean') return createError('Value of exclusiveMaximum must be a boolean', node, ctx);
+        if (node && node.exclusiveMaximum && typeof node.exclusiveMaximum !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     minimum() {
       return (node, ctx) => {
-        if (node && node.minimum && typeof node.minimum !== 'number') return createError('Value of minimum must be a number', node, ctx);
+        if (node && node.minimum && typeof node.minimum !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
         return null;
       };
     },
     exclusiveMinimum() {
       return (node, ctx) => {
-        if (node && node.exclusiveMinimum && typeof node.exclusiveMinimum !== 'boolean') return createError('Value of exclusiveMinimum must be a boolean', node, ctx);
+        if (node && node.exclusiveMinimum && typeof node.exclusiveMinimum !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     maxLength() {
       return (node, ctx) => {
         if (node && node.maxLength) {
-          if (typeof node.maxLength !== 'number') return createError('Value of maxLength must be a number', node, ctx);
+          if (typeof node.maxLength !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.maxLength < 0) return createError('Value of maxLength must be greater or equal to zero', node, ctx);
         }
         return null;
@@ -63,7 +63,7 @@ const OpenAPISchemaObject = {
     minLength() {
       return (node, ctx) => {
         if (node && node.minLength) {
-          if (typeof node.minLength !== 'number') return createError('Value of minLength must be a number', node, ctx);
+          if (typeof node.minLength !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.minLength < 0) return createError('Value of minLength must be greater or equal to zero', node, ctx);
         }
         return null;
@@ -73,7 +73,7 @@ const OpenAPISchemaObject = {
       return (node, ctx) => {
         if (node && node.pattern) {
           // TODO: add regexp validation.
-          if (typeof node.pattern !== 'string') return createError('Value of pattern must be a string', node, ctx);
+          if (typeof node.pattern !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };
@@ -81,7 +81,7 @@ const OpenAPISchemaObject = {
     maxItems() {
       return (node, ctx) => {
         if (node && node.maxItems) {
-          if (typeof node.maxItems !== 'number') return createError('Value of maxItems must be a number', node, ctx);
+          if (typeof node.maxItems !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.maxItems < 0) return createError('Value of maxItems must be greater or equal to zero. You can`t have negative amount of something.', node, ctx);
         }
         return null;
@@ -90,7 +90,7 @@ const OpenAPISchemaObject = {
     minItems() {
       return (node, ctx) => {
         if (node && node.minItems) {
-          if (typeof node.minItems !== 'number') return createError('Value of minItems must be a number', node, ctx);
+          if (typeof node.minItems !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.minItems < 0) return createError('Value of minItems must be greater or equal to zero. You can`t have negative amount of something.', node, ctx);
         }
         return null;
@@ -99,7 +99,7 @@ const OpenAPISchemaObject = {
     uniqueItems() {
       return (node, ctx) => {
         if (node && node.uniqueItems) {
-          if (typeof node.uniqueItems !== 'boolean') return createError('Value of uniqueItems must be a boolean', node, ctx);
+          if (typeof node.uniqueItems !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         }
         return null;
       };
@@ -107,7 +107,7 @@ const OpenAPISchemaObject = {
     maxProperties() {
       return (node, ctx) => {
         if (node && node.maxProperties) {
-          if (typeof node.maxProperties !== 'number') return createError('Value of maxProperties must be a number', node, ctx);
+          if (typeof node.maxProperties !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.maxProperties < 0) return createError('Value of maxProperties must be greater or equal to zero. You can`t have negative amount of something.', node, ctx);
         }
         return null;
@@ -116,7 +116,7 @@ const OpenAPISchemaObject = {
     minProperties() {
       return (node, ctx) => {
         if (node && node.minProperties) {
-          if (typeof node.minProperties !== 'number') return createError('Value of minProperties must be a number', node, ctx);
+          if (typeof node.minProperties !== 'number') return createErrrorFieldTypeMismatch('number', node, ctx);
           if (node.minProperties < 0) return createError('Value of minProperties must be greater or equal to zero. You can`t have negative amount of something.', node, ctx);
         }
         return null;
@@ -125,7 +125,7 @@ const OpenAPISchemaObject = {
     required() {
       return (node, ctx) => {
         if (node && node.required) {
-          if (!Array.isArray(node.required)) return createError('Value of required must be an array', node, ctx);
+          if (!Array.isArray(node.required)) return createErrrorFieldTypeMismatch('array', node, ctx);
           if (node.required.filter((item) => typeof item !== 'string').length !== 0) return createError('All values of "required" field must be strings', node, ctx);
         }
         return null;
@@ -134,7 +134,7 @@ const OpenAPISchemaObject = {
     enum() {
       return (node, ctx) => {
         if (node && node.enum) {
-          if (!Array.isArray(node.enum)) return createError('Value of enum must be an array', node, ctx);
+          if (!Array.isArray(node.enum)) return createErrrorFieldTypeMismatch('array', node, ctx);
           if (node.type
               && typeof node.type === 'string'
               // eslint-disable-next-line valid-typeof
@@ -164,37 +164,37 @@ const OpenAPISchemaObject = {
     },
     description() {
       return (node, ctx) => {
-        if (node && node.description && typeof node.description !== 'string') return createError('Value of description must be a string', node, ctx);
+        if (node && node.description && typeof node.description !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     format() {
       return (node, ctx) => {
-        if (node && node.format && typeof node.format !== 'string') return createError('Value of format must be a string', node, ctx);
+        if (node && node.format && typeof node.format !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     nullable() {
       return (node, ctx) => {
-        if (node && node.nullable && typeof node.nullable !== 'boolean') return createError('Value of nullable must be a boolean', node, ctx);
+        if (node && node.nullable && typeof node.nullable !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     readOnly() {
       return (node, ctx) => {
-        if (node && node.readOnly && typeof node.readOnly !== 'boolean') return createError('Value of readOnly must be a boolean', node, ctx);
+        if (node && node.readOnly && typeof node.readOnly !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     writeOnly() {
       return (node, ctx) => {
-        if (node && node.writeOnly && typeof node.writeOnly !== 'boolean') return createError('Value of writeOnly must be a boolean', node, ctx);
+        if (node && node.writeOnly && typeof node.writeOnly !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     deprecated() {
       return (node, ctx) => {
-        if (node && node.deprecated && typeof node.deprecated !== 'boolean') return createError('Value of deprecated must be a boolean', node, ctx);
+        if (node && node.deprecated && typeof node.deprecated !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },

--- a/src/validators/OpenAPISecuritySchema/OpenAPISecuritySchema.js
+++ b/src/validators/OpenAPISecuritySchema/OpenAPISecuritySchema.js
@@ -1,4 +1,4 @@
-import createError from '../../error';
+import createError, { createErrorMissingRequiredField, createErrrorFieldTypeMismatch } from '../../error';
 
 import OpenAPIFlows from './OpenAPIFlows';
 
@@ -6,30 +6,30 @@ export default {
   validators: {
     type() {
       return (node, ctx) => {
-        if (!node.type) return createError('The type field is required for the OpenAPI Security Scheme object', node, ctx);
-        if (typeof node.type !== 'string') return createError('The type field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (!node.type) return createErrorMissingRequiredField('type', node, ctx);
+        if (typeof node.type !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         if (!['apiKey', 'http', 'oauth2', 'openIdConnect'].includes(node.type)) return createError('The type value can only be one of the following "apiKey", "http", "oauth2", "openIdConnect" is required for the OpenAPI Security Scheme object', node, ctx);
         return null;
       };
     },
     description() {
       return (node, ctx) => {
-        if (node.description && typeof node.description !== 'string') return createError('The description field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (node.description && typeof node.description !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     name() {
       return (node, ctx) => {
         if (node.type !== 'apiKey') return null;
-        if (typeof node.name !== 'string') return createError('The name field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (typeof node.name !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     in() {
       return (node, ctx) => {
         if (node.type !== 'apiKey') return null;
-        if (!node.in) return createError('The in field is required for the OpenAPI Security Scheme object', node, ctx);
-        if (typeof node.in !== 'string') return createError('The in field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (!node.in) return createErrorMissingRequiredField('in', node, ctx);
+        if (typeof node.in !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         if (!['query', 'header', 'cookie'].includes(node.in)) return createError('The in value can only be one of the following "query", "header" or "cookie" for the OpenAPI Security Scheme object', node, ctx);
         return null;
       };
@@ -37,31 +37,31 @@ export default {
     scheme() {
       return (node, ctx) => {
         if (node.type !== 'http') return null;
-        if (!node.scheme) return createError('The scheme field is required for the OpenAPI Security Scheme object', node, ctx);
-        if (typeof node.scheme !== 'string') return createError('The scheme field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (!node.scheme) return createErrorMissingRequiredField('scheme', node, ctx);
+        if (typeof node.scheme !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     bearerFormat() {
       return (node, ctx) => {
         if (node.bearerFormat && node.type !== 'http') return createError('The bearerFormat field is applicable only for http', node, ctx);
-        if (!node.bearerFormat && node.type === 'http') return createError('The bearerFormat field is required for the OpenAPI Security Scheme object', node, ctx);
-        if (node.bearerFormat && typeof node.bearerFormat !== 'string') return createError('The bearerFormat field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (!node.bearerFormat && node.type === 'http') return createErrorMissingRequiredField('bearerFormat', node, ctx);
+        if (node.bearerFormat && typeof node.bearerFormat !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     flows() {
       return (node, ctx) => {
         if (node.type !== 'oauth2') return null;
-        if (!node.flows) return createError('The flows field is required for the Open API Security Scheme object', node, ctx);
+        if (!node.flows) return createErrorMissingRequiredField('flows', node, ctx);
         return null;
       };
     },
     openIdConnectUrl() {
       return (node, ctx) => {
         if (node.type !== 'openIdConnect') return null;
-        if (!node.openIdConnectUrl) return createError('The openIdConnectUrl field is required for the OpenAPI Security Scheme object', node, ctx);
-        if (typeof node.openIdConnectUrl !== 'string') return createError('The openIdConnectUrl field must be a string for the OpenAPI Security Scheme object', node, ctx);
+        if (!node.openIdConnectUrl) return createErrorMissingRequiredField('openIdConnectUrl', node, ctx);
+        if (typeof node.openIdConnectUrl !== 'string') return createErrrorFieldTypeMismatch('openIdConnectUrl', node, ctx);
         return null;
       };
     },

--- a/src/validators/OpenAPIServer.js
+++ b/src/validators/OpenAPIServer.js
@@ -1,22 +1,22 @@
-import createError from '../error';
+import createError, { createErrrorFieldTypeMismatch, createErrorMissingRequiredField } from '../error';
 
 const OpenAPIServerVariable = {
   validators: {
     default() {
       return (node, ctx) => {
-        if (!node || !node.default) return createError('The default field is required for the Server Variable', node, ctx, 'key');
-        if (typeof node.default !== 'string') return createError('default field of the Server Variable must be a string', node, ctx);
+        if (!node || !node.default) return createErrorMissingRequiredField('default', node, ctx, 'key');
+        if (typeof node.default !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     description() {
       return (node, ctx) => (node && node.description && typeof node.description !== 'string'
-        ? createError('description field of the Server Variable object must be a string', node, ctx) : null);
+        ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
     enum() {
       return (node, ctx) => {
         if (node && node.enum) {
-          if (!Array.isArray(node.enum)) return createError('Value of enum must be an array', node, ctx);
+          if (!Array.isArray(node.enum)) return createErrrorFieldTypeMismatch('array', node, ctx);
           if (node.type && node.enum.filter((item) => typeof item !== 'string').length !== 0) return createError('All values of "enum" field must be strings', node, ctx);
         }
         return null;
@@ -39,13 +39,14 @@ const OpenAPIServer = {
   validators: {
     url() {
       return (node, ctx) => {
-        if (!node || !node.url || typeof node.url !== 'string') return createError('url is required for a server object and must be a string', node, ctx, 'key');
+        if (!node || !node.url || typeof node.url !== 'string') return createErrorMissingRequiredField('url', node, ctx);
+        if (typeof node.url !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     description() {
       return (node, ctx) => (node && node.description && typeof node.description !== 'string'
-        ? createError('description field of the Server object must be a string', node, ctx) : null);
+        ? createErrrorFieldTypeMismatch('string', node, ctx) : null);
     },
   },
   properties: {

--- a/src/validators/OpenAPITag.js
+++ b/src/validators/OpenAPITag.js
@@ -1,13 +1,13 @@
 import OpenAPIExternalDocumentation from './OpenAPIExternalDocumentation';
-import createError from '../error';
+import { createErrorMissingRequiredField, createErrrorFieldTypeMismatch } from '../error';
 
 export default {
   validators: {
     name() {
       return (node, ctx) => {
-        if (!node.name) return createError('The name property is required for the Open API Tag object', node, ctx, 'key');
+        if (!node.name) return createErrorMissingRequiredField('name', node, ctx);
         if (node && node.name && typeof node.name !== 'string') {
-          return createError('The name field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };
@@ -15,7 +15,7 @@ export default {
     description() {
       return (node, ctx) => {
         if (node && node.description && typeof node.description !== 'string') {
-          return createError('The description field must be a string', node, ctx);
+          return createErrrorFieldTypeMismatch('string', node, ctx);
         }
         return null;
       };

--- a/src/validators/OpenAPIXML.js
+++ b/src/validators/OpenAPIXML.js
@@ -1,35 +1,35 @@
-import createError from '../error';
+import { createErrrorFieldTypeMismatch } from '../error';
 
 export default {
   validators: {
     name() {
       return (node, ctx) => {
-        if (node && node.name && typeof node.name !== 'string') return createError('name of the Xml object must be a string', node, ctx);
+        if (node && node.name && typeof node.name !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     namespace() {
       return (node, ctx) => {
         // TODO: add validation that format is uri
-        if (node && node.namespace && typeof node.namespace !== 'string') return createError('namespace of the Xml object must be a string', node, ctx);
+        if (node && node.namespace && typeof node.namespace !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     prefix() {
       return (node, ctx) => {
-        if (node && node.prefix && typeof node.prefix !== 'string') return createError('prefix of the Xml object must be a string', node, ctx);
+        if (node && node.prefix && typeof node.prefix !== 'string') return createErrrorFieldTypeMismatch('string', node, ctx);
         return null;
       };
     },
     attribute() {
       return (node, ctx) => {
-        if (node && node.attribute && typeof node.attribute !== 'boolean') return createError('attribute of the Xml object must be a boolean', node, ctx);
+        if (node && node.attribute && typeof node.attribute !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },
     wrapped() {
       return (node, ctx) => {
-        if (node && node.wrapped && typeof node.wrapped !== 'boolean') return createError('wrapped of the Xml object must be a boolean', node, ctx);
+        if (node && node.wrapped && typeof node.wrapped !== 'boolean') return createErrrorFieldTypeMismatch('boolean', node, ctx);
         return null;
       };
     },


### PR DESCRIPTION
Removed error.js from root dir and added several helpers for specific error types. Still thinking if it not reduces our customization capabilities, but generally it simplifies the codebase and makes error messages refactoring easier.