### PR TITLE
fixed failures for invalid references

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -15,11 +15,12 @@ const resolveNode = (node, ctx) => {
   let resolved = node;
   Object.keys(node).forEach((p) => {
     if (p === '$ref') {
-      nextPath = node.$ref;
+      nextPath = node.$ref.replace('#/', '').split('/');
       resolved = resolve(node[p], ctx);
       if (!resolved) {
         ctx.result.push(createError('Refernce does not exist', node, ctx));
         resolved = node;
+        nextPath = ctx.path;
       }
     }
   });

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -11,7 +11,7 @@ const validateNode = (node, definition, ctx) => {
     Object.keys(node).forEach((field) => {
       ctx.path.push(field);
 
-      if (!allowedChildren.includes(field) && field.indexOf('x-') !== 0) {
+      if (!allowedChildren.includes(field) && field.indexOf('x-') !== 0 && field.indexOf('$ref') !== 0) {
         ctx.result.push(createErrorFieldNotAllowed(field, node, ctx));
       }
 
@@ -45,7 +45,7 @@ const traverseNode = (node, definition, ctx) => {
   if (nextPath) {
     ctx.pathStack.push(ctx.path);
     prevPath = ctx.path;
-    ctx.path = nextPath.replace('#/', '').split('/');
+    ctx.path = nextPath;
   }
 
   if (Array.isArray(resolvedNode)) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -35,16 +35,16 @@ export const getLineNumberFromId = (source, charId) => {
  * @returns string
  */
 export function matchesJsonSchemaType(value, type) {
-  switch(type) {
+  switch (type) {
     case 'array':
-      return Array.isArray(value)
+      return Array.isArray(value);
     case 'object':
-      return typeof value === 'object' && value !== null && !Array.isArray(value)
+      return typeof value === 'object' && value !== null && !Array.isArray(value);
     case 'null':
-      return value === null
+      return value === null;
     case 'integer':
-      return Number.isInteger(value)
+      return Number.isInteger(value);
     default:
-      return typeof value === type
+      return typeof value === type;
   }
 }


### PR DESCRIPTION
fixed situation when if node could not be resolved by $ref value (e.g. such path does not exist in the document) the validator crashed as resolver still set the current path to the invalid value