### PR TITLE
Fix joining paths with metadata

### DIFF
--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -248,28 +248,30 @@ packageVersion: string
       for (const path of Object.keys(paths)) {
         if (!joinedDef.paths.hasOwnProperty(path)) { joinedDef.paths[path] = {}; }
         if (!potentialConflicts.paths.hasOwnProperty(path)) { potentialConflicts.paths[path] = {}; }
-        for (const operation of Object.keys(paths[path])) {
+        for (const operationOrMetadata of Object.keys(paths[path])) {
           // @ts-ignore
-          const pathOperation = paths[path][operation];
-          joinedDef.paths[path][operation] = pathOperation;
-          potentialConflicts.paths[path][operation] = [...(potentialConflicts.paths[path][operation] || []), entrypoint];
-          const { operationId } = pathOperation;
+          const pathOperationOrMetadata = paths[path][operationOrMetadata];
+          joinedDef.paths[path][operationOrMetadata] = pathOperationOrMetadata;
+          potentialConflicts.paths[path][operationOrMetadata] = [...(potentialConflicts.paths[path][operationOrMetadata] || []), entrypoint];
+          const { operationId } = pathOperationOrMetadata;
           if (operationId) {
             if (!potentialConflicts.paths.hasOwnProperty('operationIds')) { potentialConflicts.paths['operationIds'] = {}; }
             potentialConflicts.paths.operationIds[operationId] = [...(potentialConflicts.paths.operationIds[operationId] || []), entrypoint];
           }
-          let { tags, security } = joinedDef.paths[path][operation];
-          if (tags) {
-            joinedDef.paths[path][operation].tags = tags.map((tag: string) => addPrefix(tag, tagsPrefix));
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(tags), potentialConflicts, tagsPrefix, componentsPrefix });
-          } else {
-            joinedDef.paths[path][operation]['tags'] = [addPrefix('other', tagsPrefix || entrypointFilename)];
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(['other']), potentialConflicts, tagsPrefix: tagsPrefix || entrypointFilename, componentsPrefix });
-          }
-          if (!security && openapi.hasOwnProperty('security')) {
-            joinedDef.paths[path][operation]['security'] = addSecurityPrefix(openapi.security, componentsPrefix!);
-          } else if (pathOperation.security) {
-            joinedDef.paths[path][operation].security = addSecurityPrefix(pathOperation.security, componentsPrefix!);
+          if (typeof joinedDef.paths[path][operationOrMetadata] === 'object') {
+            let { tags, security } = joinedDef.paths[path][operationOrMetadata];
+            if (tags) {
+              joinedDef.paths[path][operationOrMetadata].tags = tags.map((tag: string) => addPrefix(tag, tagsPrefix));
+              populateTags({ entrypoint, entrypointFilename, tags: formatTags(tags), potentialConflicts, tagsPrefix, componentsPrefix });
+            } else {
+              joinedDef.paths[path][operationOrMetadata].tags = [addPrefix('other', tagsPrefix || entrypointFilename)];
+              populateTags({ entrypoint, entrypointFilename, tags: formatTags(['other']), potentialConflicts, tagsPrefix: tagsPrefix || entrypointFilename, componentsPrefix });
+            }
+            if (!security && openapi.hasOwnProperty('security')) {
+              joinedDef.paths[path][operationOrMetadata].security = addSecurityPrefix(openapi.security, componentsPrefix!);
+            } else if (pathOperationOrMetadata.security) {
+              joinedDef.paths[path][operationOrMetadata].security = addSecurityPrefix(pathOperationOrMetadata.security, componentsPrefix!);
+            }
           }
         }
       }


### PR DESCRIPTION
## What/Why/How?
The `join` command assumes all paths have _only_ operations that are expected to be objects, but paths can also have `string` fields like `summary` and `description`. This PR only treats objects as objects.

## Reference
https://swagger.io/docs/specification/paths-and-operations/#:~:text=In%20OpenAPI%20terms%2C%20paths%20are,as%20GET%2C%20POST%20or%20DELETE.

![image](https://user-images.githubusercontent.com/9947422/151539463-00ff89f9-0785-4c56-b34f-b25430c1bb79.png)

## Testing
There are no tests for this file, so no tests were added.

## Screenshots (optional)


## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
