### PR TITLE
feat: `response-contains-header` & `response-contains-property` built-in rules

### DIFF
--- a/docs/resources/built-in-rules.md
+++ b/docs/resources/built-in-rules.md
@@ -335,6 +335,25 @@ Verifies that each tag has a description.
 
 Verifies that tags (names) are declared in alphabetical order.
 
+### response-contains-header
+
+Enforces using specified response headers.
+
+```yaml
+lint:
+  rules:
+    response-contains-header:
+      severity: error
+      names:
+        2xx: 
+          - x-request-id
+        400:
+          - Content-Length
+```
+
+### response-contains-property
+
+The same as `response-contains-header` except for a response properties.
 
 ## Recommended config
 

--- a/docs/resources/built-in-rules.md
+++ b/docs/resources/built-in-rules.md
@@ -357,12 +357,13 @@ Enforces definition of specific response properties based on HTTP status code or
 Priority is given to more precise status codes over the status code range.
 ```yaml
 response-contains-header:
-      severity: error
-      names:
-        2XX: 
-          - created_at
-        400:
-          - title
+  severity: error
+  names:
+    2XX: 
+      - created_at
+    400:
+      - title
+```
 
 ## Recommended config
 

--- a/docs/resources/built-in-rules.md
+++ b/docs/resources/built-in-rules.md
@@ -359,7 +359,7 @@ Priority is given to more precise status codes over the status code range.
 response-contains-header:
   severity: error
   names:
-    2XX: 
+    2XX:
       - created_at
     400:
       - title

--- a/docs/resources/built-in-rules.md
+++ b/docs/resources/built-in-rules.md
@@ -345,7 +345,7 @@ lint:
     response-contains-header:
       severity: error
       names:
-        2xx: 
+        2XX: 
           - x-request-id
         400:
           - Content-Length
@@ -353,7 +353,16 @@ lint:
 
 ### response-contains-property
 
-The same as `response-contains-header` except for a response properties.
+Enforces definition of specific response properties based on HTTP status code or HTTP status code range.
+Priority is given to more precise status codes over the status code range.
+```yaml
+response-contains-header:
+      severity: error
+      names:
+        2XX: 
+          - created_at
+        400:
+          - title
 
 ## Recommended config
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { pickObjectProps, omitObjectProps, slash, generalizeResponseStatusCode } from '../utils';
+import { pickObjectProps, omitObjectProps, slash, getMatchingStatusCodeRange } from '../utils';
 
 describe('utils', () => {
   const testObject = {
@@ -72,14 +72,14 @@ describe('utils', () => {
     });
   });
 
-  describe('generalizeResponseStatusCode', () => {
+  describe('getMatchingStatusCodeRange', () => {
     it('should get the generalized form of status codes', () => {
-      expect(generalizeResponseStatusCode('202')).toEqual('2xx');
-      expect(generalizeResponseStatusCode(400)).toEqual('4xx');
+      expect(getMatchingStatusCodeRange('202')).toEqual('2xx');
+      expect(getMatchingStatusCodeRange(400)).toEqual('4xx');
     });
     it('should fail on a wrong input', () => {
-      expect(generalizeResponseStatusCode('2002')).toEqual('2002');
-      expect(generalizeResponseStatusCode(4000)).toEqual('4000');
+      expect(getMatchingStatusCodeRange('2002')).toEqual('2002');
+      expect(getMatchingStatusCodeRange(4000)).toEqual('4000');
     });
   });
 });

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { pickObjectProps, omitObjectProps, slash } from '../utils';
+import { pickObjectProps, omitObjectProps, slash, generalizeResponseStatusCode } from '../utils';
 
 describe('utils', () => {
   const testObject = {
@@ -69,6 +69,17 @@ describe('utils', () => {
     it('does not modify extended length paths', () => {
       const extended = '\\\\?\\some\\path';
       expect(slash(extended)).toBe(extended);
+    });
+  });
+
+  describe('generalizeResponseStatusCode', () => {
+    it('should get the generalized form of status codes', () => {
+      expect(generalizeResponseStatusCode('202')).toEqual('2xx');
+      expect(generalizeResponseStatusCode(400)).toEqual('4xx');
+    });
+    it('should fail on a wrong input', () => {
+      expect(generalizeResponseStatusCode('2002')).toEqual('2002');
+      expect(generalizeResponseStatusCode(4000)).toEqual('4000');
     });
   });
 });

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -74,8 +74,8 @@ describe('utils', () => {
 
   describe('getMatchingStatusCodeRange', () => {
     it('should get the generalized form of status codes', () => {
-      expect(getMatchingStatusCodeRange('202')).toEqual('2xx');
-      expect(getMatchingStatusCodeRange(400)).toEqual('4xx');
+      expect(getMatchingStatusCodeRange('202')).toEqual('2XX');
+      expect(getMatchingStatusCodeRange(400)).toEqual('4XX');
     });
     it('should fail on a wrong input', () => {
       expect(getMatchingStatusCodeRange('2002')).toEqual('2002');

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -1,0 +1,25 @@
+import { Oas2Rule, Oas3Rule } from '../../visitors';
+import { UserContext } from '../../walk';
+import { Oas3Response } from '../../typings/openapi';
+import { Oas2Response } from '../../typings/swagger';
+
+export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
+  const mustExist = options.mustExist || [];
+  return {
+    Response: {
+      skip: (_response: Oas2Response | Oas3Response, key: any) => {
+        return !['200', '201', '202'].includes(key.toString());
+      },
+      enter: (response: Oas2Response | Oas3Response, { report, location }: UserContext) => {
+        for (let element of mustExist) {
+          if (!response.headers?.[element]) {
+            report({
+              message: `Response object must have a top-level "${element}" header.`,
+              location: location.child('headers'),
+            });
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -2,24 +2,25 @@ import { Oas2Rule, Oas3Rule } from '../../visitors';
 import { UserContext } from '../../walk';
 import { Oas3Response } from '../../typings/openapi';
 import { Oas2Response } from '../../typings/swagger';
+import { generalizeResponseStatusCode } from '../../utils';
 
 export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
-  const mustExist = options.mustExist || [];
+  const names: Record<string, string[]> = options.names || {};
   return {
-    Response: {
-      skip: (_response: Oas2Response | Oas3Response, key: any) => {
-        return !['200', '201', '202'].includes(key.toString());
-      },
-      enter: (response: Oas2Response | Oas3Response, { report, location }: UserContext) => {
-        for (let element of mustExist) {
-          if (!response.headers?.[element]) {
-            report({
-              message: `Response object must have a top-level "${element}" header.`,
-              location: location.child('headers'),
-            });
+    Operation: {
+      Response: {
+        enter: (response: Oas2Response | Oas3Response, { report, location, key }: UserContext) => {
+          const expectedHeaders = names[key] || names[generalizeResponseStatusCode(key)] || [];
+          for (const expectedHeader of expectedHeaders) {
+            if (!response.headers?.[expectedHeader]) {
+              report({
+                message: `Response object must have a "${expectedHeader}" header.`,
+                location: location.child('headers'),
+              });
+            }
           }
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 };

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -2,7 +2,7 @@ import { Oas2Rule, Oas3Rule } from '../../visitors';
 import { UserContext } from '../../walk';
 import { Oas3Response } from '../../typings/openapi';
 import { Oas2Response } from '../../typings/swagger';
-import { generalizeResponseStatusCode } from '../../utils';
+import { getMatchingStatusCodeRange } from '../../utils';
 
 export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
   const names: Record<string, string[]> = options.names || {};
@@ -10,7 +10,7 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
     Operation: {
       Response: {
         enter: (response: Oas2Response | Oas3Response, { report, location, key }: UserContext) => {
-          const expectedHeaders = names[key] || names[generalizeResponseStatusCode(key)] || [];
+          const expectedHeaders = names[key] || names[getMatchingStatusCodeRange(key)] || [];
           for (const expectedHeader of expectedHeaders) {
             if (!response.headers?.[expectedHeader]) {
               report({

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -10,7 +10,11 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
     Operation: {
       Response: {
         enter: (response: Oas2Response | Oas3Response, { report, location, key }: UserContext) => {
-          const expectedHeaders = names[key] || names[getMatchingStatusCodeRange(key)] || [];
+          const expectedHeaders =
+            names[key] ||
+            names[getMatchingStatusCodeRange(key)] ||
+            names[getMatchingStatusCodeRange(key).toLowerCase()] ||
+            [];
           for (const expectedHeader of expectedHeaders) {
             if (!response.headers?.[expectedHeader]) {
               report({

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -18,8 +18,8 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
           for (const expectedHeader of expectedHeaders) {
             if (!response.headers?.[expectedHeader]) {
               report({
-                message: `Response object must have a "${expectedHeader}" header.`,
-                location: location.child('headers'),
+                message: `Response object must contain a "${expectedHeader}" header.`,
+                location: location.child('headers').key(),
               });
             }
           }

--- a/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
@@ -1,0 +1,80 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('Oas2 response-contains-header', () => {
+  it('oas2-response-contains-header: should report on response object when not contains header', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '201':
+                description: Account Created
+                headers:
+                  Content-Location:
+                    description: Location of created Account
+                    type: string
+              '404':
+                description: User not found
+			`,
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+          mustExist: ['Content-Length'],
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1accounts~1{accountId}/get/responses/201/headers",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '201':
+                description: Account Created
+                headers:
+                  Content-Location:
+                    description: Location of created Account
+                    type: string
+              '404':
+                description: User not found",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"Content-Length\\" header.",
+          "ruleId": "response-contains-header",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
@@ -4,9 +4,8 @@ import { parseYamlToDocument, makeConfig } from '../../../../__tests__/utils';
 import { BaseResolver } from '../../../resolve';
 
 describe('Oas2 response-contains-header', () => {
-  it('oas2-response-contains-header: should report on response object when not contains header', async () => {
-    const document = parseYamlToDocument(
-      outdent`
+  it('should report a response object not containing the header', async () => {
+    const document = parseYamlToDocument(outdent`
       swagger: '2.0'
       schemes:
         - https
@@ -25,16 +24,14 @@ describe('Oas2 response-contains-header', () => {
                     type: string
               '404':
                 description: User not found
-			`,
-    );
-
+    `);
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: makeConfig({
         'response-contains-header': {
           severity: 'error',
-          mustExist: ['Content-Length'],
+          names: { '2xx': ['Content-Length'], '4xx': ['Content-Length'] },
         },
       }),
     });
@@ -69,12 +66,109 @@ describe('Oas2 response-contains-header', () => {
               },
             },
           ],
-          "message": "Response object must have a top-level \\"Content-Length\\" header.",
+          "message": "Response object must have a \\"Content-Length\\" header.",
+          "ruleId": "response-contains-header",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1accounts~1{accountId}/get/responses/404/headers",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '201':
+                description: Account Created
+                headers:
+                  Content-Location:
+                    description: Location of created Account
+                    type: string
+              '404':
+                description: User not found",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a \\"Content-Length\\" header.",
           "ruleId": "response-contains-header",
           "severity": "error",
           "suggest": Array [],
         },
       ]
     `);
+  });
+
+  it('should not report a response object containing the header nor not applicable', async () => {
+    const document = parseYamlToDocument(outdent`
+      swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '201':
+                description: Account Created
+                headers:
+                  Content-Length:
+                    description: calls per hour allowed by the user
+                    schema:
+                      type: integer
+                      format: int32
+              '404':
+                description: User not found
+		`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+          names: { '2xx': ['Content-Length'], '400': ['Content-Length'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report a response object when there is no `names` section defined', async () => {
+    const document = parseYamlToDocument(outdent`
+      swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '404':
+                description: User not found
+		`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
@@ -28,7 +28,7 @@ describe('Oas2 response-contains-header', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-header': {
           severity: 'error',
           names: { '2xx': ['Content-Length'], '4xx': ['Content-Length'] },
@@ -135,7 +135,7 @@ describe('Oas2 response-contains-header', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-header': {
           severity: 'error',
           names: { '2xx': ['Content-Length'], '400': ['Content-Length'] },
@@ -163,7 +163,7 @@ describe('Oas2 response-contains-header', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-header': {
           severity: 'error',
         },

--- a/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-header.test.ts
@@ -41,7 +41,7 @@ describe('Oas2 response-contains-header', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1accounts~1{accountId}/get/responses/201/headers",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "swagger: '2.0'
@@ -66,7 +66,7 @@ describe('Oas2 response-contains-header', () => {
               },
             },
           ],
-          "message": "Response object must have a \\"Content-Length\\" header.",
+          "message": "Response object must contain a \\"Content-Length\\" header.",
           "ruleId": "response-contains-header",
           "severity": "error",
           "suggest": Array [],
@@ -75,7 +75,7 @@ describe('Oas2 response-contains-header', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1accounts~1{accountId}/get/responses/404/headers",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "swagger: '2.0'
@@ -100,7 +100,7 @@ describe('Oas2 response-contains-header', () => {
               },
             },
           ],
-          "message": "Response object must have a \\"Content-Length\\" header.",
+          "message": "Response object must contain a \\"Content-Length\\" header.",
           "ruleId": "response-contains-header",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/oas2/__tests__/response-contains-property.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-property.test.ts
@@ -1,0 +1,155 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('Oas2 response-contains-property', () => {
+  it('should report a response object not containing the property', async () => {
+    const document = parseYamlToDocument(outdent`
+      swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '200':
+                description: Account object returned
+                schema:
+                  type: object
+                  properties:
+                    created_at:
+                      description: Account creation date/time
+                      format: date-time
+                      type: string
+                    owner_email:
+                      description: Account Owner email
+                      type: string
+              '404':
+                description: User not found
+			`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { '2xx': ['id'], '4xx': ['id'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1accounts~1{accountId}/get/responses/200/schema/properties",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '200':
+                description: Account object returned
+                schema:
+                  type: object
+                  properties:
+                    created_at:
+                      description: Account creation date/time
+                      format: date-time
+                      type: string
+                    owner_email:
+                      description: Account Owner email
+                      type: string
+              '404':
+                description: User not found",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"id\\" property.",
+          "ruleId": "response-contains-property",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+
+  it('should not report a response object containing the expected property', async () => {
+    const document = parseYamlToDocument(outdent`
+      swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '200':
+                description: Account object returned
+                schema:
+                  type: object
+                  properties:
+                    created_at:
+                      description: Account creation date/time
+                      format: date-time
+                      type: string
+                    id: some-id
+              '404':
+                description: User not found
+                id: some-id
+			`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { '200': ['id'], '4xx': ['id'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report a response object when there is no `names` section defined', async () => {
+    const document = parseYamlToDocument(outdent`
+      swagger: '2.0'
+      schemes:
+        - https
+      basePath: /v2
+      paths:
+        '/accounts/{accountId}':
+          get:
+            description: Retrieve a sub account under the master account.
+            operationId: account
+            responses:
+              '404':
+                description: User not found
+    `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+});

--- a/packages/core/src/rules/oas2/__tests__/response-contains-property.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-property.test.ts
@@ -34,7 +34,7 @@ describe('Oas2 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { '2xx': ['id'], '4xx': ['id'] },
@@ -116,7 +116,7 @@ describe('Oas2 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { '200': ['id'], '4xx': ['id'] },
@@ -144,7 +144,7 @@ describe('Oas2 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
         },

--- a/packages/core/src/rules/oas2/__tests__/response-contains-property.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/response-contains-property.test.ts
@@ -47,7 +47,7 @@ describe('Oas2 response-contains-property', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1accounts~1{accountId}/get/responses/200/schema/properties",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "swagger: '2.0'
@@ -78,7 +78,7 @@ describe('Oas2 response-contains-property', () => {
               },
             },
           ],
-          "message": "Response object must have a top-level \\"id\\" property.",
+          "message": "Response object must contain a top-level \\"id\\" property.",
           "ruleId": "response-contains-property",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -37,6 +37,7 @@ import { PathExcludesPatterns } from '../common/path-excludes-patterns';
 import { RequestMimeType } from './request-mime-type';
 import { ResponseMimeType } from './response-mime-type';
 import { PathSegmentPlural } from '../common/path-segment-plural';
+import { ResponseContainsHeader } from '../common/response-contains-header';
 
 export const rules = {
   spec: OasSpec as Oas2Rule,
@@ -78,6 +79,7 @@ export const rules = {
   'request-mime-type': RequestMimeType as Oas2Rule,
   'response-mime-type': ResponseMimeType as Oas2Rule,
   'path-segment-plural': PathSegmentPlural as Oas2Rule,
+  'response-contains-header': ResponseContainsHeader as Oas2Rule,
 };
 
 export const preprocessors = {};

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -38,6 +38,7 @@ import { RequestMimeType } from './request-mime-type';
 import { ResponseMimeType } from './response-mime-type';
 import { PathSegmentPlural } from '../common/path-segment-plural';
 import { ResponseContainsHeader } from '../common/response-contains-header';
+import { ResponseContainsProperty } from './response-contains-property';
 
 export const rules = {
   spec: OasSpec as Oas2Rule,
@@ -80,6 +81,7 @@ export const rules = {
   'response-mime-type': ResponseMimeType as Oas2Rule,
   'path-segment-plural': PathSegmentPlural as Oas2Rule,
   'response-contains-header': ResponseContainsHeader as Oas2Rule,
+  'response-contains-property': ResponseContainsProperty as Oas2Rule,
 };
 
 export const preprocessors = {};

--- a/packages/core/src/rules/oas2/response-contains-property.ts
+++ b/packages/core/src/rules/oas2/response-contains-property.ts
@@ -1,0 +1,32 @@
+import { Oas2Rule } from '../../visitors';
+import { UserContext } from '../../walk';
+import { getMatchingStatusCodeRange } from '../../utils';
+
+export const ResponseContainsProperty: Oas2Rule = (options) => {
+  const names: Record<string, string[]> = options.names || {};
+  let key: string | number;
+  return {
+    Operation: {
+      Response: {
+        skip: (_response, key) => {
+          return `${key}` === '204';
+        },
+        enter: (_response, ctx: UserContext) => {
+          key = ctx.key;
+        },
+        Schema(schema, { report, location }) {
+          if (schema.type !== 'object') return;
+          const expectedProperties = names[key] || names[getMatchingStatusCodeRange(key)] || [];
+          for (const expectedProperty of expectedProperties) {
+            if (!schema.properties?.[expectedProperty]) {
+              report({
+                message: `Response object must have a top-level "${expectedProperty}" property.`,
+                location: location.child('properties'),
+              });
+            }
+          }
+        },
+      },
+    },
+  };
+};

--- a/packages/core/src/rules/oas2/response-contains-property.ts
+++ b/packages/core/src/rules/oas2/response-contains-property.ts
@@ -24,8 +24,8 @@ export const ResponseContainsProperty: Oas2Rule = (options) => {
           for (const expectedProperty of expectedProperties) {
             if (!schema.properties?.[expectedProperty]) {
               report({
-                message: `Response object must have a top-level "${expectedProperty}" property.`,
-                location: location.child('properties'),
+                message: `Response object must contain a top-level "${expectedProperty}" property.`,
+                location: location.child('properties').key(),
               });
             }
           }

--- a/packages/core/src/rules/oas2/response-contains-property.ts
+++ b/packages/core/src/rules/oas2/response-contains-property.ts
@@ -16,7 +16,11 @@ export const ResponseContainsProperty: Oas2Rule = (options) => {
         },
         Schema(schema, { report, location }) {
           if (schema.type !== 'object') return;
-          const expectedProperties = names[key] || names[getMatchingStatusCodeRange(key)] || [];
+          const expectedProperties =
+            names[key] ||
+            names[getMatchingStatusCodeRange(key)] ||
+            names[getMatchingStatusCodeRange(key).toLowerCase()] ||
+            [];
           for (const expectedProperty of expectedProperties) {
             if (!schema.properties?.[expectedProperty]) {
               report({

--- a/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
@@ -1,0 +1,74 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('Oas3 response-contains-header', () => {
+  it('oas3-response-contains-header: should report on response object when not contains header', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '200':
+                description: successful operation
+                headers:
+                  X-Rate-Limit:
+                    description: calls per hour allowed by the user
+                    schema:
+                      type: integer
+                      format: int32
+			`,
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+          mustExist: ['Content-Length'],
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1store~1subscribe/post/responses/200/headers",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '200':
+                description: successful operation
+                headers:
+                  X-Rate-Limit:
+                    description: calls per hour allowed by the user
+                    schema:
+                      type: integer
+                      format: int32",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"Content-Length\\" header.",
+          "ruleId": "response-contains-header",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
@@ -110,7 +110,7 @@ describe('Oas3 response-contains-header', () => {
         'response-contains-header': {
           severity: 'error',
           names: {
-            '2xx': ['x-request-id'],
+            '2XX': ['x-request-id'],
             '400': ['Content-Length'],
           },
         },

--- a/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
@@ -39,7 +39,7 @@ describe('Oas3 response-contains-header', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/200/headers",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -61,7 +61,7 @@ describe('Oas3 response-contains-header', () => {
               },
             },
           ],
-          "message": "Response object must have a \\"Content-Length\\" header.",
+          "message": "Response object must contain a \\"Content-Length\\" header.",
           "ruleId": "response-contains-header",
           "severity": "error",
           "suggest": Array [],
@@ -122,7 +122,7 @@ describe('Oas3 response-contains-header', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/200/headers",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -159,7 +159,7 @@ describe('Oas3 response-contains-header', () => {
               },
             },
           ],
-          "message": "Response object must have a \\"x-request-id\\" header.",
+          "message": "Response object must contain a \\"x-request-id\\" header.",
           "ruleId": "response-contains-header",
           "severity": "error",
           "suggest": Array [],
@@ -168,7 +168,7 @@ describe('Oas3 response-contains-header', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/400/headers",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -205,7 +205,7 @@ describe('Oas3 response-contains-header', () => {
               },
             },
           ],
-          "message": "Response object must have a \\"Content-Length\\" header.",
+          "message": "Response object must contain a \\"Content-Length\\" header.",
           "ruleId": "response-contains-header",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
@@ -26,7 +26,7 @@ describe('Oas3 response-contains-header', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-header': {
           severity: 'error',
           names: { '200': ['Content-Length'] },
@@ -106,7 +106,7 @@ describe('Oas3 response-contains-header', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-header': {
           severity: 'error',
           names: {
@@ -258,7 +258,7 @@ describe('Oas3 response-contains-header', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-header': {
           severity: 'error',
           names: {

--- a/packages/core/src/rules/oas3/__tests__/response-contains-property.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-property.test.ts
@@ -1,0 +1,403 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('Oas3 response-contains-property', () => {
+  it('should report a response object not containing the property', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456
+		`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { 201: ['id'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1store~1subscribe/post/responses/201/content/application~1json/schema/properties",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"id\\" property.",
+          "ruleId": "response-contains-property",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+
+  it('should report response objects not containing props for a subset of status codes', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456
+              400:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: integer
+                description: error
+      `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { '2xx': ['id'], '400': ['error'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1store~1subscribe/post/responses/201/content/application~1json/schema/properties",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456
+              400:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: integer
+                description: error",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"id\\" property.",
+          "ruleId": "response-contains-property",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1store~1subscribe/post/responses/400/content/application~1json/schema/properties",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456
+              400:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: integer
+                description: error",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"error\\" property.",
+          "ruleId": "response-contains-property",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+
+  it('should not report response objects containing specified properties', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456
+                        id: some-id
+              400:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: integer
+                        error:
+                          type: string
+      `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { '2xx': ['id'], '400': ['error'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report a response object when schema type is not object', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  text/plain:
+                    schema:
+                      type: string
+      `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { 201: ['id'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report response objects when there is no `names` field specified', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '201':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456
+              400:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: integer
+                description: error
+      `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report response objects for 204 status code', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '204':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        subscriptionId:
+                          type: string
+                          example: AAA-123-BBB-456                  
+      `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { '2xx': ['id'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should report response objects when there are no properties', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              200:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                                      
+      `);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({
+        'response-contains-property': {
+          severity: 'error',
+          names: { '2xx': ['id'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1store~1subscribe/post/responses/200/content/application~1json/schema/properties",
+              "reportOnKey": false,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              200:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                                      ",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must have a top-level \\"id\\" property.",
+          "ruleId": "response-contains-property",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/oas3/__tests__/response-contains-property.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-property.test.ts
@@ -26,7 +26,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { 201: ['id'] },
@@ -102,7 +102,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { '2xx': ['id'], '400': ['error'] },
@@ -230,7 +230,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { '2xx': ['id'], '400': ['error'] },
@@ -258,7 +258,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { 201: ['id'] },
@@ -299,7 +299,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
         },
@@ -330,7 +330,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { '2xx': ['id'] },
@@ -359,7 +359,7 @@ describe('Oas3 response-contains-property', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({
+      config: await makeConfig({
         'response-contains-property': {
           severity: 'error',
           names: { '2xx': ['id'] },

--- a/packages/core/src/rules/oas3/__tests__/response-contains-property.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-property.test.ts
@@ -39,7 +39,7 @@ describe('Oas3 response-contains-property', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/201/content/application~1json/schema/properties",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -62,7 +62,7 @@ describe('Oas3 response-contains-property', () => {
               },
             },
           ],
-          "message": "Response object must have a top-level \\"id\\" property.",
+          "message": "Response object must contain a top-level \\"id\\" property.",
           "ruleId": "response-contains-property",
           "severity": "error",
           "suggest": Array [],
@@ -115,7 +115,7 @@ describe('Oas3 response-contains-property', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/201/content/application~1json/schema/properties",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -147,7 +147,7 @@ describe('Oas3 response-contains-property', () => {
               },
             },
           ],
-          "message": "Response object must have a top-level \\"id\\" property.",
+          "message": "Response object must contain a top-level \\"id\\" property.",
           "ruleId": "response-contains-property",
           "severity": "error",
           "suggest": Array [],
@@ -156,7 +156,7 @@ describe('Oas3 response-contains-property', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/400/content/application~1json/schema/properties",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -188,7 +188,7 @@ describe('Oas3 response-contains-property', () => {
               },
             },
           ],
-          "message": "Response object must have a top-level \\"error\\" property.",
+          "message": "Response object must contain a top-level \\"error\\" property.",
           "ruleId": "response-contains-property",
           "severity": "error",
           "suggest": Array [],
@@ -372,7 +372,7 @@ describe('Oas3 response-contains-property', () => {
           "location": Array [
             Object {
               "pointer": "#/paths/~1store~1subscribe/post/responses/200/content/application~1json/schema/properties",
-              "reportOnKey": false,
+              "reportOnKey": true,
               "source": Source {
                 "absoluteRef": "",
                 "body": "openapi: 3.0.3
@@ -392,7 +392,7 @@ describe('Oas3 response-contains-property', () => {
               },
             },
           ],
-          "message": "Response object must have a top-level \\"id\\" property.",
+          "message": "Response object must contain a top-level \\"id\\" property.",
           "ruleId": "response-contains-property",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -45,6 +45,7 @@ import { PathSegmentPlural } from '../common/path-segment-plural';
 import { PathExcludesPatterns } from '../common/path-excludes-patterns';
 import { NoInvalidSchemaExamples } from '../common/no-invalid-schema-examples';
 import { NoInvalidParameterExamples } from '../common/no-invalid-parameter-examples';
+import { ResponseContainsHeader } from '../common/response-contains-header';
 
 export const rules = {
   spec: OasSpec,
@@ -94,6 +95,7 @@ export const rules = {
   'path-segment-plural': PathSegmentPlural,
   'no-invalid-schema-examples': NoInvalidSchemaExamples,
   'no-invalid-parameter-examples': NoInvalidParameterExamples,
+  'response-contains-header': ResponseContainsHeader,
 } as Oas3RuleSet;
 
 export const preprocessors = {};

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -46,6 +46,7 @@ import { PathExcludesPatterns } from '../common/path-excludes-patterns';
 import { NoInvalidSchemaExamples } from '../common/no-invalid-schema-examples';
 import { NoInvalidParameterExamples } from '../common/no-invalid-parameter-examples';
 import { ResponseContainsHeader } from '../common/response-contains-header';
+import { ResponseContainsProperty } from './response-contains-property';
 
 export const rules = {
   spec: OasSpec,
@@ -96,6 +97,7 @@ export const rules = {
   'no-invalid-schema-examples': NoInvalidSchemaExamples,
   'no-invalid-parameter-examples': NoInvalidParameterExamples,
   'response-contains-header': ResponseContainsHeader,
+  'response-contains-property': ResponseContainsProperty,
 } as Oas3RuleSet;
 
 export const preprocessors = {};

--- a/packages/core/src/rules/oas3/response-contains-property.ts
+++ b/packages/core/src/rules/oas3/response-contains-property.ts
@@ -1,0 +1,34 @@
+import { Oas3Rule } from '../../visitors';
+import { UserContext } from '../../walk';
+import { getMatchingStatusCodeRange } from '../../utils';
+
+export const ResponseContainsProperty: Oas3Rule = (options) => {
+  const names: Record<string, string[]> = options.names || {};
+  let key: string | number;
+  return {
+    Operation: {
+      Response: {
+        skip: (_response, key) => {
+          return `${key}` === '204';
+        },
+        enter: (_response, ctx: UserContext) => {
+          key = ctx.key;
+        },
+        MediaType: {
+          Schema(schema, { report, location }) {
+            if (schema.type !== 'object') return;
+            const expectedProperties = names[key] || names[getMatchingStatusCodeRange(key)] || [];
+            for (const expectedProperty of expectedProperties) {
+              if (!schema.properties?.[expectedProperty]) {
+                report({
+                  message: `Response object must have a top-level "${expectedProperty}" property.`,
+                  location: location.child('properties'),
+                });
+              }
+            }
+          },
+        },
+      },
+    },
+  };
+};

--- a/packages/core/src/rules/oas3/response-contains-property.ts
+++ b/packages/core/src/rules/oas3/response-contains-property.ts
@@ -25,8 +25,8 @@ export const ResponseContainsProperty: Oas3Rule = (options) => {
             for (const expectedProperty of expectedProperties) {
               if (!schema.properties?.[expectedProperty]) {
                 report({
-                  message: `Response object must have a top-level "${expectedProperty}" property.`,
-                  location: location.child('properties'),
+                  message: `Response object must contain a top-level "${expectedProperty}" property.`,
+                  location: location.child('properties').key(),
                 });
               }
             }

--- a/packages/core/src/rules/oas3/response-contains-property.ts
+++ b/packages/core/src/rules/oas3/response-contains-property.ts
@@ -17,7 +17,11 @@ export const ResponseContainsProperty: Oas3Rule = (options) => {
         MediaType: {
           Schema(schema, { report, location }) {
             if (schema.type !== 'object') return;
-            const expectedProperties = names[key] || names[getMatchingStatusCodeRange(key)] || [];
+            const expectedProperties =
+              names[key] ||
+              names[getMatchingStatusCodeRange(key)] ||
+              names[getMatchingStatusCodeRange(key).toLowerCase()] ||
+              [];
             for (const expectedProperty of expectedProperties) {
               if (!schema.properties?.[expectedProperty]) {
                 report({

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -189,5 +189,5 @@ export function assignExisting<T>(target: Record<string, T>, obj: Record<string,
   }
 }
 
-export const generalizeResponseStatusCode = (code: number | string): string =>
+export const getMatchingStatusCodeRange = (code: number | string): string =>
   `${code}`.replace(/^(\d)\d\d$/, (_, firstDigit) => `${firstDigit}xx`);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -190,4 +190,4 @@ export function assignExisting<T>(target: Record<string, T>, obj: Record<string,
 }
 
 export const getMatchingStatusCodeRange = (code: number | string): string =>
-  `${code}`.replace(/^(\d)\d\d$/, (_, firstDigit) => `${firstDigit}xx`);
+  `${code}`.replace(/^(\d)\d\d$/, (_, firstDigit) => `${firstDigit}XX`);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -188,3 +188,6 @@ export function assignExisting<T>(target: Record<string, T>, obj: Record<string,
     }
   }
 }
+
+export const generalizeResponseStatusCode = (code: number | string): string =>
+  `${code}`.replace(/^(\d)\d\d$/, (_, firstDigit) => `${firstDigit}xx`);


### PR DESCRIPTION
## What/Why/How?
Closes #390 & #389 respectively

## Check yourself
- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
