### PR TITLE
feat: added --public option for push command

### DIFF
--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -86,7 +86,8 @@ destination      | string    | Conditional. The location in the API registry whe
 --skip-decorator | [string] | Ignore one or more decorators. See the [Skip decorator section](#skip-decorator) for usage examples.
 --upsert, -u | boolean | Upsert an API to the API registry. See [the Upsert an API with push section](#upsert-an-api-with-push) for more information.  |
 --version     | boolean | Show version number.  |
---region,-r    | string | Specify which region to use when logging in. Supported values: `us`, `eu`. The `eu` region is limited to enterprise customers. Default value is `us`. Read more about [configuring the region](../configuration/index.mdx#region).
+--region,-r    | string | Specify which region to use when logging in. Supported values: `us`, `eu`. The `eu` region is limited to enterprise customers. Default value is `us`. Read more about [configuring the region](../configuration/index.mdx#region).  |
+-- public    | boolean | Optional. Make API definition public accessible from API Registry. Read more about [public option](#public).  |
 
 ## Examples
 
@@ -259,6 +260,15 @@ openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator
 
 ```bash Skip multiple decorators
 openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator=test/remove-internal-operations --skip-decorator=test/remove-internal-schemas
+```
+
+### Public
+
+The `--public` option allows upload your API definition and make it public from API Registry. By default, it's not available to the public.
+For more information check [registry access](../../../api-registry/settings/manage-access/#set-up-access-to-api-registry) section.
+
+```bash
+openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --public
 ```
 
 ### Set up CI from Redocly Workflows

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -87,7 +87,7 @@ destination      | string    | Conditional. The location in the API registry whe
 --upsert, -u | boolean | Upsert an API to the API registry. See [the Upsert an API with push section](#upsert-an-api-with-push) for more information.  |
 --version     | boolean | Show version number.  |
 --region,-r    | string | Specify which region to use when logging in. Supported values: `us`, `eu`. The `eu` region is limited to enterprise customers. Default value is `us`. Read more about [configuring the region](../configuration/index.mdx#region).  |
--- public    | boolean | Optional. Make API definitions publicly accessible from the API Registry. Read more about [using the public option](#public).  |
+-- public    | boolean | Make API definitions publicly accessible from the API Registry. Read more about [using the public option](#public).  |
 
 ## Examples
 

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -87,7 +87,7 @@ destination      | string    | Conditional. The location in the API registry whe
 --upsert, -u | boolean | Upsert an API to the API registry. See [the Upsert an API with push section](#upsert-an-api-with-push) for more information.  |
 --version     | boolean | Show version number.  |
 --region,-r    | string | Specify which region to use when logging in. Supported values: `us`, `eu`. The `eu` region is limited to enterprise customers. Default value is `us`. Read more about [configuring the region](../configuration/index.mdx#region).  |
--- public    | boolean | Optional. Make API definition public accessible from API Registry. Read more about [public option](#public).  |
+-- public    | boolean | Optional. Make API definitions publicly accessible from the API Registry. Read more about [using the public option](#public).  |
 
 ## Examples
 
@@ -264,8 +264,8 @@ openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator
 
 ### Public
 
-The `--public` option allows upload your API definition and make it public from API Registry. By default, it's not available to the public.
-For more information check [registry access](../../../api-registry/settings/manage-access/#set-up-access-to-api-registry) section.
+The `--public` option allows you to upload your API definition and make it publicly accessible from the API Registry. By default, definitions uploaded with the `push` command are not available to the public.
+For more information on how to configure access to your APIs, check the [registry access](../../../api-registry/settings/manage-access/#set-up-access-to-api-registry) section.
 
 ```bash
 openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --public

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -31,6 +31,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
+      'public': true
     });
 
     expect(redoclyClient.registryApi.prepareFileUpload).toBeCalledTimes(1);
@@ -39,6 +40,7 @@ describe('push', () => {
       branch: 'test',
       filePaths: ['filePath'],
       isUpsert: true,
+      isPublic: true,
       name: 'my-api',
       organizationId: 'org',
       rootFilePath: 'filePath',

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -35,6 +35,7 @@ type PushArgs = {
   'run-id'?: string;
   region?: Region;
   'skip-decorator'?: string[];
+  'public'?: boolean;
 };
 
 export async function handlePush(argv: PushArgs): Promise<void> {
@@ -147,6 +148,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
         filePaths,
         branch: branchName,
         isUpsert: upsert,
+        isPublic: argv['public']
       });
     } catch (error) {
       if (error.message === 'ORGANIZATION_NOT_FOUND') {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -106,6 +106,10 @@ yargs
             array: true,
             type: 'string',
           },
+          'public': {
+            description: 'Make API registry available to the public',
+            type: 'boolean',
+          },
         }),
     transformPush(handlePush),
   )

--- a/packages/core/src/redocly/registry-api-types.ts
+++ b/packages/core/src/redocly/registry-api-types.ts
@@ -16,6 +16,7 @@ export namespace RegistryApiTypes {
     filePaths: string[];
     branch?: string;
     isUpsert?: boolean;
+    isPublic?: boolean;
   }
 
   export interface PrepareFileuploadOKResponse {

--- a/packages/core/src/redocly/registry-api.ts
+++ b/packages/core/src/redocly/registry-api.ts
@@ -104,6 +104,7 @@ export class RegistryApi {
     filePaths,
     branch,
     isUpsert,
+    isPublic,
   }: RegistryApiTypes.PushApiParams) {
     const response = await this.request(
       `/${organizationId}/${name}/${version}`,
@@ -118,6 +119,7 @@ export class RegistryApi {
           filePaths,
           branch,
           isUpsert,
+          isPublic,
         }),
       },
       this.region,


### PR DESCRIPTION
## What/Why/How?

Added public option for push command. Make API registry public accessible.

## Reference
Resolve https://github.com/Redocly/workflows/issues/1958
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
