### PR TITLE
fix: preview server hot reload

### DIFF
--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -98,19 +98,24 @@ export default async function startPreviewServer(
         });
       }
     } else {
-      const filePath =
+      let filePath =
         // @ts-ignore
         {
           '/hot.js': path.join(__dirname, 'hot.js'),
           '/oauth2-redirect.html': path.join(__dirname, 'oauth2-redirect.html'),
           '/simplewebsocket.min.js': require.resolve('simple-websocket/simplewebsocket.min.js'),
-        }[request.url || ''] ||
-        path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${request.url}`);
+        }[request.url || ''];
 
-      if (!isSubdir(process.cwd(), filePath)) {
-        respondWithGzip('404 Not Found', request, response, { 'Content-Type': 'text/html' }, 404);
-        console.timeEnd(colorette.dim(`GET ${request.url}`));
-        return;
+      if (!filePath) {
+        const basePath = htmlTemplate ? path.dirname(htmlTemplate) : process.cwd();
+
+        filePath = path.resolve(basePath, `.${request.url}`);
+
+        if (!isSubdir(basePath, filePath)) {
+          respondWithGzip('404 Not Found', request, response, { 'Content-Type': 'text/html' }, 404);
+          console.timeEnd(colorette.dim(`GET ${request.url}`));
+          return;
+        }
       }
 
       const extname = String(path.extname(filePath)).toLowerCase() as keyof typeof mimeTypes;


### PR DESCRIPTION
## What/Why/How?
This PR fixes preview server hot reloads for the `openapi-cli` package global installation. 

As @nbourguig has pointed out, the issue was introduced with https://github.com/Redocly/openapi-cli/pull/347. The check only allowed files from the `CWD` to be served by the preview server while the scripts needed for hot reload were in the global installation directory. Now the check only applies to arbitrary files.

## Reference
closes https://github.com/Redocly/openapi-cli/issues/538

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
