### PR TITLE
chore: fix docker using openapi-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@ RUN npm ci --no-optional --ignore-scripts
 COPY . /build/
 RUN npm run prepare
 
-# Install openapi-cli globally, similar to npm install --global @redocly/openapi-cli
+# Install redocly-cli globally, similar to npm install --global @redocly/cli
 # but the local package is used here
-RUN mv -- "$(npm pack packages/cli/)" redocly-openapi-cli.tgz && \
-	  npm install --global redocly-openapi-cli.tgz
+RUN mv -- "$(npm pack packages/cli/)" redocly-cli.tgz && \
+	  npm install --global redocly-cli.tgz
 
 # npm pack in the previous RUN command does not include these assets
-RUN cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/default.hbs && \
-	  cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/hot.js
+RUN cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/default.hbs && \
+	  cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/hot.js
 
 # Clean up to reduce image size
 RUN npm cache clean --force && rm -rf /build


### PR DESCRIPTION
## What/Why/How?

Fix: Docker fails when using the wrong folder name (old name of `openapi-cli`).

## Reference

https://github.com/Redocly/redocly-cli/runs/6325051442?check_suite_focus=true

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
