### PR TITLE
chore: bump to v1.0.0-beta.97

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,11 @@ tocMaxDepth: 2
 
 - Added the `--public` option to the `push` command. With this option, you can upload OpenAPI definitions and make them publicly accessible.
 
+### Fixes
+
+- Fixed Dockerfile after changing the package name from `@redocly/openapi-cli` to `@redocly/cli`.
+- Fixed an issue with `process.*` in core package that caused crashes in client-side builds.
+
 ## 1.0.0-beta.96 (2022-05-06)
 
 Technical release for changing the package name from `@redocly/openapi-cli` to `@redocly/cli`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ tocMaxDepth: 2
 
 ## 1.0.0-beta.96 (2022-05-06)
 
-Technical release for changing the package name.
+Technical release for changing the package name from `@redocly/openapi-cli` to `@redocly/cli`.
 
 ## 1.0.0-beta.95 (2022-05-04)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ tocMaxDepth: 2
 ### Features
 
 - Added the `--public` option to the `push` command. With this option, you can upload OpenAPI definitions and make them publicly accessible.
+- Changed assertions syntax to this pattern: `assert/{assert name}`
 
 ### Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ tocMaxDepth: 2
 
 ### Features
 
-- Added `--public` option to the `push` command. Allows upload OpenAPI definition and make it public accessible.
+- Added the `--public` option to the `push` command. With this option, you can upload OpenAPI definitions and make them publicly accessible.
 
 ## 1.0.0-beta.96 (2022-05-06)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,8 +13,8 @@ tocMaxDepth: 2
 
 ### Fixes
 
-- Fixed Dockerfile after changing the package name from `@redocly/openapi-cli` to `@redocly/cli`.
 - Fixed an issue with `process.*` in core package that caused crashes in client-side builds.
+- Fixed `preview-docs` hot reload.
 
 ## 1.0.0-beta.96 (2022-05-06)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ tocMaxDepth: 2
 
 # Redocly CLI changelog
 
+## 1.0.0-beta.97 (2022-05-10)
+
+### Features
+
+- Added `--public` option to the `push` command. Allows upload OpenAPI definition and make it public accessible.
+
 ## 1.0.0-beta.96 (2022-05-06)
 
 Technical release for changing the package name.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.96",
+  "version": "1.0.0-beta.97",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.96",
+      "version": "1.0.0-beta.97",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -10123,10 +10123,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.96",
+      "version": "1.0.0-beta.97",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.96",
+        "@redocly/openapi-core": "1.0.0-beta.97",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -10151,7 +10151,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.96",
+      "version": "1.0.0-beta.97",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",
@@ -10909,7 +10909,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.96",
+        "@redocly/openapi-core": "1.0.0-beta.97",
         "@types/yargs": "16.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.96",
+  "version": "1.0.0-beta.97",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.96",
+  "version": "1.0.0-beta.97",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -35,7 +35,7 @@
     "Andriy Leliv <andriy@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.96",
+    "@redocly/openapi-core": "1.0.0-beta.97",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.96",
+  "version": "1.0.0-beta.97",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.96",
+      "version": "1.0.0-beta.97",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.96",
+  "version": "1.0.0-beta.97",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?
- Chore: Docker fails when using the wrong folder name (old name of openapi-cli) https://github.com/Redocly/redocly-cli/pull/677
- Fix: Fixed issue with process.* in core package https://github.com/Redocly/redocly-cli/pull/541
- Chore: Update dependencies to eliminate using path in minimatch and fix not recognising URL as a standard https://github.com/Redocly/redocly-cli/pull/674
- Feature: Added `--public` option for `push` command https://github.com/Redocly/redocly-cli/pull/667
- Fix: Fixed preview server hot reloads for the openapi-cli package global installation. https://github.com/Redocly/redocly-cli/pull/673
- Feature: Changed assertions syntax to: `assert/{assert name}` https://github.com/Redocly/redocly-cli/pull/662

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
