### PR TITLE
chore: fix array items types and sync redocly configuration options

### DIFF
--- a/packages/core/src/types/oas3.ts
+++ b/packages/core/src/types/oas3.ts
@@ -303,8 +303,6 @@ const Schema: NodeType = {
     additionalItems: (value: any) => {
       if (typeof value === 'boolean') {
         return { type: 'boolean' };
-      } else if (Array.isArray(value)) {
-        return listOf('Schema');
       } else {
         return 'Schema';
       }

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -142,9 +142,7 @@ const Schema: NodeType = {
     summary: { type: 'string' },
     properties: 'SchemaProperties',
     items: (value: any) => {
-      if (Array.isArray(value)) {
-        return listOf('Schema');
-      } else if (typeof value === 'boolean') {
+      if (typeof value === 'boolean') {
         return { type: 'boolean' };
       } else {
         return 'Schema';

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -568,6 +568,7 @@ const ConfigReferenceDocs: NodeType = {
     showRightPanelToggle: { type: 'boolean' },
     showWebhookVerb: { type: 'boolean' },
     showObjectSchemaExamples: { type: 'boolean' },
+    disableTryItRequestUrlEncoding: { type: 'boolean' },
     sidebarLinks: 'ConfigSidebarLinks',
     sideNavStyle: { type: 'string' },
     simpleOneOfTypeLabel: { type: 'boolean' },


### PR DESCRIPTION
## What/Why/How?
PR fix types for additionalItems for OpenApi 3.0 and items for OpenApi 3.1.
## Reference
related to  https://github.com/Redocly/redocly-cli/pull/707
https://github.com/Redocly/redoc/pull/2018

also, sync redocly configuration options(add `disableTryItRequestUrlEncoding`)
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
