### PR TITLE
fix: allow scalar property with falsy values

### DIFF
--- a/packages/core/src/rules/common/__tests__/scalar-property-missing-example.test.ts
+++ b/packages/core/src/rules/common/__tests__/scalar-property-missing-example.test.ts
@@ -235,4 +235,30 @@ describe('Oas3.1 scalar-property-missing-example', () => {
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should not report on a nullable scalar property values', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            User:
+              type: object
+              properties:
+                testBool:
+                  type: string
+                  nullable: true
+                  example: null
+      `,
+      'foobar.yaml',
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'scalar-property-missing-example': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/packages/core/src/rules/common/__tests__/scalar-property-missing-example.test.ts
+++ b/packages/core/src/rules/common/__tests__/scalar-property-missing-example.test.ts
@@ -204,4 +204,35 @@ describe('Oas3.1 scalar-property-missing-example', () => {
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should not report on a scalar property of falsy values', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            User:
+              type: object
+              properties:
+                testBool:
+                  type: boolean
+                  example: false
+                testString:
+                  type: string
+                  example: ""
+                testNumber:
+                  type: number
+                  example: 0
+      `,
+      'foobar.yaml',
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'scalar-property-missing-example': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/packages/core/src/rules/common/scalar-property-missing-example.ts
+++ b/packages/core/src/rules/common/scalar-property-missing-example.ts
@@ -36,7 +36,7 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
 };
 
 function isNotDefined(value: unknown): boolean {
-  return value === null || value === undefined;
+  return value === undefined;
 }
 
 function isScalarSchema(schema: Oas2Schema | Oas3Schema | Oas3_1Schema) {

--- a/packages/core/src/rules/common/scalar-property-missing-example.ts
+++ b/packages/core/src/rules/common/scalar-property-missing-example.ts
@@ -19,7 +19,10 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
           continue;
         }
 
-        if (!propSchema.example && !(propSchema as Oas3_1Schema).examples) {
+        if (
+          isNotDefined(propSchema.example) &&
+          isNotDefined((propSchema as Oas3_1Schema).examples)
+        ) {
           report({
             message: `Scalar property should have "example"${
               oasVersion === OasVersion.Version3_1 ? ' or "examples"' : ''
@@ -31,6 +34,10 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
     },
   };
 };
+
+function isNotDefined(value: unknown): boolean {
+  return value === null || value === undefined;
+}
 
 function isScalarSchema(schema: Oas2Schema | Oas3Schema | Oas3_1Schema) {
   if (!schema.type) {

--- a/packages/core/src/rules/common/scalar-property-missing-example.ts
+++ b/packages/core/src/rules/common/scalar-property-missing-example.ts
@@ -20,8 +20,8 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
         }
 
         if (
-          isNotDefined(propSchema.example) &&
-          isNotDefined((propSchema as Oas3_1Schema).examples)
+          propSchema.example === undefined &&
+          (propSchema as Oas3_1Schema).examples === undefined
         ) {
           report({
             message: `Scalar property should have "example"${
@@ -34,10 +34,6 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
     },
   };
 };
-
-function isNotDefined(value: unknown): boolean {
-  return value === undefined;
-}
 
 function isScalarSchema(schema: Oas2Schema | Oas3Schema | Oas3_1Schema) {
   if (!schema.type) {


### PR DESCRIPTION
## What/Why/How?
`scalar-property-missing-example` rule was reporting an error for falsy values like '', 0, false in the example.

## Reference
N/a

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
