### PR TITLE
docs: fix incorrect response-contains-property rule example

### DIFF
--- a/docs/resources/built-in-rules.md
+++ b/docs/resources/built-in-rules.md
@@ -354,9 +354,10 @@ lint:
 ### response-contains-property
 
 Enforces definition of specific response properties based on HTTP status code or HTTP status code range.
-Priority is given to more precise status codes over the status code range.
+A specific status code takes priority over the status code range.
+
 ```yaml
-response-contains-header:
+response-contains-property:
   severity: error
   names:
     2XX:
@@ -364,7 +365,6 @@ response-contains-header:
     400:
       - title
 ```
-
 
 ### scalar-property-missing-example
 


### PR DESCRIPTION
## What/Why/How?

Incorrect `response-contains-property` rule example.

Closed in favor of #741

## Reference

https://redocly.com/docs/cli/resources/built-in-rules/#response-contains-property

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
