### PR TITLE
fix: push shows an error when batch-id isn't added

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -86,7 +86,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
     );
   }
 
-  if (!batchId?.trim()) {
+  if (batchId && !batchId.trim()) {
     exitWithError(
       `The ${blue(`batch-id`)} option value is not valid, please avoid using an empty string.`
     );


### PR DESCRIPTION
## What/Why/How?
Push shows an error when batch-id isn't added

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
