### PR TITLE
docs: make folder tree for split command in quick start more readable

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -166,29 +166,29 @@ bundled.yaml: split processed in 76ms
 So, what just happened? Take a look in the newly created `bundled` directory. That's where the magic is! See how the `split` command automatically broke the single API definition into its constituent parts and very kindly organized them in the new directory?
 
 ```bash
+.
 ├── code samples
-│   └── C#
-│       └── postundefined
+│   ├── C#
+│   |   └── postundefined
 │   └── PHP
 │       └── postundefined
 ├── components
-│   └── headers
-│       └── ExpiresAfter.yaml
-│   └── responses
-│       └── Problem.yaml
+│   ├── headers
+│   |   └── ExpiresAfter.yaml
+│   ├── responses
+│   |   └── Problem.yaml
 │   └── schemas
-│       └── Email.yaml
-│       └── Problem.yaml
-│       └── Schema.yaml
+│       ├── Email.yaml
+│       ├── Problem.yaml
+│       ├── Schema.yaml
 │       └── User.yaml
 ├── paths
-│       └── echo.yaml
-│       └── pathItem.yaml
-│       └── pathItemWithExamples.yaml
-│       └── users@{username}.yaml
+│   ├── echo.yaml
+│   ├── pathItem.yaml
+│   ├── pathItemWithExamples.yaml
+│   └── users@{username}.yaml
 └── openapi.yaml
 ```
-
 
 :::info Note
 


### PR DESCRIPTION
## What/Why/How?

Incorrect formatting of the ASCII folder tree makes it hard to skim and understand

## Reference

https://redocly.com/docs/cli/quickstart/#split---divide-your-large-definition-into-smaller-parts

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
