### PR TITLE
chore: add colorette to ignore browser build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,8 @@
     "fs": false,
     "path": "path-browserify",
     "os": false,
-    "node-fetch": false
+    "node-fetch": false,
+    "colorette": false
   },
   "homepage": "https://github.com/Redocly/redocly-cli",
   "keywords": [


### PR DESCRIPTION
## What/Why/How?
Ignore `collorette` for browser build in openapi-core. It should be removed after finishing https://github.com/Redocly/redocly-cli/issues/539. 
This package is used in `redoc` and also effect it.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
