### PR TITLE
chore: add scalar-property-missing-example rule to the config types

### DIFF
--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -50,6 +50,7 @@ const builtInRulesList = [
   'no-invalid-parameter-examples',
   'response-contains-header',
   'response-contains-property',
+  'scalar-property-missing-example',
 ];
 const nodeTypesList = [
   'DefinitionRoot',


### PR DESCRIPTION
## What/Why/How?

`scalar-property-missing-example` rule has been missing in Config types.

## Reference

https://redocly.com/docs/cli/resources/built-in-rules/#scalar-property-missing-example

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
