### PR TITLE
chore: move coverage report into a separate job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,6 +54,8 @@ jobs:
         run: npm ci
         env:
           CI: true
+      - name: Bundle
+        run: npm run webpack-bundle
       - name: Coverage Report
         uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
         continue-on-error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,10 +50,6 @@ jobs:
           restore-keys: |
             npm-${{ hashFiles('package-lock.json') }}
             npm-
-      - name: Install dependencies
-        run: npm ci
-        env:
-          CI: true
       - name: Coverage Report
         uses: artiomtr/jest-coverage-report-action@v2.0.8
         continue-on-error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,11 +54,10 @@ jobs:
         run: npm ci
         env:
           CI: true
-      - name: Bundle
-        run: npm run webpack-bundle
       - name: Coverage Report
         uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
         continue-on-error: true
         with:
           skip-step: none
           annotations: none
+          test-script: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report.json --bail --coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,9 +55,9 @@ jobs:
         env:
           CI: true
       - name: Coverage Report
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
+        uses: artiomtr/jest-coverage-report-action@v2.0.8
         continue-on-error: true
         with:
           skip-step: none
           annotations: none
-          test-script: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report.json --bail --coverage
+          test-script: npm run jest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
       - name: Unit Tests
-        run: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report-incoming.json --bail --coverage
+        run: npm run jest -- --silent --ci --testLocationInResults --bail --coverage
       - name: E2E Tests
         run: npm run e2e
         env:
@@ -50,11 +50,6 @@ jobs:
           restore-keys: |
             npm-${{ hashFiles('package-lock.json') }}
             npm-
-      - name: Environments
-        run: |
-          echo
-          echo Using Node $(node -v), NPM $(npm -v)
-          echo
       - name: Install dependencies
         run: npm ci
         env:
@@ -65,4 +60,3 @@ jobs:
         with:
           skip-step: none
           annotations: none
-          test-script: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report.json --bail --coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,14 +33,36 @@ jobs:
         run: npm run typecheck
       - name: Unit Tests
         run: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report-incoming.json --bail --coverage
-      - name: Coverage Report
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
-        with:
-          skip-step: none
-          coverage-file: report-incoming.json
-          annotations: none
-          test-script: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report.json --bail --coverage
       - name: E2E Tests
         run: npm run e2e
         env:
           CI: true
+
+  coverage-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
+      - name: Environments
+        run: |
+          echo
+          echo Using Node $(node -v), NPM $(npm -v)
+          echo
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CI: true
+      - name: Coverage Report
+        uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
+        continue-on-error: true
+        with:
+          skip-step: none
+          annotations: none
+          test-script: npm run jest -- --silent --ci --json --testLocationInResults --outputFile=report.json --bail --coverage


### PR DESCRIPTION
## What/Why/How?

Fixes github action failing on MR from forks due to lacking permissions by splitting coverage report into a separate always-passing job.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
