### PR TITLE
fix: fix multiple tags duplication

### DIFF
--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -111,6 +111,7 @@ describe('E2E', () => {
         'reference-in-description',
         'two-files-with-no-errors',
         'fails-if-component-conflicts',
+        'multiple-tags-in-same-files'
       ];
 
       test.each(testDirNames)('test: %s', (dir) => {

--- a/__tests__/join/multiple-tags-in-same-files/bar.yaml
+++ b/__tests__/join/multiple-tags-in-same-files/bar.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+tags:
+  - name: Pets
+    description: Pets description
+  - name: Dog
+    description: Wild description
+info:
+  version: 1.0.0
+  title: Example OpenAPI 3 definition.
+  description: Information about API
+  license:
+    name: MIT
+    url: 'https://opensource.org/licenses/MIT'
+servers:
+  - url: 'https://redocly.com/v1'
+paths:
+  '/pets/{petId}':
+    post:
+      tags:
+        - Pets
+      summary: PetsId example
+      operationId: examplePetsId
+      responses:
+        '201':
+          description: example description
+
+  '/dog/{dogId}':
+    post:
+      tags: 
+        -  Dog
+      summary: Dog example
+      operationId: exampleDogId
+      responses:
+        '201':
+          description: example description

--- a/__tests__/join/multiple-tags-in-same-files/foo.yaml
+++ b/__tests__/join/multiple-tags-in-same-files/foo.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+tags:
+  - name: Store
+    description: Store tags
+info:
+  version: 1.0.0
+  title: Example OpenAPI 3 definition.
+  description: Information about API
+  license:
+    name: MIT
+    url: 'https://opensource.org/licenses/MIT'
+servers:
+  - url: 'https://redocly.com/v1'
+paths:
+  /cart:
+    get:
+      summary: Example cart
+      operationId: exampleCart
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int
+      responses:
+        '200':
+          description: example description
+  /store:
+    get:
+      tags:
+        - Store
+      summary: Store summary
+      operationId: exampleStore
+      responses:
+        '200':
+          description: Store 200 description

--- a/__tests__/join/multiple-tags-in-same-files/snapshot.js
+++ b/__tests__/join/multiple-tags-in-same-files/snapshot.js
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E join without options test: multiple-tags-in-same-files 1`] = `
+
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Example OpenAPI 3 definition.
+  description: Information about API
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+tags:
+  - name: Store
+    description: Store tags
+    x-displayName: Store
+  - name: foo_other
+    x-displayName: other
+  - name: Pets
+    description: Pets description
+    x-displayName: Pets
+  - name: Dog
+    description: Wild description
+    x-displayName: Dog
+x-tagGroups:
+  - name: foo
+    tags:
+      - Store
+      - foo_other
+    description: Information about API
+  - name: bar
+    tags:
+      - Pets
+      - Dog
+    description: Information about API
+servers:
+  - url: https://redocly.com/v1
+paths:
+  /cart:
+    get:
+      summary: Example cart
+      operationId: exampleCart
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int
+      responses:
+        '200':
+          description: example description
+      tags:
+        - foo_other
+  /store:
+    get:
+      tags:
+        - Store
+      summary: Store summary
+      operationId: exampleStore
+      responses:
+        '200':
+          description: Store 200 description
+  /pets/{petId}:
+    post:
+      tags:
+        - Pets
+      summary: PetsId example
+      operationId: examplePetsId
+      responses:
+        '201':
+          description: example description
+  /dog/{dogId}:
+    post:
+      tags:
+        - Dog
+      summary: Dog example
+      operationId: exampleDogId
+      responses:
+        '201':
+          description: example description
+components: {}
+
+openapi.yaml: join processed in <test>ms
+
+
+`;

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -200,10 +200,10 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
           tag.hasOwnProperty('description') && tagDuplicate.description !== tag.description;
 
         potentialConflicts.tags.description[entrypointTagName].push(
-          ...(isTagDescriptionNotEqual ? [entrypoint] : []),
+          ...(isTagDescriptionNotEqual ? [entrypoint] : [])
         );
-      } else {
-        // Instead add tag to joinedDef;
+      } else if (!tagDuplicate) {
+        // Instead add tag to joinedDef if there no duplicate;
         tag['x-displayName'] = tag['x-displayName'] || tag.name;
         tag.name = entrypointTagName;
         joinedDef.tags.push(tag);
@@ -215,7 +215,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
       if (!withoutXTagGroups) {
         createXTagGroups(entrypointFilename);
-        populateXTagGroups(entrypointTagName, getIndexGroup(entrypointFilename));
+        if (!tagDuplicate) {
+          populateXTagGroups(entrypointTagName, getIndexGroup(entrypointFilename));
+        }
       }
 
       const doesEntrypointExist =


### PR DESCRIPTION
## What/Why/How?
After the `join` command tags can be duplicated which cause issue with bad display on Reference Docs for example. This should be fixed.
<img width="627" alt="Screenshot 2022-07-08 at 11 53 17" src="https://user-images.githubusercontent.com/52038205/177956335-c01e3531-97cf-4c4b-82af-ad4832db7d3f.png">
<img width="895" alt="Screenshot 2022-07-08 at 12 00 50" src="https://user-images.githubusercontent.com/52038205/177957561-d11c3d6c-e31c-445d-bd2a-233bad1a06f9.png">

## Reference
resolve #755
## Testing

## Screenshots (optional)
Definition Bar:
<img width="564" alt="Screenshot 2022-07-08 at 11 46 38" src="https://user-images.githubusercontent.com/52038205/177956012-1a09df92-bf77-4a9e-ab67-e32b40b0f690.png">
Definition Foo:
<img width="580" alt="Screenshot 2022-07-08 at 11 46 58" src="https://user-images.githubusercontent.com/52038205/177956260-a6d12eb6-5f40-46e3-8baa-7738922e7edd.png">
After fix:
<img width="391" alt="Screenshot 2022-07-08 at 11 47 56" src="https://user-images.githubusercontent.com/52038205/177956400-12d02944-28f8-46bf-9b3d-b9c62c69faac.png">
<img width="841" alt="Screenshot 2022-07-08 at 12 00 07" src="https://user-images.githubusercontent.com/52038205/177957628-b2e71fd7-3483-41fd-b247-af28ee9e8f9a.png">


## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
