### PR TITLE
fix: fix enum type mismatch message

### DIFF
--- a/__tests__/lint/no-enum-type-mismatch-error/snapshot.js
+++ b/__tests__/lint/no-enum-type-mismatch-error/snapshot.js
@@ -5,7 +5,7 @@ exports[`E2E lint no-enum-type-mismatch-error 1`] = `
 validating /openapi.yaml...
 [1] openapi.yaml:21:21 at #/paths/~1ping/get/responses/200/content/application~1json/schema/enum/3
 
-Enum value \`string\` must be of one type. Allowed types: \`integer,array\`.
+Enum value \`string\` must be of allowed types: \`integer,array\`.
 
 19 |                 - [ 1, 2, 3, string]
 20 |                 - 3

--- a/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
@@ -153,7 +153,7 @@ describe('Oas3 typed enum', () => {
               "source": "foobar.yaml",
             },
           ],
-          "message": "Enum value \`string\` must be of one type. Allowed types: \`integer,array\`.",
+          "message": "Enum value \`string\` must be of allowed types: \`integer,array\`.",
           "ruleId": "no-enum-type-mismatch",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/common/no-enum-type-mismatch.ts
+++ b/packages/core/src/rules/common/no-enum-type-mismatch.ts
@@ -39,7 +39,7 @@ export const NoEnumTypeMismatch: Oas3Rule | Oas2Rule = () => {
 
         for (const mismatchedKey of Object.keys(mismatchedResults)) {
           report({
-            message: `Enum value \`${mismatchedKey}\` must be of one type. Allowed types: \`${schema.type}\`.`,
+            message: `Enum value \`${mismatchedKey}\` must be of allowed types: \`${schema.type}\`.`,
             location: location.child(['enum', schema.enum.indexOf(mismatchedKey)]),
           });
         };


### PR DESCRIPTION
## What/Why/How?

The current message is wrong, because in 3.1 you can define multiple types. The behavior works fine though except for `type: any` and an issue is opened for that (#786).

## Testing

Tests were adjusted as well.

## Screenshots (optional)

<img width="712" alt="2022-07-31_06-00-53" src="https://user-images.githubusercontent.com/1161871/182023010-02ba993e-6721-4057-924a-5c7c51bccfee.png">


## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
