### PR TITLE
fix: match type any

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Hi! We're really excited that you are interested in contributing to Redocly CLI.
 
 - The best way to get your bug fixed is to provide a (reduced) test case. This means listing and explaining the steps we should take to try and hit the same problem you're having. It helps us understand in which conditions the issue appears, and gives us a better idea of what may be causing it.
 
-- Abide by our [Code of Conduct](https://redoc.ly/code-of-conduct/) in all your interactions on this repository, and show patience and respect to other community members.
+- Abide by our [Code of Conduct](https://redocly.com/code-of-conduct/) in all your interactions on this repository, and show patience and respect to other community members.
 
 ## Pull Request Guidelines
 Before submitting a pull request, please make sure the following is done:

--- a/packages/core/src/rules/__tests__/utils.test.ts
+++ b/packages/core/src/rules/__tests__/utils.test.ts
@@ -1,0 +1,73 @@
+import {
+  matchesJsonSchemaType,
+} from '../utils';
+
+describe('matches-json-schema-type', () => {
+  it('should report true on any type', () => {
+    const results = matchesJsonSchemaType(123, 'any', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true on a null value with nullable type', () => {
+    const results = matchesJsonSchemaType(null, 'string', true);
+    expect(results).toBe(true);
+  });
+
+  it('should report true on a value and type integer', () => {
+    const results = matchesJsonSchemaType(123, 'integer', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report false when the value is not integer and type is integer', () => {
+    const results = matchesJsonSchemaType(3.14, 'integer', false);
+    expect(results).toBe(false);
+  });
+
+  it('should report true when the value is a number and type is number', () => {
+    const results = matchesJsonSchemaType(3.14, 'number', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is an integer and type is number', () => {
+    const results = matchesJsonSchemaType(3, 'number', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is true and type is boolean', () => {
+    const results = matchesJsonSchemaType(true, 'boolean', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is false and type is boolean', () => {
+    const results = matchesJsonSchemaType(false, 'boolean', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is a string and type is boolean', () => {
+    const results = matchesJsonSchemaType('test', 'boolean', false);
+    expect(results).toBe(false);
+  });
+
+  it('should report true on an array value with array type', () => {
+    const results = matchesJsonSchemaType(['foo', 'bar'], 'array', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report false on an array value with object type', () => {
+    const results = matchesJsonSchemaType(['foo', 'bar'], 'object', false);
+    expect(results).toBe(false);
+  });
+
+  it('should report true on an object value with object type', () => {
+    const car = {type:"Fiat", model:"500", color:"white"};
+    const results = matchesJsonSchemaType(car, 'object', true);
+    expect(results).toBe(true);
+  });
+
+  it('should report false on an object value with array type', () => {
+    const car = {type:"Fiat", model:"500", color:"white"};
+    const results = matchesJsonSchemaType(car, 'array', true);
+    expect(results).toBe(false);
+  });
+
+});

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -23,7 +23,7 @@ export function oasTypeOf(value: unknown) {
  */
 export function matchesJsonSchemaType(value: unknown, type: string, nullable: boolean): boolean {
   if (nullable && value === null) {
-    return value === null;
+    return true;
   }
 
   switch (type) {
@@ -35,6 +35,8 @@ export function matchesJsonSchemaType(value: unknown, type: string, nullable: bo
       return value === null;
     case 'integer':
       return Number.isInteger(value);
+    case 'any':
+      return true;
     default:
       return typeof value === type;
   }


### PR DESCRIPTION
## What/Why/How?

Fixes missing match for `type: any`.

## Reference

Fixes #785 

## Testing

Added tests for the method.

## Check yourself

I think there is an issue with the prettier config. I did not include the prettier run here as it adjusted so many files and seems also out of date with the current code style in some places.

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
