### PR TITLE
chore: run prettier with trailing comma all

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "printWidth": 100,
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }

--- a/__tests__/bundle/bundle-lint-format/emptyFormatValue-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/emptyFormatValue-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`] = `
+exports[
+  `E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`
+] = `
 
 [1] openapi.yaml:20:11 at #/paths/~1my_post/post/requestBody/content/application~1json
 

--- a/__tests__/bundle/bundle-lint-format/noFormatParameter-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/noFormatParameter-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`] = `
+exports[
+  `E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`
+] = `
 
 [1] openapi.yaml:20:11 at #/paths/~1my_post/post/requestBody/content/application~1json
 

--- a/__tests__/bundle/bundle-remove-unused-components/oas2/remove-unused-components-snapshot.js
+++ b/__tests__/bundle/bundle-remove-unused-components/oas2/remove-unused-components-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle with option: remove-unused-components oas2: should remove unused components 1`] = `
+exports[
+  `E2E bundle with option: remove-unused-components oas2: should remove unused components 1`
+] = `
 swagger: '2.0'
 host: api.instagram.com
 paths:

--- a/__tests__/bundle/bundle-remove-unused-components/oas3/remove-unused-components-snapshot.js
+++ b/__tests__/bundle/bundle-remove-unused-components/oas3/remove-unused-components-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle with option: remove-unused-components oas3: should remove unused components 1`] = `
+exports[
+  `E2E bundle with option: remove-unused-components oas3: should remove unused components 1`
+] = `
 openapi: 3.1.0
 paths:
   /store/order:

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, statSync, existsSync } from 'fs';
 import { join, relative } from 'path';
 //@ts-ignore
 import { toMatchSpecificSnapshot } from './specific-snapshot';
-import { getCommandOutput, getEntrypoints, callSerializer ,getParams } from './helpers';
+import { getCommandOutput, getEntrypoints, callSerializer, getParams } from './helpers';
 
 expect.extend({
   toMatchExtendedSpecificSnapshot(received, snapshotFile) {
@@ -21,7 +21,7 @@ describe('E2E', () => {
       if (statSync(testPath).isFile()) continue;
       if (!existsSync(join(testPath, '.redocly.yaml'))) continue;
 
-      const args = getParams('../../../packages/cli/src/index.ts','lint');
+      const args = getParams('../../../packages/cli/src/index.ts', 'lint');
 
       it(file, () => {
         const result = getCommandOutput(args, testPath);
@@ -50,7 +50,7 @@ describe('E2E', () => {
       const relativeValidOpenapiFile = relative(folderPath, validOpenapiFile);
       const args = [relativeValidOpenapiFile, ...(option ? [`--lint-config=${option}`] : [])];
 
-      const passedArgs = getParams('../../../packages/cli/src/index.ts','lint', args);
+      const passedArgs = getParams('../../../packages/cli/src/index.ts', 'lint', args);
 
       const result = getCommandOutput(passedArgs, folderPath);
       (expect(result) as any).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
@@ -60,7 +60,7 @@ describe('E2E', () => {
       const folderPath = join(__dirname, 'lint-config/invalid-definition-and-config');
       const relativeInvalidOpenapiFile = relative(folderPath, invalidOpenapiFile);
       const args = [relativeInvalidOpenapiFile, `--lint-config=error`];
-      const passedArgs = getParams('../../../packages/cli/src/index.ts','lint', args);
+      const passedArgs = getParams('../../../packages/cli/src/index.ts', 'lint', args);
 
       const result = getCommandOutput(passedArgs, folderPath);
 
@@ -72,7 +72,9 @@ describe('E2E', () => {
     test('without option: outDir', () => {
       const folderPath = join(__dirname, `split/missing-outDir`);
 
-      const args = getParams('../../../packages/cli/src/index.ts','split', ['../../../__tests__/split/test-split/spec.json']);
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
+        '../../../__tests__/split/test-split/spec.json',
+      ]);
 
       const result = getCommandOutput(args, folderPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
@@ -81,7 +83,7 @@ describe('E2E', () => {
     test('swagger', () => {
       const folderPath = join(__dirname, `split/oas2`);
 
-      const args = getParams('../../../packages/cli/src/index.ts','split', [
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
         '../../../__tests__/split/oas2/openapi.yaml',
         '--outDir=output',
       ]);
@@ -94,7 +96,10 @@ describe('E2E', () => {
       const folderPath = join(__dirname, `split/oas3-no-errors`);
       const file = '../../../__tests__/split/oas3-no-errors/openapi.yaml';
 
-      const args = getParams('../../../packages/cli/src/index.ts','split', [file, '--outDir=output']);
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
+        file,
+        '--outDir=output',
+      ]);
 
       const result = getCommandOutput(args, folderPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
@@ -111,12 +116,12 @@ describe('E2E', () => {
         'reference-in-description',
         'two-files-with-no-errors',
         'fails-if-component-conflicts',
-        'multiple-tags-in-same-files'
+        'multiple-tags-in-same-files',
       ];
 
       test.each(testDirNames)('test: %s', (dir) => {
         const testPath = join(__dirname, `join/${dir}`);
-        const args = getParams('../../../packages/cli/src/index.ts','join', entrypoints);
+        const args = getParams('../../../packages/cli/src/index.ts', 'join', entrypoints);
         const result = getCommandOutput(args, testPath);
         (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
       });
@@ -133,7 +138,7 @@ describe('E2E', () => {
       test.each(options)('test with option: %s', (option) => {
         const testPath = join(__dirname, `join/${option.name}`);
         const argsWithOptions = [...entrypoints, ...[`--${option.name}=${option.value}`]];
-        const args = getParams('../../../packages/cli/src/index.ts','join', argsWithOptions);
+        const args = getParams('../../../packages/cli/src/index.ts', 'join', argsWithOptions);
         const result = getCommandOutput(args, testPath);
         (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
       });
@@ -153,7 +158,7 @@ describe('E2E', () => {
 
       const entryPoints = getEntrypoints(testPath);
 
-      const args = getParams('../../../packages/cli/src/index.ts','bundle', [
+      const args = getParams('../../../packages/cli/src/index.ts', 'bundle', [
         '--lint',
         '--max-problems=1',
         '--format=stylish',
@@ -170,7 +175,7 @@ describe('E2E', () => {
   describe('bundle lint format', () => {
     const folderPath = join(__dirname, 'bundle/bundle-lint-format');
     const entryPoints = getEntrypoints(folderPath);
-    const args = getParams('../../../packages/cli/src/index.ts','bundle', [
+    const args = getParams('../../../packages/cli/src/index.ts', 'bundle', [
       '--lint',
       '--max-problems=1',
       '-o=/tmp/null',

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -19,7 +19,7 @@ type CLICommands =
 export function getParams(
   indexEntryPoint: string,
   command: CLICommands,
-  args: string[] = []
+  args: string[] = [],
 ): string[] {
   return ['--transpile-only', indexEntryPoint, command, ...args];
 }

--- a/__tests__/join/prefix-components-with-info-prop/snapshot.js
+++ b/__tests__/join/prefix-components-with-info-prop/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'prefix-components-with-info-prop', value: 'title' } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'prefix-components-with-info-prop', value: 'title' } 1`
+] = `
 
 openapi: 3.0.0
 info:

--- a/__tests__/join/prefix-tags-with-filename/snapshot.js
+++ b/__tests__/join/prefix-tags-with-filename/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'prefix-tags-with-filename', value: true } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'prefix-tags-with-filename', value: true } 1`
+] = `
 
 openapi: 3.0.0
 info:

--- a/__tests__/join/prefix-tags-with-info-prop/snapshot.js
+++ b/__tests__/join/prefix-tags-with-info-prop/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'prefix-tags-with-info-prop', value: 'title' } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'prefix-tags-with-info-prop', value: 'title' } 1`
+] = `
 
 openapi: 3.0.0
 info:

--- a/__tests__/join/without-x-tag-groups/snapshot.js
+++ b/__tests__/join/without-x-tag-groups/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'without-x-tag-groups', value: true } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'without-x-tag-groups', value: true } 1`
+] = `
 
 
 warning: 1 conflict(s) on the \`Pet\` tags description.

--- a/__tests__/lint-config/invalid-config--lint-config-error/snapshot.js
+++ b/__tests__/lint-config/invalid-config--lint-config-error/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--lint-config-error', option: 'error' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--lint-config-error', option: 'error' } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/context
 

--- a/__tests__/lint-config/invalid-config--lint-config-off/snapshot.js
+++ b/__tests__/lint-config/invalid-config--lint-config-off/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--lint-config-off', option: 'off' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--lint-config-off', option: 'off' } 1`
+] = `
 
 No configurations were defined in extends -- using built in recommended configuration by default.
 Warning! This default behavior is going to be deprecated soon.

--- a/__tests__/lint-config/invalid-config--lint-config-warn/snapshot.js
+++ b/__tests__/lint-config/invalid-config--lint-config-warn/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--lint-config-warn', option: 'warn' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--lint-config-warn', option: 'warn' } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/context
 

--- a/__tests__/lint-config/invalid-config--no-option/snapshot.js
+++ b/__tests__/lint-config/invalid-config--no-option/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--no-option', option: null } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--no-option', option: null } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/context
 

--- a/__tests__/lint-config/invalid-config-assertation-config-type/snapshot.js
+++ b/__tests__/lint-config/invalid-config-assertation-config-type/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config-assertation-config-type', option: 'error' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config-assertation-config-type', option: 'error' } 1`
+] = `
 
 [1] .redocly.yaml:8:17 at #/lint/rules/assert~1path-item-mutually-required/context/0/type
 

--- a/__tests__/lint-config/invalid-config-assertation-name/snapshot.js
+++ b/__tests__/lint-config/invalid-config-assertation-name/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config-assertation-name', option: 'error' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config-assertation-name', option: 'error' } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/asset~1path-item-mutually-required
 

--- a/__tests__/lint-config/invlid-lint-config-saverity/snapshot.js
+++ b/__tests__/lint-config/invlid-lint-config-saverity/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invlid-lint-config-saverity', option: 'something' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invlid-lint-config-saverity', option: 'something' } 1`
+] = `
 
 index.ts lint [entrypoints...]
 

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require("../lib/index");
+require('../lib/index');

--- a/packages/cli/src/__mocks__/perf_hooks.ts
+++ b/packages/cli/src/__mocks__/perf_hooks.ts
@@ -1,3 +1,3 @@
 export const performance = {
-    now: jest.fn()
-}
+  now: jest.fn(),
+};

--- a/packages/cli/src/__mocks__/utils.ts
+++ b/packages/cli/src/__mocks__/utils.ts
@@ -1,4 +1,6 @@
-export const getFallbackEntryPointsOrExit = jest.fn((entrypoints) => entrypoints.map(() => ({ path: '' })));
+export const getFallbackEntryPointsOrExit = jest.fn((entrypoints) =>
+  entrypoints.map(() => ({ path: '' })),
+);
 export const dumpBundle = jest.fn(() => '');
 export const slash = jest.fn();
 export const pluralize = jest.fn();

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -6,7 +6,7 @@ import SpyInstance = jest.SpyInstance;
 jest.mock('@redocly/openapi-core');
 jest.mock('../../utils');
 
-(getMergedConfig as jest.Mock).mockImplementation(config => config)
+(getMergedConfig as jest.Mock).mockImplementation((config) => config);
 
 describe('bundle', () => {
   let processExitMock: SpyInstance;
@@ -99,7 +99,7 @@ describe('bundle', () => {
     (getTotals as jest.Mock).mockReturnValue({
       errors: 1,
       warnings: 0,
-      ignored: 0
+      ignored: 0,
     });
 
     await handleBundle(
@@ -116,5 +116,4 @@ describe('bundle', () => {
     exitCb?.();
     expect(processExitMock).toHaveBeenCalledWith(1);
   });
-
 });

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -43,7 +43,9 @@ describe('handleLint', () => {
       return process.on(_e, cb);
     });
     getMergedConfigMock.mockReturnValue(ConfigFixture);
-    (doesYamlFileExist  as jest.Mock<any, any>).mockImplementation((path) => path === 'redocly.yaml')
+    (doesYamlFileExist as jest.Mock<any, any>).mockImplementation(
+      (path) => path === 'redocly.yaml',
+    );
   });
 
   afterEach(() => {
@@ -54,7 +56,7 @@ describe('handleLint', () => {
     it('should fail if config file does not exist', async () => {
       await handleLint({ ...argvMock, config: 'config.yaml' }, versionMock);
       expect(exitWithError).toHaveBeenCalledWith(
-        'Please, provide valid path to the configuration file'
+        'Please, provide valid path to the configuration file',
       );
       expect(loadConfig).toHaveBeenCalledTimes(0);
     });
@@ -68,7 +70,7 @@ describe('handleLint', () => {
     it('should call loadConfig with args if such exist', async () => {
       await handleLint(
         { ...argvMock, config: 'redocly.yaml', extends: ['some/path'] },
-        versionMock
+        versionMock,
       );
       expect(loadConfig).toHaveBeenCalledWith('redocly.yaml', ['some/path'], undefined);
     });
@@ -96,7 +98,7 @@ describe('handleLint', () => {
           'skip-rule': ['rule'],
           'generate-ignore-file': true,
         },
-        versionMock
+        versionMock,
       );
       expect(ConfigFixture.lint.skipRules).toHaveBeenCalledWith(['rule']);
       expect(ConfigFixture.lint.skipPreprocessors).toHaveBeenCalledWith(['preprocessor']);

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -32,7 +32,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
-      'public': true,
+      public: true,
       'batch-id': '123',
       'batch-size': 2,
     });
@@ -59,7 +59,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
-      'public': true,
+      public: true,
       'batch-id': ' ',
       'batch-size': 2,
     });
@@ -73,7 +73,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
-      'public': true,
+      public: true,
       'batch-id': '123',
       'batch-size': 1,
     });

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,10 +1,9 @@
 import { Totals } from '@redocly/openapi-core';
-import { isSubdir, pathToFilename, printConfigLintTotals} from '../utils';
+import { isSubdir, pathToFilename, printConfigLintTotals } from '../utils';
 import { red, yellow } from 'colorette';
 
-
 jest.mock('os');
-jest.mock('colorette')
+jest.mock('colorette');
 
 describe('isSubdir', () => {
   it('can correctly determine if subdir', () => {
@@ -41,10 +40,9 @@ describe('isSubdir', () => {
   });
 
   afterEach(() => {
-    jest.resetModules()
-  })
+    jest.resetModules();
+  });
 });
-
 
 describe('pathToFilename', () => {
   it('should use correct path separator', () => {
@@ -52,7 +50,6 @@ describe('pathToFilename', () => {
     expect(processedPath).toEqual('user_createWithList');
   });
 });
-
 
 describe('printConfigLintTotals', () => {
   const totalProblemsMock: Totals = {

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -24,7 +24,7 @@ import {
   handleError,
   printLintTotals,
   writeYaml,
-  exitWithError
+  exitWithError,
 } from '../utils';
 import { isObject, isString } from '../js-utils';
 
@@ -51,7 +51,6 @@ type JoinArgv = {
   'without-x-tag-groups'?: boolean;
 };
 
-
 export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   const startedAt = performance.now();
   if (argv.entrypoints.length < 2) {
@@ -76,24 +75,26 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
       `You use ${yellow(usedTagsOptions.join(', '))} together.\nPlease choose only one! \n\n`,
     );
   }
- 
+
   const config: Config = await loadConfig();
   const entrypoints = await getFallbackEntryPointsOrExit(argv.entrypoints, config);
   const externalRefResolver = new BaseResolver(config.resolve);
   const documents = await Promise.all(
     entrypoints.map(
-      ({ path }) => externalRefResolver.resolveDocument(null, path, true) as Promise<Document>
-    )
+      ({ path }) => externalRefResolver.resolveDocument(null, path, true) as Promise<Document>,
+    ),
   );
 
   const bundleResults = await Promise.all(
-    documents.map(document => bundleDocument({
-      document,
-      config: config.lint,
-      externalRefResolver
-    }).catch(e => {
-      exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`)
-    }))
+    documents.map((document) =>
+      bundleDocument({
+        document,
+        config: config.lint,
+        externalRefResolver,
+      }).catch((e) => {
+        exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`);
+      }),
+    ),
   );
 
   for (const { problems, bundle: document } of bundleResults as any) {
@@ -101,17 +102,23 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
     if (fileTotals.errors) {
       formatProblems(problems, {
         totals: fileTotals,
-        version: document.parsed.version
+        version: document.parsed.version,
       });
-      exitWithError(`❌ Errors encountered while bundling ${blue(document.source.absoluteRef)}: join will not proceed.\n`);
+      exitWithError(
+        `❌ Errors encountered while bundling ${blue(
+          document.source.absoluteRef,
+        )}: join will not proceed.\n`,
+      );
     }
   }
 
   for (const document of documents) {
     try {
-      const version = detectOpenAPI(document.parsed)
+      const version = detectOpenAPI(document.parsed);
       if (version !== OasVersion.Version3_0) {
-        return exitWithError(`Only OpenAPI 3 is supported: ${blue(document.source.absoluteRef)} \n\n`);
+        return exitWithError(
+          `Only OpenAPI 3 is supported: ${blue(document.source.absoluteRef)} \n\n`,
+        );
       }
     } catch (e) {
       return exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`);
@@ -139,22 +146,37 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
     const { tags, info } = openapi;
     const entrypoint = path.relative(process.cwd(), document.source.absoluteRef);
     const entrypointFilename = getEntrypointFilename(entrypoint);
-    const tagsPrefix = prefixTagsWithFilename ? entrypointFilename : getInfoPrefix(info, prefixTagsWithInfoProp, 'tags');
+    const tagsPrefix = prefixTagsWithFilename
+      ? entrypointFilename
+      : getInfoPrefix(info, prefixTagsWithInfoProp, 'tags');
     const componentsPrefix = getInfoPrefix(info, prefixComponentsWithInfoProp, COMPONENTS);
 
     if (openapi.hasOwnProperty('x-tagGroups')) {
-      process.stderr.write(yellow(`warning: x-tagGroups at ${blue(entrypoint)} will be skipped \n`));
+      process.stderr.write(
+        yellow(`warning: x-tagGroups at ${blue(entrypoint)} will be skipped \n`),
+      );
     }
 
-    const context = { entrypoint, entrypointFilename, tags, potentialConflicts, tagsPrefix, componentsPrefix };
-    if (tags) { populateTags(context); }
+    const context = {
+      entrypoint,
+      entrypointFilename,
+      tags,
+      potentialConflicts,
+      tagsPrefix,
+      componentsPrefix,
+    };
+    if (tags) {
+      populateTags(context);
+    }
     collectServers(openapi);
     collectInfoDescriptions(openapi, context);
     collectExternalDocs(openapi, context);
     collectPaths(openapi, context);
     collectComponents(openapi, context);
     collectXWebhooks(openapi, context);
-    if (componentsPrefix) { replace$Refs(openapi, componentsPrefix); }
+    if (componentsPrefix) {
+      replace$Refs(openapi, componentsPrefix);
+    }
   }
 
   iteratePotentialConflicts(potentialConflicts, withoutXTagGroups);
@@ -163,7 +185,7 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   if (potentialConflictsTotal) {
     return exitWithError(`Please fix conflicts before running ${yellow('join')}.`);
-  } 
+  }
 
   writeYaml(joinedDef, specFilename, noRefs);
   printExecutionTime('join', startedAt, specFilename);
@@ -200,7 +222,7 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
           tag.hasOwnProperty('description') && tagDuplicate.description !== tag.description;
 
         potentialConflicts.tags.description[entrypointTagName].push(
-          ...(isTagDescriptionNotEqual ? [entrypoint] : [])
+          ...(isTagDescriptionNotEqual ? [entrypoint] : []),
         );
       } else if (!tagDuplicate) {
         // Instead add tag to joinedDef if there no duplicate;
@@ -252,7 +274,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   }
 
   function populateXTagGroups(entrypointTagName: string, indexGroup: number) {
-    if (!joinedDef[xTagGroups][indexGroup][Tags].find((t: Oas3Tag) => t.name === entrypointTagName)) {
+    if (
+      !joinedDef[xTagGroups][indexGroup][Tags].find((t: Oas3Tag) => t.name === entrypointTagName)
+    ) {
       joinedDef[xTagGroups][indexGroup][Tags].push(entrypointTagName);
     }
   }
@@ -260,7 +284,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   function collectServers(openapi: Oas3Definition) {
     const { servers } = openapi;
     if (servers) {
-      if (!joinedDef.hasOwnProperty('servers')) { joinedDef['servers'] = []; }
+      if (!joinedDef.hasOwnProperty('servers')) {
+        joinedDef['servers'] = [];
+      }
       for (const server of servers) {
         if (!joinedDef.servers.some((s: any) => s.url === server.url)) {
           joinedDef.servers.push(server);
@@ -271,10 +297,7 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   function collectInfoDescriptions(
     openapi: Oas3Definition,
-    {
-      entrypointFilename,
-      componentsPrefix
-    }: JoinDocumentContext
+    { entrypointFilename, componentsPrefix }: JoinDocumentContext,
   ) {
     const { info } = openapi;
     if (info?.description) {
@@ -297,7 +320,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
     const { externalDocs } = openapi;
     if (externalDocs) {
       if (joinedDef.hasOwnProperty('externalDocs')) {
-        process.stderr.write(yellow(`warning: skip externalDocs from ${blue(path.basename(entrypoint))} \n`));
+        process.stderr.write(
+          yellow(`warning: skip externalDocs from ${blue(path.basename(entrypoint))} \n`),
+        );
         return;
       }
       joinedDef['externalDocs'] = externalDocs;
@@ -311,37 +336,75 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
       entrypoint,
       potentialConflicts,
       tagsPrefix,
-      componentsPrefix
-    }: JoinDocumentContext
+      componentsPrefix,
+    }: JoinDocumentContext,
   ) {
     const { paths } = openapi;
     if (paths) {
-      if (!joinedDef.hasOwnProperty('paths')) { joinedDef['paths'] = {}; }
+      if (!joinedDef.hasOwnProperty('paths')) {
+        joinedDef['paths'] = {};
+      }
       for (const path of Object.keys(paths)) {
-        if (!joinedDef.paths.hasOwnProperty(path)) { joinedDef.paths[path] = {}; }
-        if (!potentialConflicts.paths.hasOwnProperty(path)) { potentialConflicts.paths[path] = {}; }
+        if (!joinedDef.paths.hasOwnProperty(path)) {
+          joinedDef.paths[path] = {};
+        }
+        if (!potentialConflicts.paths.hasOwnProperty(path)) {
+          potentialConflicts.paths[path] = {};
+        }
         for (const operation of Object.keys(paths[path])) {
           // @ts-ignore
           const pathOperation = paths[path][operation];
           joinedDef.paths[path][operation] = pathOperation;
-          potentialConflicts.paths[path][operation] = [...(potentialConflicts.paths[path][operation] || []), entrypoint];
+          potentialConflicts.paths[path][operation] = [
+            ...(potentialConflicts.paths[path][operation] || []),
+            entrypoint,
+          ];
           const { operationId } = pathOperation;
           if (operationId) {
-            if (!potentialConflicts.paths.hasOwnProperty('operationIds')) { potentialConflicts.paths['operationIds'] = {}; }
-            potentialConflicts.paths.operationIds[operationId] = [...(potentialConflicts.paths.operationIds[operationId] || []), entrypoint];
+            if (!potentialConflicts.paths.hasOwnProperty('operationIds')) {
+              potentialConflicts.paths['operationIds'] = {};
+            }
+            potentialConflicts.paths.operationIds[operationId] = [
+              ...(potentialConflicts.paths.operationIds[operationId] || []),
+              entrypoint,
+            ];
           }
           let { tags, security } = joinedDef.paths[path][operation];
           if (tags) {
-            joinedDef.paths[path][operation].tags = tags.map((tag: string) => addPrefix(tag, tagsPrefix));
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(tags), potentialConflicts, tagsPrefix, componentsPrefix });
+            joinedDef.paths[path][operation].tags = tags.map((tag: string) =>
+              addPrefix(tag, tagsPrefix),
+            );
+            populateTags({
+              entrypoint,
+              entrypointFilename,
+              tags: formatTags(tags),
+              potentialConflicts,
+              tagsPrefix,
+              componentsPrefix,
+            });
           } else {
-            joinedDef.paths[path][operation]['tags'] = [addPrefix('other', tagsPrefix || entrypointFilename)];
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(['other']), potentialConflicts, tagsPrefix: tagsPrefix || entrypointFilename, componentsPrefix });
+            joinedDef.paths[path][operation]['tags'] = [
+              addPrefix('other', tagsPrefix || entrypointFilename),
+            ];
+            populateTags({
+              entrypoint,
+              entrypointFilename,
+              tags: formatTags(['other']),
+              potentialConflicts,
+              tagsPrefix: tagsPrefix || entrypointFilename,
+              componentsPrefix,
+            });
           }
           if (!security && openapi.hasOwnProperty('security')) {
-            joinedDef.paths[path][operation]['security'] = addSecurityPrefix(openapi.security, componentsPrefix!);
+            joinedDef.paths[path][operation]['security'] = addSecurityPrefix(
+              openapi.security,
+              componentsPrefix!,
+            );
           } else if (pathOperation.security) {
-            joinedDef.paths[path][operation].security = addSecurityPrefix(pathOperation.security, componentsPrefix!);
+            joinedDef.paths[path][operation].security = addSecurityPrefix(
+              pathOperation.security,
+              componentsPrefix!,
+            );
           }
         }
       }
@@ -350,15 +413,13 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   function collectComponents(
     openapi: Oas3Definition,
-    {
-      entrypoint,
-      potentialConflicts,
-      componentsPrefix
-    }: JoinDocumentContext
+    { entrypoint, potentialConflicts, componentsPrefix }: JoinDocumentContext,
   ) {
     const { components } = openapi;
     if (components) {
-      if (!joinedDef.hasOwnProperty(COMPONENTS)) { joinedDef[COMPONENTS] = {}; }
+      if (!joinedDef.hasOwnProperty(COMPONENTS)) {
+        joinedDef[COMPONENTS] = {};
+      }
       for (const component of Object.keys(components)) {
         if (!potentialConflicts[COMPONENTS].hasOwnProperty(component)) {
           potentialConflicts[COMPONENTS][component] = {};
@@ -369,7 +430,8 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
         for (const item of Object.keys(componentObj)) {
           const componentPrefix = addPrefix(item, componentsPrefix!);
           potentialConflicts.components[component][componentPrefix] = [
-            ...(potentialConflicts.components[component][item] || []), { [entrypoint]: componentObj[item]}
+            ...(potentialConflicts.components[component][item] || []),
+            { [entrypoint]: componentObj[item] },
           ];
           joinedDef.components[component][componentPrefix] = componentObj[item];
         }
@@ -384,33 +446,52 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
       entrypoint,
       potentialConflicts,
       tagsPrefix,
-      componentsPrefix
-    }: JoinDocumentContext
+      componentsPrefix,
+    }: JoinDocumentContext,
   ) {
     const xWebhooks = 'x-webhooks';
     // @ts-ignore
     const openapiXWebhooks = openapi[xWebhooks];
     if (openapiXWebhooks) {
-      if (!joinedDef.hasOwnProperty(xWebhooks)) { joinedDef[xWebhooks] = {}; }
+      if (!joinedDef.hasOwnProperty(xWebhooks)) {
+        joinedDef[xWebhooks] = {};
+      }
       for (const webhook of Object.keys(openapiXWebhooks)) {
         joinedDef[xWebhooks][webhook] = openapiXWebhooks[webhook];
 
-        if (!potentialConflicts.xWebhooks.hasOwnProperty(webhook)) { potentialConflicts.xWebhooks[webhook] = {}; }
+        if (!potentialConflicts.xWebhooks.hasOwnProperty(webhook)) {
+          potentialConflicts.xWebhooks[webhook] = {};
+        }
         for (const operation of Object.keys(openapiXWebhooks[webhook])) {
-          potentialConflicts.xWebhooks[webhook][operation] = [...(potentialConflicts.xWebhooks[webhook][operation] || []), entrypoint];
+          potentialConflicts.xWebhooks[webhook][operation] = [
+            ...(potentialConflicts.xWebhooks[webhook][operation] || []),
+            entrypoint,
+          ];
         }
         for (const operationKey of Object.keys(joinedDef[xWebhooks][webhook])) {
           let { tags } = joinedDef[xWebhooks][webhook][operationKey];
           if (tags) {
-            joinedDef[xWebhooks][webhook][operationKey].tags = tags.map((tag: string) => addPrefix(tag, tagsPrefix));
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(tags), potentialConflicts, tagsPrefix, componentsPrefix });
+            joinedDef[xWebhooks][webhook][operationKey].tags = tags.map((tag: string) =>
+              addPrefix(tag, tagsPrefix),
+            );
+            populateTags({
+              entrypoint,
+              entrypointFilename,
+              tags: formatTags(tags),
+              potentialConflicts,
+              tagsPrefix,
+              componentsPrefix,
+            });
           }
         }
       }
     }
   }
 
-  function addInfoSectionAndSpecVersion(documents: any, prefixComponentsWithInfoProp: string | undefined) {
+  function addInfoSectionAndSpecVersion(
+    documents: any,
+    prefixComponentsWithInfoProp: string | undefined,
+  ) {
     const firstEntrypoint = documents[0];
     const openapi = firstEntrypoint.parsed;
     const componentsPrefix = getInfoPrefix(openapi.info, prefixComponentsWithInfoProp, COMPONENTS);
@@ -485,11 +566,11 @@ function prefixTagSuggestion(conflictsLength: number) {
   process.stderr.write(
     green(
       `\n${conflictsLength} conflict(s) on tags.\nSuggestion: please use ${blue(
-        'prefix-tags-with-filename'
+        'prefix-tags-with-filename',
       )}, ${blue('prefix-tags-with-info-prop')} or ${blue(
-        'without-x-tag-groups'
-      )} to prevent naming conflicts.\n\n`
-    )
+        'without-x-tag-groups',
+      )} to prevent naming conflicts.\n\n`,
+    ),
   );
 }
 
@@ -504,11 +585,11 @@ function filterConflicts(entities: object) {
 }
 
 function getEntrypointFilename(filePath: string) {
-  return path.basename(filePath, path.extname(filePath))
+  return path.basename(filePath, path.extname(filePath));
 }
 
 function addPrefix(tag: string, tagsPrefix: string) {
-  return tagsPrefix ? tagsPrefix +'_'+ tag : tag;
+  return tagsPrefix ? tagsPrefix + '_' + tag : tag;
 }
 
 function formatTags(tags: string[]) {
@@ -519,26 +600,44 @@ function addComponentsPrefix(description: string, componentsPrefix: string) {
   return description.replace(/"(#\/components\/.*?)"/g, (match) => {
     const componentName = path.basename(match);
     return match.replace(componentName, addPrefix(componentName, componentsPrefix));
-  })
+  });
 }
 
 function addSecurityPrefix(security: any, componentsPrefix: string) {
-  return componentsPrefix ? security?.map((s: any) => {
-    const key = Object.keys(s)[0];
-    return { [componentsPrefix +'_'+ key]: s[key] }
-  }) : security;
+  return componentsPrefix
+    ? security?.map((s: any) => {
+        const key = Object.keys(s)[0];
+        return { [componentsPrefix + '_' + key]: s[key] };
+      })
+    : security;
 }
 
 function getInfoPrefix(info: any, prefixArg: string | undefined, type: string) {
   if (!prefixArg) return '';
   if (!info) exitWithError('Info section is not found in specification. \n');
-  if (!info[prefixArg]) exitWithError(`${yellow(`prefix-${type}-with-info-prop`)} argument value is not found in info section. \n`);
-  if (!isString(info[prefixArg])) exitWithError(`${yellow(`prefix-${type}-with-info-prop`)} argument value should be string. \n\n`);
-  if (info[prefixArg].length > 50) exitWithError(`${yellow(`prefix-${type}-with-info-prop`)} argument value length should not exceed 50 characters. \n\n`);
+  if (!info[prefixArg])
+    exitWithError(
+      `${yellow(`prefix-${type}-with-info-prop`)} argument value is not found in info section. \n`,
+    );
+  if (!isString(info[prefixArg]))
+    exitWithError(
+      `${yellow(`prefix-${type}-with-info-prop`)} argument value should be string. \n\n`,
+    );
+  if (info[prefixArg].length > 50)
+    exitWithError(
+      `${yellow(
+        `prefix-${type}-with-info-prop`,
+      )} argument value length should not exceed 50 characters. \n\n`,
+    );
   return info[prefixArg];
 }
 
-async function validateEntrypoint(document: Document, config: LintConfig, externalRefResolver: BaseResolver, packageVersion: string) {
+async function validateEntrypoint(
+  document: Document,
+  config: LintConfig,
+  externalRefResolver: BaseResolver,
+  packageVersion: string,
+) {
   try {
     const results = await lintDocument({ document, config, externalRefResolver });
     const fileTotals = getTotals(results);
@@ -561,7 +660,7 @@ function replace$Refs(obj: any, componentsPrefix: string) {
   crawl(obj, (node: any) => {
     if (node.$ref && isString(node.$ref) && node.$ref.startsWith(`#/${COMPONENTS}/`)) {
       const name = path.basename(node.$ref);
-      node.$ref = node.$ref.replace(name, componentsPrefix +'_'+ name);
+      node.$ref = node.$ref.replace(name, componentsPrefix + '_' + name);
     } else if (
       node.discriminator &&
       node.discriminator.mapping &&
@@ -570,9 +669,14 @@ function replace$Refs(obj: any, componentsPrefix: string) {
       const { mapping } = node.discriminator;
       for (const name of Object.keys(mapping)) {
         if (isString(mapping[name]) && mapping[name].startsWith(`#/${COMPONENTS}/`)) {
-          mapping[name] = mapping[name].split('/').map((name: string, i: number, arr: []) => {
-            return (arr.length - 1 === i && !name.includes(componentsPrefix)) ? componentsPrefix+'_'+name : name;
-          }).join('/')
+          mapping[name] = mapping[name]
+            .split('/')
+            .map((name: string, i: number, arr: []) => {
+              return arr.length - 1 === i && !name.includes(componentsPrefix)
+                ? componentsPrefix + '_' + name
+                : name;
+            })
+            .join('/');
         }
       }
     }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -13,7 +13,7 @@ import {
   RawConfig,
   RuleSeverity,
   ProblemSeverity,
-  doesYamlFileExist
+  doesYamlFileExist,
 } from '@redocly/openapi-core';
 import {
   getExecutionTime,
@@ -23,7 +23,7 @@ import {
   printLintTotals,
   printConfigLintTotals,
   printUnusedWarnings,
-  exitWithError
+  exitWithError,
 } from '../utils';
 import { Totals } from '../types';
 import { blue, gray, red } from 'colorette';
@@ -42,7 +42,6 @@ export type LintOptions = {
 };
 
 export async function handleLint(argv: LintOptions, version: string) {
-
   if (argv.config && !doesYamlFileExist(argv.config)) {
     return exitWithError('Please, provide valid path to the configuration file');
   }
@@ -50,7 +49,7 @@ export async function handleLint(argv: LintOptions, version: string) {
   const config: Config = await loadConfig(
     argv.config,
     argv.extends,
-    lintConfigCallback(argv, version)
+    lintConfigCallback(argv, version),
   );
 
   const entrypoints = await getFallbackEntryPointsOrExit(argv.entrypoints, config);
@@ -114,7 +113,7 @@ export async function handleLint(argv: LintOptions, version: string) {
   if (argv['generate-ignore-file']) {
     config.lint.saveIgnore();
     process.stderr.write(
-      `Generated ignore file with ${totalIgnored} ${pluralize('problem', totalIgnored)}.\n\n`
+      `Generated ignore file with ${totalIgnored} ${pluralize('problem', totalIgnored)}.\n\n`,
     );
   } else {
     printLintTotals(totals, entrypoints.length);

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -36,7 +36,7 @@ type PushArgs = {
   'batch-size'?: number;
   region?: Region;
   'skip-decorator'?: string[];
-  'public'?: boolean;
+  public?: boolean;
 };
 
 export async function handlePush(argv: PushArgs): Promise<void> {
@@ -88,13 +88,13 @@ export async function handlePush(argv: PushArgs): Promise<void> {
 
   if (batchId && !batchId.trim()) {
     exitWithError(
-      `The ${blue(`batch-id`)} option value is not valid, please avoid using an empty string.`
+      `The ${blue(`batch-id`)} option value is not valid, please avoid using an empty string.`,
     );
   }
 
   if (batchSize && batchSize < 2) {
     exitWithError(
-      `The ${blue(`batch-size`)} option value is not valid, please use the integer bigger than 1.`
+      `The ${blue(`batch-size`)} option value is not valid, please use the integer bigger than 1.`,
     );
   }
 

--- a/packages/cli/src/commands/split/__tests__/index.test.ts
+++ b/packages/cli/src/commands/split/__tests__/index.test.ts
@@ -1,9 +1,7 @@
 import { iteratePathItems, handleSplit } from '../index';
 import * as path from 'path';
 import * as openapiCore from '@redocly/openapi-core';
-import {
-  ComponentsFiles,
-} from '../types'; 
+import { ComponentsFiles } from '../types';
 import { blue, green } from 'colorette';
 
 const utils = require('../../../utils');
@@ -23,86 +21,105 @@ describe('#split', () => {
   const componentsFiles: ComponentsFiles = {};
 
   it('should split the file and show the success message', async () => {
-    const filePath = "packages/cli/src/commands/split/__tests__/fixtures/spec.json";
+    const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/spec.json';
     jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-    await handleSplit (
-      {
-        entrypoint: filePath,
-        outDir: openapiDir,
-        separator: '_',
-      }
-    );
+    await handleSplit({
+      entrypoint: filePath,
+      outDir: openapiDir,
+      separator: '_',
+    });
 
     expect(process.stderr.write).toBeCalledTimes(2);
     expect((process.stderr.write as jest.Mock).mock.calls[0][0]).toBe(
       `🪓 Document: ${blue(filePath!)} ${green('is successfully split')}
-    and all related files are saved to the directory: ${blue(openapiDir)} \n`
+    and all related files are saved to the directory: ${blue(openapiDir)} \n`,
     );
     expect((process.stderr.write as jest.Mock).mock.calls[1][0]).toContain(
-      `${filePath}: split processed in <test>ms`
+      `${filePath}: split processed in <test>ms`,
     );
   });
 
-
   it('should use the correct separator', async () => {
-    const filePath = "packages/cli/src/commands/split/__tests__/fixtures/spec.json";
+    const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/spec.json';
 
     jest.spyOn(utils, 'pathToFilename').mockImplementation(() => 'newFilePath');
 
-    await handleSplit (
-      {
-        entrypoint: filePath,
-        outDir: openapiDir,
-        separator: '_',
-      }
-    );
+    await handleSplit({
+      entrypoint: filePath,
+      outDir: openapiDir,
+      separator: '_',
+    });
 
     expect(utils.pathToFilename).toBeCalledWith(expect.anything(), '_');
     utils.pathToFilename.mockRestore();
   });
 
   it('should have correct path with paths', () => {
-    const openapi = require("./fixtures/spec.json");
-    
+    const openapi = require('./fixtures/spec.json');
+
     jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'paths/test.yaml');
     jest.spyOn(path, 'relative').mockImplementation(() => 'paths/test.yaml');
-    iteratePathItems(openapi.paths, openapiDir, path.join(openapiDir, 'paths'), componentsFiles, '_');
+    iteratePathItems(
+      openapi.paths,
+      openapiDir,
+      path.join(openapiDir, 'paths'),
+      componentsFiles,
+      '_',
+    );
 
     expect(openapiCore.slash).toHaveBeenCalledWith('paths/test.yaml');
     expect(path.relative).toHaveBeenCalledWith('test', 'test/paths/test.yaml');
   });
 
   it('should have correct path with webhooks', () => {
-    const openapi = require("./fixtures/webhooks.json");
+    const openapi = require('./fixtures/webhooks.json');
 
     jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'webhooks/test.yaml');
     jest.spyOn(path, 'relative').mockImplementation(() => 'webhooks/test.yaml');
-    iteratePathItems(openapi.webhooks, openapiDir, path.join(openapiDir, 'webhooks'), componentsFiles, 'webhook_');
+    iteratePathItems(
+      openapi.webhooks,
+      openapiDir,
+      path.join(openapiDir, 'webhooks'),
+      componentsFiles,
+      'webhook_',
+    );
 
     expect(openapiCore.slash).toHaveBeenCalledWith('webhooks/test.yaml');
     expect(path.relative).toHaveBeenCalledWith('test', 'test/webhooks/test.yaml');
   });
 
   it('should have correct path with x-webhooks', () => {
-    const openapi = require("./fixtures/spec.json");
+    const openapi = require('./fixtures/spec.json');
 
     jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'webhooks/test.yaml');
     jest.spyOn(path, 'relative').mockImplementation(() => 'webhooks/test.yaml');
-    iteratePathItems(openapi['x-webhooks'], openapiDir, path.join(openapiDir, 'webhooks'), componentsFiles, 'webhook_');
+    iteratePathItems(
+      openapi['x-webhooks'],
+      openapiDir,
+      path.join(openapiDir, 'webhooks'),
+      componentsFiles,
+      'webhook_',
+    );
 
     expect(openapiCore.slash).toHaveBeenCalledWith('webhooks/test.yaml');
     expect(path.relative).toHaveBeenCalledWith('test', 'test/webhooks/test.yaml');
   });
 
   it('should create correct folder name for code samples', async () => {
-    const openapi = require("./fixtures/samples.json");
+    const openapi = require('./fixtures/samples.json');
 
-    const fs = require('fs')
+    const fs = require('fs');
     jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
 
     jest.spyOn(utils, 'escapeLanguageName');
-    iteratePathItems(openapi.paths, openapiDir, path.join(openapiDir, 'paths'), componentsFiles, '_');
+    iteratePathItems(
+      openapi.paths,
+      openapiDir,
+      path.join(openapiDir, 'paths'),
+      componentsFiles,
+      '_',
+    );
 
     expect(utils.escapeLanguageName).nthCalledWith(1, 'C#');
     expect(utils.escapeLanguageName).nthReturnedWith(1, 'C_sharp');

--- a/packages/cli/src/commands/split/types.ts
+++ b/packages/cli/src/commands/split/types.ts
@@ -9,9 +9,21 @@ import {
   Oas3ComponentName,
   Oas3_1Webhooks,
   Oas2Definition,
-  Referenced
-} from "@redocly/openapi-core";
-export { Oas3_1Definition, Oas3Definition, Oas2Definition, Oas3Components, Oas3Paths, Oas3PathItem, Oas3ComponentName, Oas3_1Schema, Oas3Schema, Oas3_1Webhooks, Referenced }
+  Referenced,
+} from '@redocly/openapi-core';
+export {
+  Oas3_1Definition,
+  Oas3Definition,
+  Oas2Definition,
+  Oas3Components,
+  Oas3Paths,
+  Oas3PathItem,
+  Oas3ComponentName,
+  Oas3_1Schema,
+  Oas3Schema,
+  Oas3_1Webhooks,
+  Referenced,
+};
 export type Definition = Oas3_1Definition | Oas3Definition | Oas2Definition;
 export interface ComponentsFiles {
   [schemas: string]: any;
@@ -34,7 +46,7 @@ enum OPENAPI3_METHOD {
   Options = 'options',
   Head = 'head',
   Patch = 'patch',
-  Trace = 'trace'
+  Trace = 'trace',
 }
 
 export const OPENAPI3_METHOD_NAMES: OPENAPI3_METHOD[] = [
@@ -45,7 +57,7 @@ export const OPENAPI3_METHOD_NAMES: OPENAPI3_METHOD[] = [
   OPENAPI3_METHOD.Options,
   OPENAPI3_METHOD.Head,
   OPENAPI3_METHOD.Patch,
-  OPENAPI3_METHOD.Trace
+  OPENAPI3_METHOD.Trace,
 ];
 
 export enum OPENAPI3_COMPONENT {
@@ -57,7 +69,7 @@ export enum OPENAPI3_COMPONENT {
   RequestBodies = 'requestBodies',
   Links = 'links',
   Callbacks = 'callbacks',
-  SecuritySchemes = 'securitySchemes'
+  SecuritySchemes = 'securitySchemes',
 }
 
 export const OPENAPI3_COMPONENT_NAMES: OPENAPI3_COMPONENT[] = [
@@ -69,5 +81,5 @@ export const OPENAPI3_COMPONENT_NAMES: OPENAPI3_COMPONENT[] = [
   OPENAPI3_COMPONENT.Headers,
   OPENAPI3_COMPONENT.Links,
   OPENAPI3_COMPONENT.Callbacks,
-  OPENAPI3_COMPONENT.SecuritySchemes
+  OPENAPI3_COMPONENT.SecuritySchemes,
 ];

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -18,22 +18,22 @@ import {
   WalkContext,
   walkDocument,
   Stats,
-  bundle
+  bundle,
 } from '@redocly/openapi-core';
 
-import { getFallbackEntryPointsOrExit } from '../utils'
+import { getFallbackEntryPointsOrExit } from '../utils';
 import { printExecutionTime } from '../utils';
 
 const statsAccumulator: StatsAccumulator = {
   refs: { metric: '🚗 References', total: 0, color: 'red', items: new Set() },
   externalDocs: { metric: '📦 External Documents', total: 0, color: 'magenta' },
-  schemas: { metric: '📈 Schemas', total: 0, color: 'white'},
+  schemas: { metric: '📈 Schemas', total: 0, color: 'white' },
   parameters: { metric: '👉 Parameters', total: 0, color: 'yellow', items: new Set() },
   links: { metric: '🔗 Links', total: 0, color: 'cyan', items: new Set() },
   pathItems: { metric: '➡️ Path Items', total: 0, color: 'green' },
   operations: { metric: '👷 Operations', total: 0, color: 'yellow' },
   tags: { metric: '🔖 Tags', total: 0, color: 'white', items: new Set() },
-}
+};
 
 function printStatsStylish(statsAccumulator: StatsAccumulator) {
   for (const node in statsAccumulator) {
@@ -48,7 +48,7 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
     json[key] = {
       metric: statsAccumulator[key as StatsName].metric,
       total: statsAccumulator[key as StatsName].total,
-    }
+    };
   }
   process.stdout.write(JSON.stringify(json, null, 2));
 }
@@ -56,18 +56,21 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
 function printStats(statsAccumulator: StatsAccumulator, entrypoint: string, format: string) {
   process.stderr.write(`Document: ${colors.magenta(entrypoint)} stats:\n\n`);
   switch (format) {
-    case 'stylish': printStatsStylish(statsAccumulator); break;
-    case 'json': printStatsJson(statsAccumulator); break;
+    case 'stylish':
+      printStatsStylish(statsAccumulator);
+      break;
+    case 'json':
+      printStatsJson(statsAccumulator);
+      break;
   }
 }
 
-export async function handleStats (argv: {
-  config?: string;
-  entrypoint?: string;
-  format: string;
-}) {
+export async function handleStats(argv: { config?: string; entrypoint?: string; format: string }) {
   const config: Config = await loadConfig(argv.config);
-  const [{ path }] = await getFallbackEntryPointsOrExit(argv.entrypoint ? [argv.entrypoint] : [], config);
+  const [{ path }] = await getFallbackEntryPointsOrExit(
+    argv.entrypoint ? [argv.entrypoint] : [],
+    config,
+  );
   const externalRefResolver = new BaseResolver(config.resolve);
   const { bundle: document } = await bundle({ config, ref: path });
   const lintConfig: LintConfig = config.lint;
@@ -78,7 +81,7 @@ export async function handleStats (argv: {
       oasMajorVersion === OasMajorVersion.Version3 ? Oas3Types : Oas2Types,
       oasVersion,
     ),
-    lintConfig
+    lintConfig,
   );
 
   const startedAt = performance.now();
@@ -86,7 +89,7 @@ export async function handleStats (argv: {
     problems: [],
     oasVersion: oasVersion,
     visitorsData: {},
-  }
+  };
 
   const resolvedRefMap = await resolveDocument({
     rootDocument: document,
@@ -94,12 +97,15 @@ export async function handleStats (argv: {
     externalRefResolver,
   });
 
-  const statsVisitor = normalizeVisitors([{
-    severity: 'warn',
-    ruleId: 'stats',
-    visitor: Stats(statsAccumulator)
-  }],
-    types
+  const statsVisitor = normalizeVisitors(
+    [
+      {
+        severity: 'warn',
+        ruleId: 'stats',
+        visitor: Stats(statsAccumulator),
+      },
+    ],
+    types,
   );
 
   walkDocument({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ yargs
           default: 'stylish' as OutputFormat,
         },
       }),
-    handleStats
+    handleStats,
   )
   .command(
     'split [entrypoint]',
@@ -54,7 +54,7 @@ yargs
           },
         })
         .demandOption('entrypoint'),
-    handleSplit
+    handleSplit,
   )
   .command(
     'join [entrypoints...]',
@@ -90,7 +90,7 @@ yargs
         }),
     (argv) => {
       handleJoin(argv, version);
-    }
+    },
   )
   .command(
     'push [maybeEntrypointOrAliasOrDestination] [maybeDestination] [maybeBranchName]',
@@ -127,7 +127,7 @@ yargs
         })
         .implies('batch-id', 'batch-size')
         .implies('batch-size', 'batch-id'),
-    transformPush(handlePush)
+    transformPush(handlePush),
   )
   .command(
     'lint [entrypoints...]',
@@ -167,11 +167,7 @@ yargs
         },
         'lint-config': {
           description: 'Apply severity for linting the config file.',
-          choices: [
-            'warn',
-            'error',
-            'off',
-          ] as ReadonlyArray<RuleSeverity>,
+          choices: ['warn', 'error', 'off'] as ReadonlyArray<RuleSeverity>,
           default: 'warn' as RuleSeverity,
         },
         config: {
@@ -188,7 +184,7 @@ yargs
       }),
     (argv) => {
       handleLint(argv, version);
-    }
+    },
   )
   .command(
     'bundle [entrypoints...]',
@@ -264,7 +260,7 @@ yargs
       }),
     (argv) => {
       handleBundle(argv, version);
-    }
+    },
   )
   .command(
     'login',
@@ -281,7 +277,7 @@ yargs
           choices: regionChoices,
         },
       }),
-    handleLogin
+    handleLogin,
   )
   .command(
     'logout',
@@ -291,7 +287,7 @@ yargs
       const client = new RedoclyClient();
       client.logout();
       process.stdout.write('Logged out from the Redocly account. ✋\n');
-    }
+    },
   )
   .command(
     'preview-docs [entrypoint]',
@@ -334,7 +330,7 @@ yargs
           type: 'string',
         },
       }),
-    previewDocs
+    previewDocs,
   )
   .completion('completion', 'Generate completion script.')
   .demandCommand(1)

--- a/packages/cli/src/js-utils.ts
+++ b/packages/cli/src/js-utils.ts
@@ -1,6 +1,6 @@
 export function isObject(obj: any) {
   const type = typeof obj;
-  return type === 'function' || type === 'object' && !!obj;
+  return type === 'function' || (type === 'object' && !!obj);
 }
 
 export function isEmptyObject(obj: any) {
@@ -8,5 +8,5 @@ export function isEmptyObject(obj: any) {
 }
 
 export function isString(str: string) {
-  return Object.prototype.toString.call(str) === "[object String]";
+  return Object.prototype.toString.call(str) === '[object String]';
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname, join, resolve } from 'path';
 import { blue, gray, green, red, yellow } from 'colorette';
-import { performance } from "perf_hooks";
+import { performance } from 'perf_hooks';
 import * as glob from 'glob-promise';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -13,19 +13,23 @@ import {
   ResolveError,
   YamlParseError,
   parseYaml,
-  stringifyYaml
+  stringifyYaml,
 } from '@redocly/openapi-core';
 import { Totals, outputExtensions, Entrypoint } from './types';
 
-export async function getFallbackEntryPointsOrExit(argsEntrypoints: string[] | undefined, config: Config): Promise<Entrypoint[]> {
-  const  { apis } = config;
-  const shouldFallbackToAllDefinitions = !isNotEmptyArray(argsEntrypoints) && apis && Object.keys(apis).length > 0;
+export async function getFallbackEntryPointsOrExit(
+  argsEntrypoints: string[] | undefined,
+  config: Config,
+): Promise<Entrypoint[]> {
+  const { apis } = config;
+  const shouldFallbackToAllDefinitions =
+    !isNotEmptyArray(argsEntrypoints) && apis && Object.keys(apis).length > 0;
   const res = shouldFallbackToAllDefinitions
     ? Object.entries(apis).map(([alias, { root }]) => ({
         path: resolve(getConfigDirectory(config), root),
         alias,
       }))
-    : (await expandGlobsInEntrypoints(argsEntrypoints!, config));
+    : await expandGlobsInEntrypoints(argsEntrypoints!, config);
   if (!isNotEmptyArray(res)) {
     process.stderr.write('error: missing required argument `entrypoints`.\n');
     process.exit(1);
@@ -48,11 +52,15 @@ function getAliasOrPath(config: Config, aliasOrPath: string): Entrypoint {
 }
 
 async function expandGlobsInEntrypoints(args: string[], config: Config) {
-  return (await Promise.all((args as string[]).map(async aliasOrPath => {
-    return glob.hasMagic(aliasOrPath)
-      ? (await glob(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
-      : getAliasOrPath(config, aliasOrPath);
-  }))).flat();
+  return (
+    await Promise.all(
+      (args as string[]).map(async (aliasOrPath) => {
+        return glob.hasMagic(aliasOrPath)
+          ? (await glob(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
+          : getAliasOrPath(config, aliasOrPath);
+      }),
+    )
+  ).flat();
 }
 
 export function getExecutionTime(startedAt: number) {
@@ -75,10 +83,7 @@ export function pathToFilename(path: string, pathSeparator: string) {
 }
 
 export function escapeLanguageName(lang: string) {
-  return lang
-    .replace(/#/g, "_sharp")
-    .replace(/\//, '_')
-    .replace(/\s/g, '');
+  return lang.replace(/#/g, '_sharp').replace(/\//, '_').replace(/\s/g, '');
 }
 
 export class CircularJSONNotSupportedError extends Error {
@@ -175,11 +180,12 @@ export function handleError(e: Error, ref: string) {
       `Failed to parse entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`,
     );
     // TODO: codeframe
-  } else { // @ts-ignore
+  } else {
+    // @ts-ignore
     if (e instanceof CircularJSONNotSupportedError) {
       process.stderr.write(
         red(`Detected circular reference which can't be converted to JSON.\n`) +
-        `Try to use ${blue('yaml')} output or remove ${blue('--dereferenced')}.\n\n`,
+          `Try to use ${blue('yaml')} output or remove ${blue('--dereferenced')}.\n\n`,
       );
     } else {
       process.stderr.write(`Something went wrong when processing ${ref}:\n\n  - ${e.message}.\n\n`);
@@ -245,7 +251,7 @@ export function printConfigLintTotals(totals: Totals): void {
     process.stderr.write(
       yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n`),
     );
-  };
+  }
 }
 
 export function getOutputFileName(
@@ -312,7 +318,7 @@ export function printUnusedWarnings(config: LintConfig) {
 }
 
 export function exitWithError(message: string) {
-  process.stderr.write(red(message)+ '\n\n');
+  process.stderr.write(red(message) + '\n\n');
   process.exit(1);
 }
 

--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -48,7 +48,7 @@ export const yamlSerializer = {
 export function makeConfigForRuleset(
   rules: Oas3RuleSet,
   plugin?: Partial<Plugin>,
-  version: string = 'oas3'
+  version: string = 'oas3',
 ) {
   const rulesConf: Record<string, RuleConfig> = {};
   const ruleId = 'test';
@@ -72,7 +72,7 @@ export function makeConfigForRuleset(
 export async function makeConfig(
   rules: Record<string, RuleConfig>,
   decorators?: Record<string, DecoratorConfig>,
-  configPath?: string
+  configPath?: string,
 ) {
   return new LintConfig(
     await resolveLint({
@@ -83,6 +83,6 @@ export async function makeConfig(
         decorators,
       },
     }),
-    configPath
+    configPath,
   );
 }

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -98,14 +98,14 @@ describe('bundle', () => {
   });
 
   it('should pull hosted schema', async () => {
-    const fetchMock = jest.fn(
-      () => Promise.resolve({
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
         ok: true,
         text: () => 'External schema content',
         headers: {
-          get: () => ''
-        }
-      })
+          get: () => '',
+        },
+      }),
     );
 
     const { bundle: res, problems } = await bundle({
@@ -113,31 +113,28 @@ describe('bundle', () => {
       externalRefResolver: new BaseResolver({
         http: {
           customFetch: fetchMock,
-          headers: []
-        }
+          headers: [],
+        },
       }),
-      ref: path.join(__dirname, 'fixtures/refs/hosted.yaml')
+      ref: path.join(__dirname, 'fixtures/refs/hosted.yaml'),
     });
 
     expect(problems).toHaveLength(0);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://someexternal.schema",
-      {
-        headers: {}
-      }
-    );
+    expect(fetchMock).toHaveBeenCalledWith('https://someexternal.schema', {
+      headers: {},
+    });
     expect(res.parsed).toMatchSnapshot();
   });
 
   it('should not bundle url refs if used with keepUrlRefs', async () => {
     const fetchMock = jest.fn(() =>
-        Promise.resolve({
-          ok: true,
-          text: () => 'External schema content',
-          headers: {
-            get: () => '',
-          },
-        }),
+      Promise.resolve({
+        ok: true,
+        text: () => 'External schema content',
+        headers: {
+          get: () => '',
+        },
+      }),
     );
     const { bundle: res, problems } = await bundle({
       config: new Config({} as ResolvedConfig),

--- a/packages/core/src/__tests__/codeframes.test.ts
+++ b/packages/core/src/__tests__/codeframes.test.ts
@@ -106,7 +106,6 @@ describe('Location', () => {
     expect(preciseLocation.end).toEqual({ line: 2, col: 9 });
   });
 
-
   it('should return first line for empty doc', () => {
     const loc = {
       reportOnKey: false,

--- a/packages/core/src/__tests__/js-yaml.test.ts
+++ b/packages/core/src/__tests__/js-yaml.test.ts
@@ -48,7 +48,7 @@ describe('js-yaml', () => {
 
   test('should correctly dump date and string', () => {
     expect(stringifyYaml(parseYaml(yamlToDump))).toMatchInlineSnapshot(
-    `
+      `
     "date: '2022-01-21T11:29:56.694Z'
     dateWithoutQuotes: '2020-01-01'
     dateWithQuotes: '2020-01-01'
@@ -57,7 +57,8 @@ describe('js-yaml', () => {
     stringWithQuotes: test
     stringWithDoubleQuotes: test
     "
-    `);
+    `,
+    );
   });
 
   test('parse and stringify', () => {
@@ -65,7 +66,8 @@ describe('js-yaml', () => {
   });
 
   test('should throw an error for unsupported types', () => {
-    expect(() => stringifyYaml({ foo: () => {} }))
-      .toThrow('unacceptable kind of an object to dump [object Function]');
+    expect(() => stringifyYaml({ foo: () => {} })).toThrow(
+      'unacceptable kind of an object to dump [object Function]',
+    );
   });
 });

--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -71,7 +71,7 @@ describe('lint', () => {
           links:
             color: '#6CC496'
       `,
-      ''
+      '',
     );
     const results = await lintConfig({ document });
 
@@ -118,7 +118,7 @@ describe('lint', () => {
         plugins:
           - './local-plugin.js'
       `,
-      ''
+      '',
     );
     const results = await lintConfig({ document });
 
@@ -183,7 +183,7 @@ describe('lint', () => {
                       type: string
                       const: ABC
         `,
-      'foobar.yaml'
+      'foobar.yaml',
     );
 
     const results = await lintDocument({
@@ -200,10 +200,10 @@ describe('lint', () => {
       outdent`
       openapi: 3.0
     `,
-      ''
+      '',
     );
     expect(() => detectOpenAPI(testDocument.parsed)).toThrow(
-      `Invalid OpenAPI version: should be a string but got "number"`
+      `Invalid OpenAPI version: should be a string but got "number"`,
     );
   });
 
@@ -232,7 +232,7 @@ describe('lint', () => {
                   '200':
                     description: callback successfully processed
     `,
-      'foobar.yaml'
+      'foobar.yaml',
     );
 
     const results = await lintDocument({
@@ -266,7 +266,7 @@ describe('lint', () => {
                 summary: Exist 
                 description: example description
       `,
-      absoluteRef
+      absoluteRef,
     );
 
     const configFilePath = path.join(__dirname, 'fixtures');

--- a/packages/core/src/__tests__/login.test.ts
+++ b/packages/core/src/__tests__/login.test.ts
@@ -6,10 +6,10 @@ describe.skip('login', () => {
     Object.defineProperty(client, 'registryApi', {
       value: {
         setAccessTokens: jest.fn(),
-        authStatus: jest.fn(() => true)
+        authStatus: jest.fn(() => true),
       },
       writable: true,
-      configurable: true
+      configurable: true,
     });
     await client.login('token'); // TODO: bug with rewrite local config file
     expect(client.registryApi.setAccessTokens).toHaveBeenCalled();

--- a/packages/core/src/__tests__/ref-utils.test.ts
+++ b/packages/core/src/__tests__/ref-utils.test.ts
@@ -97,24 +97,24 @@ describe('ref-utils', () => {
   });
 
   describe('refBaseName', () => {
-    it("returns base name for file reference", () => {
-      expect(refBaseName("../testcase/Pet.yaml")).toStrictEqual("Pet");
+    it('returns base name for file reference', () => {
+      expect(refBaseName('../testcase/Pet.yaml')).toStrictEqual('Pet');
     });
 
-    it("returns base name for local file reference", () => {
-      expect(refBaseName("Cat.json")).toStrictEqual("Cat");
+    it('returns base name for local file reference', () => {
+      expect(refBaseName('Cat.json')).toStrictEqual('Cat');
     });
 
-    it("returns base name for url reference", () => {
-      expect(refBaseName("http://example.com/tests/crocodile.json")).toStrictEqual("crocodile");
+    it('returns base name for url reference', () => {
+      expect(refBaseName('http://example.com/tests/crocodile.json')).toStrictEqual('crocodile');
     });
 
-    it("returns base name for file with multiple dots in name", () => {
-      expect(refBaseName("feline.tiger.v1.yaml")).toStrictEqual("feline.tiger.v1");
+    it('returns base name for file with multiple dots in name', () => {
+      expect(refBaseName('feline.tiger.v1.yaml')).toStrictEqual('feline.tiger.v1');
     });
 
-    it("returns base name for file without any dots in name", () => {
-      expect(refBaseName("abcdefg")).toStrictEqual("abcdefg");
+    it('returns base name for file without any dots in name', () => {
+      expect(refBaseName('abcdefg')).toStrictEqual('abcdefg');
     });
   });
 });

--- a/packages/core/src/__tests__/resolve.test.ts
+++ b/packages/core/src/__tests__/resolve.test.ts
@@ -192,8 +192,11 @@ describe('collect refs', () => {
 
     expect(resolvedRefs).toBeDefined();
 
-    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1)).sort())
-      .toMatchInlineSnapshot(`
+    expect(
+      Array.from(resolvedRefs.keys())
+        .map((ref) => ref.substring(cwd.length + 1))
+        .sort(),
+    ).toMatchInlineSnapshot(`
       Array [
         "openapi-with-back.yaml::./schemas/type-a.yaml#/",
         "openapi-with-back.yaml::./schemas/type-b.yaml#/",
@@ -208,7 +211,7 @@ describe('collect refs', () => {
           const getKey = (el: any): string => el?.allOf?.type || el?.type || '';
 
           return getKey(firstEl).localeCompare(getKey(secondEl));
-        })
+        }),
     ).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/core/src/__tests__/walk.test.ts
+++ b/packages/core/src/__tests__/walk.test.ts
@@ -4,7 +4,11 @@ import * as path from 'path';
 
 import { lintDocument } from '../lint';
 
-import { parseYamlToDocument, replaceSourceWithRef, makeConfigForRuleset } from '../../__tests__/utils';
+import {
+  parseYamlToDocument,
+  replaceSourceWithRef,
+  makeConfigForRuleset,
+} from '../../__tests__/utils';
 import { BaseResolver, Document } from '../resolve';
 import { listOf } from '../types';
 import { Oas3RuleSet } from '../oas-types';

--- a/packages/core/src/benchmark/benchmark.js
+++ b/packages/core/src/benchmark/benchmark.js
@@ -31,7 +31,7 @@ function prepareRevision(revision) {
   const hash = exec(`git rev-parse "${revision}"`);
   const dir = path.join(os.tmpdir(), 'redocly-cli-benchmark', hash);
   if (fs.existsSync(dir)) {
-    fs.rmdirSync(dir, { recursive: true});
+    fs.rmdirSync(dir, { recursive: true });
   }
   fs.mkdirSync(dir, { recursive: true });
 
@@ -48,7 +48,10 @@ function tscBuild(dir) {
   process.chdir(dir);
   execSync('npm run compile', { stdio: 'inherit' });
   exec(
-    `cp ${path.join(dir, 'packages/core/src/benchmark/benches/*.yaml')} ${path.join(dir, 'packages/core/lib/benchmark/benches/')}`,
+    `cp ${path.join(dir, 'packages/core/src/benchmark/benches/*.yaml')} ${path.join(
+      dir,
+      'packages/core/lib/benchmark/benches/',
+    )}`,
   );
   process.chdir(oldCwd);
   return path.join(dir, 'packages/core/lib/benchmark/benches');
@@ -70,7 +73,8 @@ async function collectSamples(modulePath) {
 
 // T-Distribution two-tailed critical values for 95% confidence.
 // See http://www.itl.nist.gov/div898/handbook/eda/section3/eda3672.htm.
-const tTable = /* prettier-ignore */ {
+const tTable =
+  /* prettier-ignore */ {
   '1':  12.706, '2':  4.303, '3':  3.182, '4':  2.776, '5':  2.571, '6':  2.447,
   '7':  2.365,  '8':  2.306, '9':  2.262, '10': 2.228, '11': 2.201, '12': 2.179,
   '13': 2.16,   '14': 2.145, '15': 2.131, '16': 2.12,  '17': 2.11,  '18': 2.101,
@@ -255,7 +259,9 @@ function matchBenchmarks(patterns) {
   let benchmarks = findFiles(LOCAL_DIR('../lib/benchmark/benches'), '*.bench.js');
   if (patterns.length > 0) {
     benchmarks = benchmarks.filter((benchmark) =>
-      patterns.some((pattern) => path.join('../lib/benchmark/benches', benchmark).includes(pattern)),
+      patterns.some((pattern) =>
+        path.join('../lib/benchmark/benches', benchmark).includes(pattern),
+      ),
     );
   }
 

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -7,7 +7,7 @@ import { Oas3_1Types } from './types/oas3_1';
 import { NormalizedNodeType, normalizeTypes, NodeType } from './types';
 import { WalkContext, walkDocument, UserContext, ResolveResult } from './walk';
 import { detectOpenAPI, openAPIMajor, OasMajorVersion } from './oas-types';
-import {isAbsoluteUrl, isRef, Location, refBaseName} from './ref-utils';
+import { isAbsoluteUrl, isRef, Location, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
 import { reportUnresolvedRef } from './rules/no-unresolved-refs';
 import { isPlainObject } from './utils';
@@ -113,10 +113,11 @@ export async function bundleDocument(opts: {
     decorators.push({
       severity: 'error',
       ruleId: 'remove-unused-components',
-      visitor: oasMajorVersion === OasMajorVersion.Version2
-        ? RemoveUnusedComponentsOas2({})
-        : RemoveUnusedComponentsOas3({})
-    })
+      visitor:
+        oasMajorVersion === OasMajorVersion.Version2
+          ? RemoveUnusedComponentsOas2({})
+          : RemoveUnusedComponentsOas3({}),
+    });
   }
 
   const resolvedRefMap = await resolveDocument({
@@ -287,7 +288,7 @@ function makeBundleVisitor(
   }
 
   function resolveBundledComponent(node: OasRef, resolved: ResolveResult<any>, ctx: UserContext) {
-    const newRefId = makeRefId(ctx.location.source.absoluteRef, node.$ref)
+    const newRefId = makeRefId(ctx.location.source.absoluteRef, node.$ref);
     resolvedRefMap.set(newRefId, {
       document: rootDocument,
       isRemote: false,

--- a/packages/core/src/config/__tests__/config-resolvers.test.ts
+++ b/packages/core/src/config/__tests__/config-resolvers.test.ts
@@ -141,13 +141,13 @@ describe('resolveLint', () => {
     });
 
     expect(Array.isArray(lint.rules?.assertions)).toEqual(true);
-    expect(lint.rules?.assertions).toMatchObject( [
+    expect(lint.rules?.assertions).toMatchObject([
       {
         subject: 'PathItem',
         property: 'get',
         message: 'Every path item must have a GET operation.',
         defined: true,
-        assertionId: 'path-item-get-defined'
+        assertionId: 'path-item-get-defined',
       },
       {
         subject: 'Tag',
@@ -156,9 +156,9 @@ describe('resolveLint', () => {
         severity: 'error',
         minLength: 13,
         pattern: '/\\.$/',
-        assertionId: 'tag-description'
-      }
-    ])
+        assertionId: 'tag-description',
+      },
+    ]);
   });
 
   it('should resolve extends with url file config witch contains path to nested config', async () => {

--- a/packages/core/src/config/__tests__/fixtures/resolve-config/api/plugin.js
+++ b/packages/core/src/config/__tests__/fixtures/resolve-config/api/plugin.js
@@ -21,7 +21,10 @@ const rules = {
       return {
         SecurityScheme(scheme, { location, report }) {
           if (scheme.type === 'openIdConnect') {
-            if (scheme.openIdConnectUrl && !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')) {
+            if (
+              scheme.openIdConnectUrl &&
+              !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')
+            ) {
               report({
                 message:
                   'openIdConnectUrl must be a URL that ends with /.well-known/openid-configuration',
@@ -56,7 +59,6 @@ const configs = {
     },
   },
 };
-
 
 module.exports = {
   id,

--- a/packages/core/src/config/__tests__/fixtures/resolve-config/plugin.js
+++ b/packages/core/src/config/__tests__/fixtures/resolve-config/plugin.js
@@ -21,7 +21,10 @@ const rules = {
       return {
         SecurityScheme(scheme, { location, report }) {
           if (scheme.type === 'openIdConnect') {
-            if (scheme.openIdConnectUrl && !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')) {
+            if (
+              scheme.openIdConnectUrl &&
+              !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')
+            ) {
               report({
                 message:
                   'openIdConnectUrl must be a URL that ends with /.well-known/openid-configuration',

--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -9,7 +9,7 @@ describe('loadConfig', () => {
     jest
       .spyOn(RedoclyClient.prototype, 'getTokens')
       .mockImplementation(() =>
-        Promise.resolve([{ region: 'us', token: 'accessToken', valid: true }])
+        Promise.resolve([{ region: 'us', token: 'accessToken', valid: true }]),
       );
     const config = await loadConfig();
     expect(config.resolve.http.headers).toStrictEqual([
@@ -32,7 +32,7 @@ describe('loadConfig', () => {
     jest
       .spyOn(RedoclyClient.prototype, 'getTokens')
       .mockImplementation(() =>
-        Promise.resolve([{ region: 'eu', token: 'accessToken', valid: true }])
+        Promise.resolve([{ region: 'eu', token: 'accessToken', valid: true }]),
       );
     const config = await loadConfig();
     expect(config.resolve.http.headers).toStrictEqual([

--- a/packages/core/src/config/all.ts
+++ b/packages/core/src/config/all.ts
@@ -1,5 +1,4 @@
-import type { PluginLintConfig } from "./types";
-
+import type { PluginLintConfig } from './types';
 
 export default {
   rules: {
@@ -20,7 +19,7 @@ export default {
     'operation-description': 'error',
     'operation-2xx-response': 'error',
     'operation-4xx-response': 'error',
-    'assertions': 'error',
+    assertions: 'error',
     'operation-operationId': 'error',
     'operation-summary': 'error',
     'operation-operationId-unique': 'error',

--- a/packages/core/src/config/builtIn.ts
+++ b/packages/core/src/config/builtIn.ts
@@ -15,8 +15,8 @@ export const builtInConfigs: Record<string, LintRawConfig> = {
   minimal,
   all,
   'redocly-registry': {
-    decorators: { 'registry-dependencies': 'on' }
-  }
+    decorators: { 'registry-dependencies': 'on' },
+  },
 };
 
 export const defaultPlugin: Plugin = {
@@ -34,4 +34,4 @@ export const defaultPlugin: Plugin = {
     oas2: oas2Decorators,
   },
   configs: builtInConfigs,
-}
+};

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -230,13 +230,15 @@ export class LintConfig {
 
     for (const usedVersion of Array.from(this._usedVersions)) {
       rules.push(
-        ...Object.keys(this.rules[usedVersion]).filter((name) => !this._usedRules.has(name))
+        ...Object.keys(this.rules[usedVersion]).filter((name) => !this._usedRules.has(name)),
       );
       decorators.push(
-        ...Object.keys(this.decorators[usedVersion]).filter((name) => !this._usedRules.has(name))
+        ...Object.keys(this.decorators[usedVersion]).filter((name) => !this._usedRules.has(name)),
       );
       preprocessors.push(
-        ...Object.keys(this.preprocessors[usedVersion]).filter((name) => !this._usedRules.has(name))
+        ...Object.keys(this.preprocessors[usedVersion]).filter(
+          (name) => !this._usedRules.has(name),
+        ),
       );
     }
 

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -52,7 +52,7 @@ async function addConfigMetadata({
                 value: item.token,
               },
             ]
-          : [])
+          : []),
       );
     }
   }
@@ -63,7 +63,7 @@ async function addConfigMetadata({
 export async function loadConfig(
   configPath: string | undefined = findConfig(),
   customExtends?: string[],
-  processRawConfig?: (rawConfig: RawConfig) => void | Promise<void>
+  processRawConfig?: (rawConfig: RawConfig) => void | Promise<void>,
 ): Promise<Config> {
   const rawConfig = await getConfig(configPath);
   if (typeof processRawConfig === 'function') {
@@ -81,7 +81,7 @@ export const CONFIG_FILE_NAMES = ['redocly.yaml', 'redocly.yml', '.redocly.yaml'
 export function findConfig(dir?: string): string | undefined {
   if (!fs.hasOwnProperty('existsSync')) return;
   const existingConfigFiles = CONFIG_FILE_NAMES.map((name) =>
-    dir ? path.resolve(dir, name) : name
+    dir ? path.resolve(dir, name) : name,
   ).filter(fs.existsSync);
   if (existingConfigFiles.length > 1) {
     throw new Error(`

--- a/packages/core/src/config/minimal.ts
+++ b/packages/core/src/config/minimal.ts
@@ -18,7 +18,7 @@ export default {
     'operation-description': 'off',
     'operation-2xx-response': 'warn',
     'operation-4xx-response': 'off',
-    'assertions': 'warn',
+    assertions: 'warn',
     'operation-operationId': 'warn',
     'operation-summary': 'warn',
     'operation-operationId-unique': 'warn',

--- a/packages/core/src/config/recommended.ts
+++ b/packages/core/src/config/recommended.ts
@@ -17,7 +17,7 @@ export default {
     'path-parameters-defined': 'error',
     'operation-description': 'off',
     'operation-2xx-response': 'warn',
-    'assertions': 'warn',
+    assertions: 'warn',
     'operation-4xx-response': 'warn',
     'operation-operationId': 'warn',
     'operation-summary': 'error',

--- a/packages/core/src/config/rules.ts
+++ b/packages/core/src/config/rules.ts
@@ -31,7 +31,7 @@ export function initRules<T extends Function, P extends RuleSet<T>>(
             severity: ruleSettings.severity,
             ruleId,
             visitor: visitor,
-          }))
+          }));
         }
 
         return {
@@ -41,6 +41,6 @@ export function initRules<T extends Function, P extends RuleSet<T>>(
         };
       }),
     )
-    .flatMap(visitor => visitor)
+    .flatMap((visitor) => visitor)
     .filter(notUndefined);
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -137,7 +137,7 @@ export type Api = {
   'features.openapi'?: Record<string, any>;
   'features.mockServer'?: Record<string, any>;
 };
-export type ResolvedApi = Omit<Api, 'lint'> & { lint: Omit<ResolvedLintConfig, 'plugins'>};
+export type ResolvedApi = Omit<Api, 'lint'> & { lint: Omit<ResolvedLintConfig, 'plugins'> };
 
 export type RawConfig = {
   apis?: Record<string, Api>;
@@ -151,7 +151,7 @@ export type RawConfig = {
 
 export type ResolvedConfig = Omit<RawConfig, 'lint' | 'apis'> & {
   lint: ResolvedLintConfig;
-  apis: Record<string,ResolvedApi>
+  apis: Record<string, ResolvedApi>;
 };
 
 export type RulesFields =

--- a/packages/core/src/config/utils.ts
+++ b/packages/core/src/config/utils.ts
@@ -199,9 +199,7 @@ export function getUniquePlugins(plugins: Plugin[]): Plugin[] {
       results.push(p);
       seen.add(p.id);
     } else if (p.id) {
-      process.stderr.write(
-        `Duplicate plugin id "${yellow(p.id)}".\n`,
-      );
+      process.stderr.write(`Duplicate plugin id "${yellow(p.id)}".\n`);
     }
   }
   return results;

--- a/packages/core/src/decorators/__tests__/filter-in.test.ts
+++ b/packages/core/src/decorators/__tests__/filter-in.test.ts
@@ -26,7 +26,7 @@ describe('oas3 filter-in', () => {
             post:
               operationId: storeOrder
               callbacks:
-                x-access: protected`
+                x-access: protected`,
   );
 
   it('should include /user path and remove y parameter', async () => {
@@ -51,7 +51,7 @@ describe('oas3 filter-in', () => {
           y:
             x-access: private
             name: y            
-    `
+    `,
     );
     const { bundle: res } = await bundleDocument({
       document: testDocument,
@@ -84,7 +84,7 @@ describe('oas3 filter-in', () => {
             value: ['Public', 'Protected'],
             matchStrategy: 'all',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -125,7 +125,7 @@ describe('oas3 filter-in', () => {
               operationId: storeOrder
               parameters:
                 - name: api_key
-                 `
+                 `,
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -138,7 +138,7 @@ describe('oas3 filter-in', () => {
             value: ['Public', 'Global'],
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -179,7 +179,7 @@ describe('oas3 filter-in', () => {
             value: 'non-existing-audience',
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -215,7 +215,7 @@ describe('oas3 filter-in', () => {
             post: 
                summary: test
                x-audience: Private     
-                 `
+                 `,
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -228,7 +228,7 @@ describe('oas3 filter-in', () => {
             value: ['Public', 'Global'],
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -274,7 +274,7 @@ describe('oas2 filter-in', () => {
                 '200':
                   description: List of recent media entries.
                   x-access: [private, protected]
-      `
+      `,
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -287,7 +287,7 @@ describe('oas2 filter-in', () => {
             value: ['public', 'global'],
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`

--- a/packages/core/src/decorators/__tests__/filter-out.test.ts
+++ b/packages/core/src/decorators/__tests__/filter-out.test.ts
@@ -27,7 +27,8 @@ describe('oas3 filter-out', () => {
               callbacks:
                 x-access: protected
                 orderInProgress:
-                  x-internal: true`);
+                  x-internal: true`,
+  );
 
   it('should remove /pet path and y parameter', async () => {
     const testDocument = parseYamlToDocument(
@@ -46,7 +47,7 @@ describe('oas3 filter-out', () => {
           y:
             x-access: private
             name: y  
-    `
+    `,
     );
     const { bundle: res } = await bundleDocument({
       document: testDocument,
@@ -75,7 +76,7 @@ describe('oas3 filter-out', () => {
             value: ['Private', 'Protected'],
             matchStrategy: 'all',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -106,7 +107,7 @@ describe('oas3 filter-out', () => {
             value: ['Private', 'Protected'],
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -132,7 +133,8 @@ describe('oas3 filter-out', () => {
                     type: object
       components: {}
             
-        `);
+        `,
+    );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
       externalRefResolver: new BaseResolver(),
@@ -144,7 +146,7 @@ describe('oas3 filter-out', () => {
             value: 'private',
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`
@@ -185,7 +187,8 @@ describe('oas3 filter-out', () => {
           x:
             name: x
             
-            `);
+            `,
+    );
     const { bundle: res } = await bundleDocument({
       document: testDocument,
       externalRefResolver: new BaseResolver(),
@@ -236,7 +239,8 @@ describe('oas3 filter-out', () => {
           x:
             name: x
             
-            `);
+            `,
+    );
     const { bundle: res } = await bundleDocument({
       document: testDocument,
       externalRefResolver: new BaseResolver(),
@@ -296,7 +300,7 @@ describe('oas2 filter-out', () => {
             '200':
                   description: List of recent media entries.
                   x-access: [protected, public]            
-      `
+      `,
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -309,7 +313,7 @@ describe('oas2 filter-out', () => {
             value: ['private', 'protected'],
             matchStrategy: 'any',
           },
-        }
+        },
       ),
     });
     expect(res.parsed).toMatchInlineSnapshot(`

--- a/packages/core/src/decorators/common/filters/filter-helper.ts
+++ b/packages/core/src/decorators/common/filters/filter-helper.ts
@@ -45,9 +45,9 @@ export function filter(node: any, ctx: UserContext, criteria: (item: any) => boo
 export function checkIfMatchByStrategy(
   nodeValue: any,
   decoratorValue: any,
-  strategy: 'all' | 'any'
+  strategy: 'all' | 'any',
 ): boolean {
-  if (nodeValue===undefined || decoratorValue===undefined) {
+  if (nodeValue === undefined || decoratorValue === undefined) {
     return false;
   }
 

--- a/packages/core/src/decorators/common/remove-x-internal.ts
+++ b/packages/core/src/decorators/common/remove-x-internal.ts
@@ -53,7 +53,7 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({ internalFlagPro
     any: {
       enter: (node, ctx) => {
         removeInternal(node, ctx);
-      }
-    }
-  }
-}
+      },
+    },
+  };
+};

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -14,7 +14,7 @@ const coreVersion = require('../../package.json').version;
 
 import { NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject } from '../walk';
 import { getCodeframe, getLineColLocation } from './codeframes';
-import { env } from "../config";
+import { env } from '../config';
 
 export type Totals = {
   errors: number;
@@ -243,7 +243,7 @@ export function formatProblems(
   function formatStylish(problem: OnlyLineColProblem, locationPad: number, ruleIdPad: number) {
     const color = COLORS[problem.severity];
     if (!SEVERITY_NAMES[problem.severity]) {
-      return 'Error not found severity. Please check your config file. Allowed values: \`warn,error,off\`'
+      return 'Error not found severity. Please check your config file. Allowed values: `warn,error,off`';
     }
     const severityName = color(SEVERITY_NAMES[problem.severity].toLowerCase().padEnd(7));
     const { start } = problem.location[0];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,9 +33,8 @@ export {
   getConfig,
   findConfig,
   CONFIG_FILE_NAMES,
-  RuleSeverity
+  RuleSeverity,
 } from './config';
-
 
 export { RedoclyClient, isRedoclyRegistryURL } from './redocly';
 

--- a/packages/core/src/js-yaml/index.ts
+++ b/packages/core/src/js-yaml/index.ts
@@ -1,18 +1,13 @@
 // TODO: add a type for "types" https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/js-yaml/index.d.ts
 // @ts-ignore
-import { JSON_SCHEMA, types, LoadOptions, DumpOptions, load, dump  } from 'js-yaml';
+import { JSON_SCHEMA, types, LoadOptions, DumpOptions, load, dump } from 'js-yaml';
 
 const DEFAULT_SCHEMA_WITHOUT_TIMESTAMP = JSON_SCHEMA.extend({
   implicit: [types.merge],
-  explicit: [
-    types.binary,
-    types.omap,
-    types.pairs,
-    types.set,
-  ],
+  explicit: [types.binary, types.omap, types.pairs, types.set],
 });
 
 export const parseYaml = (str: string, opts?: LoadOptions): unknown =>
-  load(str, {schema: DEFAULT_SCHEMA_WITHOUT_TIMESTAMP, ...opts});
+  load(str, { schema: DEFAULT_SCHEMA_WITHOUT_TIMESTAMP, ...opts });
 
 export const stringifyYaml = (obj: any, opts?: DumpOptions): string => dump(obj, opts);

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -1,7 +1,5 @@
 import { BaseResolver, resolveDocument, Document, makeDocumentFromString } from './resolve';
-import {
-  normalizeVisitors,
-} from './visitors';
+import { normalizeVisitors } from './visitors';
 import { Oas3_1Types } from './types/oas3_1';
 import { Oas3Types } from './types/oas3';
 import { Oas2Types } from './types/oas2';
@@ -13,7 +11,6 @@ import { releaseAjvInstance } from './rules/ajv';
 import { detectOpenAPI, Oas3RuleSet, OasMajorVersion, OasVersion, openAPIMajor } from './oas-types';
 import { ConfigTypes } from './types/redocly-yaml';
 import { OasSpec } from './rules/common/spec';
-
 
 export async function lint(opts: {
   ref: string;
@@ -62,7 +59,11 @@ export async function lintDocument(opts: {
   const rules = config.getRulesForOasVersion(oasMajorVersion);
   const types = normalizeTypes(
     config.extendTypes(
-      customTypes ?? oasMajorVersion === OasMajorVersion.Version3 ? (oasVersion === OasVersion.Version3_1 ? Oas3_1Types : Oas3Types) : Oas2Types,
+      customTypes ?? oasMajorVersion === OasMajorVersion.Version3
+        ? oasVersion === OasVersion.Version3_1
+          ? Oas3_1Types
+          : Oas3Types
+        : Oas2Types,
       oasVersion,
     ),
     config,
@@ -80,7 +81,7 @@ export async function lintDocument(opts: {
   const resolvedRefMap = await resolveDocument({
     rootDocument: document,
     rootType: types.DefinitionRoot,
-    externalRefResolver
+    externalRefResolver,
   });
 
   walkDocument({
@@ -93,10 +94,7 @@ export async function lintDocument(opts: {
   return ctx.problems.map((problem) => config.addProblemToIgnore(problem));
 }
 
-export async function lintConfig(opts: {
-  document: Document
-  severity?: ProblemSeverity 
-}) {
+export async function lintConfig(opts: { document: Document; severity?: ProblemSeverity }) {
   const { document, severity } = opts;
 
   const ctx: WalkContext = {
@@ -111,7 +109,13 @@ export async function lintConfig(opts: {
   });
 
   const types = normalizeTypes(ConfigTypes, config);
-  const rules = [{ severity: severity || 'error', ruleId: 'configuration spec', visitor: OasSpec({ severity: 'error' }) }];
+  const rules = [
+    {
+      severity: severity || 'error',
+      ruleId: 'configuration spec',
+      visitor: OasSpec({ severity: 'error' }),
+    },
+  ];
   const normalizedVisitors = normalizeVisitors(rules, types);
 
   walkDocument({

--- a/packages/core/src/oas-types.ts
+++ b/packages/core/src/oas-types.ts
@@ -1,9 +1,4 @@
-import {
-  Oas3Rule,
-  Oas3Preprocessor,
-  Oas2Rule,
-  Oas2Preprocessor,
-} from './visitors';
+import { Oas3Rule, Oas3Preprocessor, Oas2Rule, Oas2Preprocessor } from './visitors';
 
 export type RuleSet<T> = Record<string, T>;
 

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -59,55 +59,57 @@ describe('RedoclyClient', () => {
 
   it('should resolve all tokens', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
-      return { token: "accessToken", us: "accessToken", eu: "eu-accessToken" };
+      return { token: 'accessToken', us: 'accessToken', eu: 'eu-accessToken' };
     });
     const client = new RedoclyClient();
     const tokens = client.getAllTokens();
     expect(tokens).toStrictEqual([
       { region: 'us', token: 'accessToken' },
-      { region: 'eu', token: 'eu-accessToken' }
+      { region: 'eu', token: 'eu-accessToken' },
     ]);
     spy.mockRestore();
   });
 
   it('should resolve valid tokens data', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
-      return { us: "accessToken", eu: "eu-accessToken" }
+      return { us: 'accessToken', eu: 'eu-accessToken' };
     });
     const client = new RedoclyClient();
     const tokens = await client.getValidTokens();
     expect(tokens).toStrictEqual([
       { region: 'us', token: 'accessToken', valid: true },
-      { region: 'eu', token: 'eu-accessToken', valid: true }
+      { region: 'eu', token: 'eu-accessToken', valid: true },
     ]);
     spy.mockRestore();
   });
 
   it('should not call setAccessTokens by default', () => {
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({}));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({}));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).not.toHaveBeenCalled()
+    expect(client.setAccessTokens).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 
   it('should set correct accessTokens - backward compatibility: default US region', () => {
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ token: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ token: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).toBeCalledWith(
-      expect.objectContaining({ us: testToken })
-    );
+    expect(client.setAccessTokens).toBeCalledWith(expect.objectContaining({ us: testToken }));
     spy.mockRestore();
   });
 
   it('should set correct accessTokens - backward compatibility: EU region', () => {
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ token: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ token: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient('eu');
-    expect(client.setAccessTokens).toBeCalledWith(
-      expect.objectContaining({ eu: testToken })
-    );
+    expect(client.setAccessTokens).toBeCalledWith(expect.objectContaining({ eu: testToken }));
     spy.mockRestore();
   });
 
@@ -116,25 +118,29 @@ describe('RedoclyClient', () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation();
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).toHaveBeenNthCalledWith(1, { "us": REDOCLY_AUTHORIZATION_TOKEN });
+    expect(client.setAccessTokens).toHaveBeenNthCalledWith(1, { us: REDOCLY_AUTHORIZATION_TOKEN });
     spy.mockRestore();
   });
 
   it('should set correct accessTokens prioritizing REDOCLY_AUTHORIZATION env over token in file', () => {
     process.env.REDOCLY_AUTHORIZATION = REDOCLY_AUTHORIZATION_TOKEN;
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ token: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ token: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { "us": REDOCLY_AUTHORIZATION_TOKEN });
+    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { us: REDOCLY_AUTHORIZATION_TOKEN });
     spy.mockRestore();
   });
 
   it('should set correct accessTokens prioritizing REDOCLY_AUTHORIZATION env over EU token', () => {
     process.env.REDOCLY_AUTHORIZATION = REDOCLY_AUTHORIZATION_TOKEN;
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ us: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ us: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient('eu');
-    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { "eu": REDOCLY_AUTHORIZATION_TOKEN });
+    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { eu: REDOCLY_AUTHORIZATION_TOKEN });
     spy.mockRestore();
   });
 });

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -28,7 +28,9 @@ export class RedoclyClient {
 
   loadRegion(region?: Region) {
     if (region && !DOMAINS[region]) {
-      throw new Error(`Invalid argument: region in config file.\nGiven: ${green(region)}, choices: "us", "eu".`);
+      throw new Error(
+        `Invalid argument: region in config file.\nGiven: ${green(region)}, choices: "us", "eu".`,
+      );
     }
 
     if (env.REDOCLY_DOMAIN) {

--- a/packages/core/src/redocly/registry-api.ts
+++ b/packages/core/src/redocly/registry-api.ts
@@ -106,7 +106,7 @@ export class RegistryApi {
     isUpsert,
     isPublic,
     batchId,
-    batchSize
+    batchSize,
   }: RegistryApiTypes.PushApiParams) {
     const response = await this.request(
       `/${organizationId}/${name}/${version}`,
@@ -123,7 +123,7 @@ export class RegistryApi {
           isUpsert,
           isPublic,
           batchId,
-          batchSize
+          batchSize,
         }),
       },
       this.region,

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -145,7 +145,7 @@ export class BaseResolver {
   async resolveDocument(
     base: string | null,
     ref: string,
-    isRoot: boolean = false
+    isRoot: boolean = false,
   ): Promise<Document | ResolveError | YamlParseError> {
     const absoluteRef = this.resolveExternalRef(base, ref);
     const cachedDocument = this.cache.get(absoluteRef);
@@ -316,7 +316,10 @@ export async function resolveDocument(opts: {
       let targetDoc: Document;
       try {
         targetDoc = isRemote
-          ? ((await externalRefResolver.resolveDocument(document.source.absoluteRef, uri!)) as Document)
+          ? ((await externalRefResolver.resolveDocument(
+              document.source.absoluteRef,
+              uri!,
+            )) as Document)
           : document;
       } catch (error) {
         const resolvedRef = {

--- a/packages/core/src/rules/ajv.ts
+++ b/packages/core/src/rules/ajv.ts
@@ -73,8 +73,7 @@ export function validateJsonSchema(
 
   function beatifyErrorMessage(error: ErrorObject) {
     let message = error.message;
-    let suggest =
-      error.keyword === 'enum' ? error.params.allowedValues : undefined;
+    let suggest = error.keyword === 'enum' ? error.params.allowedValues : undefined;
     if (suggest) {
       message += ` ${suggest.map((e: any) => `"${e}"`).join(', ')}`;
     }

--- a/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
@@ -114,7 +114,7 @@ describe('Oas3 typed enum', () => {
     `);
   });
 
-  it('should report on enum object, \'string\' value in enum does not have allowed types', async () => {
+  it("should report on enum object, 'string' value in enum does not have allowed types", async () => {
     const document = parseYamlToDocument(
       outdent`
           openapi: 3.1.0
@@ -185,7 +185,7 @@ describe('Oas3 typed enum', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: await makeConfig({ 'spec': 'error', 'no-enum-type-mismatch': 'error' }),
+      config: await makeConfig({ spec: 'error', 'no-enum-type-mismatch': 'error' }),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`

--- a/packages/core/src/rules/common/__tests__/paths-kebab-case.test.ts
+++ b/packages/core/src/rules/common/__tests__/paths-kebab-case.test.ts
@@ -84,25 +84,25 @@ describe('Oas3 paths-kebab-case', () => {
   });
 
   it('should allow trailing slash in path with "paths-kebab-case" rule', async () => {
-      const document = parseYamlToDocument(
-        outdent`
+    const document = parseYamlToDocument(
+      outdent`
             openapi: 3.0.0
             paths:
               /some/:
                 get:
                   summary: List all pets
           `,
-        'foobar.yaml',
-      );
+      'foobar.yaml',
+    );
 
-      const results = await lintDocument({
-        externalRefResolver: new BaseResolver(),
-        document,
-        config: await makeConfig({
-          'paths-kebab-case': 'error',
-          'no-path-trailing-slash': 'off',
-        }),
-      });
-      expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'paths-kebab-case': 'error',
+        'no-path-trailing-slash': 'off',
+      }),
     });
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -25,7 +25,7 @@ describe('Oas3 spec', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: await makeConfig({ 'spec': 'error' }),
+      config: await makeConfig({ spec: 'error' }),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`

--- a/packages/core/src/rules/common/assertions/__tests__/asserts.test.ts
+++ b/packages/core/src/rules/common/assertions/__tests__/asserts.test.ts
@@ -15,230 +15,613 @@ describe('oas3 assertions', () => {
     describe('pattern', () => {
       it('value should match regex pattern', () => {
         expect(asserts.pattern('test string', '/test/', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.pattern('test string', '/test me/', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.pattern(['test string', 'test me'], '/test/', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.pattern(['test string', 'test me'], '/test me/', baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.pattern('./components/smth/test.yaml', '/^(./)?components/.*.yaml$/', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.pattern('./other.yaml', '/^(./)?components/.*.yaml$/', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.pattern('test string', '/test me/', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.pattern(['test string', 'test me'], '/test/', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.pattern(['test string', 'test me'], '/test me/', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.pattern(
+            './components/smth/test.yaml',
+            '/^(./)?components/.*.yaml$/',
+            baseLocation,
+          ),
+        ).toEqual({ isValid: true });
+        expect(
+          asserts.pattern('./other.yaml', '/^(./)?components/.*.yaml$/', baseLocation),
+        ).toEqual({ isValid: false, location: baseLocation });
       });
     });
 
     describe('ref', () => {
       it('value should have ref', () => {
-        expect(asserts.ref({ $ref: 'text' }, true, baseLocation, { $ref: 'text' })).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.ref({}, true, baseLocation, {})).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(asserts.ref({ $ref: 'text' }, true, baseLocation, { $ref: 'text' })).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.ref({}, true, baseLocation, {})).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
       });
 
       it('value should not have ref', () => {
-        expect(asserts.ref({ $ref: 'text' }, false, baseLocation, { $ref: 'text' })).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.ref({}, false, baseLocation, {})).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.ref({ $ref: 'text' }, false, baseLocation, { $ref: 'text' })).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.ref({}, false, baseLocation, {})).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
       });
 
       it('value should match regex pattern', () => {
-        expect(asserts.ref({ $ref: 'test string' }, '/test/', baseLocation, { $ref: 'test string' })).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.ref({ $ref: 'test string' }, '/test me/', baseLocation, { $ref: 'test string' })).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.ref({ $ref: './components/smth/test.yaml' }, '/^(./)?components/.*.yaml$/', baseLocation, { $ref: './components/smth/test.yaml' })).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.ref({ $ref: './paths/smth/test.yaml' }, '/^(./)?components/.*.yaml$/', baseLocation, { $ref: './paths/smth/test.yaml' })).toEqual({ isValid: false, location: baseLocation });
+        expect(
+          asserts.ref({ $ref: 'test string' }, '/test/', baseLocation, { $ref: 'test string' }),
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.ref({ $ref: 'test string' }, '/test me/', baseLocation, { $ref: 'test string' }),
+        ).toEqual({ isValid: false, location: baseLocation });
+        expect(
+          asserts.ref(
+            { $ref: './components/smth/test.yaml' },
+            '/^(./)?components/.*.yaml$/',
+            baseLocation,
+            { $ref: './components/smth/test.yaml' },
+          ),
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.ref(
+            { $ref: './paths/smth/test.yaml' },
+            '/^(./)?components/.*.yaml$/',
+            baseLocation,
+            { $ref: './paths/smth/test.yaml' },
+          ),
+        ).toEqual({ isValid: false, location: baseLocation });
       });
     });
 
     describe('enum', () => {
       it('value should be among predefined keys', () => {
         expect(asserts.enum('test', ['test', 'example'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.enum(['test'], ['test', 'example'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.enum(['test', 'example'], ['test', 'example'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.enum(['test', 'example', 'foo'], ['test', 'example'], baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo').key() });
-        expect(asserts.enum('test', ['foo', 'example'], baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.enum(['test', 'foo'], ['test', 'example'], baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo').key() });
+        expect(asserts.enum(['test'], ['test', 'example'], baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.enum(['test', 'example'], ['test', 'example'], baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.enum(['test', 'example', 'foo'], ['test', 'example'], baseLocation)).toEqual(
+          { isValid: false, location: baseLocation.child('foo').key() },
+        );
+        expect(asserts.enum('test', ['foo', 'example'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.enum(['test', 'foo'], ['test', 'example'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo').key(),
+        });
       });
     });
 
     describe('defined', () => {
       it('value should be defined', () => {
-        expect(asserts.defined('test', true, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.defined(undefined, true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.defined('test', true, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.defined(undefined, true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be undefined', () => {
-        expect(asserts.defined(undefined, false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.defined('test', false, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.defined(undefined, false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.defined('test', false, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('undefined', () => {
       it('value should be undefined', () => {
-        expect(asserts.undefined(undefined, true, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.undefined('test', true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.undefined(undefined, true, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.undefined('test', true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be defined', () => {
-        expect(asserts.undefined('test', false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.undefined(undefined, false, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.undefined('test', false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.undefined(undefined, false, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('required', () => {
       it('values should be required', () => {
-        expect(asserts.required(['one', 'two', 'three'], ['one', 'two'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.required(['one', 'two'], ['one', 'two', 'three'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(asserts.required(['one', 'two', 'three'], ['one', 'two'], baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.required(['one', 'two'], ['one', 'two', 'three'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
       });
     });
 
     describe('nonEmpty', () => {
       it('value should not be empty', () => {
-        expect(asserts.nonEmpty('test', true, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty('', true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.nonEmpty(null, true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.nonEmpty(undefined, true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.nonEmpty('test', true, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty('', true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(null, true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(undefined, true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be empty', () => {
-        expect(asserts.nonEmpty('', false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty(null, false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty(undefined, false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty('test', false, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.nonEmpty('', false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(null, false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(undefined, false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty('test', false, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('minLength', () => {
       it('value should have less or equal than 5 symbols length', () => {
-        expect(asserts.minLength('test', 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.minLength([1, 2, 3, 4], 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.minLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.minLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.minLength('example', 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.minLength([], 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.minLength('', 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.minLength('test', 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([1, 2, 3, 4], 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.minLength('example', 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([], 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.minLength('', 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('maxLength', () => {
       it('value should have more or equal than 5 symbols length', () => {
-        expect(asserts.maxLength('test', 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength([1, 2, 3, 4], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.maxLength('example', 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.maxLength([], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength('', 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
+        expect(asserts.maxLength('test', 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([1, 2, 3, 4], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength('example', 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength('', 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
       });
     });
 
     describe('casing', () => {
       it('value should be camelCase', () => {
-        expect(asserts.casing(['testExample', 'fooBar'], 'camelCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['testExample', 'FooBar'], 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('FooBar').key() });
+        expect(asserts.casing(['testExample', 'fooBar'], 'camelCase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['testExample', 'FooBar'], 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('FooBar').key(),
+        });
         expect(asserts.casing('testExample', 'camelCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing('TestExample', 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test_example', 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TestExample', 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test_example', 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be PascalCase', () => {
-        expect(asserts.casing('TestExample', 'PascalCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TestExample', 'FooBar'], 'PascalCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TestExample', 'fooBar'], 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('fooBar').key() });
-        expect(asserts.casing('testExample', 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test_example', 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TestExample', 'PascalCase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TestExample', 'FooBar'], 'PascalCase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TestExample', 'fooBar'], 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('fooBar').key(),
+        });
+        expect(asserts.casing('testExample', 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test_example', 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be kebab-case', () => {
-        expect(asserts.casing('test-example', 'kebab-case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test-example', 'foo-bar'], 'kebab-case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test-example', 'foo_bar'], 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo_bar').key() });
-        expect(asserts.casing('testExample', 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test_example', 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('test-example', 'kebab-case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test-example', 'foo-bar'], 'kebab-case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test-example', 'foo_bar'], 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo_bar').key(),
+        });
+        expect(asserts.casing('testExample', 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test_example', 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be snake_case', () => {
-        expect(asserts.casing('test_example', 'snake_case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test_example', 'foo_bar'], 'snake_case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test_example', 'foo-bar'], 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo-bar').key() });
-        expect(asserts.casing('testExample', 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('test_example', 'snake_case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test_example', 'foo_bar'], 'snake_case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test_example', 'foo-bar'], 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo-bar').key(),
+        });
+        expect(asserts.casing('testExample', 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be MACRO_CASE', () => {
-        expect(asserts.casing('TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST_EXAMPLE', 'FOO_BAR'], 'MACRO_CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST_EXAMPLE', 'FOO-BAR'], 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('FOO-BAR').key() });
-        expect(asserts.casing('TEST_EXAMPLE_', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('_TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST__EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST-EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('testExample', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST_EXAMPLE', 'FOO_BAR'], 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST_EXAMPLE', 'FOO-BAR'], 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('FOO-BAR').key(),
+        });
+        expect(asserts.casing('TEST_EXAMPLE_', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('_TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST__EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST-EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('testExample', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be COBOL-CASE', () => {
-        expect(asserts.casing('TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST-EXAMPLE', 'FOO-BAR'], 'COBOL-CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST-EXAMPLE', 'FOO_BAR'], 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('FOO_BAR').key() });
-        expect(asserts.casing('TEST-EXAMPLE-', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('0TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('-TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST--EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST_EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('testExample', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST-EXAMPLE', 'FOO-BAR'], 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST-EXAMPLE', 'FOO_BAR'], 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('FOO_BAR').key(),
+        });
+        expect(asserts.casing('TEST-EXAMPLE-', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('0TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('-TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST--EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST_EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('testExample', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be flatcase', () => {
         expect(asserts.casing('testexample', 'flatcase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['testexample', 'foobar'], 'flatcase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['testexample', 'foo_bar'], 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo_bar').key() });
-        expect(asserts.casing('testexample_', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('0testexample', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('testExample', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing(['testexample', 'foobar'], 'flatcase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['testexample', 'foo_bar'], 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo_bar').key(),
+        });
+        expect(asserts.casing('testexample_', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('0testexample', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('testExample', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe.skip('sortOrder', () => {
       it('value should be ordered in ASC direction', () => {
-        expect(asserts.sortOrder(['example', 'foo', 'test'], 'asc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'foo', 'test'], { direction: 'asc' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example'], 'asc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'test', 'foo'], 'asc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'foo', 'test'], 'desc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }], { direction: 'asc', property: 'name' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }], { direction: 'desc', property: 'name' }, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.sortOrder(['example', 'foo', 'test'], 'asc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(['example', 'foo', 'test'], { direction: 'asc' }, baseLocation),
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(asserts.sortOrder(['example'], 'asc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['example', 'test', 'foo'], 'asc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['example', 'foo', 'test'], 'desc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }],
+            { direction: 'asc', property: 'name' },
+            baseLocation,
+          ),
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }],
+            { direction: 'desc', property: 'name' },
+            baseLocation,
+          ),
+        ).toEqual({ isValid: false, location: baseLocation });
       });
       it('value should be ordered in DESC direction', () => {
-        expect(asserts.sortOrder(['test', 'foo', 'example'], 'desc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['test', 'foo', 'example'], { direction: 'desc' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example'], 'desc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'test', 'foo'], 'desc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder(['test', 'foo', 'example'], 'asc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }], { direction: 'desc', property: 'name' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }], { direction: 'asc', property: 'name' }, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.sortOrder(['test', 'foo', 'example'], 'desc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(['test', 'foo', 'example'], { direction: 'desc' }, baseLocation),
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(asserts.sortOrder(['example'], 'desc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['example', 'test', 'foo'], 'desc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['test', 'foo', 'example'], 'asc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }],
+            { direction: 'desc', property: 'name' },
+            baseLocation,
+          ),
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }],
+            { direction: 'asc', property: 'name' },
+            baseLocation,
+          ),
+        ).toEqual({ isValid: false, location: baseLocation });
       });
     });
 
     describe('mutuallyExclusive', () => {
       it('node should not have more than one property from predefined list', () => {
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), [], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'test'], baseLocation),
+        ).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), [], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar'], baseLocation),
+        ).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation),
+        ).toEqual({ isValid: false, location: baseLocation.key() });
       });
     });
 
     describe('mutuallyRequired', () => {
       it('node should have all the properties from predefined list', () => {
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'baz'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), [], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar'], baseLocation),
+        ).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'baz'], baseLocation),
+        ).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.mutuallyRequired(Object.keys(fakeNode), [], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'test'], baseLocation),
+        ).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation),
+        ).toEqual({ isValid: false, location: baseLocation.key() });
       });
     });
 
     describe('requireAny', () => {
       it('node must have at least one property from predefined list', () => {
-        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'bar'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), [], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'test1'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'bar'], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), [], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'test1'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation),
+        ).toEqual({ isValid: true, location: baseLocation.key() });
       });
     });
   });

--- a/packages/core/src/rules/common/assertions/asserts.ts
+++ b/packages/core/src/rules/common/assertions/asserts.ts
@@ -98,7 +98,7 @@ export const asserts: Asserts = {
   nonEmpty: (
     value: string | undefined | null,
     condition: boolean = true,
-    baseLocation: Location
+    baseLocation: Location,
   ) => {
     const isEmpty = typeof value === 'undefined' || value === null || value === '';
     return { isValid: condition ? !isEmpty : isEmpty, location: baseLocation };

--- a/packages/core/src/rules/common/assertions/utils.ts
+++ b/packages/core/src/rules/common/assertions/utils.ts
@@ -23,7 +23,7 @@ export type AssertToApply = {
 export function buildVisitorObject(
   subject: string,
   context: Record<string, any>[],
-  subjectVisitor: any
+  subjectVisitor: any,
 ) {
   if (!context) {
     return { [subject]: subjectVisitor };
@@ -46,7 +46,7 @@ export function buildVisitorObject(
 
     if (matchParentKeys && excludeParentKeys) {
       throw new Error(
-        `Both 'matchParentKeys' and 'excludeParentKeys' can't be under one context item`
+        `Both 'matchParentKeys' and 'excludeParentKeys' can't be under one context item`,
       );
     }
 
@@ -75,11 +75,11 @@ export function buildVisitorObject(
 export function buildSubjectVisitor(
   properties: string | string[],
   asserts: AssertToApply[],
-  context?: Record<string, any>[]
+  context?: Record<string, any>[],
 ) {
   return (
     node: any,
-    { report, location, rawLocation, key, type, resolve, rawNode }: UserContext
+    { report, location, rawLocation, key, type, resolve, rawNode }: UserContext,
   ) => {
     // We need to check context's last node if it has the same type as subject node;
     // if yes - that means we didn't create context's last node visitor,

--- a/packages/core/src/rules/common/info-license.ts
+++ b/packages/core/src/rules/common/info-license.ts
@@ -7,7 +7,7 @@ export const InfoLicense: Oas3Rule | Oas2Rule = () => {
       if (!info.license) {
         report({
           message: missingRequiredField('Info', 'license'),
-          location: { reportOnKey: true }
+          location: { reportOnKey: true },
         });
       }
     },

--- a/packages/core/src/rules/common/no-enum-type-mismatch.ts
+++ b/packages/core/src/rules/common/no-enum-type-mismatch.ts
@@ -23,26 +23,29 @@ export const NoEnumTypeMismatch: Oas3Rule | Oas2Rule = () => {
       }
 
       if (schema.enum && schema.type && Array.isArray(schema.type)) {
-        const mismatchedResults: { [key: string]: string[]; } = {};
+        const mismatchedResults: { [key: string]: string[] } = {};
         for (const enumValue of schema.enum) {
           mismatchedResults[enumValue] = [];
 
           for (const type of schema.type) {
-            const valid = matchesJsonSchemaType(enumValue, type as string, schema.nullable as boolean);
-            if (!valid)
-              mismatchedResults[enumValue].push(type);
+            const valid = matchesJsonSchemaType(
+              enumValue,
+              type as string,
+              schema.nullable as boolean,
+            );
+            if (!valid) mismatchedResults[enumValue].push(type);
           }
 
-          if(mismatchedResults[enumValue].length !== schema.type.length)
+          if (mismatchedResults[enumValue].length !== schema.type.length)
             delete mismatchedResults[enumValue];
-        };
+        }
 
         for (const mismatchedKey of Object.keys(mismatchedResults)) {
           report({
             message: `Enum value \`${mismatchedKey}\` must be of one type. Allowed types: \`${schema.type}\`.`,
             location: location.child(['enum', schema.enum.indexOf(mismatchedKey)]),
           });
-        };
+        }
       }
     },
   };

--- a/packages/core/src/rules/common/operation-operationId.ts
+++ b/packages/core/src/rules/common/operation-operationId.ts
@@ -12,6 +12,6 @@ export const OperationOperationId: Oas3Rule | Oas2Rule = () => {
           validateDefinedAndNonEmpty('operationId', operation, ctx);
         },
       },
-    }
+    },
   };
 };

--- a/packages/core/src/rules/common/path-not-include-query.ts
+++ b/packages/core/src/rules/common/path-not-include-query.ts
@@ -12,6 +12,6 @@ export const PathNotIncludeQuery: Oas3Rule | Oas2Rule = () => {
           });
         }
       },
-    }
+    },
   };
 };

--- a/packages/core/src/rules/common/paths-kebab-case.ts
+++ b/packages/core/src/rules/common/paths-kebab-case.ts
@@ -4,7 +4,10 @@ import { UserContext } from '../../walk';
 export const PathsKebabCase: Oas3Rule | Oas2Rule = () => {
   return {
     PathItem(_path: object, { report, key }: UserContext) {
-      const segments = (key as string).substr(1).split('/').filter(s => s !== ''); // filter out empty segments
+      const segments = (key as string)
+        .substr(1)
+        .split('/')
+        .filter((s) => s !== ''); // filter out empty segments
       if (!segments.every((segment) => /^{.+}$/.test(segment) || /^[a-z0-9-.]+$/.test(segment))) {
         report({
           message: `\`${key}\` does not use kebab-case.`,

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -6,7 +6,7 @@ import { isPlainObject } from '../../utils';
 
 export const OasSpec: Oas3Rule | Oas2Rule = () => {
   return {
-    any(node: any, { report, type, location, key, resolve, ignoreNextVisitorsOnNode } ) {
+    any(node: any, { report, type, location, key, resolve, ignoreNextVisitorsOnNode }) {
       const nodeType = oasTypeOf(node);
 
       if (type.items) {
@@ -40,15 +40,16 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
       const allowed = type.allowed?.(node);
       if (allowed && isPlainObject(node)) {
         for (const propName in node) {
-          if (allowed.includes(propName) ||
-           (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
-           !Object.keys(type.properties).includes(propName)
+          if (
+            allowed.includes(propName) ||
+            (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
+            !Object.keys(type.properties).includes(propName)
           ) {
             continue;
           }
           report({
             message: `The field \`${propName}\` is not allowed here.`,
-            location: location.child([propName]).key()
+            location: location.child([propName]).key(),
           });
         }
       }
@@ -63,7 +64,9 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
         }
         if (!hasProperty)
           report({
-            message: `Must contain at least one of the following fields: ${type.requiredOneOf?.join(', ')}.`,
+            message: `Must contain at least one of the following fields: ${type.requiredOneOf?.join(
+              ', ',
+            )}.`,
             location: [{ reportOnKey: true }],
           });
       }
@@ -134,7 +137,7 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
             report({
               message: `The value of the ${propName} field must be greater than or equal to ${propSchema.minimum}`,
               location: location.child([propName]),
-            })
+            });
           }
         }
       }

--- a/packages/core/src/rules/oas2/__tests__/spec/referenceableScalars.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/spec/referenceableScalars.test.ts
@@ -1,5 +1,9 @@
 import { outdent } from 'outdent';
-import { parseYamlToDocument, replaceSourceWithRef, makeConfig } from '../../../../../__tests__/utils';
+import {
+  parseYamlToDocument,
+  replaceSourceWithRef,
+  makeConfig,
+} from '../../../../../__tests__/utils';
 import { lintDocument } from '../../../../lint';
 import { BaseResolver } from '../../../../resolve';
 

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -57,7 +57,7 @@ export const rules = {
   'no-path-trailing-slash': NoPathTrailingSlash as Oas2Rule,
   'operation-2xx-response': Operation2xxResponse as Oas2Rule,
   'operation-4xx-response': Operation4xxResponse as Oas2Rule,
-  'assertions': Assertions as Oas2Rule,
+  assertions: Assertions as Oas2Rule,
   'operation-operationId-unique': OperationIdUnique as Oas2Rule,
   'operation-parameters-unique': OperationParametersUnique as Oas2Rule,
   'path-parameters-defined': PathParamsDefined as Oas2Rule,

--- a/packages/core/src/rules/oas2/remove-unused-components.ts
+++ b/packages/core/src/rules/oas2/remove-unused-components.ts
@@ -4,9 +4,16 @@ import { Oas2Components } from '../../typings/swagger';
 import { isEmptyObject } from '../../utils';
 
 export const RemoveUnusedComponents: Oas2Rule = () => {
-  let components = new Map<string, { used: boolean; componentType?: keyof Oas2Components; name: string }>();
+  let components = new Map<
+    string,
+    { used: boolean; componentType?: keyof Oas2Components; name: string }
+  >();
 
-  function registerComponent(location: Location, componentType: keyof Oas2Components, name: string): void {
+  function registerComponent(
+    location: Location,
+    componentType: keyof Oas2Components,
+    name: string,
+  ): void {
     components.set(location.absolutePointer, {
       used: components.get(location.absolutePointer)?.used || false,
       componentType,
@@ -17,9 +24,7 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
   return {
     ref: {
       leave(ref, { type, resolve, key }) {
-        if (
-          ['Schema', 'Parameter', 'Response', 'SecurityScheme'].includes(type.name)
-        ) {
+        if (['Schema', 'Parameter', 'Response', 'SecurityScheme'].includes(type.name)) {
           const resolvedRef = resolve(ref);
           if (!resolvedRef.location) return;
           components.set(resolvedRef.location.absolutePointer, {
@@ -27,7 +32,7 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
             name: key.toString(),
           });
         }
-      }
+      },
     },
     DefinitionRoot: {
       leave(root, ctx) {
@@ -35,7 +40,7 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
         data.removedCount = 0;
 
         let rootComponents = new Set<keyof Oas2Components>();
-        components.forEach(usageInfo => {
+        components.forEach((usageInfo) => {
           const { used, name, componentType } = usageInfo;
           if (!used && componentType) {
             rootComponents.add(componentType);
@@ -71,6 +76,6 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
       SecurityScheme(_securityScheme, { location, key }) {
         registerComponent(location, 'securityDefinitions', key.toString());
       },
-    }
+    },
   };
 };

--- a/packages/core/src/rules/oas3/__tests__/no-empty-enum-servers.com.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-empty-enum-servers.com.test.ts
@@ -18,7 +18,7 @@ describe('Oas3 as3-no-servers-empty-enum', () => {
                 enum: []
                 default: a
         components: {}
-      `
+      `,
     );
 
     const results = await lintDocument({
@@ -72,7 +72,7 @@ describe('Oas3 as3-no-servers-empty-enum', () => {
               var:
                 enum: []
         components: {}
-      `
+      `,
     );
 
     const results = await lintDocument({
@@ -111,7 +111,7 @@ describe('Oas3 as3-no-servers-empty-enum', () => {
           - url: https://example.com/{var}
             variables: {}
         components: {}
-      `
+      `,
     );
 
     const results = await lintDocument({
@@ -135,7 +135,7 @@ describe('Oas3 as3-no-servers-empty-enum', () => {
             variables:
               var: {}
         components: {}
-      `
+      `,
     );
 
     const results = await lintDocument({
@@ -162,7 +162,7 @@ describe('Oas3 as3-no-servers-empty-enum', () => {
                   - a
                 default: a
         components: {}
-      `
+      `,
     );
 
     const results = await lintDocument({
@@ -191,7 +191,7 @@ describe('Oas3 as3-no-servers-empty-enum', () => {
                   - null
                 default: 'some string'
         components: {}
-      `
+      `,
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -57,7 +57,7 @@ export const rules = {
   'info-license-url': InfoLicenseUrl,
   'operation-2xx-response': Operation2xxResponse,
   'operation-4xx-response': Operation4xxResponse,
-  'assertions': Assertions,
+  assertions: Assertions,
   'operation-operationId-unique': OperationIdUnique,
   'operation-parameters-unique': OperationParametersUnique,
   'path-parameters-defined': PathParamsDefined,

--- a/packages/core/src/rules/oas3/no-empty-servers.ts
+++ b/packages/core/src/rules/oas3/no-empty-servers.ts
@@ -6,7 +6,7 @@ export const NoEmptyServers: Oas3Rule = () => {
       if (!root.hasOwnProperty('servers')) {
         report({
           message: 'Servers must be present.',
-          location: location.child(['openapi']).key()
+          location: location.child(['openapi']).key(),
         });
         return;
       }

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -13,14 +13,22 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
         const { location, resolve } = ctx;
         if (!mediaType.schema) return;
         if (mediaType.example) {
-         resolveAndValidateExample(mediaType.example, location.child('example'));
+          resolveAndValidateExample(mediaType.example, location.child('example'));
         } else if (mediaType.examples) {
           for (const exampleName of Object.keys(mediaType.examples)) {
-            resolveAndValidateExample(mediaType.examples[exampleName], location.child(['examples', exampleName, 'value']), true);
+            resolveAndValidateExample(
+              mediaType.examples[exampleName],
+              location.child(['examples', exampleName, 'value']),
+              true,
+            );
           }
         }
 
-        function resolveAndValidateExample(example: Oas3Example | any, location: Location, isMultiple?: boolean) {
+        function resolveAndValidateExample(
+          example: Oas3Example | any,
+          location: Location,
+          isMultiple?: boolean,
+        ) {
           if (isRef(example)) {
             const resolved = resolve<Oas3Example>(example);
             if (!resolved.location) return;

--- a/packages/core/src/rules/oas3/no-servers-empty-enum.ts
+++ b/packages/core/src/rules/oas3/no-servers-empty-enum.ts
@@ -25,16 +25,17 @@ export const NoEmptyEnumServers: Oas3Rule = () => {
         invalidVariables.push(...enumErrors);
       }
 
-      for(const invalidVariable of invalidVariables) {
-        if(invalidVariable === enumError.empty) {
+      for (const invalidVariable of invalidVariables) {
+        if (invalidVariable === enumError.empty) {
           report({
             message: 'Server variable with `enum` must be a non-empty array.',
             location: location.child(['servers']).key(),
           });
         }
-        if(invalidVariable === enumError.invalidDefaultValue) {
+        if (invalidVariable === enumError.invalidDefaultValue) {
           report({
-            message: 'Server variable define `enum` and `default`. `enum` must include default value',
+            message:
+              'Server variable define `enum` and `default`. `enum` must include default value',
             location: location.child(['servers']).key(),
           });
         }
@@ -43,20 +44,18 @@ export const NoEmptyEnumServers: Oas3Rule = () => {
   };
 };
 
-function checkEnumVariables(server: Oas3Server): enumError[] | undefined{
-  if (server.variables && Object.keys(server.variables).length === 0)
-    return;
+function checkEnumVariables(server: Oas3Server): enumError[] | undefined {
+  if (server.variables && Object.keys(server.variables).length === 0) return;
 
   const errors: enumError[] = [];
-  for(var variable in server.variables) {
+  for (var variable in server.variables) {
     const serverVariable = server.variables[variable];
     if (!serverVariable.enum) continue;
 
     if (Array.isArray(serverVariable.enum) && serverVariable.enum?.length === 0)
       errors.push(enumError.empty);
 
-    if (!serverVariable.default)
-      continue;
+    if (!serverVariable.default) continue;
 
     const defaultValue = server.variables[variable].default;
     if (serverVariable.enum && !serverVariable.enum.includes(defaultValue))

--- a/packages/core/src/rules/oas3/remove-unused-components.ts
+++ b/packages/core/src/rules/oas3/remove-unused-components.ts
@@ -1,12 +1,19 @@
 import { Oas3Rule } from '../../visitors';
 import { Location } from '../../ref-utils';
-import { Oas3Components } from '../../typings/openapi'
+import { Oas3Components } from '../../typings/openapi';
 import { isEmptyObject } from '../../utils';
 
 export const RemoveUnusedComponents: Oas3Rule = () => {
-  let components = new Map<string, { used: boolean; componentType?: keyof Oas3Components; name: string }>();
+  let components = new Map<
+    string,
+    { used: boolean; componentType?: keyof Oas3Components; name: string }
+  >();
 
-  function registerComponent(location: Location, componentType: keyof Oas3Components, name: string): void {
+  function registerComponent(
+    location: Location,
+    componentType: keyof Oas3Components,
+    name: string,
+  ): void {
     components.set(location.absolutePointer, {
       used: components.get(location.absolutePointer)?.used || false,
       componentType,
@@ -18,7 +25,9 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
     ref: {
       leave(ref, { type, resolve, key }) {
         if (
-          ['Schema', 'Header', 'Parameter', 'Response', 'Example', 'RequestBody'].includes(type.name)
+          ['Schema', 'Header', 'Parameter', 'Response', 'Example', 'RequestBody'].includes(
+            type.name,
+          )
         ) {
           const resolvedRef = resolve(ref);
           if (!resolvedRef.location) return;
@@ -27,14 +36,14 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
             name: key.toString(),
           });
         }
-      }
+      },
     },
     DefinitionRoot: {
       leave(root, ctx) {
         const data = ctx.getVisitorData() as { removedCount: number };
         data.removedCount = 0;
 
-        components.forEach(usageInfo => {
+        components.forEach((usageInfo) => {
           const { used, componentType, name } = usageInfo;
           if (!used && componentType) {
             let componentChild = root.components![componentType];
@@ -45,7 +54,9 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
             }
           }
         });
-        if (isEmptyObject(root.components)) { delete root.components; }
+        if (isEmptyObject(root.components)) {
+          delete root.components;
+        }
       },
     },
     NamedSchemas: {

--- a/packages/core/src/rules/other/stats.ts
+++ b/packages/core/src/rules/other/stats.ts
@@ -4,10 +4,26 @@ import { StatsAccumulator } from '../../typings/common';
 
 export const Stats = (statsAccumulator: StatsAccumulator) => {
   return {
-    ExternalDocs: { leave() { statsAccumulator.externalDocs.total++; }},
-    ref: { enter(ref: OasRef) { statsAccumulator.refs.items!.add(ref['$ref']); }},
-    Tag: { leave(tag: Oas3Tag) { statsAccumulator.tags.items!.add(tag.name); }},
-    Link: { leave(link: any) { statsAccumulator.links.items!.add(link.operationId); }},
+    ExternalDocs: {
+      leave() {
+        statsAccumulator.externalDocs.total++;
+      },
+    },
+    ref: {
+      enter(ref: OasRef) {
+        statsAccumulator.refs.items!.add(ref['$ref']);
+      },
+    },
+    Tag: {
+      leave(tag: Oas3Tag) {
+        statsAccumulator.tags.items!.add(tag.name);
+      },
+    },
+    Link: {
+      leave(link: any) {
+        statsAccumulator.links.items!.add(link.operationId);
+      },
+    },
     DefinitionRoot: {
       leave() {
         statsAccumulator.parameters.total = statsAccumulator.parameters.items!.size;
@@ -19,26 +35,39 @@ export const Stats = (statsAccumulator: StatsAccumulator) => {
     WebhooksMap: {
       Operation: {
         leave(operation: any) {
-          operation.tags.forEach((tag: string) => { statsAccumulator.tags.items!.add(tag); })
-        }
-      }
+          operation.tags.forEach((tag: string) => {
+            statsAccumulator.tags.items!.add(tag);
+          });
+        },
+      },
     },
     PathMap: {
       PathItem: {
-        leave() { statsAccumulator.pathItems.total++; },
+        leave() {
+          statsAccumulator.pathItems.total++;
+        },
         Operation: {
           leave(operation: any) {
             statsAccumulator.operations.total++;
-            operation.tags && operation.tags.forEach((tag: string) => { statsAccumulator.tags.items!.add(tag); })
-          }
+            operation.tags &&
+              operation.tags.forEach((tag: string) => {
+                statsAccumulator.tags.items!.add(tag);
+              });
+          },
         },
-        Parameter: { leave(parameter: Oas2Parameter | Oas3Parameter) {
-          statsAccumulator.parameters.items!.add(parameter.name)
-        }},
+        Parameter: {
+          leave(parameter: Oas2Parameter | Oas3Parameter) {
+            statsAccumulator.parameters.items!.add(parameter.name);
+          },
+        },
       },
     },
     NamedSchemas: {
-      Schema: { leave() { statsAccumulator.schemas.total++; }}
-    }
-  }
-}
+      Schema: {
+        leave() {
+          statsAccumulator.schemas.total++;
+        },
+      },
+    },
+  };
+};

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -24,7 +24,7 @@ export type NodeType = {
   items?: string;
   required?: string[] | ((value: any, key: string | number | undefined) => string[]);
   requiredOneOf?: string[];
-  allowed?: ((value: any) => string[] | undefined);
+  allowed?: (value: any) => string[] | undefined;
   extensionsPrefix?: string;
 };
 type PropType = string | NodeType | ScalarSchema | undefined | null;
@@ -37,7 +37,7 @@ export type NormalizedNodeType = {
   items?: NormalizedNodeType;
   required?: string[] | ((value: any, key: string | number | undefined) => string[]);
   requiredOneOf?: string[];
-  allowed?: ((value: any) => string[] | undefined);
+  allowed?: (value: any) => string[] | undefined;
   extensionsPrefix?: string;
 };
 

--- a/packages/core/src/typings/common.ts
+++ b/packages/core/src/typings/common.ts
@@ -5,5 +5,13 @@ export interface StatsRow {
   items?: Set<string>;
 }
 
-export type StatsName = 'operations' | 'refs' | 'tags' | 'externalDocs' | 'pathItems' | 'links' | 'schemas' | 'parameters';
+export type StatsName =
+  | 'operations'
+  | 'refs'
+  | 'tags'
+  | 'externalDocs'
+  | 'pathItems'
+  | 'links'
+  | 'schemas'
+  | 'parameters';
 export type StatsAccumulator = Record<StatsName, StatsRow>;

--- a/packages/core/src/typings/openapi.ts
+++ b/packages/core/src/typings/openapi.ts
@@ -156,7 +156,7 @@ export interface Oas3Schema {
 export type Oas3_1Schema = Oas3Schema & {
   type?: string | string[];
   examples?: any[];
-}
+};
 
 export interface Oas3_1Definition extends Oas3Definition {
   webhooks?: Oas3_1Webhooks;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -78,16 +78,16 @@ function match(url: string, pattern: string) {
 
 export function pickObjectProps<T extends Record<string, unknown>>(
   object: T,
-  keys: Array<string>
+  keys: Array<string>,
 ): T {
   return Object.fromEntries(
-    keys.filter((key: string) => key in object).map((key: string) => [key, object[key]])
+    keys.filter((key: string) => key in object).map((key: string) => [key, object[key]]),
   ) as T;
 }
 
 export function omitObjectProps<T extends Record<string, unknown>>(
   object: T,
-  keys: Array<string>
+  keys: Array<string>,
 ): T {
   return Object.fromEntries(Object.entries(object).filter(([key]) => !keys.includes(key))) as T;
 }
@@ -107,7 +107,7 @@ export function splitCamelCaseIntoWords(str: string) {
 export function validateMimeType(
   { type, value }: any,
   { report, location }: UserContext,
-  allowedValues: string[]
+  allowedValues: string[],
 ) {
   const ruleType = type === 'consumes' ? 'request' : 'response';
   if (!allowedValues)
@@ -127,7 +127,7 @@ export function validateMimeType(
 export function validateMimeTypeOAS3(
   { type, value }: any,
   { report, location }: UserContext,
-  allowedValues: string[]
+  allowedValues: string[],
 ) {
   const ruleType = type === 'consumes' ? 'request' : 'response';
   if (!allowedValues)

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -125,7 +125,7 @@ export function walkDocument<T>(opts: {
     type: NormalizedNodeType,
     location: Location,
     parent: any,
-    key: string | number
+    key: string | number,
   ) {
     const resolve: ResolveFn = (ref, from = currentLocation.source.absoluteRef) => {
       if (!isRef(ref)) return { location, node: ref };
@@ -174,7 +174,7 @@ export function walkDocument<T>(opts: {
               oasVersion: ctx.oasVersion,
               getVisitorData: getVisitorDataFn.bind(undefined, ruleId),
             },
-            { node: resolvedNode, location: resolvedLocation, error }
+            { node: resolvedNode, location: resolvedLocation, error },
           );
           if (resolvedLocation?.source.absoluteRef && ctx.refTypes) {
             ctx.refTypes.set(resolvedLocation?.source.absoluteRef, type);
@@ -190,7 +190,7 @@ export function walkDocument<T>(opts: {
 
       const anyEnterVisitors = normalizedVisitors.any.enter;
       const currentEnterVisitors = anyEnterVisitors.concat(
-        normalizedVisitors[type.name]?.enter || []
+        normalizedVisitors[type.name]?.enter || [],
       );
 
       const activatedContexts: Array<VisitorSkippedLevelContext | VisitorLevelContext> = [];
@@ -233,7 +233,7 @@ export function walkDocument<T>(opts: {
             while (ctx) {
               ctx.activatedOn!.value.nextLevelTypeActivated = pushStack(
                 ctx.activatedOn!.value.nextLevelTypeActivated,
-                type
+                type,
               );
               ctx = ctx.parent;
             }
@@ -247,7 +247,7 @@ export function walkDocument<T>(opts: {
                 node,
                 context,
                 ruleId,
-                severity
+                severity,
               );
               if (ignoreNextVisitorsOnNode) break;
             }
@@ -311,7 +311,7 @@ export function walkDocument<T>(opts: {
 
       const anyLeaveVisitors = normalizedVisitors.any.leave;
       const currentLeaveVisitors = (normalizedVisitors[type.name]?.leave || []).concat(
-        anyLeaveVisitors
+        anyLeaveVisitors,
       );
 
       for (const context of activatedContexts.reverse()) {
@@ -323,7 +323,7 @@ export function walkDocument<T>(opts: {
             let ctx: VisitorLevelContext | null = context.parent;
             while (ctx) {
               ctx.activatedOn!.value.nextLevelTypeActivated = popStack(
-                ctx.activatedOn!.value.nextLevelTypeActivated
+                ctx.activatedOn!.value.nextLevelTypeActivated,
               );
               ctx = ctx.parent;
             }
@@ -360,7 +360,7 @@ export function walkDocument<T>(opts: {
               oasVersion: ctx.oasVersion,
               getVisitorData: getVisitorDataFn.bind(undefined, ruleId),
             },
-            { node: resolvedNode, location: resolvedLocation, error }
+            { node: resolvedNode, location: resolvedLocation, error },
           );
         }
       }
@@ -373,7 +373,7 @@ export function walkDocument<T>(opts: {
       node: any,
       context: VisitorLevelContext,
       ruleId: string,
-      severity: ProblemSeverity
+      severity: ProblemSeverity,
     ) {
       const report = reportFn.bind(undefined, ruleId, severity);
       let ignoreNextVisitorsOnNode = false;
@@ -397,7 +397,7 @@ export function walkDocument<T>(opts: {
           getVisitorData: getVisitorDataFn.bind(undefined, ruleId),
         },
         collectParents(context),
-        context
+        context,
       );
       return { ignoreNextVisitorsOnNode };
     }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -43,9 +43,7 @@ module.exports = {
     __dirname: false,
   },
 
-  plugins: [
-    new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true }),
-  ],
+  plugins: [new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true })],
 
   optimization: {
     splitChunks: {


### PR DESCRIPTION
## What/Why/How?

I ran `npm run prettier` before I opened my pull request #786, but I realized I could not commit the prettier changes to that PR because there are so many changes to so many files. I also noticed that we use a lot of trailing commas which were adjusted by prettier. 

I adjusted the prettier config to have `all` for trailing commas. I'm not sure if that is correct or not, but either way, shouldn't we:

- run prettier and commit, such as I've done in this PR
- add a GitHub action to run prettier with the check flag: https://prettier.io/docs/en/cli.html#--check to prevent deviations so we don't end up with such a big difference?

## Check yourself

- [x] Code is linted

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
