### PR TITLE
chore: run prettier with trailing comma default

### DIFF
--- a/__tests__/bundle/bundle-lint-format/emptyFormatValue-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/emptyFormatValue-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`] = `
+exports[
+  `E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`
+] = `
 
 [1] openapi.yaml:20:11 at #/paths/~1my_post/post/requestBody/content/application~1json
 

--- a/__tests__/bundle/bundle-lint-format/noFormatParameter-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/noFormatParameter-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`] = `
+exports[
+  `E2E bundle lint format bundle lint: no format parameter or empty value should be formatted as codeframe 1`
+] = `
 
 [1] openapi.yaml:20:11 at #/paths/~1my_post/post/requestBody/content/application~1json
 

--- a/__tests__/bundle/bundle-remove-unused-components/oas2/remove-unused-components-snapshot.js
+++ b/__tests__/bundle/bundle-remove-unused-components/oas2/remove-unused-components-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle with option: remove-unused-components oas2: should remove unused components 1`] = `
+exports[
+  `E2E bundle with option: remove-unused-components oas2: should remove unused components 1`
+] = `
 swagger: '2.0'
 host: api.instagram.com
 paths:

--- a/__tests__/bundle/bundle-remove-unused-components/oas3/remove-unused-components-snapshot.js
+++ b/__tests__/bundle/bundle-remove-unused-components/oas3/remove-unused-components-snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle with option: remove-unused-components oas3: should remove unused components 1`] = `
+exports[
+  `E2E bundle with option: remove-unused-components oas3: should remove unused components 1`
+] = `
 openapi: 3.1.0
 paths:
   /store/order:

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, statSync, existsSync } from 'fs';
 import { join, relative } from 'path';
 //@ts-ignore
 import { toMatchSpecificSnapshot } from './specific-snapshot';
-import { getCommandOutput, getEntrypoints, callSerializer ,getParams } from './helpers';
+import { getCommandOutput, getEntrypoints, callSerializer, getParams } from './helpers';
 
 expect.extend({
   toMatchExtendedSpecificSnapshot(received, snapshotFile) {
@@ -21,7 +21,7 @@ describe('E2E', () => {
       if (statSync(testPath).isFile()) continue;
       if (!existsSync(join(testPath, '.redocly.yaml'))) continue;
 
-      const args = getParams('../../../packages/cli/src/index.ts','lint');
+      const args = getParams('../../../packages/cli/src/index.ts', 'lint');
 
       it(file, () => {
         const result = getCommandOutput(args, testPath);
@@ -50,7 +50,7 @@ describe('E2E', () => {
       const relativeValidOpenapiFile = relative(folderPath, validOpenapiFile);
       const args = [relativeValidOpenapiFile, ...(option ? [`--lint-config=${option}`] : [])];
 
-      const passedArgs = getParams('../../../packages/cli/src/index.ts','lint', args);
+      const passedArgs = getParams('../../../packages/cli/src/index.ts', 'lint', args);
 
       const result = getCommandOutput(passedArgs, folderPath);
       (expect(result) as any).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
@@ -60,7 +60,7 @@ describe('E2E', () => {
       const folderPath = join(__dirname, 'lint-config/invalid-definition-and-config');
       const relativeInvalidOpenapiFile = relative(folderPath, invalidOpenapiFile);
       const args = [relativeInvalidOpenapiFile, `--lint-config=error`];
-      const passedArgs = getParams('../../../packages/cli/src/index.ts','lint', args);
+      const passedArgs = getParams('../../../packages/cli/src/index.ts', 'lint', args);
 
       const result = getCommandOutput(passedArgs, folderPath);
 
@@ -72,7 +72,9 @@ describe('E2E', () => {
     test('without option: outDir', () => {
       const folderPath = join(__dirname, `split/missing-outDir`);
 
-      const args = getParams('../../../packages/cli/src/index.ts','split', ['../../../__tests__/split/test-split/spec.json']);
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
+        '../../../__tests__/split/test-split/spec.json',
+      ]);
 
       const result = getCommandOutput(args, folderPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
@@ -81,7 +83,7 @@ describe('E2E', () => {
     test('swagger', () => {
       const folderPath = join(__dirname, `split/oas2`);
 
-      const args = getParams('../../../packages/cli/src/index.ts','split', [
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
         '../../../__tests__/split/oas2/openapi.yaml',
         '--outDir=output',
       ]);
@@ -94,7 +96,10 @@ describe('E2E', () => {
       const folderPath = join(__dirname, `split/oas3-no-errors`);
       const file = '../../../__tests__/split/oas3-no-errors/openapi.yaml';
 
-      const args = getParams('../../../packages/cli/src/index.ts','split', [file, '--outDir=output']);
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
+        file,
+        '--outDir=output',
+      ]);
 
       const result = getCommandOutput(args, folderPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
@@ -111,12 +116,12 @@ describe('E2E', () => {
         'reference-in-description',
         'two-files-with-no-errors',
         'fails-if-component-conflicts',
-        'multiple-tags-in-same-files'
+        'multiple-tags-in-same-files',
       ];
 
       test.each(testDirNames)('test: %s', (dir) => {
         const testPath = join(__dirname, `join/${dir}`);
-        const args = getParams('../../../packages/cli/src/index.ts','join', entrypoints);
+        const args = getParams('../../../packages/cli/src/index.ts', 'join', entrypoints);
         const result = getCommandOutput(args, testPath);
         (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
       });
@@ -133,7 +138,7 @@ describe('E2E', () => {
       test.each(options)('test with option: %s', (option) => {
         const testPath = join(__dirname, `join/${option.name}`);
         const argsWithOptions = [...entrypoints, ...[`--${option.name}=${option.value}`]];
-        const args = getParams('../../../packages/cli/src/index.ts','join', argsWithOptions);
+        const args = getParams('../../../packages/cli/src/index.ts', 'join', argsWithOptions);
         const result = getCommandOutput(args, testPath);
         (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
       });
@@ -153,7 +158,7 @@ describe('E2E', () => {
 
       const entryPoints = getEntrypoints(testPath);
 
-      const args = getParams('../../../packages/cli/src/index.ts','bundle', [
+      const args = getParams('../../../packages/cli/src/index.ts', 'bundle', [
         '--lint',
         '--max-problems=1',
         '--format=stylish',
@@ -170,7 +175,7 @@ describe('E2E', () => {
   describe('bundle lint format', () => {
     const folderPath = join(__dirname, 'bundle/bundle-lint-format');
     const entryPoints = getEntrypoints(folderPath);
-    const args = getParams('../../../packages/cli/src/index.ts','bundle', [
+    const args = getParams('../../../packages/cli/src/index.ts', 'bundle', [
       '--lint',
       '--max-problems=1',
       '-o=/tmp/null',
@@ -183,9 +188,9 @@ describe('E2E', () => {
         const params = [...args, `--format=${format}`];
         const result = getCommandOutput(params, folderPath);
         (<any>expect(result)).toMatchSpecificSnapshot(
-          join(folderPath, `${format}-format-snapshot.js`),
+          join(folderPath, `${format}-format-snapshot.js`)
         );
-      },
+      }
     );
 
     test.each(['noFormatParameter', 'emptyFormatValue'])(
@@ -195,7 +200,7 @@ describe('E2E', () => {
         const params = [...args, ...formatArgument];
         const result = getCommandOutput(params, folderPath);
         (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, `${format}-snapshot.js`));
-      },
+      }
     );
   });
 
@@ -211,7 +216,7 @@ describe('E2E', () => {
       ];
       const result = getCommandOutput(args, folderPath);
       (<any>expect(result)).toMatchSpecificSnapshot(
-        join(folderPath, 'remove-unused-components-snapshot.js'),
+        join(folderPath, 'remove-unused-components-snapshot.js')
       );
     });
   });

--- a/__tests__/join/prefix-components-with-info-prop/snapshot.js
+++ b/__tests__/join/prefix-components-with-info-prop/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'prefix-components-with-info-prop', value: 'title' } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'prefix-components-with-info-prop', value: 'title' } 1`
+] = `
 
 openapi: 3.0.0
 info:

--- a/__tests__/join/prefix-tags-with-filename/snapshot.js
+++ b/__tests__/join/prefix-tags-with-filename/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'prefix-tags-with-filename', value: true } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'prefix-tags-with-filename', value: true } 1`
+] = `
 
 openapi: 3.0.0
 info:

--- a/__tests__/join/prefix-tags-with-info-prop/snapshot.js
+++ b/__tests__/join/prefix-tags-with-info-prop/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'prefix-tags-with-info-prop', value: 'title' } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'prefix-tags-with-info-prop', value: 'title' } 1`
+] = `
 
 openapi: 3.0.0
 info:

--- a/__tests__/join/without-x-tag-groups/snapshot.js
+++ b/__tests__/join/without-x-tag-groups/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E join with options test with option: { name: 'without-x-tag-groups', value: true } 1`] = `
+exports[
+  `E2E join with options test with option: { name: 'without-x-tag-groups', value: true } 1`
+] = `
 
 
 warning: 1 conflict(s) on the \`Pet\` tags description.

--- a/__tests__/lint-config/invalid-config--lint-config-error/snapshot.js
+++ b/__tests__/lint-config/invalid-config--lint-config-error/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--lint-config-error', option: 'error' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--lint-config-error', option: 'error' } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/context
 

--- a/__tests__/lint-config/invalid-config--lint-config-off/snapshot.js
+++ b/__tests__/lint-config/invalid-config--lint-config-off/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--lint-config-off', option: 'off' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--lint-config-off', option: 'off' } 1`
+] = `
 
 No configurations were defined in extends -- using built in recommended configuration by default.
 Warning! This default behavior is going to be deprecated soon.

--- a/__tests__/lint-config/invalid-config--lint-config-warn/snapshot.js
+++ b/__tests__/lint-config/invalid-config--lint-config-warn/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--lint-config-warn', option: 'warn' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--lint-config-warn', option: 'warn' } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/context
 

--- a/__tests__/lint-config/invalid-config--no-option/snapshot.js
+++ b/__tests__/lint-config/invalid-config--no-option/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config--no-option', option: null } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config--no-option', option: null } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/context
 

--- a/__tests__/lint-config/invalid-config-assertation-config-type/snapshot.js
+++ b/__tests__/lint-config/invalid-config-assertation-config-type/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config-assertation-config-type', option: 'error' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config-assertation-config-type', option: 'error' } 1`
+] = `
 
 [1] .redocly.yaml:8:17 at #/lint/rules/assert~1path-item-mutually-required/context/0/type
 

--- a/__tests__/lint-config/invalid-config-assertation-name/snapshot.js
+++ b/__tests__/lint-config/invalid-config-assertation-name/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invalid-config-assertation-name', option: 'error' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invalid-config-assertation-name', option: 'error' } 1`
+] = `
 
 [1] .redocly.yaml:6:5 at #/lint/rules/asset~1path-item-mutually-required
 

--- a/__tests__/lint-config/invlid-lint-config-saverity/snapshot.js
+++ b/__tests__/lint-config/invlid-lint-config-saverity/snapshot.js
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E lint-config test with option: { dirName: 'invlid-lint-config-saverity', option: 'something' } 1`] = `
+exports[
+  `E2E lint-config test with option: { dirName: 'invlid-lint-config-saverity', option: 'something' } 1`
+] = `
 
 index.ts lint [entrypoints...]
 

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require("../lib/index");
+require('../lib/index');

--- a/packages/cli/src/__mocks__/perf_hooks.ts
+++ b/packages/cli/src/__mocks__/perf_hooks.ts
@@ -1,3 +1,3 @@
 export const performance = {
-    now: jest.fn()
-}
+  now: jest.fn(),
+};

--- a/packages/cli/src/__mocks__/utils.ts
+++ b/packages/cli/src/__mocks__/utils.ts
@@ -1,4 +1,6 @@
-export const getFallbackEntryPointsOrExit = jest.fn((entrypoints) => entrypoints.map(() => ({ path: '' })));
+export const getFallbackEntryPointsOrExit = jest.fn((entrypoints) =>
+  entrypoints.map(() => ({ path: '' }))
+);
 export const dumpBundle = jest.fn(() => '');
 export const slash = jest.fn();
 export const pluralize = jest.fn();

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -6,7 +6,7 @@ import SpyInstance = jest.SpyInstance;
 jest.mock('@redocly/openapi-core');
 jest.mock('../../utils');
 
-(getMergedConfig as jest.Mock).mockImplementation(config => config)
+(getMergedConfig as jest.Mock).mockImplementation((config) => config);
 
 describe('bundle', () => {
   let processExitMock: SpyInstance;
@@ -36,7 +36,7 @@ describe('bundle', () => {
         ext: 'yaml',
         format: 'codeframe',
       },
-      '1.0.0',
+      '1.0.0'
     );
 
     expect(lint).toBeCalledTimes(0);
@@ -52,7 +52,7 @@ describe('bundle', () => {
         ext: 'yaml',
         format: 'codeframe',
       },
-      '1.0.0',
+      '1.0.0'
     );
 
     exitCb?.();
@@ -69,7 +69,7 @@ describe('bundle', () => {
         format: 'codeframe',
         lint: true,
       },
-      '1.0.0',
+      '1.0.0'
     );
 
     expect(lint).toBeCalledTimes(entrypoints.length);
@@ -86,7 +86,7 @@ describe('bundle', () => {
         format: 'codeframe',
         lint: true,
       },
-      '1.0.0',
+      '1.0.0'
     );
 
     exitCb?.();
@@ -99,7 +99,7 @@ describe('bundle', () => {
     (getTotals as jest.Mock).mockReturnValue({
       errors: 1,
       warnings: 0,
-      ignored: 0
+      ignored: 0,
     });
 
     await handleBundle(
@@ -109,12 +109,11 @@ describe('bundle', () => {
         format: 'codeframe',
         lint: true,
       },
-      '1.0.0',
+      '1.0.0'
     );
 
     expect(lint).toBeCalledTimes(entrypoints.length);
     exitCb?.();
     expect(processExitMock).toHaveBeenCalledWith(1);
   });
-
 });

--- a/packages/cli/src/__tests__/commands/join.test.ts
+++ b/packages/cli/src/__tests__/commands/join.test.ts
@@ -22,11 +22,11 @@ describe('handleJoin fails', () => {
         'without-x-tag-groups': true,
         'prefix-tags-with-filename': true,
       },
-      'cli-version',
+      'cli-version'
     );
 
     expect(exitWithError).toHaveBeenCalledWith(
-      `You use prefix-tags-with-filename, prefix-tags-with-info-prop, without-x-tag-groups together.\nPlease choose only one! \n\n`,
+      `You use prefix-tags-with-filename, prefix-tags-with-info-prop, without-x-tag-groups together.\nPlease choose only one! \n\n`
     );
   });
 
@@ -37,11 +37,11 @@ describe('handleJoin fails', () => {
         'without-x-tag-groups': true,
         'prefix-tags-with-filename': true,
       },
-      'cli-version',
+      'cli-version'
     );
 
     expect(exitWithError).toHaveBeenCalledWith(
-      `You use prefix-tags-with-filename, without-x-tag-groups together.\nPlease choose only one! \n\n`,
+      `You use prefix-tags-with-filename, without-x-tag-groups together.\nPlease choose only one! \n\n`
     );
   });
 });

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -43,7 +43,9 @@ describe('handleLint', () => {
       return process.on(_e, cb);
     });
     getMergedConfigMock.mockReturnValue(ConfigFixture);
-    (doesYamlFileExist  as jest.Mock<any, any>).mockImplementation((path) => path === 'redocly.yaml')
+    (doesYamlFileExist as jest.Mock<any, any>).mockImplementation(
+      (path) => path === 'redocly.yaml'
+    );
   });
 
   afterEach(() => {

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -32,7 +32,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
-      'public': true,
+      public: true,
       'batch-id': '123',
       'batch-size': 2,
     });
@@ -59,7 +59,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
-      'public': true,
+      public: true,
       'batch-id': ' ',
       'batch-size': 2,
     });
@@ -73,7 +73,7 @@ describe('push', () => {
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
       branchName: 'test',
-      'public': true,
+      public: true,
       'batch-id': '123',
       'batch-size': 1,
     });

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,10 +1,9 @@
 import { Totals } from '@redocly/openapi-core';
-import { isSubdir, pathToFilename, printConfigLintTotals} from '../utils';
+import { isSubdir, pathToFilename, printConfigLintTotals } from '../utils';
 import { red, yellow } from 'colorette';
 
-
 jest.mock('os');
-jest.mock('colorette')
+jest.mock('colorette');
 
 describe('isSubdir', () => {
   it('can correctly determine if subdir', () => {
@@ -41,10 +40,9 @@ describe('isSubdir', () => {
   });
 
   afterEach(() => {
-    jest.resetModules()
-  })
+    jest.resetModules();
+  });
 });
-
 
 describe('pathToFilename', () => {
   it('should use correct path separator', () => {
@@ -52,7 +50,6 @@ describe('pathToFilename', () => {
     expect(processedPath).toEqual('user_createWithList');
   });
 });
-
 
 describe('printConfigLintTotals', () => {
   const totalProblemsMock: Totals = {
@@ -79,7 +76,7 @@ describe('printConfigLintTotals', () => {
   it('should print warnign and error', () => {
     printConfigLintTotals({ ...totalProblemsMock, warnings: 2 });
     expect(process.stderr.write).toHaveBeenCalledWith(
-      '❌ Your config has 1 error and 2 warnings.\n',
+      '❌ Your config has 1 error and 2 warnings.\n'
     );
     expect(redColoretteMocks).toHaveBeenCalledWith('❌ Your config has 1 error and 2 warnings.\n');
   });

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -41,7 +41,7 @@ export async function handleBundle(
     'remove-unused-components'?: boolean;
     'keep-url-references'?: boolean;
   },
-  version: string,
+  version: string
 ) {
   const config = await loadConfig(argv.config, argv.extends);
   const removeUnusedComponents =
@@ -63,10 +63,10 @@ export async function handleBundle(
         if (config.lint.recommendedFallback) {
           process.stderr.write(
             `No configurations were defined in extends -- using built in ${blue(
-              'recommended',
+              'recommended'
             )} configuration by default.\n${red(
-              'Warning! This default behavior is going to be deprecated soon.',
-            )}\n\n`,
+              'Warning! This default behavior is going to be deprecated soon.'
+            )}\n\n`
           );
         }
         const results = await lint({
@@ -107,7 +107,7 @@ export async function handleBundle(
         path,
         entrypoints.length,
         argv.output,
-        argv.ext,
+        argv.ext
       );
 
       if (fileTotals.errors === 0 || argv.force) {
@@ -134,7 +134,7 @@ export async function handleBundle(
       if (argv.metafile) {
         if (entrypoints.length > 1) {
           process.stderr.write(
-            yellow(`[WARNING] "--metafile" cannot be used with multiple entrypoints. Skipping...`),
+            yellow(`[WARNING] "--metafile" cannot be used with multiple entrypoints. Skipping...`)
           );
         }
         {
@@ -147,19 +147,19 @@ export async function handleBundle(
         if (argv.force) {
           process.stderr.write(
             `❓ Created a bundle for ${blue(path)} at ${blue(outputFile)} with errors ${green(
-              elapsed,
-            )}.\n${yellow('Errors ignored because of --force')}.\n`,
+              elapsed
+            )}.\n${yellow('Errors ignored because of --force')}.\n`
           );
         } else {
           process.stderr.write(
             `❌ Errors encountered while bundling ${blue(
-              path,
-            )}: bundle not created (use --force to ignore errors).\n`,
+              path
+            )}: bundle not created (use --force to ignore errors).\n`
           );
         }
       } else {
         process.stderr.write(
-          `📦 Created a bundle for ${blue(path)} at ${blue(outputFile)} ${green(elapsed)}.\n`,
+          `📦 Created a bundle for ${blue(path)} at ${blue(outputFile)} ${green(elapsed)}.\n`
         );
       }
 

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -24,7 +24,7 @@ import {
   handleError,
   printLintTotals,
   writeYaml,
-  exitWithError
+  exitWithError,
 } from '../utils';
 import { isObject, isString } from '../js-utils';
 
@@ -51,7 +51,6 @@ type JoinArgv = {
   'without-x-tag-groups'?: boolean;
 };
 
-
 export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   const startedAt = performance.now();
   if (argv.entrypoints.length < 2) {
@@ -73,10 +72,10 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   if (usedTagsOptions.length > 1) {
     return exitWithError(
-      `You use ${yellow(usedTagsOptions.join(', '))} together.\nPlease choose only one! \n\n`,
+      `You use ${yellow(usedTagsOptions.join(', '))} together.\nPlease choose only one! \n\n`
     );
   }
- 
+
   const config: Config = await loadConfig();
   const entrypoints = await getFallbackEntryPointsOrExit(argv.entrypoints, config);
   const externalRefResolver = new BaseResolver(config.resolve);
@@ -87,13 +86,15 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   );
 
   const bundleResults = await Promise.all(
-    documents.map(document => bundleDocument({
-      document,
-      config: config.lint,
-      externalRefResolver
-    }).catch(e => {
-      exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`)
-    }))
+    documents.map((document) =>
+      bundleDocument({
+        document,
+        config: config.lint,
+        externalRefResolver,
+      }).catch((e) => {
+        exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`);
+      })
+    )
   );
 
   for (const { problems, bundle: document } of bundleResults as any) {
@@ -101,17 +102,23 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
     if (fileTotals.errors) {
       formatProblems(problems, {
         totals: fileTotals,
-        version: document.parsed.version
+        version: document.parsed.version,
       });
-      exitWithError(`❌ Errors encountered while bundling ${blue(document.source.absoluteRef)}: join will not proceed.\n`);
+      exitWithError(
+        `❌ Errors encountered while bundling ${blue(
+          document.source.absoluteRef
+        )}: join will not proceed.\n`
+      );
     }
   }
 
   for (const document of documents) {
     try {
-      const version = detectOpenAPI(document.parsed)
+      const version = detectOpenAPI(document.parsed);
       if (version !== OasVersion.Version3_0) {
-        return exitWithError(`Only OpenAPI 3 is supported: ${blue(document.source.absoluteRef)} \n\n`);
+        return exitWithError(
+          `Only OpenAPI 3 is supported: ${blue(document.source.absoluteRef)} \n\n`
+        );
       }
     } catch (e) {
       return exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`);
@@ -139,22 +146,37 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
     const { tags, info } = openapi;
     const entrypoint = path.relative(process.cwd(), document.source.absoluteRef);
     const entrypointFilename = getEntrypointFilename(entrypoint);
-    const tagsPrefix = prefixTagsWithFilename ? entrypointFilename : getInfoPrefix(info, prefixTagsWithInfoProp, 'tags');
+    const tagsPrefix = prefixTagsWithFilename
+      ? entrypointFilename
+      : getInfoPrefix(info, prefixTagsWithInfoProp, 'tags');
     const componentsPrefix = getInfoPrefix(info, prefixComponentsWithInfoProp, COMPONENTS);
 
     if (openapi.hasOwnProperty('x-tagGroups')) {
-      process.stderr.write(yellow(`warning: x-tagGroups at ${blue(entrypoint)} will be skipped \n`));
+      process.stderr.write(
+        yellow(`warning: x-tagGroups at ${blue(entrypoint)} will be skipped \n`)
+      );
     }
 
-    const context = { entrypoint, entrypointFilename, tags, potentialConflicts, tagsPrefix, componentsPrefix };
-    if (tags) { populateTags(context); }
+    const context = {
+      entrypoint,
+      entrypointFilename,
+      tags,
+      potentialConflicts,
+      tagsPrefix,
+      componentsPrefix,
+    };
+    if (tags) {
+      populateTags(context);
+    }
     collectServers(openapi);
     collectInfoDescriptions(openapi, context);
     collectExternalDocs(openapi, context);
     collectPaths(openapi, context);
     collectComponents(openapi, context);
     collectXWebhooks(openapi, context);
-    if (componentsPrefix) { replace$Refs(openapi, componentsPrefix); }
+    if (componentsPrefix) {
+      replace$Refs(openapi, componentsPrefix);
+    }
   }
 
   iteratePotentialConflicts(potentialConflicts, withoutXTagGroups);
@@ -163,7 +185,7 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   if (potentialConflictsTotal) {
     return exitWithError(`Please fix conflicts before running ${yellow('join')}.`);
-  } 
+  }
 
   writeYaml(joinedDef, specFilename, noRefs);
   printExecutionTime('join', startedAt, specFilename);
@@ -252,7 +274,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   }
 
   function populateXTagGroups(entrypointTagName: string, indexGroup: number) {
-    if (!joinedDef[xTagGroups][indexGroup][Tags].find((t: Oas3Tag) => t.name === entrypointTagName)) {
+    if (
+      !joinedDef[xTagGroups][indexGroup][Tags].find((t: Oas3Tag) => t.name === entrypointTagName)
+    ) {
       joinedDef[xTagGroups][indexGroup][Tags].push(entrypointTagName);
     }
   }
@@ -260,7 +284,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
   function collectServers(openapi: Oas3Definition) {
     const { servers } = openapi;
     if (servers) {
-      if (!joinedDef.hasOwnProperty('servers')) { joinedDef['servers'] = []; }
+      if (!joinedDef.hasOwnProperty('servers')) {
+        joinedDef['servers'] = [];
+      }
       for (const server of servers) {
         if (!joinedDef.servers.some((s: any) => s.url === server.url)) {
           joinedDef.servers.push(server);
@@ -271,10 +297,7 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   function collectInfoDescriptions(
     openapi: Oas3Definition,
-    {
-      entrypointFilename,
-      componentsPrefix
-    }: JoinDocumentContext
+    { entrypointFilename, componentsPrefix }: JoinDocumentContext
   ) {
     const { info } = openapi;
     if (info?.description) {
@@ -287,7 +310,7 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
       ) {
         joinedDef[xTagGroups][groupIndex]['description'] = addComponentsPrefix(
           info.description,
-          componentsPrefix!,
+          componentsPrefix!
         );
       }
     }
@@ -297,7 +320,9 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
     const { externalDocs } = openapi;
     if (externalDocs) {
       if (joinedDef.hasOwnProperty('externalDocs')) {
-        process.stderr.write(yellow(`warning: skip externalDocs from ${blue(path.basename(entrypoint))} \n`));
+        process.stderr.write(
+          yellow(`warning: skip externalDocs from ${blue(path.basename(entrypoint))} \n`)
+        );
         return;
       }
       joinedDef['externalDocs'] = externalDocs;
@@ -311,37 +336,75 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
       entrypoint,
       potentialConflicts,
       tagsPrefix,
-      componentsPrefix
+      componentsPrefix,
     }: JoinDocumentContext
   ) {
     const { paths } = openapi;
     if (paths) {
-      if (!joinedDef.hasOwnProperty('paths')) { joinedDef['paths'] = {}; }
+      if (!joinedDef.hasOwnProperty('paths')) {
+        joinedDef['paths'] = {};
+      }
       for (const path of Object.keys(paths)) {
-        if (!joinedDef.paths.hasOwnProperty(path)) { joinedDef.paths[path] = {}; }
-        if (!potentialConflicts.paths.hasOwnProperty(path)) { potentialConflicts.paths[path] = {}; }
+        if (!joinedDef.paths.hasOwnProperty(path)) {
+          joinedDef.paths[path] = {};
+        }
+        if (!potentialConflicts.paths.hasOwnProperty(path)) {
+          potentialConflicts.paths[path] = {};
+        }
         for (const operation of Object.keys(paths[path])) {
           // @ts-ignore
           const pathOperation = paths[path][operation];
           joinedDef.paths[path][operation] = pathOperation;
-          potentialConflicts.paths[path][operation] = [...(potentialConflicts.paths[path][operation] || []), entrypoint];
+          potentialConflicts.paths[path][operation] = [
+            ...(potentialConflicts.paths[path][operation] || []),
+            entrypoint,
+          ];
           const { operationId } = pathOperation;
           if (operationId) {
-            if (!potentialConflicts.paths.hasOwnProperty('operationIds')) { potentialConflicts.paths['operationIds'] = {}; }
-            potentialConflicts.paths.operationIds[operationId] = [...(potentialConflicts.paths.operationIds[operationId] || []), entrypoint];
+            if (!potentialConflicts.paths.hasOwnProperty('operationIds')) {
+              potentialConflicts.paths['operationIds'] = {};
+            }
+            potentialConflicts.paths.operationIds[operationId] = [
+              ...(potentialConflicts.paths.operationIds[operationId] || []),
+              entrypoint,
+            ];
           }
           let { tags, security } = joinedDef.paths[path][operation];
           if (tags) {
-            joinedDef.paths[path][operation].tags = tags.map((tag: string) => addPrefix(tag, tagsPrefix));
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(tags), potentialConflicts, tagsPrefix, componentsPrefix });
+            joinedDef.paths[path][operation].tags = tags.map((tag: string) =>
+              addPrefix(tag, tagsPrefix)
+            );
+            populateTags({
+              entrypoint,
+              entrypointFilename,
+              tags: formatTags(tags),
+              potentialConflicts,
+              tagsPrefix,
+              componentsPrefix,
+            });
           } else {
-            joinedDef.paths[path][operation]['tags'] = [addPrefix('other', tagsPrefix || entrypointFilename)];
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(['other']), potentialConflicts, tagsPrefix: tagsPrefix || entrypointFilename, componentsPrefix });
+            joinedDef.paths[path][operation]['tags'] = [
+              addPrefix('other', tagsPrefix || entrypointFilename),
+            ];
+            populateTags({
+              entrypoint,
+              entrypointFilename,
+              tags: formatTags(['other']),
+              potentialConflicts,
+              tagsPrefix: tagsPrefix || entrypointFilename,
+              componentsPrefix,
+            });
           }
           if (!security && openapi.hasOwnProperty('security')) {
-            joinedDef.paths[path][operation]['security'] = addSecurityPrefix(openapi.security, componentsPrefix!);
+            joinedDef.paths[path][operation]['security'] = addSecurityPrefix(
+              openapi.security,
+              componentsPrefix!
+            );
           } else if (pathOperation.security) {
-            joinedDef.paths[path][operation].security = addSecurityPrefix(pathOperation.security, componentsPrefix!);
+            joinedDef.paths[path][operation].security = addSecurityPrefix(
+              pathOperation.security,
+              componentsPrefix!
+            );
           }
         }
       }
@@ -350,15 +413,13 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
   function collectComponents(
     openapi: Oas3Definition,
-    {
-      entrypoint,
-      potentialConflicts,
-      componentsPrefix
-    }: JoinDocumentContext
+    { entrypoint, potentialConflicts, componentsPrefix }: JoinDocumentContext
   ) {
     const { components } = openapi;
     if (components) {
-      if (!joinedDef.hasOwnProperty(COMPONENTS)) { joinedDef[COMPONENTS] = {}; }
+      if (!joinedDef.hasOwnProperty(COMPONENTS)) {
+        joinedDef[COMPONENTS] = {};
+      }
       for (const component of Object.keys(components)) {
         if (!potentialConflicts[COMPONENTS].hasOwnProperty(component)) {
           potentialConflicts[COMPONENTS][component] = {};
@@ -369,7 +430,8 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
         for (const item of Object.keys(componentObj)) {
           const componentPrefix = addPrefix(item, componentsPrefix!);
           potentialConflicts.components[component][componentPrefix] = [
-            ...(potentialConflicts.components[component][item] || []), { [entrypoint]: componentObj[item]}
+            ...(potentialConflicts.components[component][item] || []),
+            { [entrypoint]: componentObj[item] },
           ];
           joinedDef.components[component][componentPrefix] = componentObj[item];
         }
@@ -384,33 +446,52 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
       entrypoint,
       potentialConflicts,
       tagsPrefix,
-      componentsPrefix
+      componentsPrefix,
     }: JoinDocumentContext
   ) {
     const xWebhooks = 'x-webhooks';
     // @ts-ignore
     const openapiXWebhooks = openapi[xWebhooks];
     if (openapiXWebhooks) {
-      if (!joinedDef.hasOwnProperty(xWebhooks)) { joinedDef[xWebhooks] = {}; }
+      if (!joinedDef.hasOwnProperty(xWebhooks)) {
+        joinedDef[xWebhooks] = {};
+      }
       for (const webhook of Object.keys(openapiXWebhooks)) {
         joinedDef[xWebhooks][webhook] = openapiXWebhooks[webhook];
 
-        if (!potentialConflicts.xWebhooks.hasOwnProperty(webhook)) { potentialConflicts.xWebhooks[webhook] = {}; }
+        if (!potentialConflicts.xWebhooks.hasOwnProperty(webhook)) {
+          potentialConflicts.xWebhooks[webhook] = {};
+        }
         for (const operation of Object.keys(openapiXWebhooks[webhook])) {
-          potentialConflicts.xWebhooks[webhook][operation] = [...(potentialConflicts.xWebhooks[webhook][operation] || []), entrypoint];
+          potentialConflicts.xWebhooks[webhook][operation] = [
+            ...(potentialConflicts.xWebhooks[webhook][operation] || []),
+            entrypoint,
+          ];
         }
         for (const operationKey of Object.keys(joinedDef[xWebhooks][webhook])) {
           let { tags } = joinedDef[xWebhooks][webhook][operationKey];
           if (tags) {
-            joinedDef[xWebhooks][webhook][operationKey].tags = tags.map((tag: string) => addPrefix(tag, tagsPrefix));
-            populateTags({ entrypoint, entrypointFilename, tags: formatTags(tags), potentialConflicts, tagsPrefix, componentsPrefix });
+            joinedDef[xWebhooks][webhook][operationKey].tags = tags.map((tag: string) =>
+              addPrefix(tag, tagsPrefix)
+            );
+            populateTags({
+              entrypoint,
+              entrypointFilename,
+              tags: formatTags(tags),
+              potentialConflicts,
+              tagsPrefix,
+              componentsPrefix,
+            });
           }
         }
       }
     }
   }
 
-  function addInfoSectionAndSpecVersion(documents: any, prefixComponentsWithInfoProp: string | undefined) {
+  function addInfoSectionAndSpecVersion(
+    documents: any,
+    prefixComponentsWithInfoProp: string | undefined
+  ) {
     const firstEntrypoint = documents[0];
     const openapi = firstEntrypoint.parsed;
     const componentsPrefix = getInfoPrefix(openapi.info, prefixComponentsWithInfoProp, COMPONENTS);
@@ -475,9 +556,9 @@ function duplicateTagDescriptionWarning(conflicts: [string, any][]) {
   process.stderr.write(
     yellow(
       `\nwarning: ${tagsKeys.length} conflict(s) on the ${red(
-        tagsKeys.join(joinString),
-      )} tags description.\n`,
-    ),
+        tagsKeys.join(joinString)
+      )} tags description.\n`
+    )
   );
 }
 
@@ -504,11 +585,11 @@ function filterConflicts(entities: object) {
 }
 
 function getEntrypointFilename(filePath: string) {
-  return path.basename(filePath, path.extname(filePath))
+  return path.basename(filePath, path.extname(filePath));
 }
 
 function addPrefix(tag: string, tagsPrefix: string) {
-  return tagsPrefix ? tagsPrefix +'_'+ tag : tag;
+  return tagsPrefix ? tagsPrefix + '_' + tag : tag;
 }
 
 function formatTags(tags: string[]) {
@@ -519,26 +600,44 @@ function addComponentsPrefix(description: string, componentsPrefix: string) {
   return description.replace(/"(#\/components\/.*?)"/g, (match) => {
     const componentName = path.basename(match);
     return match.replace(componentName, addPrefix(componentName, componentsPrefix));
-  })
+  });
 }
 
 function addSecurityPrefix(security: any, componentsPrefix: string) {
-  return componentsPrefix ? security?.map((s: any) => {
-    const key = Object.keys(s)[0];
-    return { [componentsPrefix +'_'+ key]: s[key] }
-  }) : security;
+  return componentsPrefix
+    ? security?.map((s: any) => {
+        const key = Object.keys(s)[0];
+        return { [componentsPrefix + '_' + key]: s[key] };
+      })
+    : security;
 }
 
 function getInfoPrefix(info: any, prefixArg: string | undefined, type: string) {
   if (!prefixArg) return '';
   if (!info) exitWithError('Info section is not found in specification. \n');
-  if (!info[prefixArg]) exitWithError(`${yellow(`prefix-${type}-with-info-prop`)} argument value is not found in info section. \n`);
-  if (!isString(info[prefixArg])) exitWithError(`${yellow(`prefix-${type}-with-info-prop`)} argument value should be string. \n\n`);
-  if (info[prefixArg].length > 50) exitWithError(`${yellow(`prefix-${type}-with-info-prop`)} argument value length should not exceed 50 characters. \n\n`);
+  if (!info[prefixArg])
+    exitWithError(
+      `${yellow(`prefix-${type}-with-info-prop`)} argument value is not found in info section. \n`
+    );
+  if (!isString(info[prefixArg]))
+    exitWithError(
+      `${yellow(`prefix-${type}-with-info-prop`)} argument value should be string. \n\n`
+    );
+  if (info[prefixArg].length > 50)
+    exitWithError(
+      `${yellow(
+        `prefix-${type}-with-info-prop`
+      )} argument value length should not exceed 50 characters. \n\n`
+    );
   return info[prefixArg];
 }
 
-async function validateEntrypoint(document: Document, config: LintConfig, externalRefResolver: BaseResolver, packageVersion: string) {
+async function validateEntrypoint(
+  document: Document,
+  config: LintConfig,
+  externalRefResolver: BaseResolver,
+  packageVersion: string
+) {
   try {
     const results = await lintDocument({ document, config, externalRefResolver });
     const fileTotals = getTotals(results);
@@ -561,7 +660,7 @@ function replace$Refs(obj: any, componentsPrefix: string) {
   crawl(obj, (node: any) => {
     if (node.$ref && isString(node.$ref) && node.$ref.startsWith(`#/${COMPONENTS}/`)) {
       const name = path.basename(node.$ref);
-      node.$ref = node.$ref.replace(name, componentsPrefix +'_'+ name);
+      node.$ref = node.$ref.replace(name, componentsPrefix + '_' + name);
     } else if (
       node.discriminator &&
       node.discriminator.mapping &&
@@ -570,9 +669,14 @@ function replace$Refs(obj: any, componentsPrefix: string) {
       const { mapping } = node.discriminator;
       for (const name of Object.keys(mapping)) {
         if (isString(mapping[name]) && mapping[name].startsWith(`#/${COMPONENTS}/`)) {
-          mapping[name] = mapping[name].split('/').map((name: string, i: number, arr: []) => {
-            return (arr.length - 1 === i && !name.includes(componentsPrefix)) ? componentsPrefix+'_'+name : name;
-          }).join('/')
+          mapping[name] = mapping[name]
+            .split('/')
+            .map((name: string, i: number, arr: []) => {
+              return arr.length - 1 === i && !name.includes(componentsPrefix)
+                ? componentsPrefix + '_' + name
+                : name;
+            })
+            .join('/');
         }
       }
     }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -13,7 +13,7 @@ import {
   RawConfig,
   RuleSeverity,
   ProblemSeverity,
-  doesYamlFileExist
+  doesYamlFileExist,
 } from '@redocly/openapi-core';
 import {
   getExecutionTime,
@@ -23,7 +23,7 @@ import {
   printLintTotals,
   printConfigLintTotals,
   printUnusedWarnings,
-  exitWithError
+  exitWithError,
 } from '../utils';
 import { Totals } from '../types';
 import { blue, gray, red } from 'colorette';
@@ -42,7 +42,6 @@ export type LintOptions = {
 };
 
 export async function handleLint(argv: LintOptions, version: string) {
-
   if (argv.config && !doesYamlFileExist(argv.config)) {
     return exitWithError('Please, provide valid path to the configuration file');
   }
@@ -72,10 +71,10 @@ export async function handleLint(argv: LintOptions, version: string) {
       if (resolvedConfig.lint.recommendedFallback) {
         process.stderr.write(
           `No configurations were defined in extends -- using built in ${blue(
-            'recommended',
+            'recommended'
           )} configuration by default.\n${red(
-            'Warning! This default behavior is going to be deprecated soon.',
-          )}\n\n`,
+            'Warning! This default behavior is going to be deprecated soon.'
+          )}\n\n`
         );
       }
       process.stderr.write(gray(`validating ${path.replace(process.cwd(), '')}...\n`));
@@ -125,7 +124,7 @@ export async function handleLint(argv: LintOptions, version: string) {
   // defer process exit to allow STDOUT pipe to flush
   // see https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072
   process.once('exit', () =>
-    process.exit(totals.errors === 0 || argv['generate-ignore-file'] ? 0 : 1),
+    process.exit(totals.errors === 0 || argv['generate-ignore-file'] ? 0 : 1)
   );
 }
 

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -5,9 +5,9 @@ import { promptUser } from '../utils';
 export function promptClientToken(domain: string) {
   return promptUser(
     green(
-      `\n  🔑 Copy your API key from ${blue(`https://app.${domain}/profile`)} and paste it below`,
+      `\n  🔑 Copy your API key from ${blue(`https://app.${domain}/profile`)} and paste it below`
     ),
-    true,
+    true
   );
 }
 

--- a/packages/cli/src/commands/preview-docs/index.ts
+++ b/packages/cli/src/commands/preview-docs/index.ts
@@ -29,7 +29,7 @@ export async function previewDocs(argv: {
 
   const entrypoints = await getFallbackEntryPointsOrExit(
     argv.entrypoint ? [argv.entrypoint] : [],
-    config,
+    config
   );
   const entrypoint = entrypoints[0];
 
@@ -68,8 +68,8 @@ export async function previewDocs(argv: {
             : colorette.yellow(
                 `Created a bundle for ${
                   entrypoint.alias || entrypoint.path
-                } with errors. Docs may be broken or not accurate\n`,
-              ),
+                } with errors. Docs may be broken or not accurate\n`
+              )
         );
       }
 
@@ -87,8 +87,8 @@ export async function previewDocs(argv: {
   if (!isAuthorized) {
     process.stderr.write(
       `Using Redoc community edition.\nLogin with redocly ${colorette.blue(
-        'login',
-      )} or use an enterprise license key to preview with the premium docs.\n\n`,
+        'login'
+      )} or use an enterprise license key to preview with the premium docs.\n\n`
     );
   }
 
@@ -128,8 +128,8 @@ export async function previewDocs(argv: {
   watcher.on('ready', () => {
     process.stdout.write(
       `\n  👀  Watching ${colorette.blue(
-        entrypoint.path,
-      )} and all related resources for changes\n\n`,
+        entrypoint.path
+      )} and all related resources for changes\n\n`
     );
   });
 
@@ -176,11 +176,11 @@ export function debounce(func: Function, wait: number, immediate?: boolean) {
 function handleError(e: Error, ref: string) {
   if (e instanceof ResolveError) {
     process.stderr.write(
-      `Failed to resolve entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`,
+      `Failed to resolve entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`
     );
   } else if (e instanceof YamlParseError) {
     process.stderr.write(
-      `Failed to parse entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`,
+      `Failed to parse entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`
     );
   } else {
     process.stderr.write(`Something went wrong when processing ${ref}:\n\n  - ${e.message}.\n\n`);

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -12,7 +12,7 @@ function getPageHTML(
   htmlTemplate: string,
   redocOptions: object = {},
   useRedocPro: boolean,
-  wsPort: number,
+  wsPort: number
 ) {
   let templateSrc = readFileSync(htmlTemplate, 'utf-8');
 
@@ -58,7 +58,7 @@ export default async function startPreviewServer(
     getBundle,
     getOptions,
     useRedocPro,
-  }: { getBundle: Function; getOptions: Function; useRedocPro: boolean },
+  }: { getBundle: Function; getOptions: Function; useRedocPro: boolean }
 ) {
   const defaultTemplate = path.join(__dirname, 'default.hbs');
   const handler = async (request: IncomingMessage, response: any) => {
@@ -72,7 +72,7 @@ export default async function startPreviewServer(
         response,
         {
           'Content-Type': 'text/html',
-        },
+        }
       );
     } else if (request.url === '/openapi.json') {
       const bundle = await getBundle();
@@ -90,7 +90,7 @@ export default async function startPreviewServer(
           response,
           {
             'Content-Type': 'application/json',
-          },
+          }
         );
       } else {
         respondWithGzip(JSON.stringify(bundle), request, response, {
@@ -134,7 +134,7 @@ export default async function startPreviewServer(
             request,
             response,
             {},
-            500,
+            500
           );
         }
       }
@@ -147,7 +147,7 @@ export default async function startPreviewServer(
   const server = startHttpServer(port, host, handler);
   server.on('listening', () => {
     process.stdout.write(
-      `\n  🔎  Preview server running at ${colorette.blue(`http://${host}:${port}\n`)}`,
+      `\n  🔎  Preview server running at ${colorette.blue(`http://${host}:${port}\n`)}`
     );
   });
 

--- a/packages/cli/src/commands/preview-docs/preview-server/server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/server.ts
@@ -28,7 +28,7 @@ export function respondWithGzip(
   request: http.IncomingMessage,
   response: http.ServerResponse,
   headers = {},
-  code = 200,
+  code = 200
 ) {
   let compressedStream;
   const acceptEncoding = (request.headers['accept-encoding'] as string) || '';

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -36,7 +36,7 @@ type PushArgs = {
   'batch-size'?: number;
   region?: Region;
   'skip-decorator'?: string[];
-  'public'?: boolean;
+  public?: boolean;
 };
 
 export async function handlePush(argv: PushArgs): Promise<void> {
@@ -61,8 +61,8 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   ) {
     exitWithError(
       `Destination argument value is not valid, please use the right format: ${yellow(
-        '<@organization-id/api-name@api-version>',
-      )}`,
+        '<@organization-id/api-name@api-version>'
+      )}`
     );
   }
 
@@ -71,8 +71,8 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   if (!organizationId) {
     return exitWithError(
       `No organization provided, please use the right format: ${yellow(
-        '<@organization-id/api-name@api-version>',
-      )} or specify the 'organization' field in the config file.`,
+        '<@organization-id/api-name@api-version>'
+      )} or specify the 'organization' field in the config file.`
     );
   }
   const entrypoint =
@@ -81,8 +81,8 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   if (name && version && !entrypoint) {
     exitWithError(
       `No entrypoint found that matches ${blue(
-        `${name}@${version}`,
-      )}. Please make sure you have provided the correct data in the config file.`,
+        `${name}@${version}`
+      )}. Please make sure you have provided the correct data in the config file.`
     );
   }
 
@@ -114,8 +114,8 @@ export async function handlePush(argv: PushArgs): Promise<void> {
       process.stdout.write(
         `Uploading ${filesToUpload.files.length} ${pluralize(
           'file',
-          filesToUpload.files.length,
-        )}:\n`,
+          filesToUpload.files.length
+        )}:\n`
       );
 
       let uploaded = 0;
@@ -137,12 +137,12 @@ export async function handlePush(argv: PushArgs): Promise<void> {
         filePaths.push(filePath);
 
         process.stdout.write(
-          `Uploading ${file.contents ? 'bundle for ' : ''}${blue(file.filePath)}...`,
+          `Uploading ${file.contents ? 'bundle for ' : ''}${blue(file.filePath)}...`
         );
 
         const uploadResponse = await uploadFileToS3(
           signedUploadUrl,
-          file.contents || file.filePath,
+          file.contents || file.filePath
         );
 
         const fileCounter = `(${++uploaded}/${filesToUpload.files.length})`;
@@ -175,9 +175,9 @@ export async function handlePush(argv: PushArgs): Promise<void> {
 
       if (error.message === 'API_VERSION_NOT_FOUND') {
         exitWithError(`The definition version ${blue(name)}/${blue(
-          version,
+          version
         )} does not exist in organization ${blue(organizationId)}!\n${yellow(
-          'Suggestion:',
+          'Suggestion:'
         )} please use ${blue('-u')} or ${blue('--upsert')} to create definition.
         `);
       }
@@ -186,7 +186,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
     }
 
     process.stdout.write(
-      `Definition: ${blue(entrypoint!)} is successfully pushed to Redocly API Registry \n`,
+      `Definition: ${blue(entrypoint!)} is successfully pushed to Redocly API Registry \n`
     );
   }
   printExecutionTime('push', startedAt, entrypoint || `apis in organization ${organizationId}`);
@@ -222,9 +222,7 @@ async function collectFilesToUpload(entrypoint: string, config: Config) {
 
   if (fileTotals.errors === 0) {
     process.stdout.write(
-      `Created a bundle for ${blue(entrypoint)} ${
-        fileTotals.warnings > 0 ? 'with warnings' : ''
-      }\n`,
+      `Created a bundle for ${blue(entrypoint)} ${fileTotals.warnings > 0 ? 'with warnings' : ''}\n`
     );
   } else {
     exitWithError(`Failed to create a bundle for ${blue(entrypoint)}\n`);
@@ -232,7 +230,7 @@ async function collectFilesToUpload(entrypoint: string, config: Config) {
 
   const fileExt = path.extname(entrypointPath).split('.').pop();
   files.push(
-    getFileEntry(entrypointPath, dumpBundle(openapiBundle.parsed, fileExt as BundleOutputFormat)),
+    getFileEntry(entrypointPath, dumpBundle(openapiBundle.parsed, fileExt as BundleOutputFormat))
   );
 
   if (fs.existsSync('package.json')) {
@@ -302,7 +300,7 @@ function validateDestinationWithoutOrganization(destination: string) {
 
 export function getDestinationProps(
   destination: string | undefined,
-  organization: string | undefined,
+  organization: string | undefined
 ) {
   return destination && validateDestination(destination)
     ? destination.substring(1).split(/[@\/]/)
@@ -330,8 +328,8 @@ export const transformPush =
     if (!!maybeBranchName) {
       process.stderr.write(
         yellow(
-          'Deprecation warning: Do not use the third parameter as a branch name. Please use a separate --branch option instead.',
-        ),
+          'Deprecation warning: Do not use the third parameter as a branch name. Please use a separate --branch option instead.'
+        )
       );
     }
     const entrypoint = maybeDestination ? maybeEntrypointOrAliasOrDestination : undefined;

--- a/packages/cli/src/commands/split/__tests__/index.test.ts
+++ b/packages/cli/src/commands/split/__tests__/index.test.ts
@@ -1,9 +1,7 @@
 import { iteratePathItems, handleSplit } from '../index';
 import * as path from 'path';
 import * as openapiCore from '@redocly/openapi-core';
-import {
-  ComponentsFiles,
-} from '../types'; 
+import { ComponentsFiles } from '../types';
 import { blue, green } from 'colorette';
 
 const utils = require('../../../utils');
@@ -23,16 +21,14 @@ describe('#split', () => {
   const componentsFiles: ComponentsFiles = {};
 
   it('should split the file and show the success message', async () => {
-    const filePath = "packages/cli/src/commands/split/__tests__/fixtures/spec.json";
+    const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/spec.json';
     jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-    await handleSplit (
-      {
-        entrypoint: filePath,
-        outDir: openapiDir,
-        separator: '_',
-      }
-    );
+    await handleSplit({
+      entrypoint: filePath,
+      outDir: openapiDir,
+      separator: '_',
+    });
 
     expect(process.stderr.write).toBeCalledTimes(2);
     expect((process.stderr.write as jest.Mock).mock.calls[0][0]).toBe(
@@ -44,65 +40,86 @@ describe('#split', () => {
     );
   });
 
-
   it('should use the correct separator', async () => {
-    const filePath = "packages/cli/src/commands/split/__tests__/fixtures/spec.json";
+    const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/spec.json';
 
     jest.spyOn(utils, 'pathToFilename').mockImplementation(() => 'newFilePath');
 
-    await handleSplit (
-      {
-        entrypoint: filePath,
-        outDir: openapiDir,
-        separator: '_',
-      }
-    );
+    await handleSplit({
+      entrypoint: filePath,
+      outDir: openapiDir,
+      separator: '_',
+    });
 
     expect(utils.pathToFilename).toBeCalledWith(expect.anything(), '_');
     utils.pathToFilename.mockRestore();
   });
 
   it('should have correct path with paths', () => {
-    const openapi = require("./fixtures/spec.json");
-    
+    const openapi = require('./fixtures/spec.json');
+
     jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'paths/test.yaml');
     jest.spyOn(path, 'relative').mockImplementation(() => 'paths/test.yaml');
-    iteratePathItems(openapi.paths, openapiDir, path.join(openapiDir, 'paths'), componentsFiles, '_');
+    iteratePathItems(
+      openapi.paths,
+      openapiDir,
+      path.join(openapiDir, 'paths'),
+      componentsFiles,
+      '_'
+    );
 
     expect(openapiCore.slash).toHaveBeenCalledWith('paths/test.yaml');
     expect(path.relative).toHaveBeenCalledWith('test', 'test/paths/test.yaml');
   });
 
   it('should have correct path with webhooks', () => {
-    const openapi = require("./fixtures/webhooks.json");
+    const openapi = require('./fixtures/webhooks.json');
 
     jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'webhooks/test.yaml');
     jest.spyOn(path, 'relative').mockImplementation(() => 'webhooks/test.yaml');
-    iteratePathItems(openapi.webhooks, openapiDir, path.join(openapiDir, 'webhooks'), componentsFiles, 'webhook_');
+    iteratePathItems(
+      openapi.webhooks,
+      openapiDir,
+      path.join(openapiDir, 'webhooks'),
+      componentsFiles,
+      'webhook_'
+    );
 
     expect(openapiCore.slash).toHaveBeenCalledWith('webhooks/test.yaml');
     expect(path.relative).toHaveBeenCalledWith('test', 'test/webhooks/test.yaml');
   });
 
   it('should have correct path with x-webhooks', () => {
-    const openapi = require("./fixtures/spec.json");
+    const openapi = require('./fixtures/spec.json');
 
     jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'webhooks/test.yaml');
     jest.spyOn(path, 'relative').mockImplementation(() => 'webhooks/test.yaml');
-    iteratePathItems(openapi['x-webhooks'], openapiDir, path.join(openapiDir, 'webhooks'), componentsFiles, 'webhook_');
+    iteratePathItems(
+      openapi['x-webhooks'],
+      openapiDir,
+      path.join(openapiDir, 'webhooks'),
+      componentsFiles,
+      'webhook_'
+    );
 
     expect(openapiCore.slash).toHaveBeenCalledWith('webhooks/test.yaml');
     expect(path.relative).toHaveBeenCalledWith('test', 'test/webhooks/test.yaml');
   });
 
   it('should create correct folder name for code samples', async () => {
-    const openapi = require("./fixtures/samples.json");
+    const openapi = require('./fixtures/samples.json');
 
-    const fs = require('fs')
+    const fs = require('fs');
     jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
 
     jest.spyOn(utils, 'escapeLanguageName');
-    iteratePathItems(openapi.paths, openapiDir, path.join(openapiDir, 'paths'), componentsFiles, '_');
+    iteratePathItems(
+      openapi.paths,
+      openapiDir,
+      path.join(openapiDir, 'paths'),
+      componentsFiles,
+      '_'
+    );
 
     expect(utils.escapeLanguageName).nthCalledWith(1, 'C#');
     expect(utils.escapeLanguageName).nthReturnedWith(1, 'C_sharp');

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -5,7 +5,14 @@ import * as path from 'path';
 import { performance } from 'perf_hooks';
 const isEqual = require('lodash.isequal');
 
-import { printExecutionTime, pathToFilename, readYaml, writeYaml, exitWithError, escapeLanguageName } from '../../utils';
+import {
+  printExecutionTime,
+  pathToFilename,
+  readYaml,
+  writeYaml,
+  exitWithError,
+  escapeLanguageName,
+} from '../../utils';
 import { isString, isObject, isEmptyObject } from '../../js-utils';
 import {
   Definition,
@@ -23,14 +30,10 @@ import {
   componentsPath,
   OPENAPI3_METHOD_NAMES,
   OPENAPI3_COMPONENT_NAMES,
-  Referenced
+  Referenced,
 } from './types';
 
-export async function handleSplit (argv: {
-  entrypoint: string;
-  outDir: string
-  separator: string
-}) {
+export async function handleSplit(argv: { entrypoint: string; outDir: string; separator: string }) {
   const startedAt = performance.now();
   const { entrypoint, outDir, separator } = argv;
   validateDefinitionFileName(entrypoint!);
@@ -38,27 +41,45 @@ export async function handleSplit (argv: {
   splitDefinition(openapi, outDir, separator);
   process.stderr.write(
     `🪓 Document: ${blue(entrypoint!)} ${green('is successfully split')}
-    and all related files are saved to the directory: ${blue(outDir)} \n`,
+    and all related files are saved to the directory: ${blue(outDir)} \n`
   );
   printExecutionTime('split', startedAt, entrypoint!);
 }
 
-function splitDefinition(openapi: Oas3Definition | Oas3_1Definition, openapiDir: string, pathSeparator: string) {
+function splitDefinition(
+  openapi: Oas3Definition | Oas3_1Definition,
+  openapiDir: string,
+  pathSeparator: string
+) {
   fs.mkdirSync(openapiDir, { recursive: true });
 
   const componentsFiles: ComponentsFiles = {};
   iterateComponents(openapi, openapiDir, componentsFiles);
-  iteratePathItems(openapi.paths, openapiDir, path.join(openapiDir, 'paths'), componentsFiles, pathSeparator);
-  const webhooks = (openapi as Oas3_1Definition).webhooks || (openapi as Oas3Definition)['x-webhooks'];
+  iteratePathItems(
+    openapi.paths,
+    openapiDir,
+    path.join(openapiDir, 'paths'),
+    componentsFiles,
+    pathSeparator
+  );
+  const webhooks =
+    (openapi as Oas3_1Definition).webhooks || (openapi as Oas3Definition)['x-webhooks'];
   // use webhook_ prefix for code samples to prevent potential name-clashes with paths samples
-  iteratePathItems(webhooks, openapiDir, path.join(openapiDir, 'webhooks'), componentsFiles, pathSeparator, 'webhook_');
+  iteratePathItems(
+    webhooks,
+    openapiDir,
+    path.join(openapiDir, 'webhooks'),
+    componentsFiles,
+    pathSeparator,
+    'webhook_'
+  );
 
   replace$Refs(openapi, openapiDir, componentsFiles);
   writeYaml(openapi, path.join(openapiDir, 'openapi.yaml'));
 }
 
 function isStartsWithComponents(node: string) {
-  return node.startsWith(componentsPath)
+  return node.startsWith(componentsPath);
 }
 
 function isNotYaml(filename: string) {
@@ -77,7 +98,10 @@ function validateDefinitionFileName(fileName: string) {
   if (!fs.existsSync(fileName)) exitWithError(`File ${blue(fileName)} does not exist \n`);
   const file = loadFile(fileName);
   if ((file as Oas2Definition).swagger) exitWithError('OpenAPI 2 is not supported by this command');
-  if (!(file as Oas3Definition | Oas3_1Definition).openapi) exitWithError('File does not conform to the OpenAPI Specification. OpenAPI version is not specified');
+  if (!(file as Oas3Definition | Oas3_1Definition).openapi)
+    exitWithError(
+      'File does not conform to the OpenAPI Specification. OpenAPI version is not specified'
+    );
   return true;
 }
 
@@ -90,8 +114,8 @@ function langToExt(lang: string) {
     bash: '.sh',
     javascript: '.js',
     js: '.js',
-    python: '.py'
-  }
+    python: '.py',
+  };
   return langObj[lang];
 }
 
@@ -111,7 +135,7 @@ function traverseDirectoryDeep(directory: string, callback: any, componentsFiles
 function traverseDirectoryDeepCallback(
   filename: string,
   directory: string,
-  componentsFiles: object,
+  componentsFiles: object
 ) {
   if (isNotYaml(filename)) return;
   const pathData = readYaml(filename);
@@ -127,11 +151,7 @@ function crawl(object: any, visitor: any) {
   }
 }
 
-function replace$Refs(
-  obj: any,
-  relativeFrom: string,
-  componentFiles = {} as ComponentsFiles
-) {
+function replace$Refs(obj: any, relativeFrom: string, componentFiles = {} as ComponentsFiles) {
   crawl(obj, (node: any) => {
     if (node.$ref && isString(node.$ref) && isStartsWithComponents(node.$ref)) {
       replace(node, '$ref');
@@ -156,7 +176,9 @@ function replace$Refs(
     const filesGroupName = componentFiles[groupName];
     if (!filesGroupName || !filesGroupName[name!]) return;
     let filename = path.relative(relativeFrom, filesGroupName[name!].filename);
-    if (!filename.startsWith('.')) { filename = '.' + path.sep + filename; }
+    if (!filename.startsWith('.')) {
+      filename = '.' + path.sep + filename;
+    }
     node[key] = filename;
   }
 }
@@ -182,30 +204,40 @@ function implicitlyReferenceDiscriminator(
   const discriminatorEnum = discriminatorPropSchema && discriminatorPropSchema.enum;
   const mapping = (obj.discriminator.mapping = obj.discriminator.mapping || {});
   for (const name of Object.keys(implicitMapping)) {
-    if (discriminatorEnum && !discriminatorEnum.includes(name)) { continue; }
+    if (discriminatorEnum && !discriminatorEnum.includes(name)) {
+      continue;
+    }
     if (mapping[name] && mapping[name] !== implicitMapping[name]) {
-      process.stderr.write(yellow(
-        `warning: explicit mapping overlaps with local mapping entry ${red(name)} at ${blue(filename)}. Please check it.`
-      ));
+      process.stderr.write(
+        yellow(
+          `warning: explicit mapping overlaps with local mapping entry ${red(name)} at ${blue(
+            filename
+          )}. Please check it.`
+        )
+      );
     }
     mapping[name] = implicitMapping[name];
   }
 }
 
 function isNotSecurityComponentType(componentType: string) {
-  return componentType !== OPENAPI3_COMPONENT.SecuritySchemes
+  return componentType !== OPENAPI3_COMPONENT.SecuritySchemes;
 }
 
 function findComponentTypes(components: any) {
-  return OPENAPI3_COMPONENT_NAMES
-    .filter(item => isNotSecurityComponentType(item) && Object.keys(components).includes(item))
+  return OPENAPI3_COMPONENT_NAMES.filter(
+    (item) => isNotSecurityComponentType(item) && Object.keys(components).includes(item)
+  );
 }
 
 function doesFileDiffer(filename: string, componentData: any) {
   return fs.existsSync(filename) && !isEqual(readYaml(filename), componentData);
 }
 
-function removeEmptyComponents(openapi: Oas3Definition | Oas3_1Definition, componentType: Oas3ComponentName) {
+function removeEmptyComponents(
+  openapi: Oas3Definition | Oas3_1Definition,
+  componentType: Oas3ComponentName
+) {
   if (openapi.components && isEmptyObject(openapi.components[componentType])) {
     delete openapi.components[componentType];
   }
@@ -237,19 +269,21 @@ function gatherComponentsFiles(
 ) {
   let inherits = [];
   if (componentType === OPENAPI3_COMPONENT.Schemas) {
-    inherits = ((components?.[componentType]?.[componentName] as Oas3Schema)?.allOf || []).map((s: any) => s.$ref).filter(Boolean);
+    inherits = ((components?.[componentType]?.[componentName] as Oas3Schema)?.allOf || [])
+      .map((s: any) => s.$ref)
+      .filter(Boolean);
   }
   componentsFiles[componentType] = componentsFiles[componentType] || {};
   componentsFiles[componentType][componentName] = { inherits, filename };
 }
 
 function iteratePathItems(
-  pathItems: Record<string,  Referenced<Oas3PathItem>> | undefined,
+  pathItems: Record<string, Referenced<Oas3PathItem>> | undefined,
   openapiDir: string,
   outDir: string,
   componentsFiles: object,
   pathSeparator: string,
-  codeSamplesPathPrefix: string = '',
+  codeSamplesPathPrefix: string = ''
 ) {
   if (!pathItems) return;
   fs.mkdirSync(outDir, { recursive: true });
@@ -259,7 +293,7 @@ function iteratePathItems(
     const pathData = pathItems[pathName] as Oas3PathItem;
 
     if (isRef(pathData)) continue;
-    
+
     for (const method of OPENAPI3_METHOD_NAMES) {
       const methodData = pathData[method];
       const methodDataXCode = methodData?.['x-code-samples'] || methodData?.['x-codeSamples'];
@@ -273,20 +307,20 @@ function iteratePathItems(
           'code_samples',
           escapeLanguageName(sample.lang),
           codeSamplesPathPrefix + pathToFilename(pathName, pathSeparator),
-          method + langToExt(sample.lang),
+          method + langToExt(sample.lang)
         );
 
         fs.mkdirSync(path.dirname(sampleFileName), { recursive: true });
         fs.writeFileSync(sampleFileName, sample.source);
         // @ts-ignore
         sample.source = {
-          $ref: slash(path.relative(outDir, sampleFileName))
+          $ref: slash(path.relative(outDir, sampleFileName)),
         };
       }
     }
     writeYaml(pathData, pathFile);
     pathItems[pathName] = {
-      $ref: slash(path.relative(openapiDir, pathFile))
+      $ref: slash(path.relative(openapiDir, pathFile)),
     };
 
     traverseDirectoryDeep(outDir, traverseDirectoryDeepCallback, componentsFiles);
@@ -329,9 +363,13 @@ function iterateComponents(
         );
 
         if (doesFileDiffer(filename, componentData)) {
-          process.stderr.write(yellow(
-            `warning: conflict for ${componentName} - file already exists with different content: ${blue(filename)} ... Skip.\n`
-          ));
+          process.stderr.write(
+            yellow(
+              `warning: conflict for ${componentName} - file already exists with different content: ${blue(
+                filename
+              )} ... Skip.\n`
+            )
+          );
         } else {
           writeYaml(componentData, filename);
         }

--- a/packages/cli/src/commands/split/types.ts
+++ b/packages/cli/src/commands/split/types.ts
@@ -9,9 +9,21 @@ import {
   Oas3ComponentName,
   Oas3_1Webhooks,
   Oas2Definition,
-  Referenced
-} from "@redocly/openapi-core";
-export { Oas3_1Definition, Oas3Definition, Oas2Definition, Oas3Components, Oas3Paths, Oas3PathItem, Oas3ComponentName, Oas3_1Schema, Oas3Schema, Oas3_1Webhooks, Referenced }
+  Referenced,
+} from '@redocly/openapi-core';
+export {
+  Oas3_1Definition,
+  Oas3Definition,
+  Oas2Definition,
+  Oas3Components,
+  Oas3Paths,
+  Oas3PathItem,
+  Oas3ComponentName,
+  Oas3_1Schema,
+  Oas3Schema,
+  Oas3_1Webhooks,
+  Referenced,
+};
 export type Definition = Oas3_1Definition | Oas3Definition | Oas2Definition;
 export interface ComponentsFiles {
   [schemas: string]: any;
@@ -34,7 +46,7 @@ enum OPENAPI3_METHOD {
   Options = 'options',
   Head = 'head',
   Patch = 'patch',
-  Trace = 'trace'
+  Trace = 'trace',
 }
 
 export const OPENAPI3_METHOD_NAMES: OPENAPI3_METHOD[] = [
@@ -45,7 +57,7 @@ export const OPENAPI3_METHOD_NAMES: OPENAPI3_METHOD[] = [
   OPENAPI3_METHOD.Options,
   OPENAPI3_METHOD.Head,
   OPENAPI3_METHOD.Patch,
-  OPENAPI3_METHOD.Trace
+  OPENAPI3_METHOD.Trace,
 ];
 
 export enum OPENAPI3_COMPONENT {
@@ -57,7 +69,7 @@ export enum OPENAPI3_COMPONENT {
   RequestBodies = 'requestBodies',
   Links = 'links',
   Callbacks = 'callbacks',
-  SecuritySchemes = 'securitySchemes'
+  SecuritySchemes = 'securitySchemes',
 }
 
 export const OPENAPI3_COMPONENT_NAMES: OPENAPI3_COMPONENT[] = [
@@ -69,5 +81,5 @@ export const OPENAPI3_COMPONENT_NAMES: OPENAPI3_COMPONENT[] = [
   OPENAPI3_COMPONENT.Headers,
   OPENAPI3_COMPONENT.Links,
   OPENAPI3_COMPONENT.Callbacks,
-  OPENAPI3_COMPONENT.SecuritySchemes
+  OPENAPI3_COMPONENT.SecuritySchemes,
 ];

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -18,22 +18,22 @@ import {
   WalkContext,
   walkDocument,
   Stats,
-  bundle
+  bundle,
 } from '@redocly/openapi-core';
 
-import { getFallbackEntryPointsOrExit } from '../utils'
+import { getFallbackEntryPointsOrExit } from '../utils';
 import { printExecutionTime } from '../utils';
 
 const statsAccumulator: StatsAccumulator = {
   refs: { metric: '🚗 References', total: 0, color: 'red', items: new Set() },
   externalDocs: { metric: '📦 External Documents', total: 0, color: 'magenta' },
-  schemas: { metric: '📈 Schemas', total: 0, color: 'white'},
+  schemas: { metric: '📈 Schemas', total: 0, color: 'white' },
   parameters: { metric: '👉 Parameters', total: 0, color: 'yellow', items: new Set() },
   links: { metric: '🔗 Links', total: 0, color: 'cyan', items: new Set() },
   pathItems: { metric: '➡️ Path Items', total: 0, color: 'green' },
   operations: { metric: '👷 Operations', total: 0, color: 'yellow' },
   tags: { metric: '🔖 Tags', total: 0, color: 'white', items: new Set() },
-}
+};
 
 function printStatsStylish(statsAccumulator: StatsAccumulator) {
   for (const node in statsAccumulator) {
@@ -48,7 +48,7 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
     json[key] = {
       metric: statsAccumulator[key as StatsName].metric,
       total: statsAccumulator[key as StatsName].total,
-    }
+    };
   }
   process.stdout.write(JSON.stringify(json, null, 2));
 }
@@ -56,18 +56,21 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
 function printStats(statsAccumulator: StatsAccumulator, entrypoint: string, format: string) {
   process.stderr.write(`Document: ${colors.magenta(entrypoint)} stats:\n\n`);
   switch (format) {
-    case 'stylish': printStatsStylish(statsAccumulator); break;
-    case 'json': printStatsJson(statsAccumulator); break;
+    case 'stylish':
+      printStatsStylish(statsAccumulator);
+      break;
+    case 'json':
+      printStatsJson(statsAccumulator);
+      break;
   }
 }
 
-export async function handleStats (argv: {
-  config?: string;
-  entrypoint?: string;
-  format: string;
-}) {
+export async function handleStats(argv: { config?: string; entrypoint?: string; format: string }) {
   const config: Config = await loadConfig(argv.config);
-  const [{ path }] = await getFallbackEntryPointsOrExit(argv.entrypoint ? [argv.entrypoint] : [], config);
+  const [{ path }] = await getFallbackEntryPointsOrExit(
+    argv.entrypoint ? [argv.entrypoint] : [],
+    config
+  );
   const externalRefResolver = new BaseResolver(config.resolve);
   const { bundle: document } = await bundle({ config, ref: path });
   const lintConfig: LintConfig = config.lint;
@@ -76,7 +79,7 @@ export async function handleStats (argv: {
   const types = normalizeTypes(
     lintConfig.extendTypes(
       oasMajorVersion === OasMajorVersion.Version3 ? Oas3Types : Oas2Types,
-      oasVersion,
+      oasVersion
     ),
     lintConfig
   );
@@ -86,7 +89,7 @@ export async function handleStats (argv: {
     problems: [],
     oasVersion: oasVersion,
     visitorsData: {},
-  }
+  };
 
   const resolvedRefMap = await resolveDocument({
     rootDocument: document,
@@ -94,11 +97,14 @@ export async function handleStats (argv: {
     externalRefResolver,
   });
 
-  const statsVisitor = normalizeVisitors([{
-    severity: 'warn',
-    ruleId: 'stats',
-    visitor: Stats(statsAccumulator)
-  }],
+  const statsVisitor = normalizeVisitors(
+    [
+      {
+        severity: 'warn',
+        ruleId: 'stats',
+        visitor: Stats(statsAccumulator),
+      },
+    ],
     types
   );
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -167,11 +167,7 @@ yargs
         },
         'lint-config': {
           description: 'Apply severity for linting the config file.',
-          choices: [
-            'warn',
-            'error',
-            'off',
-          ] as ReadonlyArray<RuleSeverity>,
+          choices: ['warn', 'error', 'off'] as ReadonlyArray<RuleSeverity>,
           default: 'warn' as RuleSeverity,
         },
         config: {

--- a/packages/cli/src/js-utils.ts
+++ b/packages/cli/src/js-utils.ts
@@ -1,6 +1,6 @@
 export function isObject(obj: any) {
   const type = typeof obj;
-  return type === 'function' || type === 'object' && !!obj;
+  return type === 'function' || (type === 'object' && !!obj);
 }
 
 export function isEmptyObject(obj: any) {
@@ -8,5 +8,5 @@ export function isEmptyObject(obj: any) {
 }
 
 export function isString(str: string) {
-  return Object.prototype.toString.call(str) === "[object String]";
+  return Object.prototype.toString.call(str) === '[object String]';
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname, join, resolve } from 'path';
 import { blue, gray, green, red, yellow } from 'colorette';
-import { performance } from "perf_hooks";
+import { performance } from 'perf_hooks';
 import * as glob from 'glob-promise';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -13,19 +13,23 @@ import {
   ResolveError,
   YamlParseError,
   parseYaml,
-  stringifyYaml
+  stringifyYaml,
 } from '@redocly/openapi-core';
 import { Totals, outputExtensions, Entrypoint } from './types';
 
-export async function getFallbackEntryPointsOrExit(argsEntrypoints: string[] | undefined, config: Config): Promise<Entrypoint[]> {
-  const  { apis } = config;
-  const shouldFallbackToAllDefinitions = !isNotEmptyArray(argsEntrypoints) && apis && Object.keys(apis).length > 0;
+export async function getFallbackEntryPointsOrExit(
+  argsEntrypoints: string[] | undefined,
+  config: Config
+): Promise<Entrypoint[]> {
+  const { apis } = config;
+  const shouldFallbackToAllDefinitions =
+    !isNotEmptyArray(argsEntrypoints) && apis && Object.keys(apis).length > 0;
   const res = shouldFallbackToAllDefinitions
     ? Object.entries(apis).map(([alias, { root }]) => ({
         path: resolve(getConfigDirectory(config), root),
         alias,
       }))
-    : (await expandGlobsInEntrypoints(argsEntrypoints!, config));
+    : await expandGlobsInEntrypoints(argsEntrypoints!, config);
   if (!isNotEmptyArray(res)) {
     process.stderr.write('error: missing required argument `entrypoints`.\n');
     process.exit(1);
@@ -48,11 +52,15 @@ function getAliasOrPath(config: Config, aliasOrPath: string): Entrypoint {
 }
 
 async function expandGlobsInEntrypoints(args: string[], config: Config) {
-  return (await Promise.all((args as string[]).map(async aliasOrPath => {
-    return glob.hasMagic(aliasOrPath)
-      ? (await glob(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
-      : getAliasOrPath(config, aliasOrPath);
-  }))).flat();
+  return (
+    await Promise.all(
+      (args as string[]).map(async (aliasOrPath) => {
+        return glob.hasMagic(aliasOrPath)
+          ? (await glob(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
+          : getAliasOrPath(config, aliasOrPath);
+      })
+    )
+  ).flat();
 }
 
 export function getExecutionTime(startedAt: number) {
@@ -75,10 +83,7 @@ export function pathToFilename(path: string, pathSeparator: string) {
 }
 
 export function escapeLanguageName(lang: string) {
-  return lang
-    .replace(/#/g, "_sharp")
-    .replace(/\//, '_')
-    .replace(/\s/g, '');
+  return lang.replace(/#/g, '_sharp').replace(/\//, '_').replace(/\s/g, '');
 }
 
 export class CircularJSONNotSupportedError extends Error {
@@ -168,18 +173,19 @@ export function pluralize(label: string, num: number) {
 export function handleError(e: Error, ref: string) {
   if (e instanceof ResolveError) {
     process.stderr.write(
-      `Failed to resolve entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`,
+      `Failed to resolve entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`
     );
   } else if (e instanceof YamlParseError) {
     process.stderr.write(
-      `Failed to parse entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`,
+      `Failed to parse entrypoint definition at ${ref}:\n\n  - ${e.message}.\n\n`
     );
     // TODO: codeframe
-  } else { // @ts-ignore
+  } else {
+    // @ts-ignore
     if (e instanceof CircularJSONNotSupportedError) {
       process.stderr.write(
         red(`Detected circular reference which can't be converted to JSON.\n`) +
-        `Try to use ${blue('yaml')} output or remove ${blue('--dereferenced')}.\n\n`,
+          `Try to use ${blue('yaml')} output or remove ${blue('--dereferenced')}.\n\n`
       );
     } else {
       process.stderr.write(`Something went wrong when processing ${ref}:\n\n  - ${e.message}.\n\n`);
@@ -200,30 +206,27 @@ export function printLintTotals(totals: Totals, definitionsCount: number) {
           totals.warnings > 0
             ? ` and ${totals.warnings} ${pluralize('warning', totals.warnings)}`
             : ''
-        }.\n${ignored}`,
-      ),
+        }.\n${ignored}`
+      )
     );
   } else if (totals.warnings > 0) {
     process.stderr.write(
-      green(`Woohoo! Your OpenAPI ${pluralize('definition is', definitionsCount)} valid. 🎉\n`),
+      green(`Woohoo! Your OpenAPI ${pluralize('definition is', definitionsCount)} valid. 🎉\n`)
     );
     process.stderr.write(
-      yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n${ignored}`),
+      yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n${ignored}`)
     );
   } else {
     process.stderr.write(
       green(
-        `Woohoo! Your OpenAPI ${pluralize(
-          'definition is',
-          definitionsCount,
-        )} valid. 🎉\n${ignored}`,
-      ),
+        `Woohoo! Your OpenAPI ${pluralize('definition is', definitionsCount)} valid. 🎉\n${ignored}`
+      )
     );
   }
 
   if (totals.errors > 0) {
     process.stderr.write(
-      gray(`run \`openapi lint --generate-ignore-file\` to add all problems to the ignore file.\n`),
+      gray(`run \`openapi lint --generate-ignore-file\` to add all problems to the ignore file.\n`)
     );
   }
 
@@ -238,21 +241,21 @@ export function printConfigLintTotals(totals: Totals): void {
           totals.warnings > 0
             ? ` and ${totals.warnings} ${pluralize('warning', totals.warnings)}`
             : ''
-        }.\n`,
-      ),
+        }.\n`
+      )
     );
   } else if (totals.warnings > 0) {
     process.stderr.write(
-      yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n`),
+      yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n`)
     );
-  };
+  }
 }
 
 export function getOutputFileName(
   entrypoint: string,
   entries: number,
   output?: string,
-  ext?: BundleOutputFormat,
+  ext?: BundleOutputFormat
 ) {
   if (!output) {
     return { outputFile: 'stdout', ext: ext || 'yaml' };
@@ -283,26 +286,26 @@ export function printUnusedWarnings(config: LintConfig) {
   if (rules.length) {
     process.stderr.write(
       yellow(
-        `[WARNING] Unused rules found in ${blue(config.configFile || '')}: ${rules.join(', ')}.\n`,
-      ),
+        `[WARNING] Unused rules found in ${blue(config.configFile || '')}: ${rules.join(', ')}.\n`
+      )
     );
   }
   if (preprocessors.length) {
     process.stderr.write(
       yellow(
         `[WARNING] Unused preprocessors found in ${blue(
-          config.configFile || '',
-        )}: ${preprocessors.join(', ')}.\n`,
-      ),
+          config.configFile || ''
+        )}: ${preprocessors.join(', ')}.\n`
+      )
     );
   }
   if (decorators.length) {
     process.stderr.write(
       yellow(
         `[WARNING] Unused decorators found in ${blue(config.configFile || '')}: ${decorators.join(
-          ', ',
-        )}.\n`,
-      ),
+          ', '
+        )}.\n`
+      )
     );
   }
 
@@ -312,7 +315,7 @@ export function printUnusedWarnings(config: LintConfig) {
 }
 
 export function exitWithError(message: string) {
-  process.stderr.write(red(message)+ '\n\n');
+  process.stderr.write(red(message) + '\n\n');
   process.exit(1);
 }
 

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -28,7 +28,7 @@ describe('bundle', () => {
           shared_a:
             name: shared-a
     `,
-    '',
+    ''
   );
 
   it('change nothing with only internal refs', async () => {
@@ -60,7 +60,7 @@ describe('bundle', () => {
     });
     expect(problems).toHaveLength(1);
     expect(problems[0].message).toEqual(
-      `Two schemas are referenced with the same name but different content. Renamed param-b to param-b-2.`,
+      `Two schemas are referenced with the same name but different content. Renamed param-b to param-b-2.`
     );
     expect(res.parsed).toMatchSnapshot();
   });
@@ -98,13 +98,13 @@ describe('bundle', () => {
   });
 
   it('should pull hosted schema', async () => {
-    const fetchMock = jest.fn(
-      () => Promise.resolve({
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
         ok: true,
         text: () => 'External schema content',
         headers: {
-          get: () => ''
-        }
+          get: () => '',
+        },
       })
     );
 
@@ -113,31 +113,28 @@ describe('bundle', () => {
       externalRefResolver: new BaseResolver({
         http: {
           customFetch: fetchMock,
-          headers: []
-        }
+          headers: [],
+        },
       }),
-      ref: path.join(__dirname, 'fixtures/refs/hosted.yaml')
+      ref: path.join(__dirname, 'fixtures/refs/hosted.yaml'),
     });
 
     expect(problems).toHaveLength(0);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://someexternal.schema",
-      {
-        headers: {}
-      }
-    );
+    expect(fetchMock).toHaveBeenCalledWith('https://someexternal.schema', {
+      headers: {},
+    });
     expect(res.parsed).toMatchSnapshot();
   });
 
   it('should not bundle url refs if used with keepUrlRefs', async () => {
     const fetchMock = jest.fn(() =>
-        Promise.resolve({
-          ok: true,
-          text: () => 'External schema content',
-          headers: {
-            get: () => '',
-          },
-        }),
+      Promise.resolve({
+        ok: true,
+        text: () => 'External schema content',
+        headers: {
+          get: () => '',
+        },
+      })
     );
     const { bundle: res, problems } = await bundle({
       config: new Config({} as ResolvedConfig),

--- a/packages/core/src/__tests__/codeframes.test.ts
+++ b/packages/core/src/__tests__/codeframes.test.ts
@@ -17,7 +17,7 @@ describe('Location', () => {
             license:
               name: MIT
               url: https://google.com
-        `,
+        `
       ),
     };
     const preciseLocation = getLineColLocation(loc);
@@ -37,7 +37,7 @@ describe('Location', () => {
             license:
               name: MIT
               url: https://google.com
-        `,
+        `
       ),
     };
     const preciseLocation = getLineColLocation(loc);
@@ -57,7 +57,7 @@ describe('Location', () => {
             license:
               name: MIT
               url: https://google.com
-        `,
+        `
       ),
     };
     const preciseLocation = getLineColLocation(loc);
@@ -77,7 +77,7 @@ describe('Location', () => {
             license:
               name: MIT
               url: https://google.com
-        `,
+        `
       ),
     };
     const preciseLocation = getLineColLocation(loc);
@@ -98,14 +98,13 @@ describe('Location', () => {
             license:
               name: MIT
               url: https://google.com
-        `,
+        `
       ),
     };
     const preciseLocation = getLineColLocation(loc);
     expect(preciseLocation.start).toEqual({ line: 2, col: 1 });
     expect(preciseLocation.end).toEqual({ line: 2, col: 9 });
   });
-
 
   it('should return first line for empty doc', () => {
     const loc = {
@@ -158,7 +157,7 @@ describe('codeframes', () => {
             license:
               name: MIT
               url: https://google.com
-            `,
+            `
       ),
     };
 
@@ -222,7 +221,7 @@ describe('codeframes', () => {
             license:
               name: MIT
               url: https://google.com
-            `,
+            `
       ),
     };
 
@@ -256,7 +255,7 @@ describe('codeframes', () => {
               name: MIT,
               url: https://google.com
             }
-            `,
+            `
       ),
     };
 
@@ -299,7 +298,7 @@ describe('codeframes', () => {
               field5: MIT
               url: https://google.com
           openapi: 3.0.2
-          `,
+          `
       ),
     };
 
@@ -343,7 +342,7 @@ describe('codeframes', () => {
               field3: MIT
               field4: MIT
               field5: MIT
-          `,
+          `
       ),
     };
 
@@ -390,7 +389,7 @@ describe('codeframes', () => {
                     in: wrong
               post:
                 operationId: test2
-          `,
+          `
       ),
     };
 
@@ -425,7 +424,7 @@ describe('codeframes', () => {
             license:
               name: MIT
               url: https://google.com
-          `,
+          `
       ),
     };
 
@@ -483,7 +482,7 @@ describe('codeframes', () => {
           license:
             name: MIT
             url: https://google.com
-      `,
+      `
       ),
     };
 

--- a/packages/core/src/__tests__/js-yaml.test.ts
+++ b/packages/core/src/__tests__/js-yaml.test.ts
@@ -48,7 +48,7 @@ describe('js-yaml', () => {
 
   test('should correctly dump date and string', () => {
     expect(stringifyYaml(parseYaml(yamlToDump))).toMatchInlineSnapshot(
-    `
+      `
     "date: '2022-01-21T11:29:56.694Z'
     dateWithoutQuotes: '2020-01-01'
     dateWithQuotes: '2020-01-01'
@@ -57,7 +57,8 @@ describe('js-yaml', () => {
     stringWithQuotes: test
     stringWithDoubleQuotes: test
     "
-    `);
+    `
+    );
   });
 
   test('parse and stringify', () => {
@@ -65,7 +66,8 @@ describe('js-yaml', () => {
   });
 
   test('should throw an error for unsupported types', () => {
-    expect(() => stringifyYaml({ foo: () => {} }))
-      .toThrow('unacceptable kind of an object to dump [object Function]');
+    expect(() => stringifyYaml({ foo: () => {} })).toThrow(
+      'unacceptable kind of an object to dump [object Function]'
+    );
   });
 });

--- a/packages/core/src/__tests__/login.test.ts
+++ b/packages/core/src/__tests__/login.test.ts
@@ -6,10 +6,10 @@ describe.skip('login', () => {
     Object.defineProperty(client, 'registryApi', {
       value: {
         setAccessTokens: jest.fn(),
-        authStatus: jest.fn(() => true)
+        authStatus: jest.fn(() => true),
       },
       writable: true,
-      configurable: true
+      configurable: true,
     });
     await client.login('token'); // TODO: bug with rewrite local config file
     expect(client.registryApi.setAccessTokens).toHaveBeenCalled();

--- a/packages/core/src/__tests__/normalizeVisitors.test.ts
+++ b/packages/core/src/__tests__/normalizeVisitors.test.ts
@@ -22,7 +22,7 @@ describe('Normalize visitors', () => {
         ruleId,
         severity: 'error' as 'error',
         visitor: ruleset[ruleId]({}),
-      })),
+      }))
     );
 
     const normalized = normalizeVisitors(visitors, normalizeTypes(Oas3Types));
@@ -66,7 +66,7 @@ describe('Normalize visitors', () => {
         ruleId,
         severity: 'error' as 'error',
         visitor: ruleset[ruleId]({}),
-      })),
+      }))
     );
 
     const normalized = normalizeVisitors(visitors, normalizeTypes(Oas3Types));
@@ -104,7 +104,7 @@ describe('Normalize visitors', () => {
         ruleId,
         severity: 'error' as 'error',
         visitor: ruleset[ruleId]({}),
-      })),
+      }))
     );
 
     const normalized = normalizeVisitors(visitors, normalizeTypes(Oas3Types));
@@ -139,7 +139,7 @@ describe('Normalize visitors', () => {
         ruleId,
         severity: 'error' as 'error',
         visitor: ruleset[ruleId]({}),
-      })),
+      }))
     );
 
     const normalized = normalizeVisitors(visitors, normalizeTypes(Oas3Types));

--- a/packages/core/src/__tests__/ref-utils.test.ts
+++ b/packages/core/src/__tests__/ref-utils.test.ts
@@ -84,7 +84,7 @@ describe('ref-utils', () => {
                 name:
                   type: string
       `,
-      '',
+      ''
     );
 
     const result = await lintDocument({
@@ -97,24 +97,24 @@ describe('ref-utils', () => {
   });
 
   describe('refBaseName', () => {
-    it("returns base name for file reference", () => {
-      expect(refBaseName("../testcase/Pet.yaml")).toStrictEqual("Pet");
+    it('returns base name for file reference', () => {
+      expect(refBaseName('../testcase/Pet.yaml')).toStrictEqual('Pet');
     });
 
-    it("returns base name for local file reference", () => {
-      expect(refBaseName("Cat.json")).toStrictEqual("Cat");
+    it('returns base name for local file reference', () => {
+      expect(refBaseName('Cat.json')).toStrictEqual('Cat');
     });
 
-    it("returns base name for url reference", () => {
-      expect(refBaseName("http://example.com/tests/crocodile.json")).toStrictEqual("crocodile");
+    it('returns base name for url reference', () => {
+      expect(refBaseName('http://example.com/tests/crocodile.json')).toStrictEqual('crocodile');
     });
 
-    it("returns base name for file with multiple dots in name", () => {
-      expect(refBaseName("feline.tiger.v1.yaml")).toStrictEqual("feline.tiger.v1");
+    it('returns base name for file with multiple dots in name', () => {
+      expect(refBaseName('feline.tiger.v1.yaml')).toStrictEqual('feline.tiger.v1');
     });
 
-    it("returns base name for file without any dots in name", () => {
-      expect(refBaseName("abcdefg")).toStrictEqual("abcdefg");
+    it('returns base name for file without any dots in name', () => {
+      expect(refBaseName('abcdefg')).toStrictEqual('abcdefg');
     });
   });
 });

--- a/packages/core/src/__tests__/resolve-http.test.ts
+++ b/packages/core/src/__tests__/resolve-http.test.ts
@@ -19,7 +19,7 @@ describe('Resolve http-headers', () => {
             C:
               $ref: 'https://sample.com/test/a/test.yaml'
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const fetchMock = jest.fn(() => Promise.resolve({ ok: true, text: Promise.resolve('') }));

--- a/packages/core/src/__tests__/resolve.test.ts
+++ b/packages/core/src/__tests__/resolve.test.ts
@@ -18,7 +18,7 @@ describe('collect refs', () => {
             contact: {}
             license: {}
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const resolvedRefs = await resolveDocument({
@@ -35,7 +35,7 @@ describe('collect refs', () => {
       Array [
         "foobar.yaml::#/defs/info",
       ]
-    `,
+    `
     );
     expect(Array.from(resolvedRefs.values()).map((info) => info.node)).toEqual([
       { contact: {}, license: {} },
@@ -56,7 +56,7 @@ describe('collect refs', () => {
             contact: {}
             license: {}
       `,
-      '',
+      ''
     );
 
     try {
@@ -89,7 +89,7 @@ describe('collect refs', () => {
             contact: {}
             license: {}
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const resolvedRefs = await resolveDocument({
@@ -125,7 +125,7 @@ describe('collect refs', () => {
         loop2:
           $ref: '#/info'
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     try {
@@ -147,7 +147,7 @@ describe('collect refs', () => {
         info:
           $ref: "./externalInfo.yaml#/info"
       `,
-      path.join(cwd, 'foobar.yaml'),
+      path.join(cwd, 'foobar.yaml')
     );
 
     const resolvedRefs = await resolveDocument({
@@ -181,7 +181,7 @@ describe('collect refs', () => {
     const externalRefResolver = new BaseResolver();
     const rootDocument = await externalRefResolver.resolveDocument(
       null,
-      `${cwd}/openapi-with-back.yaml`,
+      `${cwd}/openapi-with-back.yaml`
     );
 
     const resolvedRefs = await resolveDocument({
@@ -192,8 +192,11 @@ describe('collect refs', () => {
 
     expect(resolvedRefs).toBeDefined();
 
-    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1)).sort())
-      .toMatchInlineSnapshot(`
+    expect(
+      Array.from(resolvedRefs.keys())
+        .map((ref) => ref.substring(cwd.length + 1))
+        .sort()
+    ).toMatchInlineSnapshot(`
       Array [
         "openapi-with-back.yaml::./schemas/type-a.yaml#/",
         "openapi-with-back.yaml::./schemas/type-b.yaml#/",
@@ -345,7 +348,7 @@ describe('collect refs', () => {
     const externalRefResolver = new BaseResolver();
     const rootDocument = await externalRefResolver.resolveDocument(
       null,
-      `${cwd}/openapi-with-md-description.yaml`,
+      `${cwd}/openapi-with-md-description.yaml`
     );
 
     expect(rootDocument).toBeDefined();
@@ -383,7 +386,7 @@ describe('collect refs', () => {
         components:
           $ref: "./transitive/components.yaml#/components/schemas/a"
       `,
-      path.join(cwd, 'foobar.yaml'),
+      path.join(cwd, 'foobar.yaml')
     );
 
     const resolvedRefs = await resolveDocument({

--- a/packages/core/src/__tests__/walk.test.ts
+++ b/packages/core/src/__tests__/walk.test.ts
@@ -4,7 +4,11 @@ import * as path from 'path';
 
 import { lintDocument } from '../lint';
 
-import { parseYamlToDocument, replaceSourceWithRef, makeConfigForRuleset } from '../../__tests__/utils';
+import {
+  parseYamlToDocument,
+  replaceSourceWithRef,
+  makeConfigForRuleset,
+} from '../../__tests__/utils';
 import { BaseResolver, Document } from '../resolve';
 import { listOf } from '../types';
 import { Oas3RuleSet } from '../oas-types';
@@ -43,7 +47,7 @@ describe('walk order', () => {
           contact: {}
           license: {}
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -70,14 +74,10 @@ describe('walk order', () => {
             leave: jest.fn((op) => calls.push(`leave operation: ${op.operationId}`)),
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(
-                  `enter operation ${parents.Operation.operationId} > param ${param.name}`,
-                ),
+                calls.push(`enter operation ${parents.Operation.operationId} > param ${param.name}`)
               ),
               leave: jest.fn((param, _ctx, parents) =>
-                calls.push(
-                  `leave operation ${parents.Operation.operationId} > param ${param.name}`,
-                ),
+                calls.push(`leave operation ${parents.Operation.operationId} > param ${param.name}`)
               ),
             },
           },
@@ -110,7 +110,7 @@ describe('walk order', () => {
                 - name: post_a
 
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -154,14 +154,10 @@ describe('walk order', () => {
             leave: jest.fn((op) => calls.push(`leave operation: ${op.operationId}`)),
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(
-                  `enter operation ${parents.Operation.operationId} > param ${param.name}`,
-                ),
+                calls.push(`enter operation ${parents.Operation.operationId} > param ${param.name}`)
               ),
               leave: jest.fn((param, _ctx, parents) =>
-                calls.push(
-                  `leave operation ${parents.Operation.operationId} > param ${param.name}`,
-                ),
+                calls.push(`leave operation ${parents.Operation.operationId} > param ${param.name}`)
               ),
             },
           },
@@ -194,7 +190,7 @@ describe('walk order', () => {
                 - name: post_a
 
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -238,14 +234,10 @@ describe('walk order', () => {
             leave: jest.fn((op) => calls.push(`leave operation: ${op.operationId}`)),
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(
-                  `enter operation ${parents.Operation.operationId} > param ${param.name}`,
-                ),
+                calls.push(`enter operation ${parents.Operation.operationId} > param ${param.name}`)
               ),
               leave: jest.fn((param, _ctx, parents) =>
-                calls.push(
-                  `leave operation ${parents.Operation.operationId} > param ${param.name}`,
-                ),
+                calls.push(`leave operation ${parents.Operation.operationId} > param ${param.name}`)
               ),
             },
           },
@@ -279,7 +271,7 @@ describe('walk order', () => {
             shared_a:
               name: shared-a
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -317,7 +309,7 @@ describe('walk order', () => {
           PathItem: {
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`),
+                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`)
               ),
             },
           },
@@ -351,7 +343,7 @@ describe('walk order', () => {
             shared_a:
               name: shared-a
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -379,15 +371,15 @@ describe('walk order', () => {
           PathItem: {
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`),
+                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`)
               ),
             },
             Operation: {
               Parameter: {
                 enter: jest.fn((param, _ctx, parents) =>
                   calls.push(
-                    `enter operation ${parents.Operation.operationId} > param ${param.name}`,
-                  ),
+                    `enter operation ${parents.Operation.operationId} > param ${param.name}`
+                  )
                 ),
               },
             },
@@ -423,7 +415,7 @@ describe('walk order', () => {
             shared_b:
               name: shared-b
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -452,10 +444,10 @@ describe('walk order', () => {
           PathItem: {
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`),
+                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`)
               ),
               leave: jest.fn((param, _ctx, parents) =>
-                calls.push(`leave path ${parents.PathItem.id} > param ${param.name}`),
+                calls.push(`leave path ${parents.PathItem.id} > param ${param.name}`)
               ),
             },
             Operation(op, _ctx, parents) {
@@ -490,7 +482,7 @@ describe('walk order', () => {
             shared_a:
               name: shared-a
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -544,7 +536,7 @@ describe('walk order', () => {
                 - $ref: "#/components/parameters/shared_a"
                 - id: 'nested'
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -569,7 +561,7 @@ describe('walk order', () => {
         return {
           Parameter: {
             Schema: jest.fn((schema: any, _ctx, parents) =>
-              calls.push(`enter param ${parents.Parameter.name} > schema ${schema.id}`),
+              calls.push(`enter param ${parents.Parameter.name} > schema ${schema.id}`)
             ),
           },
         };
@@ -600,7 +592,7 @@ describe('walk order', () => {
                 - $ref: "#/components/parameters/shared_a"
                 - id: 'nested'
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -642,7 +634,7 @@ describe('walk order', () => {
             put:
               operationId: put
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -668,7 +660,7 @@ describe('walk order', () => {
           Operation: {
             skip: (op) => op.operationId === 'put',
             Parameter: jest.fn((param, _ctx, parents) =>
-              calls.push(`enter operation ${parents.Operation.operationId} > param ${param.name}`),
+              calls.push(`enter operation ${parents.Operation.operationId} > param ${param.name}`)
             ),
           },
         };
@@ -697,7 +689,7 @@ describe('walk order', () => {
             shared_a:
               name: shared-a
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -724,10 +716,10 @@ describe('walk order', () => {
           PathItem: {
             Parameter: {
               enter: jest.fn((param, _ctx, parents) =>
-                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`),
+                calls.push(`enter path ${parents.PathItem.id} > param ${param.name}`)
               ),
               leave: jest.fn((param, _ctx, parents) =>
-                calls.push(`leave path ${parents.PathItem.id} > param ${param.name}`),
+                calls.push(`leave path ${parents.PathItem.id} > param ${param.name}`)
               ),
             },
             Operation: {
@@ -735,13 +727,13 @@ describe('walk order', () => {
               Parameter: {
                 enter: jest.fn((param, _ctx, parents) =>
                   calls.push(
-                    `enter operation ${parents.Operation.operationId} > param ${param.name}`,
-                  ),
+                    `enter operation ${parents.Operation.operationId} > param ${param.name}`
+                  )
                 ),
                 leave: jest.fn((param, _ctx, parents) =>
                   calls.push(
-                    `leave operation ${parents.Operation.operationId} > param ${param.name}`,
-                  ),
+                    `leave operation ${parents.Operation.operationId} > param ${param.name}`
+                  )
                 ),
               },
             },
@@ -783,7 +775,7 @@ describe('walk order', () => {
             shared_b:
               name: shared-b
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -817,10 +809,10 @@ describe('walk order', () => {
           Schema: {
             Schema: {
               enter: jest.fn((schema: any, _ctx, parents) =>
-                calls.push(`enter nested schema ${parents.Schema.id} > ${schema.id}`),
+                calls.push(`enter nested schema ${parents.Schema.id} > ${schema.id}`)
               ),
               leave: jest.fn((schema: any, _ctx, parents) =>
-                calls.push(`leave nested schema ${parents.Schema.id} > ${schema.id}`),
+                calls.push(`leave nested schema ${parents.Schema.id} > ${schema.id}`)
               ),
             },
           },
@@ -862,7 +854,7 @@ describe('walk order', () => {
                     a:
                       id: inline-nested-nested
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     await lintDocument({
@@ -934,7 +926,7 @@ describe('walk order', () => {
             schema:
               $ref: '#/components/parameters/shared_b'
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     await lintDocument({
@@ -978,7 +970,7 @@ describe('walk order', () => {
           b:
             type: number
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     await lintDocument({
@@ -1043,7 +1035,7 @@ describe('walk order', () => {
             a:
               type: object
       `,
-      '',
+      ''
     );
 
     await lintDocument({
@@ -1131,7 +1123,7 @@ describe('context.report', () => {
             shared_a:
               name: shared_a
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -1207,7 +1199,7 @@ describe('context.report', () => {
     const externalRefResolver = new BaseResolver();
     const document = (await externalRefResolver.resolveDocument(
       null,
-      `${cwd}/openapi-with-external-refs.yaml`,
+      `${cwd}/openapi-with-external-refs.yaml`
     )) as Document;
 
     if (document === null) {
@@ -1319,7 +1311,7 @@ describe('context.resolve', () => {
                 a:
                   $ref: '#/components/schemas/b'
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     await lintDocument({
@@ -1368,7 +1360,7 @@ describe('type extensions', () => {
           parameters:
             - name: a
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     await lintDocument({
@@ -1462,7 +1454,7 @@ describe('ignoreNextRules', () => {
             put:
               operationId: put
       `,
-      '',
+      ''
     );
 
     await lintDocument({

--- a/packages/core/src/benchmark/benches/lint-with-many-rules.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-many-rules.bench.ts
@@ -9,7 +9,7 @@ export const count = 10;
 const rebillyDefinitionRef = pathResolve(pathJoin(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 
 const ruleset: any = {};

--- a/packages/core/src/benchmark/benches/lint-with-nested-rule.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-nested-rule.bench.ts
@@ -9,7 +9,7 @@ export const count = 10;
 const rebillyDefinitionRef = pathResolve(pathJoin(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 const visitor = {
   test: () => {

--- a/packages/core/src/benchmark/benches/lint-with-no-rules.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-no-rules.bench.ts
@@ -8,7 +8,7 @@ export const count = 10;
 const rebillyDefinitionRef = pathResolve(pathJoin(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 const config = makeConfigForRuleset({});
 export function measureAsync() {

--- a/packages/core/src/benchmark/benches/lint-with-top-level-rule-report.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-top-level-rule-report.bench.ts
@@ -9,7 +9,7 @@ export const count = 10;
 const rebillyDefinitionRef = pathResolve(pathJoin(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 
 const config = makeConfigForRuleset({

--- a/packages/core/src/benchmark/benches/lint-with-top-level-rule.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-top-level-rule.bench.ts
@@ -8,7 +8,7 @@ export const count = 10;
 const rebillyDefinitionRef = pathResolve(pathJoin(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 
 const config = makeConfigForRuleset({

--- a/packages/core/src/benchmark/benches/recommended-oas3.bench.ts
+++ b/packages/core/src/benchmark/benches/recommended-oas3.bench.ts
@@ -10,7 +10,7 @@ export const count = 10;
 const rebillyDefinitionRef = pathResolve(pathJoin(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 
 export function measureAsync() {

--- a/packages/core/src/benchmark/benches/resolve-with-no-external.bench.ts
+++ b/packages/core/src/benchmark/benches/resolve-with-no-external.bench.ts
@@ -10,7 +10,7 @@ export const count = 10;
 const rebillyDefinitionRef = path.resolve(path.join(__dirname, 'rebilly.yaml'));
 const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
-  rebillyDefinitionRef,
+  rebillyDefinitionRef
 );
 const externalRefResolver = new BaseResolver();
 

--- a/packages/core/src/benchmark/benchmark.js
+++ b/packages/core/src/benchmark/benchmark.js
@@ -31,7 +31,7 @@ function prepareRevision(revision) {
   const hash = exec(`git rev-parse "${revision}"`);
   const dir = path.join(os.tmpdir(), 'redocly-cli-benchmark', hash);
   if (fs.existsSync(dir)) {
-    fs.rmdirSync(dir, { recursive: true});
+    fs.rmdirSync(dir, { recursive: true });
   }
   fs.mkdirSync(dir, { recursive: true });
 
@@ -48,7 +48,10 @@ function tscBuild(dir) {
   process.chdir(dir);
   execSync('npm run compile', { stdio: 'inherit' });
   exec(
-    `cp ${path.join(dir, 'packages/core/src/benchmark/benches/*.yaml')} ${path.join(dir, 'packages/core/lib/benchmark/benches/')}`,
+    `cp ${path.join(dir, 'packages/core/src/benchmark/benches/*.yaml')} ${path.join(
+      dir,
+      'packages/core/lib/benchmark/benches/'
+    )}`
   );
   process.chdir(oldCwd);
   return path.join(dir, 'packages/core/lib/benchmark/benches');
@@ -70,7 +73,8 @@ async function collectSamples(modulePath) {
 
 // T-Distribution two-tailed critical values for 95% confidence.
 // See http://www.itl.nist.gov/div898/handbook/eda/section3/eda3672.htm.
-const tTable = /* prettier-ignore */ {
+const tTable =
+  /* prettier-ignore */ {
   '1':  12.706, '2':  4.303, '3':  3.182, '4':  2.776, '5':  2.571, '6':  2.447,
   '7':  2.365,  '8':  2.306, '9':  2.262, '10': 2.228, '11': 2.201, '12': 2.179,
   '13': 2.16,   '14': 2.145, '15': 2.131, '16': 2.12,  '17': 2.11,  '18': 2.101,
@@ -150,7 +154,7 @@ function beautifyBenchmark(results) {
         grey(' x ') +
         memPerOpStr() +
         '/op' +
-        grey(' (' + numSamples + ' runs sampled)'),
+        grey(' (' + numSamples + ' runs sampled)')
     );
 
     function nameStr() {
@@ -255,7 +259,7 @@ function matchBenchmarks(patterns) {
   let benchmarks = findFiles(LOCAL_DIR('../lib/benchmark/benches'), '*.bench.js');
   if (patterns.length > 0) {
     benchmarks = benchmarks.filter((benchmark) =>
-      patterns.some((pattern) => path.join('../lib/benchmark/benches', benchmark).includes(pattern)),
+      patterns.some((pattern) => path.join('../lib/benchmark/benches', benchmark).includes(pattern))
     );
   }
 

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -7,7 +7,7 @@ import { Oas3_1Types } from './types/oas3_1';
 import { NormalizedNodeType, normalizeTypes, NodeType } from './types';
 import { WalkContext, walkDocument, UserContext, ResolveResult } from './walk';
 import { detectOpenAPI, openAPIMajor, OasMajorVersion } from './oas-types';
-import {isAbsoluteUrl, isRef, Location, refBaseName} from './ref-utils';
+import { isAbsoluteUrl, isRef, Location, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
 import { reportUnresolvedRef } from './rules/no-unresolved-refs';
 import { isPlainObject } from './utils';
@@ -94,9 +94,9 @@ export async function bundleDocument(opts: {
           ? Oas3_1Types
           : Oas3Types
         : Oas2Types,
-      oasVersion,
+      oasVersion
     ),
-    config,
+    config
   );
 
   const preprocessors = initRules(rules as any, config, 'preprocessors', oasVersion);
@@ -113,10 +113,11 @@ export async function bundleDocument(opts: {
     decorators.push({
       severity: 'error',
       ruleId: 'remove-unused-components',
-      visitor: oasMajorVersion === OasMajorVersion.Version2
-        ? RemoveUnusedComponentsOas2({})
-        : RemoveUnusedComponentsOas3({})
-    })
+      visitor:
+        oasMajorVersion === OasMajorVersion.Version2
+          ? RemoveUnusedComponentsOas2({})
+          : RemoveUnusedComponentsOas3({}),
+    });
   }
 
   const resolvedRefMap = await resolveDocument({
@@ -137,12 +138,12 @@ export async function bundleDocument(opts: {
           skipRedoclyRegistryRefs,
           document,
           resolvedRefMap,
-          keepUrlRefs,
+          keepUrlRefs
         ),
       },
       ...decorators,
     ] as any,
-    types,
+    types
   );
 
   walkDocument({
@@ -210,7 +211,7 @@ function makeBundleVisitor(
   skipRedoclyRegistryRefs: boolean,
   rootDocument: Document,
   resolvedRefMap: ResolvedRefMap,
-  keepUrlRefs: boolean,
+  keepUrlRefs: boolean
 ) {
   let components: Record<string, Record<string, any>>;
 
@@ -287,7 +288,7 @@ function makeBundleVisitor(
   }
 
   function resolveBundledComponent(node: OasRef, resolved: ResolveResult<any>, ctx: UserContext) {
-    const newRefId = makeRefId(ctx.location.source.absoluteRef, node.$ref)
+    const newRefId = makeRefId(ctx.location.source.absoluteRef, node.$ref);
     resolvedRefMap.set(newRefId, {
       document: rootDocument,
       isRemote: false,
@@ -310,7 +311,7 @@ function makeBundleVisitor(
   function saveComponent(
     componentType: string,
     target: { node: any; location: Location },
-    ctx: UserContext,
+    ctx: UserContext
   ) {
     components[componentType] = components[componentType] || {};
     const name = getComponentName(target, componentType, ctx);
@@ -325,7 +326,7 @@ function makeBundleVisitor(
   function isEqualOrEqualRef(
     node: any,
     target: { node: any; location: Location },
-    ctx: UserContext,
+    ctx: UserContext
   ) {
     if (
       isRef(node) &&
@@ -340,7 +341,7 @@ function makeBundleVisitor(
   function getComponentName(
     target: { node: any; location: Location },
     componentType: string,
-    ctx: UserContext,
+    ctx: UserContext
   ) {
     const [fileRef, pointer] = [target.location.source.absoluteRef, target.location.pointer];
     const componentsGroup = components[componentType];

--- a/packages/core/src/config/__tests__/config-resolvers.test.ts
+++ b/packages/core/src/config/__tests__/config-resolvers.test.ts
@@ -35,12 +35,12 @@ describe('resolveLint', () => {
     expect(
       await resolveLint({
         lintConfig: { ...baseLintConfig, extends: ['minimal', 'recommended'] },
-      }),
+      })
     ).toEqual(await recommendedLintPreset);
     expect(
       await resolveLint({
         lintConfig: { ...baseLintConfig, extends: ['recommended', 'minimal'] },
-      }),
+      })
     ).toEqual(await minimalLintPreset);
   });
 
@@ -141,13 +141,13 @@ describe('resolveLint', () => {
     });
 
     expect(Array.isArray(lint.rules?.assertions)).toEqual(true);
-    expect(lint.rules?.assertions).toMatchObject( [
+    expect(lint.rules?.assertions).toMatchObject([
       {
         subject: 'PathItem',
         property: 'get',
         message: 'Every path item must have a GET operation.',
         defined: true,
-        assertionId: 'path-item-get-defined'
+        assertionId: 'path-item-get-defined',
       },
       {
         subject: 'Tag',
@@ -156,9 +156,9 @@ describe('resolveLint', () => {
         severity: 'error',
         minLength: 13,
         pattern: '/\\.$/',
-        assertionId: 'tag-description'
-      }
-    ])
+        assertionId: 'tag-description',
+      },
+    ]);
   });
 
   it('should resolve extends with url file config witch contains path to nested config', async () => {

--- a/packages/core/src/config/__tests__/fixtures/resolve-config/api/plugin.js
+++ b/packages/core/src/config/__tests__/fixtures/resolve-config/api/plugin.js
@@ -21,7 +21,10 @@ const rules = {
       return {
         SecurityScheme(scheme, { location, report }) {
           if (scheme.type === 'openIdConnect') {
-            if (scheme.openIdConnectUrl && !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')) {
+            if (
+              scheme.openIdConnectUrl &&
+              !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')
+            ) {
               report({
                 message:
                   'openIdConnectUrl must be a URL that ends with /.well-known/openid-configuration',
@@ -56,7 +59,6 @@ const configs = {
     },
   },
 };
-
 
 module.exports = {
   id,

--- a/packages/core/src/config/__tests__/fixtures/resolve-config/plugin.js
+++ b/packages/core/src/config/__tests__/fixtures/resolve-config/plugin.js
@@ -21,7 +21,10 @@ const rules = {
       return {
         SecurityScheme(scheme, { location, report }) {
           if (scheme.type === 'openIdConnect') {
-            if (scheme.openIdConnectUrl && !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')) {
+            if (
+              scheme.openIdConnectUrl &&
+              !scheme.openIdConnectUrl.endsWith('/.well-known/openid-configuration')
+            ) {
               report({
                 message:
                   'openIdConnectUrl must be a URL that ends with /.well-known/openid-configuration',

--- a/packages/core/src/config/all.ts
+++ b/packages/core/src/config/all.ts
@@ -1,5 +1,4 @@
-import type { PluginLintConfig } from "./types";
-
+import type { PluginLintConfig } from './types';
 
 export default {
   rules: {
@@ -20,7 +19,7 @@ export default {
     'operation-description': 'error',
     'operation-2xx-response': 'error',
     'operation-4xx-response': 'error',
-    'assertions': 'error',
+    assertions: 'error',
     'operation-operationId': 'error',
     'operation-summary': 'error',
     'operation-operationId-unique': 'error',

--- a/packages/core/src/config/builtIn.ts
+++ b/packages/core/src/config/builtIn.ts
@@ -15,8 +15,8 @@ export const builtInConfigs: Record<string, LintRawConfig> = {
   minimal,
   all,
   'redocly-registry': {
-    decorators: { 'registry-dependencies': 'on' }
-  }
+    decorators: { 'registry-dependencies': 'on' },
+  },
 };
 
 export const defaultPlugin: Plugin = {
@@ -34,4 +34,4 @@ export const defaultPlugin: Plugin = {
     oas2: oas2Decorators,
   },
   configs: builtInConfigs,
-}
+};

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -25,7 +25,7 @@ import { Config } from './config';
 export async function resolveConfig(rawConfig: RawConfig, configPath?: string) {
   if (rawConfig.lint?.extends?.some(isNotString)) {
     throw new Error(
-      `Error configuration format not detected in extends value must contain strings`,
+      `Error configuration format not detected in extends value must contain strings`
     );
   }
 
@@ -59,13 +59,13 @@ export async function resolveConfig(rawConfig: RawConfig, configPath?: string) {
       apis,
       lint,
     },
-    configPath,
+    configPath
   );
 }
 
 export function resolvePlugins(
   plugins: (string | Plugin)[] | null,
-  configPath: string = '',
+  configPath: string = ''
 ): Plugin[] {
   if (!plugins) return [];
 
@@ -95,9 +95,9 @@ export function resolvePlugins(
         throw new Error(
           red(
             `Plugin "id" must be unique. Plugin ${blue(p.toString())} uses id "${blue(
-              id,
-            )}" already seen in ${blue(pluginPath)}`,
-          ),
+              id
+            )}" already seen in ${blue(pluginPath)}`
+          )
         );
       }
 
@@ -124,7 +124,7 @@ export function resolvePlugins(
       if (pluginModule.preprocessors) {
         if (!pluginModule.preprocessors.oas3 && !pluginModule.preprocessors.oas2) {
           throw new Error(
-            `Plugin \`preprocessors\` must have \`oas3\` or \`oas2\` preprocessors "${p}.`,
+            `Plugin \`preprocessors\` must have \`oas3\` or \`oas2\` preprocessors "${p}.`
           );
         }
         plugin.preprocessors = {};
@@ -168,7 +168,7 @@ export async function resolveApis({
   for (const [apiName, apiContent] of Object.entries(apis || {})) {
     if (apiContent.lint?.extends?.some(isNotString)) {
       throw new Error(
-        `Error configuration format not detected in extends value must contain strings`,
+        `Error configuration format not detected in extends value must contain strings`
       );
     }
     const rawLintConfig = getMergedLintRawConfig(lintConfig, apiContent.lint);
@@ -193,13 +193,13 @@ async function resolveAndMergeNestedLint(
     resolver?: BaseResolver;
   },
   parentConfigPaths: string[] = [],
-  extendPaths: string[] = [],
+  extendPaths: string[] = []
 ): Promise<ResolvedLintConfig> {
   if (parentConfigPaths.includes(configPath)) {
     throw new Error(`Circular dependency in config file: "${configPath}"`);
   }
   const plugins = getUniquePlugins(
-    resolvePlugins([...(lintConfig?.plugins || []), defaultPlugin], configPath),
+    resolvePlugins([...(lintConfig?.plugins || []), defaultPlugin], configPath)
   );
   const pluginPaths = lintConfig?.plugins
     ?.filter(isString)
@@ -227,9 +227,9 @@ async function resolveAndMergeNestedLint(
           resolver: resolver,
         },
         [...parentConfigPaths, resolvedConfigPath],
-        extendPaths,
+        extendPaths
       );
-    }) || [],
+    }) || []
   );
 
   const { plugins: mergedPlugins = [], ...lint } = mergeExtends([
@@ -259,7 +259,7 @@ export async function resolveLint(
     resolver?: BaseResolver;
   },
   parentConfigPaths: string[] = [],
-  extendPaths: string[] = [],
+  extendPaths: string[] = []
 ): Promise<ResolvedLintConfig> {
   const resolvedLint = await resolveAndMergeNestedLint(lintOpts, parentConfigPaths, extendPaths);
 
@@ -281,9 +281,9 @@ export function resolvePreset(presetName: string, plugins: Plugin[]): ResolvedLi
     throw new Error(
       pluginId
         ? `Invalid config ${red(
-            presetName,
+            presetName
           )}: plugin ${pluginId} doesn't export config with name ${configName}.`
-        : `Invalid config ${red(presetName)}: there is no such built-in config.`,
+        : `Invalid config ${red(presetName)}: there is no such built-in config.`
     );
   }
   return preset;
@@ -291,7 +291,7 @@ export function resolvePreset(presetName: string, plugins: Plugin[]): ResolvedLi
 
 async function loadExtendLintConfig(
   filePath: string,
-  resolver: BaseResolver,
+  resolver: BaseResolver
 ): Promise<LintRawConfig> {
   try {
     const fileSource = await resolver.loadExternalRef(filePath);
@@ -328,7 +328,7 @@ function getMergedLintRawConfig(configLint: LintRawConfig, apiLint?: LintRawConf
 }
 
 function groupLintAssertionRules(
-  rules: Record<string, RuleConfig> | undefined,
+  rules: Record<string, RuleConfig> | undefined
 ): Record<string, RuleConfig> | undefined {
   if (!rules) {
     return rules;

--- a/packages/core/src/config/minimal.ts
+++ b/packages/core/src/config/minimal.ts
@@ -18,7 +18,7 @@ export default {
     'operation-description': 'off',
     'operation-2xx-response': 'warn',
     'operation-4xx-response': 'off',
-    'assertions': 'warn',
+    assertions: 'warn',
     'operation-operationId': 'warn',
     'operation-summary': 'warn',
     'operation-operationId-unique': 'warn',

--- a/packages/core/src/config/recommended.ts
+++ b/packages/core/src/config/recommended.ts
@@ -17,7 +17,7 @@ export default {
     'path-parameters-defined': 'error',
     'operation-description': 'off',
     'operation-2xx-response': 'warn',
-    'assertions': 'warn',
+    assertions: 'warn',
     'operation-4xx-response': 'warn',
     'operation-operationId': 'warn',
     'operation-summary': 'error',

--- a/packages/core/src/config/rules.ts
+++ b/packages/core/src/config/rules.ts
@@ -6,7 +6,7 @@ export function initRules<T extends Function, P extends RuleSet<T>>(
   rules: P[],
   config: LintConfig,
   type: 'rules' | 'preprocessors' | 'decorators',
-  oasVersion: OasVersion,
+  oasVersion: OasVersion
 ) {
   return rules
     .flatMap((ruleset) =>
@@ -31,7 +31,7 @@ export function initRules<T extends Function, P extends RuleSet<T>>(
             severity: ruleSettings.severity,
             ruleId,
             visitor: visitor,
-          }))
+          }));
         }
 
         return {
@@ -39,8 +39,8 @@ export function initRules<T extends Function, P extends RuleSet<T>>(
           ruleId,
           visitor: visitors, // note: actually it is only one visitor object
         };
-      }),
+      })
     )
-    .flatMap(visitor => visitor)
+    .flatMap((visitor) => visitor)
     .filter(notUndefined);
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -71,7 +71,7 @@ export type DecoratorsConfig = {
 
 export type TypesExtensionFn = (
   types: Record<string, NodeType>,
-  oasVersion: OasVersion,
+  oasVersion: OasVersion
 ) => Record<string, NodeType>;
 
 export type TypeExtensionsConfig = Partial<Record<OasMajorVersion, TypesExtensionFn>>;
@@ -137,7 +137,7 @@ export type Api = {
   'features.openapi'?: Record<string, any>;
   'features.mockServer'?: Record<string, any>;
 };
-export type ResolvedApi = Omit<Api, 'lint'> & { lint: Omit<ResolvedLintConfig, 'plugins'>};
+export type ResolvedApi = Omit<Api, 'lint'> & { lint: Omit<ResolvedLintConfig, 'plugins'> };
 
 export type RawConfig = {
   apis?: Record<string, Api>;
@@ -151,7 +151,7 @@ export type RawConfig = {
 
 export type ResolvedConfig = Omit<RawConfig, 'lint' | 'apis'> & {
   lint: ResolvedLintConfig;
-  apis: Record<string,ResolvedApi>
+  apis: Record<string, ResolvedApi>;
 };
 
 export type RulesFields =

--- a/packages/core/src/config/utils.ts
+++ b/packages/core/src/config/utils.ts
@@ -23,7 +23,7 @@ export function parsePresetName(presetName: string): { pluginId: string; configN
 }
 
 export function transformApiDefinitionsToApis(
-  apiDefinitions: Record<string, string> = {},
+  apiDefinitions: Record<string, string> = {}
 ): Record<string, Api> {
   let apis: Record<string, Api> = {};
   for (const [apiName, apiPath] of Object.entries(apiDefinitions)) {
@@ -69,11 +69,7 @@ export function mergeExtends(rulesConfList: ResolvedLintConfig[]) {
   for (let rulesConf of rulesConfList) {
     if (rulesConf.extends) {
       throw new Error(
-        `\`extends\` is not supported in shared configs yet: ${JSON.stringify(
-          rulesConf,
-          null,
-          2,
-        )}.`,
+        `\`extends\` is not supported in shared configs yet: ${JSON.stringify(rulesConf, null, 2)}.`
       );
     }
 
@@ -145,7 +141,7 @@ export function getMergedConfig(config: Config, entrypointAlias?: string): Confi
           },
           // TODO: merge everything else here
         },
-        config.configFile,
+        config.configFile
       )
     : config;
 }
@@ -164,15 +160,15 @@ export function transformConfig(rawConfig: DeprecatedRawConfig | RawConfig): Raw
   if (apiDefinitions) {
     process.stderr.write(
       `The ${yellow('apiDefinitions')} field is deprecated. Use ${green(
-        'apis',
-      )} instead. Read more about this change: https://redocly.com/docs/api-registry/guides/migration-guide-config-file/#changed-properties\n`,
+        'apis'
+      )} instead. Read more about this change: https://redocly.com/docs/api-registry/guides/migration-guide-config-file/#changed-properties\n`
     );
   }
   if (referenceDocs) {
     process.stderr.write(
       `The ${yellow('referenceDocs')} field is deprecated. Use ${green(
-        'features.openapi',
-      )} instead. Read more about this change: https://redocly.com/docs/api-registry/guides/migration-guide-config-file/#changed-properties\n`,
+        'features.openapi'
+      )} instead. Read more about this change: https://redocly.com/docs/api-registry/guides/migration-guide-config-file/#changed-properties\n`
     );
   }
   return {
@@ -199,9 +195,7 @@ export function getUniquePlugins(plugins: Plugin[]): Plugin[] {
       results.push(p);
       seen.add(p.id);
     } else if (p.id) {
-      process.stderr.write(
-        `Duplicate plugin id "${yellow(p.id)}".\n`,
-      );
+      process.stderr.write(`Duplicate plugin id "${yellow(p.id)}".\n`);
     }
   }
   return results;

--- a/packages/core/src/decorators/__tests__/filter-out.test.ts
+++ b/packages/core/src/decorators/__tests__/filter-out.test.ts
@@ -27,7 +27,8 @@ describe('oas3 filter-out', () => {
               callbacks:
                 x-access: protected
                 orderInProgress:
-                  x-internal: true`);
+                  x-internal: true`
+  );
 
   it('should remove /pet path and y parameter', async () => {
     const testDocument = parseYamlToDocument(
@@ -132,7 +133,8 @@ describe('oas3 filter-out', () => {
                     type: object
       components: {}
             
-        `);
+        `
+    );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
       externalRefResolver: new BaseResolver(),
@@ -185,7 +187,8 @@ describe('oas3 filter-out', () => {
           x:
             name: x
             
-            `);
+            `
+    );
     const { bundle: res } = await bundleDocument({
       document: testDocument,
       externalRefResolver: new BaseResolver(),
@@ -236,7 +239,8 @@ describe('oas3 filter-out', () => {
           x:
             name: x
             
-            `);
+            `
+    );
     const { bundle: res } = await bundleDocument({
       document: testDocument,
       externalRefResolver: new BaseResolver(),

--- a/packages/core/src/decorators/__tests__/remove-x-internal.test.ts
+++ b/packages/core/src/decorators/__tests__/remove-x-internal.test.ts
@@ -18,7 +18,7 @@ describe('oas3 remove-x-internal', () => {
         parameters:
           x:
             name: x
-    `,
+    `
   );
 
   it('should use `internalFlagProperty` option to remove internal paths', async () => {
@@ -87,7 +87,7 @@ describe('oas3 remove-x-internal', () => {
               name: x
             y:
               name: y
-      `,
+      `
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -160,7 +160,7 @@ describe('oas3 remove-x-internal', () => {
                     servers:
                       - url: //callback-url.path-level/v1
                         description: Path level server
-      `,
+      `
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -234,7 +234,7 @@ describe('oas3 remove-x-internal', () => {
               schema:
                 type: string
               x-internal: true
-      `,
+      `
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
@@ -297,7 +297,7 @@ describe('oas2 remove-x-internal', () => {
                 '200':
                   x-internal: true
                   description: List of recent media entries.
-      `,
+      `
     );
     const { bundle: res } = await bundleDocument({
       document: testDoc,

--- a/packages/core/src/decorators/common/filters/filter-helper.ts
+++ b/packages/core/src/decorators/common/filters/filter-helper.ts
@@ -47,7 +47,7 @@ export function checkIfMatchByStrategy(
   decoratorValue: any,
   strategy: 'all' | 'any'
 ): boolean {
-  if (nodeValue===undefined || decoratorValue===undefined) {
+  if (nodeValue === undefined || decoratorValue === undefined) {
     return false;
   }
 

--- a/packages/core/src/decorators/common/info-description-override.ts
+++ b/packages/core/src/decorators/common/info-description-override.ts
@@ -8,7 +8,7 @@ export const InfoDescriptionOverride: Oas3Decorator | Oas2Decorator = ({ filePat
       leave(info, { report, location }: UserContext) {
         if (!filePath)
           throw new Error(
-            `Parameter "filePath" is not provided for "info-description-override" rule`,
+            `Parameter "filePath" is not provided for "info-description-override" rule`
           );
         try {
           info.description = readFileAsStringSync(filePath);

--- a/packages/core/src/decorators/common/operation-description-override.ts
+++ b/packages/core/src/decorators/common/operation-description-override.ts
@@ -11,7 +11,7 @@ export const OperationDescriptionOverride: Oas3Decorator | Oas2Decorator = ({ op
         if (!operation.operationId) return;
         if (!operationIds)
           throw new Error(
-            `Parameter "operationIds" is not provided for "operation-description-override" rule`,
+            `Parameter "operationIds" is not provided for "operation-description-override" rule`
           );
         const operationId = operation.operationId;
         if (operationIds[operationId]) {

--- a/packages/core/src/decorators/common/remove-x-internal.ts
+++ b/packages/core/src/decorators/common/remove-x-internal.ts
@@ -53,7 +53,7 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({ internalFlagPro
     any: {
       enter: (node, ctx) => {
         removeInternal(node, ctx);
-      }
-    }
-  }
-}
+      },
+    },
+  };
+};

--- a/packages/core/src/decorators/common/tag-description-override.ts
+++ b/packages/core/src/decorators/common/tag-description-override.ts
@@ -8,7 +8,7 @@ export const TagDescriptionOverride: Oas3Decorator | Oas2Decorator = ({ tagNames
       leave(tag, { report }: UserContext) {
         if (!tagNames)
           throw new Error(
-            `Parameter "tagNames" is not provided for "tag-description-override" rule`,
+            `Parameter "tagNames" is not provided for "tag-description-override" rule`
           );
         if (tagNames[tag.name]) {
           try {

--- a/packages/core/src/format/codeframes.ts
+++ b/packages/core/src/format/codeframes.ts
@@ -63,7 +63,7 @@ export function getCodeframe(location: LineColLocationObject, color: boolean) {
     line: string,
     startIdx: number = -1,
     endIdx: number = +Infinity,
-    variant = gray,
+    variant = gray
   ) {
     if (!color) return line;
     if (!line) return line;
@@ -84,14 +84,14 @@ function printPrefixedLines(lines: [string, string][]): string {
 
   const padLen = Math.max(...existingLines.map(([prefix]) => prefix.length));
   const dedentLen = Math.min(
-    ...existingLines.map(([_, line]) => (line === '' ? Infinity : padSize(line))),
+    ...existingLines.map(([_, line]) => (line === '' ? Infinity : padSize(line)))
   );
 
   return existingLines
     .map(
       ([prefix, line]) =>
         gray(leftPad(padLen, prefix) + ' |') +
-        (line ? ' ' + limitLineLength(line.substring(dedentLen)) : ''),
+        (line ? ' ' + limitLineLength(line.substring(dedentLen)) : '')
     )
     .join('\n');
 }
@@ -146,7 +146,7 @@ export function getLineColLocation(location: LocationObject): LineColLocationObj
 function positionsToLoc(
   source: string,
   startPos: number,
-  endPos: number,
+  endPos: number
 ): { start: Loc; end: Loc } {
   let currentLine = 1;
   let currentCol = 1;

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -14,7 +14,7 @@ const coreVersion = require('../../package.json').version;
 
 import { NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject } from '../walk';
 import { getCodeframe, getLineColLocation } from './codeframes';
-import { env } from "../config";
+import { env } from '../config';
 
 export type Totals = {
   errors: number;
@@ -84,7 +84,7 @@ export function formatProblems(
     color?: boolean;
     totals: Totals;
     version: string;
-  },
+  }
 ) {
   const {
     maxProblems = 100,
@@ -120,7 +120,7 @@ export function formatProblems(
     case 'stylish': {
       const groupedByFile = groupByFiles(problems);
       for (const [file, { ruleIdPad, locationPad: positionPad, fileProblems }] of Object.entries(
-        groupedByFile,
+        groupedByFile
       )) {
         process.stderr.write(`${blue(path.relative(cwd, file))}:\n`);
 
@@ -156,8 +156,8 @@ export function formatProblems(
   if (totalProblems - ignoredProblems > maxProblems) {
     process.stderr.write(
       `< ... ${totalProblems - maxProblems} more problems hidden > ${gray(
-        'increase with `--max-problems N`',
-      )}\n`,
+        'increase with `--max-problems N`'
+      )}\n`
     );
   }
 
@@ -243,12 +243,12 @@ export function formatProblems(
   function formatStylish(problem: OnlyLineColProblem, locationPad: number, ruleIdPad: number) {
     const color = COLORS[problem.severity];
     if (!SEVERITY_NAMES[problem.severity]) {
-      return 'Error not found severity. Please check your config file. Allowed values: \`warn,error,off\`'
+      return 'Error not found severity. Please check your config file. Allowed values: `warn,error,off`';
     }
     const severityName = color(SEVERITY_NAMES[problem.severity].toLowerCase().padEnd(7));
     const { start } = problem.location[0];
     return `  ${`${start.line}:${start.col}`.padEnd(
-      locationPad,
+      locationPad
     )}  ${severityName}  ${problem.ruleId.padEnd(ruleIdPad)}  ${problem.message}`;
   }
 
@@ -258,7 +258,7 @@ export function formatProblems(
     const message = xmlEscape(problem.message);
     const source = xmlEscape(problem.ruleId);
     process.stdout.write(
-      `<error line="${line}" column="${col}" severity="${severity}" message="${message}" source="${source}" />\n`,
+      `<error line="${line}" column="${col}" severity="${severity}" message="${message}" source="${source}" />\n`
     );
   }
 }
@@ -307,12 +307,12 @@ const groupByFiles = (problems: NormalizedProblem[]) => {
     fileGroups[absoluteRef].fileProblems.push(mappedProblem);
     fileGroups[absoluteRef].ruleIdPad = Math.max(
       problem.ruleId.length,
-      fileGroups[absoluteRef].ruleIdPad,
+      fileGroups[absoluteRef].ruleIdPad
     );
 
     fileGroups[absoluteRef].locationPad = Math.max(
       Math.max(...mappedProblem.location.map((loc) => `${loc.start.line}:${loc.start.col}`.length)),
-      fileGroups[absoluteRef].locationPad,
+      fileGroups[absoluteRef].locationPad
     );
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,9 +33,8 @@ export {
   getConfig,
   findConfig,
   CONFIG_FILE_NAMES,
-  RuleSeverity
+  RuleSeverity,
 } from './config';
-
 
 export { RedoclyClient, isRedoclyRegistryURL } from './redocly';
 

--- a/packages/core/src/js-yaml/index.ts
+++ b/packages/core/src/js-yaml/index.ts
@@ -1,18 +1,13 @@
 // TODO: add a type for "types" https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/js-yaml/index.d.ts
 // @ts-ignore
-import { JSON_SCHEMA, types, LoadOptions, DumpOptions, load, dump  } from 'js-yaml';
+import { JSON_SCHEMA, types, LoadOptions, DumpOptions, load, dump } from 'js-yaml';
 
 const DEFAULT_SCHEMA_WITHOUT_TIMESTAMP = JSON_SCHEMA.extend({
   implicit: [types.merge],
-  explicit: [
-    types.binary,
-    types.omap,
-    types.pairs,
-    types.set,
-  ],
+  explicit: [types.binary, types.omap, types.pairs, types.set],
 });
 
 export const parseYaml = (str: string, opts?: LoadOptions): unknown =>
-  load(str, {schema: DEFAULT_SCHEMA_WITHOUT_TIMESTAMP, ...opts});
+  load(str, { schema: DEFAULT_SCHEMA_WITHOUT_TIMESTAMP, ...opts });
 
 export const stringifyYaml = (obj: any, opts?: DumpOptions): string => dump(obj, opts);

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -1,7 +1,5 @@
 import { BaseResolver, resolveDocument, Document, makeDocumentFromString } from './resolve';
-import {
-  normalizeVisitors,
-} from './visitors';
+import { normalizeVisitors } from './visitors';
 import { Oas3_1Types } from './types/oas3_1';
 import { Oas3Types } from './types/oas3';
 import { Oas2Types } from './types/oas2';
@@ -13,7 +11,6 @@ import { releaseAjvInstance } from './rules/ajv';
 import { detectOpenAPI, Oas3RuleSet, OasMajorVersion, OasVersion, openAPIMajor } from './oas-types';
 import { ConfigTypes } from './types/redocly-yaml';
 import { OasSpec } from './rules/common/spec';
-
 
 export async function lint(opts: {
   ref: string;
@@ -62,10 +59,14 @@ export async function lintDocument(opts: {
   const rules = config.getRulesForOasVersion(oasMajorVersion);
   const types = normalizeTypes(
     config.extendTypes(
-      customTypes ?? oasMajorVersion === OasMajorVersion.Version3 ? (oasVersion === OasVersion.Version3_1 ? Oas3_1Types : Oas3Types) : Oas2Types,
-      oasVersion,
+      customTypes ?? oasMajorVersion === OasMajorVersion.Version3
+        ? oasVersion === OasVersion.Version3_1
+          ? Oas3_1Types
+          : Oas3Types
+        : Oas2Types,
+      oasVersion
     ),
-    config,
+    config
   );
 
   const ctx: WalkContext = {
@@ -80,7 +81,7 @@ export async function lintDocument(opts: {
   const resolvedRefMap = await resolveDocument({
     rootDocument: document,
     rootType: types.DefinitionRoot,
-    externalRefResolver
+    externalRefResolver,
   });
 
   walkDocument({
@@ -93,10 +94,7 @@ export async function lintDocument(opts: {
   return ctx.problems.map((problem) => config.addProblemToIgnore(problem));
 }
 
-export async function lintConfig(opts: {
-  document: Document
-  severity?: ProblemSeverity 
-}) {
+export async function lintConfig(opts: { document: Document; severity?: ProblemSeverity }) {
   const { document, severity } = opts;
 
   const ctx: WalkContext = {
@@ -111,7 +109,13 @@ export async function lintConfig(opts: {
   });
 
   const types = normalizeTypes(ConfigTypes, config);
-  const rules = [{ severity: severity || 'error', ruleId: 'configuration spec', visitor: OasSpec({ severity: 'error' }) }];
+  const rules = [
+    {
+      severity: severity || 'error',
+      ruleId: 'configuration spec',
+      visitor: OasSpec({ severity: 'error' }),
+    },
+  ];
   const normalizedVisitors = normalizeVisitors(rules, types);
 
   walkDocument({

--- a/packages/core/src/oas-types.ts
+++ b/packages/core/src/oas-types.ts
@@ -1,9 +1,4 @@
-import {
-  Oas3Rule,
-  Oas3Preprocessor,
-  Oas2Rule,
-  Oas2Preprocessor,
-} from './visitors';
+import { Oas3Rule, Oas3Preprocessor, Oas2Rule, Oas2Preprocessor } from './visitors';
 
 export type RuleSet<T> = Record<string, T>;
 

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -59,55 +59,57 @@ describe('RedoclyClient', () => {
 
   it('should resolve all tokens', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
-      return { token: "accessToken", us: "accessToken", eu: "eu-accessToken" };
+      return { token: 'accessToken', us: 'accessToken', eu: 'eu-accessToken' };
     });
     const client = new RedoclyClient();
     const tokens = client.getAllTokens();
     expect(tokens).toStrictEqual([
       { region: 'us', token: 'accessToken' },
-      { region: 'eu', token: 'eu-accessToken' }
+      { region: 'eu', token: 'eu-accessToken' },
     ]);
     spy.mockRestore();
   });
 
   it('should resolve valid tokens data', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
-      return { us: "accessToken", eu: "eu-accessToken" }
+      return { us: 'accessToken', eu: 'eu-accessToken' };
     });
     const client = new RedoclyClient();
     const tokens = await client.getValidTokens();
     expect(tokens).toStrictEqual([
       { region: 'us', token: 'accessToken', valid: true },
-      { region: 'eu', token: 'eu-accessToken', valid: true }
+      { region: 'eu', token: 'eu-accessToken', valid: true },
     ]);
     spy.mockRestore();
   });
 
   it('should not call setAccessTokens by default', () => {
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({}));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({}));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).not.toHaveBeenCalled()
+    expect(client.setAccessTokens).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 
   it('should set correct accessTokens - backward compatibility: default US region', () => {
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ token: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ token: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).toBeCalledWith(
-      expect.objectContaining({ us: testToken })
-    );
+    expect(client.setAccessTokens).toBeCalledWith(expect.objectContaining({ us: testToken }));
     spy.mockRestore();
   });
 
   it('should set correct accessTokens - backward compatibility: EU region', () => {
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ token: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ token: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient('eu');
-    expect(client.setAccessTokens).toBeCalledWith(
-      expect.objectContaining({ eu: testToken })
-    );
+    expect(client.setAccessTokens).toBeCalledWith(expect.objectContaining({ eu: testToken }));
     spy.mockRestore();
   });
 
@@ -116,25 +118,29 @@ describe('RedoclyClient', () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation();
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).toHaveBeenNthCalledWith(1, { "us": REDOCLY_AUTHORIZATION_TOKEN });
+    expect(client.setAccessTokens).toHaveBeenNthCalledWith(1, { us: REDOCLY_AUTHORIZATION_TOKEN });
     spy.mockRestore();
   });
 
   it('should set correct accessTokens prioritizing REDOCLY_AUTHORIZATION env over token in file', () => {
     process.env.REDOCLY_AUTHORIZATION = REDOCLY_AUTHORIZATION_TOKEN;
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ token: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ token: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient();
-    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { "us": REDOCLY_AUTHORIZATION_TOKEN });
+    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { us: REDOCLY_AUTHORIZATION_TOKEN });
     spy.mockRestore();
   });
 
   it('should set correct accessTokens prioritizing REDOCLY_AUTHORIZATION env over EU token', () => {
     process.env.REDOCLY_AUTHORIZATION = REDOCLY_AUTHORIZATION_TOKEN;
-    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => ({ us: testToken }));
+    let spy = jest
+      .spyOn(RedoclyClient.prototype, 'readCredentialsFile')
+      .mockImplementation(() => ({ us: testToken }));
     jest.spyOn(RedoclyClient.prototype, 'setAccessTokens').mockImplementation();
     const client = new RedoclyClient('eu');
-    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { "eu": REDOCLY_AUTHORIZATION_TOKEN });
+    expect(client.setAccessTokens).toHaveBeenNthCalledWith(2, { eu: REDOCLY_AUTHORIZATION_TOKEN });
     spy.mockRestore();
   });
 });

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -28,12 +28,14 @@ export class RedoclyClient {
 
   loadRegion(region?: Region) {
     if (region && !DOMAINS[region]) {
-      throw new Error(`Invalid argument: region in config file.\nGiven: ${green(region)}, choices: "us", "eu".`);
+      throw new Error(
+        `Invalid argument: region in config file.\nGiven: ${green(region)}, choices: "us", "eu".`
+      );
     }
 
     if (env.REDOCLY_DOMAIN) {
       return (AVAILABLE_REGIONS.find(
-        (region) => DOMAINS[region as Region] === env.REDOCLY_DOMAIN,
+        (region) => DOMAINS[region as Region] === env.REDOCLY_DOMAIN
       ) || DEFAULT_REGION) as Region;
     }
     return region || DEFAULT_REGION;
@@ -91,7 +93,7 @@ export class RedoclyClient {
     const allTokens = this.getAllTokens();
 
     const verifiedTokens = await Promise.allSettled(
-      allTokens.map(({ token, region }) => this.verifyToken(token, region)),
+      allTokens.map(({ token, region }) => this.verifyToken(token, region))
     );
 
     return allTokens
@@ -134,7 +136,7 @@ export class RedoclyClient {
   async verifyToken(
     accessToken: string,
     region: Region,
-    verbose: boolean = false,
+    verbose: boolean = false
   ): Promise<{ viewerId: string; organizations: string[] }> {
     return this.registryApi.authStatus(accessToken, region, verbose);
   }

--- a/packages/core/src/redocly/registry-api.ts
+++ b/packages/core/src/redocly/registry-api.ts
@@ -31,7 +31,7 @@ export class RegistryApi {
 
     const response = await fetch(
       `${this.getBaseUrl(region)}${path}`,
-      Object.assign({}, options, { headers }),
+      Object.assign({}, options, { headers })
     );
 
     if (response.status === 401) {
@@ -49,7 +49,7 @@ export class RegistryApi {
   async authStatus(
     accessToken: string,
     region: Region,
-    verbose = false,
+    verbose = false
   ): Promise<{ viewerId: string; organizations: string[] }> {
     try {
       const response = await this.request('', { headers: { authorization: accessToken } }, region);
@@ -86,7 +86,7 @@ export class RegistryApi {
           isUpsert,
         }),
       },
-      this.region,
+      this.region
     );
 
     if (response.ok) {
@@ -106,7 +106,7 @@ export class RegistryApi {
     isUpsert,
     isPublic,
     batchId,
-    batchSize
+    batchSize,
   }: RegistryApiTypes.PushApiParams) {
     const response = await this.request(
       `/${organizationId}/${name}/${version}`,
@@ -123,10 +123,10 @@ export class RegistryApi {
           isUpsert,
           isPublic,
           batchId,
-          batchSize
+          batchSize,
         }),
       },
-      this.region,
+      this.region
     );
 
     if (response.ok) {

--- a/packages/core/src/ref-utils.ts
+++ b/packages/core/src/ref-utils.ts
@@ -18,8 +18,8 @@ export class Location {
       this.source,
       joinPointer(
         this.pointer,
-        (Array.isArray(components) ? components : [components]).map(escapePointer).join('/'),
-      ),
+        (Array.isArray(components) ? components : [components]).map(escapePointer).join('/')
+      )
     );
   }
 

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -232,7 +232,7 @@ export async function resolveDocument(opts: {
     rootNode: any,
     rootNodeDocument: Document,
     rootNodePointer: string,
-    type: any,
+    type: any
   ) {
     const rootNodeDocAbsoluteRef = rootNodeDocument.source.absoluteRef;
 
@@ -295,7 +295,7 @@ export async function resolveDocument(opts: {
               resolvedRef.node,
               resolvedRef.document,
               resolvedRef.nodePointer!,
-              type,
+              type
             );
           }
         });
@@ -306,7 +306,7 @@ export async function resolveDocument(opts: {
     async function followRef(
       document: Document,
       ref: OasRef,
-      refStack: RefFrame,
+      refStack: RefFrame
     ): Promise<ResolvedRef> {
       if (hasRef(refStack.prev, ref)) {
         throw new Error('Self-referencing circular pointer');
@@ -316,7 +316,10 @@ export async function resolveDocument(opts: {
       let targetDoc: Document;
       try {
         targetDoc = isRemote
-          ? ((await externalRefResolver.resolveDocument(document.source.absoluteRef, uri!)) as Document)
+          ? ((await externalRefResolver.resolveDocument(
+              document.source.absoluteRef,
+              uri!
+            )) as Document)
           : document;
       } catch (error) {
         const resolvedRef = {

--- a/packages/core/src/rules/__tests__/no-unresolved-refs.test.ts
+++ b/packages/core/src/rules/__tests__/no-unresolved-refs.test.ts
@@ -15,7 +15,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
               requestBody:
                 $ref: 'invalid.yaml'
       `,
-      path.join(__dirname, 'foobar.yaml'),
+      path.join(__dirname, 'foobar.yaml')
     );
 
     const results = await lintDocument({
@@ -55,7 +55,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
               requestBody:
                 $ref: 'fixtures/invalid-yaml.yaml'
       `,
-      path.join(__dirname, 'foobar.yaml'),
+      path.join(__dirname, 'foobar.yaml')
     );
 
     const results = await lintDocument({
@@ -112,7 +112,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
               requestBody:
                 $ref: 'fixtures/ref.yaml'
       `,
-      path.join(__dirname, 'foobar.yaml'),
+      path.join(__dirname, 'foobar.yaml')
     );
 
     const results = await lintDocument({
@@ -136,7 +136,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
               requestBody:
                 $ref: '#/components/requestBodies/a'
       `,
-      path.join(__dirname, 'foobar.yaml'),
+      path.join(__dirname, 'foobar.yaml')
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/ajv.ts
+++ b/packages/core/src/rules/ajv.ts
@@ -36,7 +36,7 @@ function getAjvValidator(
   schema: any,
   loc: Location,
   resolve: ResolveFn,
-  disallowAdditionalProperties: boolean,
+  disallowAdditionalProperties: boolean
 ): ValidateFunction | undefined {
   const ajv = getAjv(resolve, disallowAdditionalProperties);
 
@@ -53,7 +53,7 @@ export function validateJsonSchema(
   schemaLoc: Location,
   instancePath: string,
   resolve: ResolveFn,
-  disallowAdditionalProperties: boolean,
+  disallowAdditionalProperties: boolean
 ): { valid: boolean; errors: (ErrorObject & { suggest?: string[] })[] } {
   const validate = getAjvValidator(schema, schemaLoc, resolve, disallowAdditionalProperties);
   if (!validate) return { valid: true, errors: [] }; // unresolved refs are reported
@@ -73,8 +73,7 @@ export function validateJsonSchema(
 
   function beatifyErrorMessage(error: ErrorObject) {
     let message = error.message;
-    let suggest =
-      error.keyword === 'enum' ? error.params.allowedValues : undefined;
+    let suggest = error.keyword === 'enum' ? error.params.allowedValues : undefined;
     if (suggest) {
       message += ` ${suggest.map((e: any) => `"${e}"`).join(', ')}`;
     }

--- a/packages/core/src/rules/common/__tests__/info-description.test.ts
+++ b/packages/core/src/rules/common/__tests__/info-description.test.ts
@@ -11,7 +11,7 @@ describe('Oas3 info-description', () => {
           info:
             version: '1.0'
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -49,7 +49,7 @@ describe('Oas3 info-description', () => {
             version: '1.0'
             description: ''
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -86,7 +86,7 @@ describe('Oas3 info-description', () => {
           info:
             description: test description
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/info-license.test.ts
+++ b/packages/core/src/rules/common/__tests__/info-license.test.ts
@@ -11,7 +11,7 @@ describe('Oas3 info-license', () => {
           info:
             version: '1.0'
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -48,7 +48,7 @@ describe('Oas3 info-license', () => {
               name: MIT
               url: google.com
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/license-url.test.ts
+++ b/packages/core/src/rules/common/__tests__/license-url.test.ts
@@ -12,7 +12,7 @@ describe('Oas3 license-url', () => {
             license:
               name: MIT
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -49,7 +49,7 @@ describe('Oas3 license-url', () => {
               name: MIT
               url: google.com
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/no-ambiguous-paths.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-ambiguous-paths.test.ts
@@ -40,7 +40,7 @@ describe('no-ambiguous-paths', () => {
             get:
               summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
@@ -23,7 +23,7 @@ describe('Oas3 typed enum', () => {
                             - 2
                             - 3
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -56,7 +56,7 @@ describe('Oas3 typed enum', () => {
                             - C
                             - null
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -86,7 +86,7 @@ describe('Oas3 typed enum', () => {
                             - string
                             - 3
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -114,7 +114,7 @@ describe('Oas3 typed enum', () => {
     `);
   });
 
-  it('should report on enum object, \'string\' value in enum does not have allowed types', async () => {
+  it("should report on enum object, 'string' value in enum does not have allowed types", async () => {
     const document = parseYamlToDocument(
       outdent`
           openapi: 3.1.0
@@ -134,7 +134,7 @@ describe('Oas3 typed enum', () => {
                             - string
                             - 3
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -179,13 +179,13 @@ describe('Oas3 typed enum', () => {
                       application/json:
                         schema: null
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: await makeConfig({ 'spec': 'error', 'no-enum-type-mismatch': 'error' }),
+      config: await makeConfig({ spec: 'error', 'no-enum-type-mismatch': 'error' }),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`

--- a/packages/core/src/rules/common/__tests__/no-identical-paths.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-identical-paths.test.ts
@@ -28,7 +28,7 @@ describe('no-identical-paths', () => {
             get:
               summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/no-path-trailing-slash.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-path-trailing-slash.test.ts
@@ -13,7 +13,7 @@ describe('no-path-trailing-slash', () => {
             get:
               summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -50,7 +50,7 @@ describe('no-path-trailing-slash', () => {
             get:
               summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -71,7 +71,7 @@ describe('no-path-trailing-slash', () => {
             get:
               summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-2xx-response.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-2xx-response.test.ts
@@ -15,7 +15,7 @@ describe('Oas3 operation-2xx-response', () => {
                   400:
                     description: bad response
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -54,7 +54,7 @@ describe('Oas3 operation-2xx-response', () => {
                   200:
                     description: ok
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -77,7 +77,7 @@ describe('Oas3 operation-2xx-response', () => {
                   default:
                     description: ok
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-4xx-response.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-4xx-response.test.ts
@@ -15,7 +15,7 @@ describe('Oas3 operation-4xx-response', () => {
                   200:
                     description: ok response
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -54,7 +54,7 @@ describe('Oas3 operation-4xx-response', () => {
                   400:
                     description: error response
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -77,7 +77,7 @@ describe('Oas3 operation-4xx-response', () => {
                   default:
                     description: some default response
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-operationId-unique.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-operationId-unique.test.ts
@@ -20,7 +20,7 @@ describe('Oas3 operation-operationId-unique', () => {
               post:
                 operationId: test2
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -62,7 +62,7 @@ describe('Oas3 operation-operationId-unique', () => {
               post:
                 operationId: test3
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-operationId-url-safe.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-operationId-url-safe.test.ts
@@ -15,7 +15,7 @@ describe('Oas3 operation-operationId-url-safe', () => {
               put:
                 operationId: "invalid❤️"
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-parameters-unique.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-parameters-unique.test.ts
@@ -16,7 +16,7 @@ describe('Oas3 operation-parameters-unique', () => {
                 - name: a
                   in: query
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -59,7 +59,7 @@ describe('Oas3 operation-parameters-unique', () => {
                   - name: a
                     in: query
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -89,7 +89,7 @@ describe('Oas3 operation-parameters-unique', () => {
                   - name: a
                     in: query
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -137,7 +137,7 @@ describe('Oas3 operation-parameters-unique', () => {
                 in: query
                 name: a
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-security-defined.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-security-defined.test.ts
@@ -13,7 +13,7 @@ describe('Oas3 operation-security-defined', () => {
               get:
                 security:
                   - some: []`,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -55,7 +55,7 @@ describe('Oas3 operation-security-defined', () => {
           some:
             type: http
             scheme: basic`,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/operation-singular-tag.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-singular-tag.test.ts
@@ -18,7 +18,7 @@ describe('Oas3 operation-singular-tag', () => {
                   - a
                   - b
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -58,7 +58,7 @@ describe('Oas3 operation-singular-tag', () => {
             tags:
               - a
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/path-http-verbs-order.test.ts
+++ b/packages/core/src/rules/common/__tests__/path-http-verbs-order.test.ts
@@ -17,7 +17,7 @@ describe('Common path-http-verbs-order', () => {
             get:
               summary: post
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -81,7 +81,7 @@ describe('Common path-http-verbs-order', () => {
           trace:
             summary: trace
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/path-not-include-query.test.ts
+++ b/packages/core/src/rules/common/__tests__/path-not-include-query.test.ts
@@ -13,7 +13,7 @@ describe('Oas3 path-not-include-query', () => {
               get:
                 summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -50,7 +50,7 @@ describe('Oas3 path-not-include-query', () => {
           get:
             summary: List all pets
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/path-params-defined.test.ts
+++ b/packages/core/src/rules/common/__tests__/path-params-defined.test.ts
@@ -18,7 +18,7 @@ describe('Oas3 path-params-defined', () => {
                  - name: b
                    in: path
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -46,7 +46,7 @@ describe('Oas3 path-params-defined', () => {
                  - name: b
                    in: query
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -90,7 +90,7 @@ describe('Oas3 path-params-defined', () => {
                  - name: c
                    in: path
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/paths-kebab-case.test.ts
+++ b/packages/core/src/rules/common/__tests__/paths-kebab-case.test.ts
@@ -16,7 +16,7 @@ describe('Oas3 paths-kebab-case', () => {
               get:
                 summary: Test
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -55,7 +55,7 @@ describe('Oas3 paths-kebab-case', () => {
               get:
                 summary: Test
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -84,25 +84,25 @@ describe('Oas3 paths-kebab-case', () => {
   });
 
   it('should allow trailing slash in path with "paths-kebab-case" rule', async () => {
-      const document = parseYamlToDocument(
-        outdent`
+    const document = parseYamlToDocument(
+      outdent`
             openapi: 3.0.0
             paths:
               /some/:
                 get:
                   summary: List all pets
           `,
-        'foobar.yaml',
-      );
+      'foobar.yaml'
+    );
 
-      const results = await lintDocument({
-        externalRefResolver: new BaseResolver(),
-        document,
-        config: await makeConfig({
-          'paths-kebab-case': 'error',
-          'no-path-trailing-slash': 'off',
-        }),
-      });
-      expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'paths-kebab-case': 'error',
+        'no-path-trailing-slash': 'off',
+      }),
     });
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/packages/core/src/rules/common/__tests__/scalar-property-missing-example.test.ts
+++ b/packages/core/src/rules/common/__tests__/scalar-property-missing-example.test.ts
@@ -18,7 +18,7 @@ describe('Oas3 scalar-property-missing-example', () => {
                   type: string
                   format: email
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -62,7 +62,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                   type: string
                   format: email
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -105,7 +105,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                   format: email
                   example: john.smith@example.com
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -134,7 +134,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                   - john.smith@example.com
                   - other@example.com
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -168,7 +168,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                     type: string
                     format: url
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -193,7 +193,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                   type: string
                   format: binary
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -224,7 +224,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                   type: number
                   example: 0
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -250,7 +250,7 @@ describe('Oas3.1 scalar-property-missing-example', () => {
                   nullable: true
                   example: null
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -19,13 +19,13 @@ describe('Oas3 spec', () => {
               200:
                 description: Ok
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: await makeConfig({ 'spec': 'error' }),
+      config: await makeConfig({ spec: 'error' }),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`

--- a/packages/core/src/rules/common/__tests__/tag-description.test.ts
+++ b/packages/core/src/rules/common/__tests__/tag-description.test.ts
@@ -13,7 +13,7 @@ describe('Oas3 tag-description', () => {
             - name: secondTag
               description: some description goes here
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -51,7 +51,7 @@ describe('Oas3 tag-description', () => {
             - name: secondTag
               description: some description goes here
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/__tests__/tags-alphabetical.test.ts
+++ b/packages/core/src/rules/common/__tests__/tags-alphabetical.test.ts
@@ -13,7 +13,7 @@ describe('Oas3 tags-alphabetical', () => {
             - name: b
             - name: a
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -50,7 +50,7 @@ describe('Oas3 tags-alphabetical', () => {
         - name: a
         - name: b
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/common/assertions/__tests__/asserts.test.ts
+++ b/packages/core/src/rules/common/assertions/__tests__/asserts.test.ts
@@ -15,230 +15,613 @@ describe('oas3 assertions', () => {
     describe('pattern', () => {
       it('value should match regex pattern', () => {
         expect(asserts.pattern('test string', '/test/', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.pattern('test string', '/test me/', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.pattern(['test string', 'test me'], '/test/', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.pattern(['test string', 'test me'], '/test me/', baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.pattern('./components/smth/test.yaml', '/^(./)?components/.*.yaml$/', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.pattern('./other.yaml', '/^(./)?components/.*.yaml$/', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.pattern('test string', '/test me/', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.pattern(['test string', 'test me'], '/test/', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.pattern(['test string', 'test me'], '/test me/', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.pattern(
+            './components/smth/test.yaml',
+            '/^(./)?components/.*.yaml$/',
+            baseLocation
+          )
+        ).toEqual({ isValid: true });
+        expect(
+          asserts.pattern('./other.yaml', '/^(./)?components/.*.yaml$/', baseLocation)
+        ).toEqual({ isValid: false, location: baseLocation });
       });
     });
 
     describe('ref', () => {
       it('value should have ref', () => {
-        expect(asserts.ref({ $ref: 'text' }, true, baseLocation, { $ref: 'text' })).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.ref({}, true, baseLocation, {})).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(asserts.ref({ $ref: 'text' }, true, baseLocation, { $ref: 'text' })).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.ref({}, true, baseLocation, {})).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
       });
 
       it('value should not have ref', () => {
-        expect(asserts.ref({ $ref: 'text' }, false, baseLocation, { $ref: 'text' })).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.ref({}, false, baseLocation, {})).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.ref({ $ref: 'text' }, false, baseLocation, { $ref: 'text' })).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.ref({}, false, baseLocation, {})).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
       });
 
       it('value should match regex pattern', () => {
-        expect(asserts.ref({ $ref: 'test string' }, '/test/', baseLocation, { $ref: 'test string' })).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.ref({ $ref: 'test string' }, '/test me/', baseLocation, { $ref: 'test string' })).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.ref({ $ref: './components/smth/test.yaml' }, '/^(./)?components/.*.yaml$/', baseLocation, { $ref: './components/smth/test.yaml' })).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.ref({ $ref: './paths/smth/test.yaml' }, '/^(./)?components/.*.yaml$/', baseLocation, { $ref: './paths/smth/test.yaml' })).toEqual({ isValid: false, location: baseLocation });
+        expect(
+          asserts.ref({ $ref: 'test string' }, '/test/', baseLocation, { $ref: 'test string' })
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.ref({ $ref: 'test string' }, '/test me/', baseLocation, { $ref: 'test string' })
+        ).toEqual({ isValid: false, location: baseLocation });
+        expect(
+          asserts.ref(
+            { $ref: './components/smth/test.yaml' },
+            '/^(./)?components/.*.yaml$/',
+            baseLocation,
+            { $ref: './components/smth/test.yaml' }
+          )
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.ref(
+            { $ref: './paths/smth/test.yaml' },
+            '/^(./)?components/.*.yaml$/',
+            baseLocation,
+            { $ref: './paths/smth/test.yaml' }
+          )
+        ).toEqual({ isValid: false, location: baseLocation });
       });
     });
 
     describe('enum', () => {
       it('value should be among predefined keys', () => {
         expect(asserts.enum('test', ['test', 'example'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.enum(['test'], ['test', 'example'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.enum(['test', 'example'], ['test', 'example'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.enum(['test', 'example', 'foo'], ['test', 'example'], baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo').key() });
-        expect(asserts.enum('test', ['foo', 'example'], baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.enum(['test', 'foo'], ['test', 'example'], baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo').key() });
+        expect(asserts.enum(['test'], ['test', 'example'], baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.enum(['test', 'example'], ['test', 'example'], baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.enum(['test', 'example', 'foo'], ['test', 'example'], baseLocation)).toEqual(
+          { isValid: false, location: baseLocation.child('foo').key() }
+        );
+        expect(asserts.enum('test', ['foo', 'example'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.enum(['test', 'foo'], ['test', 'example'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo').key(),
+        });
       });
     });
 
     describe('defined', () => {
       it('value should be defined', () => {
-        expect(asserts.defined('test', true, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.defined(undefined, true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.defined('test', true, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.defined(undefined, true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be undefined', () => {
-        expect(asserts.defined(undefined, false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.defined('test', false, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.defined(undefined, false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.defined('test', false, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('undefined', () => {
       it('value should be undefined', () => {
-        expect(asserts.undefined(undefined, true, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.undefined('test', true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.undefined(undefined, true, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.undefined('test', true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be defined', () => {
-        expect(asserts.undefined('test', false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.undefined(undefined, false, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.undefined('test', false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.undefined(undefined, false, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('required', () => {
       it('values should be required', () => {
-        expect(asserts.required(['one', 'two', 'three'], ['one', 'two'], baseLocation)).toEqual({ isValid: true });
-        expect(asserts.required(['one', 'two'], ['one', 'two', 'three'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(asserts.required(['one', 'two', 'three'], ['one', 'two'], baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.required(['one', 'two'], ['one', 'two', 'three'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
       });
     });
 
     describe('nonEmpty', () => {
       it('value should not be empty', () => {
-        expect(asserts.nonEmpty('test', true, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty('', true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.nonEmpty(null, true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.nonEmpty(undefined, true, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.nonEmpty('test', true, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty('', true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(null, true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(undefined, true, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be empty', () => {
-        expect(asserts.nonEmpty('', false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty(null, false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty(undefined, false, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.nonEmpty('test', false, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.nonEmpty('', false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(null, false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty(undefined, false, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.nonEmpty('test', false, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('minLength', () => {
       it('value should have less or equal than 5 symbols length', () => {
-        expect(asserts.minLength('test', 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.minLength([1, 2, 3, 4], 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.minLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.minLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.minLength('example', 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.minLength([], 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.minLength('', 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.minLength('test', 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([1, 2, 3, 4], 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.minLength('example', 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.minLength([], 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.minLength('', 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe('maxLength', () => {
       it('value should have more or equal than 5 symbols length', () => {
-        expect(asserts.maxLength('test', 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength([1, 2, 3, 4], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.maxLength('example', 5, baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.maxLength([], 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.maxLength('', 5, baseLocation)).toEqual({ isValid: true, location: baseLocation });
+        expect(asserts.maxLength('test', 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([1, 2, 3, 4], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([1, 2, 3, 4, 5], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([1, 2, 3, 4, 5, 6], 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength('example', 5, baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength([], 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.maxLength('', 5, baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
       });
     });
 
     describe('casing', () => {
       it('value should be camelCase', () => {
-        expect(asserts.casing(['testExample', 'fooBar'], 'camelCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['testExample', 'FooBar'], 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('FooBar').key() });
+        expect(asserts.casing(['testExample', 'fooBar'], 'camelCase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['testExample', 'FooBar'], 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('FooBar').key(),
+        });
         expect(asserts.casing('testExample', 'camelCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing('TestExample', 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test_example', 'camelCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TestExample', 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test_example', 'camelCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be PascalCase', () => {
-        expect(asserts.casing('TestExample', 'PascalCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TestExample', 'FooBar'], 'PascalCase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TestExample', 'fooBar'], 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('fooBar').key() });
-        expect(asserts.casing('testExample', 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test_example', 'PascalCase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TestExample', 'PascalCase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TestExample', 'FooBar'], 'PascalCase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TestExample', 'fooBar'], 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('fooBar').key(),
+        });
+        expect(asserts.casing('testExample', 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test_example', 'PascalCase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be kebab-case', () => {
-        expect(asserts.casing('test-example', 'kebab-case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test-example', 'foo-bar'], 'kebab-case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test-example', 'foo_bar'], 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo_bar').key() });
-        expect(asserts.casing('testExample', 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test_example', 'kebab-case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('test-example', 'kebab-case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test-example', 'foo-bar'], 'kebab-case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test-example', 'foo_bar'], 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo_bar').key(),
+        });
+        expect(asserts.casing('testExample', 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test_example', 'kebab-case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be snake_case', () => {
-        expect(asserts.casing('test_example', 'snake_case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test_example', 'foo_bar'], 'snake_case', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['test_example', 'foo-bar'], 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo-bar').key() });
-        expect(asserts.casing('testExample', 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'snake_case', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('test_example', 'snake_case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test_example', 'foo_bar'], 'snake_case', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['test_example', 'foo-bar'], 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo-bar').key(),
+        });
+        expect(asserts.casing('testExample', 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'snake_case', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be MACRO_CASE', () => {
-        expect(asserts.casing('TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST_EXAMPLE', 'FOO_BAR'], 'MACRO_CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST_EXAMPLE', 'FOO-BAR'], 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('FOO-BAR').key() });
-        expect(asserts.casing('TEST_EXAMPLE_', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('_TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST__EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST-EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('testExample', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'MACRO_CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST_EXAMPLE', 'FOO_BAR'], 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST_EXAMPLE', 'FOO-BAR'], 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('FOO-BAR').key(),
+        });
+        expect(asserts.casing('TEST_EXAMPLE_', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('_TEST_EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST__EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST-EXAMPLE', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('testExample', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'MACRO_CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be COBOL-CASE', () => {
-        expect(asserts.casing('TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST-EXAMPLE', 'FOO-BAR'], 'COBOL-CASE', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['TEST-EXAMPLE', 'FOO_BAR'], 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('FOO_BAR').key() });
-        expect(asserts.casing('TEST-EXAMPLE-', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('0TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('-TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST--EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TEST_EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('testExample', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'COBOL-CASE', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing('TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST-EXAMPLE', 'FOO-BAR'], 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['TEST-EXAMPLE', 'FOO_BAR'], 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('FOO_BAR').key(),
+        });
+        expect(asserts.casing('TEST-EXAMPLE-', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('0TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('-TEST-EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST--EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TEST_EXAMPLE', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('testExample', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'COBOL-CASE', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
       it('value should be flatcase', () => {
         expect(asserts.casing('testexample', 'flatcase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['testexample', 'foobar'], 'flatcase', baseLocation)).toEqual({ isValid: true });
-        expect(asserts.casing(['testexample', 'foo_bar'], 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation.child('foo_bar').key() });
-        expect(asserts.casing('testexample_', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('0testexample', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('testExample', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('TestExample', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.casing('test-example', 'flatcase', baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.casing(['testexample', 'foobar'], 'flatcase', baseLocation)).toEqual({
+          isValid: true,
+        });
+        expect(asserts.casing(['testexample', 'foo_bar'], 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.child('foo_bar').key(),
+        });
+        expect(asserts.casing('testexample_', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('0testexample', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('testExample', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('TestExample', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.casing('test-example', 'flatcase', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
       });
     });
 
     describe.skip('sortOrder', () => {
       it('value should be ordered in ASC direction', () => {
-        expect(asserts.sortOrder(['example', 'foo', 'test'], 'asc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'foo', 'test'], { direction: 'asc' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example'], 'asc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'test', 'foo'], 'asc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'foo', 'test'], 'desc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }], { direction: 'asc', property: 'name' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }], { direction: 'desc', property: 'name' }, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.sortOrder(['example', 'foo', 'test'], 'asc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(['example', 'foo', 'test'], { direction: 'asc' }, baseLocation)
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(asserts.sortOrder(['example'], 'asc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['example', 'test', 'foo'], 'asc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['example', 'foo', 'test'], 'desc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }],
+            { direction: 'asc', property: 'name' },
+            baseLocation
+          )
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }],
+            { direction: 'desc', property: 'name' },
+            baseLocation
+          )
+        ).toEqual({ isValid: false, location: baseLocation });
       });
       it('value should be ordered in DESC direction', () => {
-        expect(asserts.sortOrder(['test', 'foo', 'example'], 'desc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['test', 'foo', 'example'], { direction: 'desc' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example'], 'desc', baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder(['example', 'test', 'foo'], 'desc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder(['test', 'foo', 'example'], 'asc', baseLocation)).toEqual({ isValid: false, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }], { direction: 'desc', property: 'name' }, baseLocation)).toEqual({ isValid: true, location: baseLocation });
-        expect(asserts.sortOrder([{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }], { direction: 'asc', property: 'name' }, baseLocation)).toEqual({ isValid: false, location: baseLocation });
+        expect(asserts.sortOrder(['test', 'foo', 'example'], 'desc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(['test', 'foo', 'example'], { direction: 'desc' }, baseLocation)
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(asserts.sortOrder(['example'], 'desc', baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['example', 'test', 'foo'], 'desc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(asserts.sortOrder(['test', 'foo', 'example'], 'asc', baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation,
+        });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }],
+            { direction: 'desc', property: 'name' },
+            baseLocation
+          )
+        ).toEqual({ isValid: true, location: baseLocation });
+        expect(
+          asserts.sortOrder(
+            [{ name: 'foo' }, { name: 'baz' }, { name: 'bar' }],
+            { direction: 'asc', property: 'name' },
+            baseLocation
+          )
+        ).toEqual({ isValid: false, location: baseLocation });
       });
     });
 
     describe('mutuallyExclusive', () => {
       it('node should not have more than one property from predefined list', () => {
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), [], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'test'], baseLocation)
+        ).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.mutuallyExclusive(Object.keys(fakeNode), [], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)
+        ).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyExclusive(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)
+        ).toEqual({ isValid: false, location: baseLocation.key() });
       });
     });
 
     describe('mutuallyRequired', () => {
       it('node should have all the properties from predefined list', () => {
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'baz'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), [], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)
+        ).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'baz'], baseLocation)
+        ).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.mutuallyRequired(Object.keys(fakeNode), [], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'test'], baseLocation)
+        ).toEqual({ isValid: false, location: baseLocation.key() });
+        expect(
+          asserts.mutuallyRequired(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)
+        ).toEqual({ isValid: false, location: baseLocation.key() });
       });
     });
 
     describe('requireAny', () => {
       it('node must have at least one property from predefined list', () => {
-        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'bar'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), [], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'test1'], baseLocation)).toEqual({ isValid: false, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
-        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)).toEqual({ isValid: true, location: baseLocation.key() });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'test'], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'bar'], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), [], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['test', 'test1'], baseLocation)).toEqual({
+          isValid: false,
+          location: baseLocation.key(),
+        });
+        expect(asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar'], baseLocation)).toEqual({
+          isValid: true,
+          location: baseLocation.key(),
+        });
+        expect(
+          asserts.requireAny(Object.keys(fakeNode), ['foo', 'bar', 'test'], baseLocation)
+        ).toEqual({ isValid: true, location: baseLocation.key() });
       });
     });
   });

--- a/packages/core/src/rules/common/assertions/index.ts
+++ b/packages/core/src/rules/common/assertions/index.ts
@@ -11,7 +11,7 @@ export const Assertions: Oas3Rule | Oas2Rule = (opts: object) => {
   // that is why we need to iterate through 'opts' values;
   // before - filter only object 'opts' values
   const assertions: any[] = Object.values(opts).filter(
-    (opt: unknown) => typeof opt === 'object' && opt !== null,
+    (opt: unknown) => typeof opt === 'object' && opt !== null
   );
 
   for (const [index, assertion] of assertions.entries()) {
@@ -42,21 +42,21 @@ export const Assertions: Oas3Rule | Oas2Rule = (opts: object) => {
       });
 
     const shouldRunOnKeys: AssertToApply | undefined = assertsToApply.find(
-      (assert: AssertToApply) => assert.runsOnKeys && !assert.runsOnValues,
+      (assert: AssertToApply) => assert.runsOnKeys && !assert.runsOnValues
     );
     const shouldRunOnValues: AssertToApply | undefined = assertsToApply.find(
-      (assert: AssertToApply) => assert.runsOnValues && !assert.runsOnKeys,
+      (assert: AssertToApply) => assert.runsOnValues && !assert.runsOnKeys
     );
 
     if (shouldRunOnValues && !assertion.property) {
       throw new Error(
-        `${shouldRunOnValues.name} can't be used on all keys. Please provide a single property.`,
+        `${shouldRunOnValues.name} can't be used on all keys. Please provide a single property.`
       );
     }
 
     if (shouldRunOnKeys && assertion.property) {
       throw new Error(
-        `${shouldRunOnKeys.name} can't be used on a single property. Please use 'property'.`,
+        `${shouldRunOnKeys.name} can't be used on a single property. Please use 'property'.`
       );
     }
 
@@ -64,7 +64,7 @@ export const Assertions: Oas3Rule | Oas2Rule = (opts: object) => {
       const subjectVisitor = buildSubjectVisitor(
         assertion.property,
         assertsToApply,
-        assertion.context,
+        assertion.context
       );
       const visitorObject = buildVisitorObject(subject, assertion.context, subjectVisitor);
       visitors.push(visitorObject);

--- a/packages/core/src/rules/common/info-license.ts
+++ b/packages/core/src/rules/common/info-license.ts
@@ -7,7 +7,7 @@ export const InfoLicense: Oas3Rule | Oas2Rule = () => {
       if (!info.license) {
         report({
           message: missingRequiredField('Info', 'license'),
-          location: { reportOnKey: true }
+          location: { reportOnKey: true },
         });
       }
     },

--- a/packages/core/src/rules/common/no-ambiguous-paths.ts
+++ b/packages/core/src/rules/common/no-ambiguous-paths.ts
@@ -10,7 +10,7 @@ export const NoAmbiguousPaths: Oas3Rule | Oas2Rule = () => {
 
       for (const currentPath of Object.keys(pathMap)) {
         const ambiguousPath = seenPaths.find((seenPath) =>
-          arePathsAmbiguous(seenPath, currentPath),
+          arePathsAmbiguous(seenPath, currentPath)
         );
         if (ambiguousPath) {
           report({

--- a/packages/core/src/rules/common/no-enum-type-mismatch.ts
+++ b/packages/core/src/rules/common/no-enum-type-mismatch.ts
@@ -10,7 +10,7 @@ export const NoEnumTypeMismatch: Oas3Rule | Oas2Rule = () => {
       if (schema.enum && !Array.isArray(schema.enum)) return;
       if (schema.enum && schema.type && !Array.isArray(schema.type)) {
         const typeMismatchedValues = schema.enum.filter(
-          (item) => !matchesJsonSchemaType(item, schema.type as string, schema.nullable as boolean),
+          (item) => !matchesJsonSchemaType(item, schema.type as string, schema.nullable as boolean)
         );
         for (const mismatchedValue of typeMismatchedValues) {
           report({
@@ -23,26 +23,29 @@ export const NoEnumTypeMismatch: Oas3Rule | Oas2Rule = () => {
       }
 
       if (schema.enum && schema.type && Array.isArray(schema.type)) {
-        const mismatchedResults: { [key: string]: string[]; } = {};
+        const mismatchedResults: { [key: string]: string[] } = {};
         for (const enumValue of schema.enum) {
           mismatchedResults[enumValue] = [];
 
           for (const type of schema.type) {
-            const valid = matchesJsonSchemaType(enumValue, type as string, schema.nullable as boolean);
-            if (!valid)
-              mismatchedResults[enumValue].push(type);
+            const valid = matchesJsonSchemaType(
+              enumValue,
+              type as string,
+              schema.nullable as boolean
+            );
+            if (!valid) mismatchedResults[enumValue].push(type);
           }
 
-          if(mismatchedResults[enumValue].length !== schema.type.length)
+          if (mismatchedResults[enumValue].length !== schema.type.length)
             delete mismatchedResults[enumValue];
-        };
+        }
 
         for (const mismatchedKey of Object.keys(mismatchedResults)) {
           report({
             message: `Enum value \`${mismatchedKey}\` must be of one type. Allowed types: \`${schema.type}\`.`,
             location: location.child(['enum', schema.enum.indexOf(mismatchedKey)]),
           });
-        };
+        }
       }
     },
   };

--- a/packages/core/src/rules/common/no-invalid-parameter-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-parameter-examples.ts
@@ -13,7 +13,7 @@ export const NoInvalidParameterExamples: any = (opts: any) => {
             parameter.schema!,
             ctx.location.child('example'),
             ctx,
-            disallowAdditionalProperties,
+            disallowAdditionalProperties
           );
         }
 
@@ -25,7 +25,7 @@ export const NoInvalidParameterExamples: any = (opts: any) => {
                 parameter.schema!,
                 ctx.location.child(['examples', key]),
                 ctx,
-                false,
+                false
               );
             }
           }

--- a/packages/core/src/rules/common/no-invalid-schema-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-schema-examples.ts
@@ -14,7 +14,7 @@ export const NoInvalidSchemaExamples: any = (opts: any) => {
               schema,
               ctx.location.child(['examples', schema.examples.indexOf(example)]),
               ctx,
-              disallowAdditionalProperties,
+              disallowAdditionalProperties
             );
           }
         }

--- a/packages/core/src/rules/common/operation-operationId.ts
+++ b/packages/core/src/rules/common/operation-operationId.ts
@@ -12,6 +12,6 @@ export const OperationOperationId: Oas3Rule | Oas2Rule = () => {
           validateDefinedAndNonEmpty('operationId', operation, ctx);
         },
       },
-    }
+    },
   };
 };

--- a/packages/core/src/rules/common/operation-parameters-unique.ts
+++ b/packages/core/src/rules/common/operation-parameters-unique.ts
@@ -14,7 +14,7 @@ export const OperationParametersUnique: Oas3Rule | Oas2Rule = () => {
       },
       Parameter(
         parameter: Oas2Parameter | Oas3Parameter,
-        { report, key, parentLocations }: UserContext,
+        { report, key, parentLocations }: UserContext
       ) {
         const paramId = `${parameter.in}___${parameter.name}`;
         if (seenPathParams.has(paramId)) {
@@ -31,7 +31,7 @@ export const OperationParametersUnique: Oas3Rule | Oas2Rule = () => {
         },
         Parameter(
           parameter: Oas2Parameter | Oas3Parameter,
-          { report, key, parentLocations }: UserContext,
+          { report, key, parentLocations }: UserContext
         ) {
           const paramId = `${parameter.in}___${parameter.name}`;
           if (seenOperationParams.has(paramId)) {

--- a/packages/core/src/rules/common/path-not-include-query.ts
+++ b/packages/core/src/rules/common/path-not-include-query.ts
@@ -12,6 +12,6 @@ export const PathNotIncludeQuery: Oas3Rule | Oas2Rule = () => {
           });
         }
       },
-    }
+    },
   };
 };

--- a/packages/core/src/rules/common/path-params-defined.ts
+++ b/packages/core/src/rules/common/path-params-defined.ts
@@ -16,7 +16,7 @@ export const PathParamsDefined: Oas3Rule | Oas2Rule = () => {
         definedPathParams = new Set();
         currentPath = key as string;
         pathTemplateParams = new Set(
-          Array.from(key!.toString().matchAll(pathRegex)).map((m) => m[1]),
+          Array.from(key!.toString().matchAll(pathRegex)).map((m) => m[1])
         );
       },
       Parameter(parameter: Oas2Parameter | Oas3Parameter, { report, location }: UserContext) {

--- a/packages/core/src/rules/common/paths-kebab-case.ts
+++ b/packages/core/src/rules/common/paths-kebab-case.ts
@@ -4,7 +4,10 @@ import { UserContext } from '../../walk';
 export const PathsKebabCase: Oas3Rule | Oas2Rule = () => {
   return {
     PathItem(_path: object, { report, key }: UserContext) {
-      const segments = (key as string).substr(1).split('/').filter(s => s !== ''); // filter out empty segments
+      const segments = (key as string)
+        .substr(1)
+        .split('/')
+        .filter((s) => s !== ''); // filter out empty segments
       if (!segments.every((segment) => /^{.+}$/.test(segment) || /^[a-z0-9-.]+$/.test(segment))) {
         report({
           message: `\`${key}\` does not use kebab-case.`,

--- a/packages/core/src/rules/common/scalar-property-missing-example.ts
+++ b/packages/core/src/rules/common/scalar-property-missing-example.ts
@@ -10,7 +10,7 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
   return {
     SchemaProperties(
       properties: { [name: string]: Oas2Schema | Oas3Schema | Oas3_1Schema },
-      { report, location, oasVersion, resolve }: UserContext,
+      { report, location, oasVersion, resolve }: UserContext
     ) {
       for (const propName of Object.keys(properties)) {
         const propSchema = resolve(properties[propName]).node;

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -6,7 +6,7 @@ import { isPlainObject } from '../../utils';
 
 export const OasSpec: Oas3Rule | Oas2Rule = () => {
   return {
-    any(node: any, { report, type, location, key, resolve, ignoreNextVisitorsOnNode } ) {
+    any(node: any, { report, type, location, key, resolve, ignoreNextVisitorsOnNode }) {
       const nodeType = oasTypeOf(node);
 
       if (type.items) {
@@ -40,15 +40,16 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
       const allowed = type.allowed?.(node);
       if (allowed && isPlainObject(node)) {
         for (const propName in node) {
-          if (allowed.includes(propName) ||
-           (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
-           !Object.keys(type.properties).includes(propName)
+          if (
+            allowed.includes(propName) ||
+            (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
+            !Object.keys(type.properties).includes(propName)
           ) {
             continue;
           }
           report({
             message: `The field \`${propName}\` is not allowed here.`,
-            location: location.child([propName]).key()
+            location: location.child([propName]).key(),
           });
         }
       }
@@ -63,7 +64,9 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
         }
         if (!hasProperty)
           report({
-            message: `Must contain at least one of the following fields: ${type.requiredOneOf?.join(', ')}.`,
+            message: `Must contain at least one of the following fields: ${type.requiredOneOf?.join(
+              ', '
+            )}.`,
             location: [{ reportOnKey: true }],
           });
       }
@@ -134,7 +137,7 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
             report({
               message: `The value of the ${propName} field must be greater than or equal to ${propSchema.minimum}`,
               location: location.child([propName]),
-            })
+            });
           }
         }
       }

--- a/packages/core/src/rules/no-unresolved-refs.ts
+++ b/packages/core/src/rules/no-unresolved-refs.ts
@@ -25,7 +25,7 @@ export const NoUnresolvedRefs: Oas3Rule = () => {
 export function reportUnresolvedRef(
   resolved: ResolveResult<any>,
   report: (m: Problem) => void,
-  location: Location,
+  location: Location
 ) {
   const error = resolved.error;
   if (error instanceof YamlParseError) {

--- a/packages/core/src/rules/oas2/__tests__/boolean-parameter-prefixes.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/boolean-parameter-prefixes.test.ts
@@ -15,7 +15,7 @@ describe('oas2 boolean-parameter-prefixes', () => {
               in: path
               type: boolean
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -67,7 +67,7 @@ describe('oas2 boolean-parameter-prefixes', () => {
                   schema:
                     type: boolean
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -91,7 +91,7 @@ describe('oas2 boolean-parameter-prefixes', () => {
                 schema:
                   type: boolean
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas2/__tests__/spec/info.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/spec/info.test.ts
@@ -20,7 +20,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -50,7 +50,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -80,7 +80,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -114,7 +114,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -140,7 +140,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -173,7 +173,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -205,7 +205,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -229,7 +229,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -261,7 +261,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -292,7 +292,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -313,7 +313,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -342,7 +342,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/core/src/rules/oas2/__tests__/spec/operation.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/spec/operation.test.ts
@@ -20,7 +20,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -47,7 +47,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -81,7 +81,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -117,7 +117,7 @@ describe('OpenAPI Schema 2.0', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/packages/core/src/rules/oas2/__tests__/spec/paths.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/spec/paths.test.ts
@@ -20,7 +20,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -37,7 +37,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -52,7 +52,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -76,7 +76,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -99,7 +99,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -133,7 +133,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         'paths-identical': 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -160,7 +160,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -187,7 +187,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -205,7 +205,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -239,7 +239,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await lintDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/packages/core/src/rules/oas2/__tests__/spec/referenceableScalars.test.ts
+++ b/packages/core/src/rules/oas2/__tests__/spec/referenceableScalars.test.ts
@@ -1,5 +1,9 @@
 import { outdent } from 'outdent';
-import { parseYamlToDocument, replaceSourceWithRef, makeConfig } from '../../../../../__tests__/utils';
+import {
+  parseYamlToDocument,
+  replaceSourceWithRef,
+  makeConfig,
+} from '../../../../../__tests__/utils';
 import { lintDocument } from '../../../../lint';
 import { BaseResolver } from '../../../../resolve';
 
@@ -15,7 +19,7 @@ describe('Referenceable scalars', () => {
             $ref: fixtures/description.md
         paths: {}
       `,
-      __dirname + '/foobar.yaml',
+      __dirname + '/foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas2/__tests__/spec/utils.ts
+++ b/packages/core/src/rules/oas2/__tests__/spec/utils.ts
@@ -5,7 +5,7 @@ import { BaseResolver } from '../../../../resolve';
 
 export async function lintDoc(
   source: string,
-  rules: Record<string, RuleConfig> = { spec: 'error' },
+  rules: Record<string, RuleConfig> = { spec: 'error' }
 ) {
   const document = parseYamlToDocument(source, 'foobar.yaml');
 
@@ -19,7 +19,7 @@ export async function lintDoc(
           extends: [],
           rules,
         },
-      }),
+      })
     ),
   });
 

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -57,7 +57,7 @@ export const rules = {
   'no-path-trailing-slash': NoPathTrailingSlash as Oas2Rule,
   'operation-2xx-response': Operation2xxResponse as Oas2Rule,
   'operation-4xx-response': Operation4xxResponse as Oas2Rule,
-  'assertions': Assertions as Oas2Rule,
+  assertions: Assertions as Oas2Rule,
   'operation-operationId-unique': OperationIdUnique as Oas2Rule,
   'operation-parameters-unique': OperationParametersUnique as Oas2Rule,
   'path-parameters-defined': PathParamsDefined as Oas2Rule,

--- a/packages/core/src/rules/oas2/remove-unused-components.ts
+++ b/packages/core/src/rules/oas2/remove-unused-components.ts
@@ -4,9 +4,16 @@ import { Oas2Components } from '../../typings/swagger';
 import { isEmptyObject } from '../../utils';
 
 export const RemoveUnusedComponents: Oas2Rule = () => {
-  let components = new Map<string, { used: boolean; componentType?: keyof Oas2Components; name: string }>();
+  let components = new Map<
+    string,
+    { used: boolean; componentType?: keyof Oas2Components; name: string }
+  >();
 
-  function registerComponent(location: Location, componentType: keyof Oas2Components, name: string): void {
+  function registerComponent(
+    location: Location,
+    componentType: keyof Oas2Components,
+    name: string
+  ): void {
     components.set(location.absolutePointer, {
       used: components.get(location.absolutePointer)?.used || false,
       componentType,
@@ -17,9 +24,7 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
   return {
     ref: {
       leave(ref, { type, resolve, key }) {
-        if (
-          ['Schema', 'Parameter', 'Response', 'SecurityScheme'].includes(type.name)
-        ) {
+        if (['Schema', 'Parameter', 'Response', 'SecurityScheme'].includes(type.name)) {
           const resolvedRef = resolve(ref);
           if (!resolvedRef.location) return;
           components.set(resolvedRef.location.absolutePointer, {
@@ -27,7 +32,7 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
             name: key.toString(),
           });
         }
-      }
+      },
     },
     DefinitionRoot: {
       leave(root, ctx) {
@@ -35,7 +40,7 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
         data.removedCount = 0;
 
         let rootComponents = new Set<keyof Oas2Components>();
-        components.forEach(usageInfo => {
+        components.forEach((usageInfo) => {
           const { used, name, componentType } = usageInfo;
           if (!used && componentType) {
             rootComponents.add(componentType);
@@ -71,6 +76,6 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
       SecurityScheme(_securityScheme, { location, key }) {
         registerComponent(location, 'securityDefinitions', key.toString());
       },
-    }
+    },
   };
 };

--- a/packages/core/src/rules/oas3/__tests__/boolean-parameter-prefixes.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/boolean-parameter-prefixes.test.ts
@@ -16,7 +16,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
               schema:
                 type: boolean
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -68,7 +68,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
                   schema:
                     type: boolean
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -92,7 +92,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
                 schema:
                   type: boolean
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/no-example-value-and-externalValue.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-example-value-and-externalValue.test.ts
@@ -14,7 +14,7 @@ describe('Oas3 oas3-no-example-value-and-externalValue', () => {
                 value: 12
                 externalValue: https://1.1.1.1
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -51,7 +51,7 @@ describe('Oas3 oas3-no-example-value-and-externalValue', () => {
               some:
                 value: 12
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
@@ -27,7 +27,7 @@ describe('no-invalid-media-type-examples', () => {
                             type: number
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -100,7 +100,7 @@ describe('no-invalid-media-type-examples', () => {
                             type: number
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -160,7 +160,7 @@ describe('no-invalid-media-type-examples', () => {
                             type: number
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -210,7 +210,7 @@ describe('no-invalid-media-type-examples', () => {
                             type: number
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -263,7 +263,7 @@ describe('no-invalid-media-type-examples', () => {
                         b: 35
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -295,7 +295,7 @@ describe('no-invalid-media-type-examples', () => {
                             type: number
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -330,7 +330,7 @@ describe('no-invalid-media-type-examples', () => {
                         $ref: '#/components/schemas/C'
 
       `,
-      __dirname + '/foobar.yaml',
+      __dirname + '/foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -358,7 +358,7 @@ describe('no-invalid-media-type-examples', () => {
                         nullable: true
 
       `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/no-server-example.com.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-server-example.com.test.ts
@@ -11,7 +11,7 @@ describe('Oas3 oas3-no-server-example.com', () => {
           servers:
             - url: example.com
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -46,7 +46,7 @@ describe('Oas3 oas3-no-server-example.com', () => {
           servers:
             - url: not-example.com
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/no-server-trailing-slash.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-server-trailing-slash.test.ts
@@ -11,7 +11,7 @@ describe('Oas3 oas3-no-server-trailing-slash', () => {
           servers:
             - url: https://somedomain.com/
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -46,7 +46,7 @@ describe('Oas3 oas3-no-server-trailing-slash', () => {
           servers:
             - url: https://somedomain.com
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -65,7 +65,7 @@ describe('Oas3 oas3-no-server-trailing-slash', () => {
           servers:
             - url: /
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/no-unused-components.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-unused-components.test.ts
@@ -36,7 +36,7 @@ describe('Oas3 no-unused-components', () => {
                 - 1
                 - 2
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/spec/callbacks.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/callbacks.test.ts
@@ -36,6 +36,6 @@ it('should not fail on valid callbacks object', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });

--- a/packages/core/src/rules/oas3/__tests__/spec/info.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/info.test.ts
@@ -23,7 +23,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -56,7 +56,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -89,7 +89,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -126,7 +126,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -155,7 +155,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -191,7 +191,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -226,7 +226,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -253,7 +253,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -288,7 +288,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -322,7 +322,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -346,7 +346,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -378,7 +378,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/core/src/rules/oas3/__tests__/spec/operation.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/operation.test.ts
@@ -23,7 +23,7 @@ it('should not report if summary field is valid', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });
 
@@ -49,7 +49,7 @@ it('should report if summary field is not string ', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`
     Array [
       Object {
@@ -82,7 +82,7 @@ it('should not report if description field is valid', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });
 
@@ -108,7 +108,7 @@ it('should report if description field is not string', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`
     Array [
       Object {
@@ -140,7 +140,7 @@ it('should not report of a valid GET operation object', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });
 
@@ -170,7 +170,7 @@ it('should not report of a valid PUT operation object', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });
 
@@ -208,7 +208,7 @@ it('should not report of a valid Post operation object', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });
 
@@ -248,6 +248,6 @@ it('should not report of a valid delete operation object', async () => {
   expect(
     await validateDoc(source, {
       spec: 'error',
-    }),
+    })
   ).toMatchInlineSnapshot(`Array []`);
 });

--- a/packages/core/src/rules/oas3/__tests__/spec/paths.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/paths.test.ts
@@ -23,7 +23,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -43,7 +43,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -61,7 +61,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -88,7 +88,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -114,7 +114,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -151,7 +151,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         'no-identical-paths': 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -188,7 +188,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -218,7 +218,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -239,7 +239,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -278,7 +278,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/packages/core/src/rules/oas3/__tests__/spec/referenceableScalars.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/referenceableScalars.test.ts
@@ -17,7 +17,7 @@ describe('Referenceable scalars', () => {
               $ref: fixtures/description.md
           paths: {}
         `,
-      __dirname + '/foobar.yaml',
+      __dirname + '/foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -32,7 +32,7 @@ describe('Referenceable scalars', () => {
               'no-unresolved-refs': 'error',
             },
           },
-        }),
+        })
       ),
     });
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
@@ -54,7 +54,7 @@ describe('Referenceable scalars', () => {
                     example:
                       $ref: not $ref, example
         `,
-      __dirname + '/foobar.yaml',
+      __dirname + '/foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -69,7 +69,7 @@ describe('Referenceable scalars', () => {
             },
             doNotResolveExamples: true,
           },
-        }),
+        })
       ),
     });
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);

--- a/packages/core/src/rules/oas3/__tests__/spec/servers.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/servers.test.ts
@@ -24,7 +24,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -49,7 +49,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -81,7 +81,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -114,7 +114,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -146,7 +146,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -171,7 +171,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -208,7 +208,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -243,7 +243,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -277,7 +277,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -317,7 +317,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         'no-undefined-server-variable': 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -357,7 +357,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -403,7 +403,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -447,7 +447,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -469,7 +469,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -493,7 +493,7 @@ describe('OpenAPI Schema', () => {
     expect(
       await validateDoc(source, {
         spec: 'error',
-      }),
+      })
     ).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
@@ -35,7 +35,7 @@ describe('Oas3 Structural visitor basic', () => {
             license: invalid
           paths: {}
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -163,7 +163,7 @@ describe('Oas3 Structural visitor basic', () => {
               x-test: vendor
           paths: {}
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({
@@ -232,7 +232,7 @@ describe('Oas3 Structural visitor basic', () => {
             contact:
               name: string
         `,
-      'foobar.yaml',
+      'foobar.yaml'
     );
 
     const results = await lintDocument({

--- a/packages/core/src/rules/oas3/__tests__/spec/utils.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/utils.ts
@@ -5,7 +5,7 @@ import { BaseResolver } from '../../../../resolve';
 
 export async function validateDoc(
   source: string,
-  rules: Record<string, RuleConfig> = { spec: 'error' },
+  rules: Record<string, RuleConfig> = { spec: 'error' }
 ) {
   const document = parseYamlToDocument(source, 'foobar.yaml');
 
@@ -19,7 +19,7 @@ export async function validateDoc(
           extends: [],
           rules,
         },
-      }),
+      })
     ),
   });
 

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -57,7 +57,7 @@ export const rules = {
   'info-license-url': InfoLicenseUrl,
   'operation-2xx-response': Operation2xxResponse,
   'operation-4xx-response': Operation4xxResponse,
-  'assertions': Assertions,
+  assertions: Assertions,
   'operation-operationId-unique': OperationIdUnique,
   'operation-parameters-unique': OperationParametersUnique,
   'path-parameters-defined': PathParamsDefined,

--- a/packages/core/src/rules/oas3/no-empty-servers.ts
+++ b/packages/core/src/rules/oas3/no-empty-servers.ts
@@ -6,7 +6,7 @@ export const NoEmptyServers: Oas3Rule = () => {
       if (!root.hasOwnProperty('servers')) {
         report({
           message: 'Servers must be present.',
-          location: location.child(['openapi']).key()
+          location: location.child(['openapi']).key(),
         });
         return;
       }

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -13,14 +13,22 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
         const { location, resolve } = ctx;
         if (!mediaType.schema) return;
         if (mediaType.example) {
-         resolveAndValidateExample(mediaType.example, location.child('example'));
+          resolveAndValidateExample(mediaType.example, location.child('example'));
         } else if (mediaType.examples) {
           for (const exampleName of Object.keys(mediaType.examples)) {
-            resolveAndValidateExample(mediaType.examples[exampleName], location.child(['examples', exampleName, 'value']), true);
+            resolveAndValidateExample(
+              mediaType.examples[exampleName],
+              location.child(['examples', exampleName, 'value']),
+              true
+            );
           }
         }
 
-        function resolveAndValidateExample(example: Oas3Example | any, location: Location, isMultiple?: boolean) {
+        function resolveAndValidateExample(
+          example: Oas3Example | any,
+          location: Location,
+          isMultiple?: boolean
+        ) {
           if (isRef(example)) {
             const resolved = resolve<Oas3Example>(example);
             if (!resolved.location) return;
@@ -32,7 +40,7 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
             mediaType.schema!,
             location,
             ctx,
-            disallowAdditionalProperties,
+            disallowAdditionalProperties
           );
         }
       },

--- a/packages/core/src/rules/oas3/no-servers-empty-enum.ts
+++ b/packages/core/src/rules/oas3/no-servers-empty-enum.ts
@@ -25,16 +25,17 @@ export const NoEmptyEnumServers: Oas3Rule = () => {
         invalidVariables.push(...enumErrors);
       }
 
-      for(const invalidVariable of invalidVariables) {
-        if(invalidVariable === enumError.empty) {
+      for (const invalidVariable of invalidVariables) {
+        if (invalidVariable === enumError.empty) {
           report({
             message: 'Server variable with `enum` must be a non-empty array.',
             location: location.child(['servers']).key(),
           });
         }
-        if(invalidVariable === enumError.invalidDefaultValue) {
+        if (invalidVariable === enumError.invalidDefaultValue) {
           report({
-            message: 'Server variable define `enum` and `default`. `enum` must include default value',
+            message:
+              'Server variable define `enum` and `default`. `enum` must include default value',
             location: location.child(['servers']).key(),
           });
         }
@@ -43,20 +44,18 @@ export const NoEmptyEnumServers: Oas3Rule = () => {
   };
 };
 
-function checkEnumVariables(server: Oas3Server): enumError[] | undefined{
-  if (server.variables && Object.keys(server.variables).length === 0)
-    return;
+function checkEnumVariables(server: Oas3Server): enumError[] | undefined {
+  if (server.variables && Object.keys(server.variables).length === 0) return;
 
   const errors: enumError[] = [];
-  for(var variable in server.variables) {
+  for (var variable in server.variables) {
     const serverVariable = server.variables[variable];
     if (!serverVariable.enum) continue;
 
     if (Array.isArray(serverVariable.enum) && serverVariable.enum?.length === 0)
       errors.push(enumError.empty);
 
-    if (!serverVariable.default)
-      continue;
+    if (!serverVariable.default) continue;
 
     const defaultValue = server.variables[variable].default;
     if (serverVariable.enum && !serverVariable.enum.includes(defaultValue))

--- a/packages/core/src/rules/oas3/remove-unused-components.ts
+++ b/packages/core/src/rules/oas3/remove-unused-components.ts
@@ -1,12 +1,19 @@
 import { Oas3Rule } from '../../visitors';
 import { Location } from '../../ref-utils';
-import { Oas3Components } from '../../typings/openapi'
+import { Oas3Components } from '../../typings/openapi';
 import { isEmptyObject } from '../../utils';
 
 export const RemoveUnusedComponents: Oas3Rule = () => {
-  let components = new Map<string, { used: boolean; componentType?: keyof Oas3Components; name: string }>();
+  let components = new Map<
+    string,
+    { used: boolean; componentType?: keyof Oas3Components; name: string }
+  >();
 
-  function registerComponent(location: Location, componentType: keyof Oas3Components, name: string): void {
+  function registerComponent(
+    location: Location,
+    componentType: keyof Oas3Components,
+    name: string
+  ): void {
     components.set(location.absolutePointer, {
       used: components.get(location.absolutePointer)?.used || false,
       componentType,
@@ -18,7 +25,9 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
     ref: {
       leave(ref, { type, resolve, key }) {
         if (
-          ['Schema', 'Header', 'Parameter', 'Response', 'Example', 'RequestBody'].includes(type.name)
+          ['Schema', 'Header', 'Parameter', 'Response', 'Example', 'RequestBody'].includes(
+            type.name
+          )
         ) {
           const resolvedRef = resolve(ref);
           if (!resolvedRef.location) return;
@@ -27,14 +36,14 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
             name: key.toString(),
           });
         }
-      }
+      },
     },
     DefinitionRoot: {
       leave(root, ctx) {
         const data = ctx.getVisitorData() as { removedCount: number };
         data.removedCount = 0;
 
-        components.forEach(usageInfo => {
+        components.forEach((usageInfo) => {
           const { used, componentType, name } = usageInfo;
           if (!used && componentType) {
             let componentChild = root.components![componentType];
@@ -45,7 +54,9 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
             }
           }
         });
-        if (isEmptyObject(root.components)) { delete root.components; }
+        if (isEmptyObject(root.components)) {
+          delete root.components;
+        }
       },
     },
     NamedSchemas: {

--- a/packages/core/src/rules/other/stats.ts
+++ b/packages/core/src/rules/other/stats.ts
@@ -4,10 +4,26 @@ import { StatsAccumulator } from '../../typings/common';
 
 export const Stats = (statsAccumulator: StatsAccumulator) => {
   return {
-    ExternalDocs: { leave() { statsAccumulator.externalDocs.total++; }},
-    ref: { enter(ref: OasRef) { statsAccumulator.refs.items!.add(ref['$ref']); }},
-    Tag: { leave(tag: Oas3Tag) { statsAccumulator.tags.items!.add(tag.name); }},
-    Link: { leave(link: any) { statsAccumulator.links.items!.add(link.operationId); }},
+    ExternalDocs: {
+      leave() {
+        statsAccumulator.externalDocs.total++;
+      },
+    },
+    ref: {
+      enter(ref: OasRef) {
+        statsAccumulator.refs.items!.add(ref['$ref']);
+      },
+    },
+    Tag: {
+      leave(tag: Oas3Tag) {
+        statsAccumulator.tags.items!.add(tag.name);
+      },
+    },
+    Link: {
+      leave(link: any) {
+        statsAccumulator.links.items!.add(link.operationId);
+      },
+    },
     DefinitionRoot: {
       leave() {
         statsAccumulator.parameters.total = statsAccumulator.parameters.items!.size;
@@ -19,26 +35,39 @@ export const Stats = (statsAccumulator: StatsAccumulator) => {
     WebhooksMap: {
       Operation: {
         leave(operation: any) {
-          operation.tags.forEach((tag: string) => { statsAccumulator.tags.items!.add(tag); })
-        }
-      }
+          operation.tags.forEach((tag: string) => {
+            statsAccumulator.tags.items!.add(tag);
+          });
+        },
+      },
     },
     PathMap: {
       PathItem: {
-        leave() { statsAccumulator.pathItems.total++; },
+        leave() {
+          statsAccumulator.pathItems.total++;
+        },
         Operation: {
           leave(operation: any) {
             statsAccumulator.operations.total++;
-            operation.tags && operation.tags.forEach((tag: string) => { statsAccumulator.tags.items!.add(tag); })
-          }
+            operation.tags &&
+              operation.tags.forEach((tag: string) => {
+                statsAccumulator.tags.items!.add(tag);
+              });
+          },
         },
-        Parameter: { leave(parameter: Oas2Parameter | Oas3Parameter) {
-          statsAccumulator.parameters.items!.add(parameter.name)
-        }},
+        Parameter: {
+          leave(parameter: Oas2Parameter | Oas3Parameter) {
+            statsAccumulator.parameters.items!.add(parameter.name);
+          },
+        },
       },
     },
     NamedSchemas: {
-      Schema: { leave() { statsAccumulator.schemas.total++; }}
-    }
-  }
-}
+      Schema: {
+        leave() {
+          statsAccumulator.schemas.total++;
+        },
+      },
+    },
+  };
+};

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -89,7 +89,7 @@ export function validateExample(
   schema: Referenced<Oas3Schema>,
   dataLoc: Location,
   { resolve, location, report }: UserContext,
-  disallowAdditionalProperties: boolean,
+  disallowAdditionalProperties: boolean
 ) {
   try {
     const { valid, errors } = validateJsonSchema(
@@ -98,7 +98,7 @@ export function validateExample(
       location.child('schema'),
       dataLoc.pointer,
       resolve,
-      disallowAdditionalProperties,
+      disallowAdditionalProperties
     );
     if (!valid) {
       for (let error of errors) {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -24,7 +24,7 @@ export type NodeType = {
   items?: string;
   required?: string[] | ((value: any, key: string | number | undefined) => string[]);
   requiredOneOf?: string[];
-  allowed?: ((value: any) => string[] | undefined);
+  allowed?: (value: any) => string[] | undefined;
   extensionsPrefix?: string;
 };
 type PropType = string | NodeType | ScalarSchema | undefined | null;
@@ -37,14 +37,14 @@ export type NormalizedNodeType = {
   items?: NormalizedNodeType;
   required?: string[] | ((value: any, key: string | number | undefined) => string[]);
   requiredOneOf?: string[];
-  allowed?: ((value: any) => string[] | undefined);
+  allowed?: (value: any) => string[] | undefined;
   extensionsPrefix?: string;
 };
 
 type NormalizedPropType = NormalizedNodeType | NormalizedScalarSchema | undefined | null;
 type NormalizedResolveTypeFn = (
   value: any,
-  key: string,
+  key: string
 ) => NormalizedNodeType | NormalizedScalarSchema | undefined | null;
 
 export function listOf(typeName: string) {
@@ -65,7 +65,7 @@ export function mapOf(typeName: string) {
 
 export function normalizeTypes(
   types: Record<string, NodeType>,
-  options: { doNotResolveExamples?: boolean } = {},
+  options: { doNotResolveExamples?: boolean } = {}
 ): Record<string, NormalizedNodeType> {
   const normalizedTypes: Record<string, NormalizedNodeType> = {};
 
@@ -132,7 +132,7 @@ export function normalizeTypes(
 }
 
 export function isNamedType(
-  t: NormalizedNodeType | NormalizedScalarSchema | null | undefined,
+  t: NormalizedNodeType | NormalizedScalarSchema | null | undefined
 ): t is NormalizedNodeType {
   return typeof t?.name === 'string';
 }

--- a/packages/core/src/typings/common.ts
+++ b/packages/core/src/typings/common.ts
@@ -5,5 +5,13 @@ export interface StatsRow {
   items?: Set<string>;
 }
 
-export type StatsName = 'operations' | 'refs' | 'tags' | 'externalDocs' | 'pathItems' | 'links' | 'schemas' | 'parameters';
+export type StatsName =
+  | 'operations'
+  | 'refs'
+  | 'tags'
+  | 'externalDocs'
+  | 'pathItems'
+  | 'links'
+  | 'schemas'
+  | 'parameters';
 export type StatsAccumulator = Record<StatsName, StatsRow>;

--- a/packages/core/src/typings/openapi.ts
+++ b/packages/core/src/typings/openapi.ts
@@ -156,7 +156,7 @@ export interface Oas3Schema {
 export type Oas3_1Schema = Oas3Schema & {
   type?: string | string[];
   examples?: any[];
-}
+};
 
 export interface Oas3_1Definition extends Oas3Definition {
   webhooks?: Oas3_1Webhooks;

--- a/packages/core/src/visitors.ts
+++ b/packages/core/src/visitors.ts
@@ -53,7 +53,7 @@ export type VisitFunction<T> = (
   node: T,
   ctx: UserContext & { ignoreNextVisitorsOnNode: () => void },
   parents?: any,
-  context?: any,
+  context?: any
 ) => void;
 
 type VisitRefFunction = (node: OasRef, ctx: UserContext, resolved: ResolveResult<any>) => void;
@@ -264,7 +264,7 @@ export type RuleInstanceConfig = {
 
 export function normalizeVisitors<T extends BaseVisitor>(
   visitorsConfig: (RuleInstanceConfig & { visitor: NestedVisitObject<any, T> })[],
-  types: Record<keyof T, NormalizedNodeType>,
+  types: Record<keyof T, NormalizedNodeType>
 ): NormalizedOasVisitors<T> {
   const normalizedVisitors: NormalizedOasVisitors<T> = {} as any;
 
@@ -301,7 +301,7 @@ export function normalizeVisitors<T extends BaseVisitor>(
     from: NormalizedNodeType,
     to: NormalizedNodeType,
     parentContext: VisitorLevelContext,
-    stack: NormalizedNodeType[] = [],
+    stack: NormalizedNodeType[] = []
   ) {
     if (stack.includes(from)) return;
 
@@ -363,7 +363,7 @@ export function normalizeVisitors<T extends BaseVisitor>(
     ruleConf: RuleInstanceConfig,
     visitor: NestedVisitObject<any, T>,
     parentContext: VisitorLevelContext | null,
-    depth = 0,
+    depth = 0
   ) {
     const visitorKeys = Object.keys(types) as Array<keyof T | 'any'>;
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -43,9 +43,7 @@ module.exports = {
     __dirname: false,
   },
 
-  plugins: [
-    new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true }),
-  ],
+  plugins: [new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true })],
 
   optimization: {
     splitChunks: {


### PR DESCRIPTION
## What/Why/How?

It's harder to contribute without a simple way to format the code.

This one results in more files changed than #787 which is why I personally prefer #787.

## Reference

Alternative to #787 

## Testing

The code coverage for percentage of lines decreases due to additional line breaks but no actual decrease in true coverage.

## Check yourself

- [x] Code is linted

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
