### PR TITLE
chore: add tests for rules utils

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Hi! We're really excited that you are interested in contributing to Redocly CLI.
 
 - The best way to get your bug fixed is to provide a (reduced) test case. This means listing and explaining the steps we should take to try and hit the same problem you're having. It helps us understand in which conditions the issue appears, and gives us a better idea of what may be causing it.
 
-- Abide by our [Code of Conduct](https://redoc.ly/code-of-conduct/) in all your interactions on this repository, and show patience and respect to other community members.
+- Abide by our [Code of Conduct](https://redocly.com/code-of-conduct/) in all your interactions on this repository, and show patience and respect to other community members.
 
 ## Pull Request Guidelines
 Before submitting a pull request, please make sure the following is done:

--- a/packages/core/src/rules/__tests__/utils.test.ts
+++ b/packages/core/src/rules/__tests__/utils.test.ts
@@ -1,0 +1,73 @@
+import {
+  matchesJsonSchemaType,
+} from '../utils';
+
+describe('matches-json-schema-type', () => {
+  it('should report true on any type', () => {
+    const results = matchesJsonSchemaType(123, 'any', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true on a null value with nullable type', () => {
+    const results = matchesJsonSchemaType(null, 'string', true);
+    expect(results).toBe(true);
+  });
+
+  it('should report true on a value and type integer', () => {
+    const results = matchesJsonSchemaType(123, 'integer', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report false when the value is not integer and type is integer', () => {
+    const results = matchesJsonSchemaType(3.14, 'integer', false);
+    expect(results).toBe(false);
+  });
+
+  it('should report true when the value is a number and type is number', () => {
+    const results = matchesJsonSchemaType(3.14, 'number', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is an integer and type is number', () => {
+    const results = matchesJsonSchemaType(3, 'number', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is true and type is boolean', () => {
+    const results = matchesJsonSchemaType(true, 'boolean', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is false and type is boolean', () => {
+    const results = matchesJsonSchemaType(false, 'boolean', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report true when the value is a string and type is boolean', () => {
+    const results = matchesJsonSchemaType('test', 'boolean', false);
+    expect(results).toBe(false);
+  });
+
+  it('should report true on an array value with array type', () => {
+    const results = matchesJsonSchemaType(['foo', 'bar'], 'array', false);
+    expect(results).toBe(true);
+  });
+
+  it('should report false on an array value with object type', () => {
+    const results = matchesJsonSchemaType(['foo', 'bar'], 'object', false);
+    expect(results).toBe(false);
+  });
+
+  it('should report true on an object value with object type', () => {
+    const car = {type:"Fiat", model:"500", color:"white"};
+    const results = matchesJsonSchemaType(car, 'object', true);
+    expect(results).toBe(true);
+  });
+
+  it('should report false on an object value with array type', () => {
+    const car = {type:"Fiat", model:"500", color:"white"};
+    const results = matchesJsonSchemaType(car, 'array', true);
+    expect(results).toBe(false);
+  });
+
+});

--- a/packages/core/src/rules/__tests__/utils.test.ts
+++ b/packages/core/src/rules/__tests__/utils.test.ts
@@ -1,14 +1,9 @@
-import {
-  fieldNonEmpty,
-  matchesJsonSchemaType,
-  missingRequiredField,
-  oasTypeOf,
-} from '../utils';
+import { fieldNonEmpty, matchesJsonSchemaType, missingRequiredField, oasTypeOf } from '../utils';
 
 describe('field-non-empty', () => {
   it('should match expected message', () => {
     const message = fieldNonEmpty('Car', 'color');
-    expect(message).toBe('Car object \`color\` must be non-empty string.');
+    expect(message).toBe('Car object `color` must be non-empty string.');
   });
 });
 
@@ -64,13 +59,13 @@ describe('matches-json-schema-type', () => {
   });
 
   it('should report true on an object value with object type', () => {
-    const car = {type:"Fiat", model:"500", color:"white"};
+    const car = { type: 'Fiat', model: '500', color: 'white' };
     const results = matchesJsonSchemaType(car, 'object', true);
     expect(results).toBe(true);
   });
 
   it('should report false on an object value with array type', () => {
-    const car = {type:"Fiat", model:"500", color:"white"};
+    const car = { type: 'Fiat', model: '500', color: 'white' };
     const results = matchesJsonSchemaType(car, 'array', true);
     expect(results).toBe(false);
   });
@@ -79,7 +74,7 @@ describe('matches-json-schema-type', () => {
 describe('missing-required-field', () => {
   it('should match expected message for missing required field', () => {
     const message = missingRequiredField('Car', 'color');
-    expect(message).toBe('Car object should contain \`color\` field.');
+    expect(message).toBe('Car object should contain `color` field.');
   });
 });
 
@@ -120,7 +115,7 @@ describe('oas-type-of', () => {
   });
 
   it('should report the correct oas type for an object', () => {
-    const car = {type:"Fiat", model:"500", color:"white"};
+    const car = { type: 'Fiat', model: '500', color: 'white' };
     const results = oasTypeOf(car);
     expect(results).toBe('object');
   });

--- a/packages/core/src/rules/__tests__/utils.test.ts
+++ b/packages/core/src/rules/__tests__/utils.test.ts
@@ -1,13 +1,18 @@
 import {
+  fieldNonEmpty,
   matchesJsonSchemaType,
+  missingRequiredField,
+  oasTypeOf,
 } from '../utils';
 
-describe('matches-json-schema-type', () => {
-  it('should report true on any type', () => {
-    const results = matchesJsonSchemaType(123, 'any', false);
-    expect(results).toBe(true);
+describe('field-non-empty', () => {
+  it('should match expected message', () => {
+    const message = fieldNonEmpty('Car', 'color');
+    expect(message).toBe('Car object \`color\` must be non-empty string.');
   });
+});
 
+describe('matches-json-schema-type', () => {
   it('should report true on a null value with nullable type', () => {
     const results = matchesJsonSchemaType(null, 'string', true);
     expect(results).toBe(true);
@@ -69,5 +74,54 @@ describe('matches-json-schema-type', () => {
     const results = matchesJsonSchemaType(car, 'array', true);
     expect(results).toBe(false);
   });
+});
 
+describe('missing-required-field', () => {
+  it('should match expected message for missing required field', () => {
+    const message = missingRequiredField('Car', 'color');
+    expect(message).toBe('Car object should contain \`color\` field.');
+  });
+});
+
+describe('oas-type-of', () => {
+  it('should report the correct oas type for a string', () => {
+    const results = oasTypeOf('word');
+    expect(results).toBe('string');
+  });
+
+  it('should report the correct oas type for an integer', () => {
+    const results = oasTypeOf(123);
+    expect(results).toBe('integer');
+  });
+
+  it('should report the correct oas type for a number', () => {
+    const results = oasTypeOf(3.14);
+    expect(results).toBe('number');
+  });
+
+  it('should report the correct oas type for a null value', () => {
+    const results = oasTypeOf(null);
+    expect(results).toBe('null');
+  });
+
+  it('should report the correct oas type for a true boolean', () => {
+    const results = oasTypeOf(true);
+    expect(results).toBe('boolean');
+  });
+
+  it('should report the correct oas type for a false boolean', () => {
+    const results = oasTypeOf(false);
+    expect(results).toBe('boolean');
+  });
+
+  it('should report the correct oas type for an array', () => {
+    const results = oasTypeOf(['foo', 'bar']);
+    expect(results).toBe('array');
+  });
+
+  it('should report the correct oas type for an object', () => {
+    const car = {type:"Fiat", model:"500", color:"white"};
+    const results = oasTypeOf(car);
+    expect(results).toBe('object');
+  });
 });

--- a/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
@@ -110,7 +110,7 @@ describe('Oas3 Structural visitor basic', () => {
               "source": "foobar.yaml",
             },
           ],
-          "message": "Expected type \`string\` but got \`number\`.",
+          "message": "Expected type \`string\` but got \`integer\`.",
           "ruleId": "spec",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -9,6 +9,8 @@ export function oasTypeOf(value: unknown) {
     return 'array';
   } else if (value === null) {
     return 'null';
+  } else if (Number.isInteger(value)) {
+    return 'integer';  
   } else {
     return typeof value;
   }
@@ -35,8 +37,6 @@ export function matchesJsonSchemaType(value: unknown, type: string, nullable: bo
       return value === null;
     case 'integer':
       return Number.isInteger(value);
-    case 'any':
-      return true;
     default:
       return typeof value === type;
   }

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -10,7 +10,7 @@ export function oasTypeOf(value: unknown) {
   } else if (value === null) {
     return 'null';
   } else if (Number.isInteger(value)) {
-    return 'integer';  
+    return 'integer';
   } else {
     return typeof value;
   }

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -23,7 +23,7 @@ export function oasTypeOf(value: unknown) {
  */
 export function matchesJsonSchemaType(value: unknown, type: string, nullable: boolean): boolean {
   if (nullable && value === null) {
-    return value === null;
+    return true;
   }
 
   switch (type) {
@@ -35,6 +35,8 @@ export function matchesJsonSchemaType(value: unknown, type: string, nullable: bo
       return value === null;
     case 'integer':
       return Number.isInteger(value);
+    case 'any':
+      return true;
     default:
       return typeof value === type;
   }


### PR DESCRIPTION
## What/Why/How?

Add tests to cover part of rules utils.

## Reference

Originally started with #786 which was erroneous because `type: any` doesn't exist any longer.

## Testing

This revealed we missed an `integer` case for one method: `oasTypeOf`.

I added that and covered it with tests.


## Screenshots (optional)

One open question:

```ts
export function missingRequiredField(type: string, field: string): string {
  return `${type} object should contain \`${field}\` field.`;
}
```

Is the correct word `should` (as is) or `must`? For example, 

> Tag object should contain `description` field.

> Tag object must contain `description` field.

## Check yourself

- [x] Code is linted (see #787)
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
