### PR TITLE
fix: incorrect return codes when exit with error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=15.0.0"
+    "node": ">=14.0.0"
   },
   "engineStrict": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=15.0.0"
   },
   "engineStrict": true,
   "scripts": {

--- a/packages/cli/src/__mocks__/utils.ts
+++ b/packages/cli/src/__mocks__/utils.ts
@@ -1,5 +1,5 @@
 export const getFallbackEntryPointsOrExit = jest.fn((entrypoints) =>
-  entrypoints.map(() => ({ path: '' }))
+  entrypoints.map((path: string) => ({ path }))
 );
 export const dumpBundle = jest.fn(() => '');
 export const slash = jest.fn();

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -63,6 +63,12 @@ describe('bundle', () => {
   it('bundles definitions w/ linting', async () => {
     const entrypoints = ['foo.yaml', 'bar.yaml', 'foobar.yaml'];
 
+    (getTotals as jest.Mock).mockReturnValue({
+      errors: 0,
+      warnings: 0,
+      ignored: 0,
+    });
+
     await handleBundle(
       {
         entrypoints,
@@ -74,7 +80,7 @@ describe('bundle', () => {
     );
 
     expect(lint).toBeCalledTimes(entrypoints.length);
-    expect(bundle).toBeCalledTimes(0);
+    expect(bundle).toBeCalledTimes(entrypoints.length);
   });
 
   it('exits with code 0 when bundles definitions w/linting w/o errors', async () => {

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -139,7 +139,7 @@ describe('bundle', () => {
     expect(handleError).toHaveBeenCalledWith(new Error('Invalid definition'), 'invalid.json');
   });
 
-  it('handleError isn\'t called when bundles a valid definition', async () => {
+  it("handleError isn't called when bundles a valid definition", async () => {
     const entrypoints = ['foo.yaml'];
 
     (getTotals as jest.Mock).mockReturnValue({

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -1,6 +1,7 @@
 import { lint, bundle, getTotals, getMergedConfig } from '@redocly/openapi-core';
 
 import { handleBundle } from '../../commands/bundle';
+import { handleError } from '../../utils';
 import SpyInstance = jest.SpyInstance;
 
 jest.mock('@redocly/openapi-core');
@@ -24,7 +25,7 @@ describe('bundle', () => {
   afterEach(() => {
     (lint as jest.Mock).mockClear();
     (bundle as jest.Mock).mockClear();
-    (getTotals as jest.Mock).mockClear();
+    (getTotals as jest.Mock).mockReset();
   });
 
   it('bundles definitions w/o linting', async () => {
@@ -73,7 +74,7 @@ describe('bundle', () => {
     );
 
     expect(lint).toBeCalledTimes(entrypoints.length);
-    expect(bundle).toBeCalledTimes(entrypoints.length);
+    expect(bundle).toBeCalledTimes(0);
   });
 
   it('exits with code 0 when bundles definitions w/linting w/o errors', async () => {
@@ -115,5 +116,48 @@ describe('bundle', () => {
     expect(lint).toBeCalledTimes(entrypoints.length);
     exitCb?.();
     expect(processExitMock).toHaveBeenCalledWith(1);
+  });
+
+  it('handleError is called when bundles an invalid definition', async () => {
+    const entrypoints = ['invalid.json'];
+
+    (bundle as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('Invalid definition');
+    });
+
+    await handleBundle(
+      {
+        entrypoints,
+        ext: 'json',
+        format: 'codeframe',
+        lint: false,
+      },
+      '1.0.0'
+    );
+
+    expect(handleError).toHaveBeenCalledTimes(1);
+    expect(handleError).toHaveBeenCalledWith(new Error('Invalid definition'), 'invalid.json');
+  });
+
+  it('handleError isn\'t called when bundles a valid definition', async () => {
+    const entrypoints = ['foo.yaml'];
+
+    (getTotals as jest.Mock).mockReturnValue({
+      errors: 0,
+      warnings: 0,
+      ignored: 0,
+    });
+
+    await handleBundle(
+      {
+        entrypoints,
+        ext: 'yaml',
+        format: 'codeframe',
+        lint: false,
+      },
+      '1.0.0'
+    );
+
+    expect(handleError).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -120,7 +120,7 @@ describe('handleLint', () => {
     it('should catch error in handleError if something fails', async () => {
       (lint as jest.Mock<any, any>).mockRejectedValueOnce('error');
       await handleLint(argvMock, versionMock);
-      expect(handleError).toHaveBeenCalledWith('error', '');
+      expect(handleError).toHaveBeenCalledWith('error', 'openapi.yaml');
     });
   });
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -107,7 +107,6 @@ export async function handleLint(argv: LintOptions, version: string) {
       const elapsed = getExecutionTime(startedAt);
       process.stderr.write(gray(`${path.replace(process.cwd(), '')}: validated in ${elapsed}\n\n`));
     } catch (e) {
-      totals.errors++;
       handleError(e, path);
     }
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -189,9 +189,10 @@ export function handleError(e: Error, ref: string) {
       );
     } else {
       process.stderr.write(`Something went wrong when processing ${ref}:\n\n  - ${e.message}.\n\n`);
-      throw e;
     }
   }
+  process.exitCode = 1;
+  throw e;
 }
 
 export function printLintTotals(totals: Totals, definitionsCount: number) {


### PR DESCRIPTION
## What/Why/How?
Resolve an issue where we always return a 0 exit code, even when the result is not successful. 
Therefore, we decided to return code 1 in the handleError function to cover move cases then mentioned in the initial issue.

## Reference
Fixed #547

## Testing
Tested locally.

## Screenshots (optional)
N/a

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
