### PR TITLE
chore: v1.0.0-beta.106

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,18 @@ tocMaxDepth: 2
 
 # Redocly CLI changelog
 
+
+## 1.0.0-beta.106 (2022-08-09)
+
+### Fixes
+
+- Now errors exit with return code `1`.
+
+### Changes
+
+- Renamed `lint` into `styleguide` in Redocly configuration.
+- Improved naming consistency.
+
 ## 1.0.0-beta.105 (2022-07-27)
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.105",
+  "version": "1.0.0-beta.106",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.105",
+      "version": "1.0.0-beta.106",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7837,10 +7837,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.105",
+      "version": "1.0.0-beta.106",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.105",
+        "@redocly/openapi-core": "1.0.0-beta.106",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -7874,7 +7874,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.105",
+      "version": "1.0.0-beta.106",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",
@@ -8668,7 +8668,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.105",
+        "@redocly/openapi-core": "1.0.0-beta.106",
         "@types/yargs": "16.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.105",
+  "version": "1.0.0-beta.106",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.105",
+  "version": "1.0.0-beta.106",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -35,7 +35,7 @@
     "Andriy Leliv <andriy@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.105",
+    "@redocly/openapi-core": "1.0.0-beta.106",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.105",
+  "version": "1.0.0-beta.106",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.105",
+      "version": "1.0.0-beta.106",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.105",
+  "version": "1.0.0-beta.106",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?

Bump Redocly CLI & Openapi Core to v1.0.0-beta.106.

Here're the changes:

[INTERNAL] chore: add tests for rules utils (#789)
[INTERNAL] chore: rename 'entrypoints' into 'apis' (#802)
fix: incorrect return codes when exit with error (#798)
[INTERNAL] chore: update issue templates (#795)
[INTERNAL] chore: Setup and run Prettier  (#797)
[INTERNAL] chore: rename 'lint' to 'styleguide' (#790)
[INTERNAL] fix: fix enum type mismatch message (#784)
[INTERNAL] chore: test for cli package (#773)
[INTERNAL] chore: fix filenames for license rules (#783)
[INTERNAL] docs: fix ref assertion examples (#777)

## Reference

This should be merged alongside the release: https://github.com/Redocly/redocly-cli/pull/791.

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
