### PR TITLE
fix: leave multiline strings in literal mode

### DIFF
--- a/__tests__/bundle/bundle-description-long/.redocly.yaml
+++ b/__tests__/bundle/bundle-description-long/.redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./test.yaml

--- a/__tests__/bundle/bundle-description-long/snapshot.js
+++ b/__tests__/bundle/bundle-description-long/snapshot.js
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle bundle-description-long 1`] = `
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Example.com
+  termsOfService: https://example.com/terms/
+  contact:
+    email: contact@example.com
+    url: http://example.com/contact
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  description: |
+    first line loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+    second line exists
+components: {}
+
+No configurations were defined in extends -- using built in recommended configuration by default.
+Warning! This default behavior is going to be deprecated soon.
+
+test.yaml:
+  1:1  error    no-empty-servers  Servers must be present.
+
+❌ Validation failed with 1 error.
+run \`openapi lint --generate-ignore-file\` to add all problems to the ignore file.
+
+bundling ./test.yaml...
+📦 Created a bundle for ./test.yaml at stdout <test>ms.
+
+`;
+
+exports[`E2E bundle with long description description should not be in folded mode 1`] = `
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Example.com
+  termsOfService: https://example.com/terms/
+  contact:
+    email: contact@example.com
+    url: http://example.com/contact
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  description: |
+    first line loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+    second line exists
+components: {}
+
+bundling test.yaml...
+📦 Created a bundle for test.yaml at stdout <test>ms.
+
+`;

--- a/__tests__/bundle/bundle-description-long/test.yaml
+++ b/__tests__/bundle/bundle-description-long/test.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Example.com
+  termsOfService: https://example.com/terms/
+  contact:
+    email: contact@example.com
+    url: http://example.com/contact
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  description: |
+    first line loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+    second line exists
+components: {}

--- a/__tests__/bundle/tag-description-override/snapshot.js
+++ b/__tests__/bundle/tag-description-override/snapshot.js
@@ -31,10 +31,8 @@ tags:
       <SchemaDefinition schemaRef="#/components/schemas/Pet" />
   - name: store_model
     x-displayName: The Order Model
-    description: >
-      <SchemaDefinition schemaRef="#/components/schemas/Order"
-      exampleRef="#/components/examples/Order" showReadOnly={true}
-      showWriteOnly={true} />
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/Order" exampleRef="#/components/examples/Order" showReadOnly={true} showWriteOnly={true} />
 paths:
   /pet/findByStatus:
     get:

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -233,4 +233,13 @@ describe('E2E', () => {
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
     });
   });
+  describe('bundle with long description', () => {
+    it('description should not be in folded mode', () => {
+      const folderPath = join(__dirname, `bundle/bundle-description-long`);
+      const args = getParams('../../../packages/cli/src/index.ts', 'bundle', ['test.yaml']);
+
+      const result = getCommandOutput(args, folderPath);
+      (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
+    });
+  });
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -107,6 +107,7 @@ export function dumpBundle(obj: any, format: BundleOutputFormat, dereference?: b
   } else {
     return stringifyYaml(obj, {
       noRefs: !dereference,
+      lineWidth: -1,
     });
   }
 }


### PR DESCRIPTION
## What/Why/How?

Fix #480. Just remove limit of line width

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
