### PR TITLE
built-in rules: `response-contains-header` 

### DIFF
--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -16,9 +16,9 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
             names[getMatchingStatusCodeRange(key).toLowerCase()] ||
             [];
           for (const expectedHeader of expectedHeaders) {
-            if (!response.headers?.[expectedHeader]) {
+            if (!response.headers?.[expectedHeader.toLowerCase()]) {
               report({
-                message: `Response object must contain a "${expectedHeader}" header.`,
+                message: `Response object must contain a "${expectedHeader.toLowerCase()}" header.`,
                 location: location.child('headers').key(),
               });
             }


### PR DESCRIPTION
force response headers toLowerCase per RFC2616#4.2
  - all headers are considered case-insensitive per the spec.

closes:    #824

## Reference
https://www.rfc-editor.org/rfc/rfc2616.html#section-4.2


- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
