### PR TITLE
fix: require schema or content for header object

### DIFF
--- a/packages/core/src/types/oas3.ts
+++ b/packages/core/src/types/oas3.ts
@@ -231,6 +231,7 @@ const Header: NodeType = {
     examples: mapOf('Example'),
     content: 'MediaTypeMap',
   },
+  requiredOneOf: ['schema', 'content'],
 };
 
 const ResponsesMap: NodeType = {


### PR DESCRIPTION
## What/Why/How?

The check was missing for header object.

## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/801

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
