### PR TITLE
docs: add documentation for spec-components-invalid-map-name rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -20,6 +20,7 @@ The *Special rules* group contains rules that may apply to multiple objects or t
 - [no-unresolved-refs](./rules/no-unresolved-refs.md)
 - [no-unused-components](./rules/no-unused-components.md)
 - [spec](./rules/spec.md)
+- [spec-components-invalid-map-name](./rules/spec-components-invalid-map-name.md)
 
 ### Info
 

--- a/docs/rules/spec-components-invalid-map-name.md
+++ b/docs/rules/spec-components-invalid-map-name.md
@@ -1,0 +1,95 @@
+# spec-components-invalid-map-name
+
+Requires that specific objects inside `components` MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`
+
+|OAS|Compatibility|
+|---|---|
+|2.0|❌|
+|3.0|✅|
+|3.1|✅|
+
+```mermaid
+flowchart TD
+
+root ==> Components -->  Examples --> Example
+
+Components ==> Responses --> Response
+Components ==> Schemas --> Schema
+Components ==> Parameters --> Parameter
+Components ==> RequestBodies --> RequestBody
+Components ==> Headers --> Header
+Components ==> SecuritySchemes --> SecurityScheme
+Components ==> Links --> Link
+Components ==> Callbacks --> Callback
+Components ==> PathItems --> PathItem
+```
+
+## API design principles
+
+This rule is for spec correctness.
+
+All the fixed fields declared below are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
+
+- schemas
+- responses
+- parameters
+- examples
+- requestBodies
+- headers
+- securitySchemes
+- links
+- callbacks
+- pathItems
+
+## Configuration
+
+|Option|Type| Description                                                                                |
+|---|---|--------------------------------------------------------------------------------------------|
+|severity|string| Possible values: `off`, `warn`, `error`. Default `error` (in `recommended` configuration). |
+
+An example configuration:
+
+```yaml
+styleguide:
+  rules:
+    spec-components-invalid-map-name: error
+```
+
+## Examples
+
+Given this configuration:
+
+```yaml
+styleguide:
+  rules:
+    spec-components-invalid-map-name: error
+```
+
+Example of **incorrect** operation response:
+```yaml
+components:
+  examples:
+    invalid identifier:
+      description: invalid identifier
+      value: 21     
+```
+
+Example of **correct** operation response:
+
+```yaml
+components:
+  examples:
+    valid_identifier:
+      description: valid identifier
+      value: 21 
+```
+
+## Related rules
+
+- [assertions](./assertions.md)
+- [spec](./spec.md)
+
+## Resources
+
+- [Rule source](https://github.com/Redocly/redocly-cli/blob/master/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts)
+- [Components docs](https://redocly.com/docs/openapi-visual-reference/components/)


### PR DESCRIPTION
## What/Why/How?
  
Add documentation for spec-components-invalid-map-name rule

## Reference

https://github.com/Redocly/redocly-cli/pull/815

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
