### PR TITLE
chore: v1.0.0-beta.109

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,23 @@ tocMaxDepth: 2
 
 # Redocly CLI changelog
 
+## 1.0.0-beta.109 (2022-09-08)
+### Features
+
+- Added rfc7007 rule.
+- Improved error message by adding `referenced from` information.
+- Added a rule for component names validation.
+- Added a new `--format` option: `summary`.
+
+
+### Fixes
+
+- Fixed an issue with multiline strings in literal mode.
+- Fixed an issue with multiline markdown with windows-style new lines.
+- Fixed a Header object spec to require `content` or `schema`.
+- Fixed a error message for `operation-4xx-response` rule.
+
+
 ## 1.0.0-beta.108 (2022-08-22)
 
 ### Changes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ tocMaxDepth: 2
 
 - Added rfc7807 problem details rule.
 - Improved error messages by adding `referenced from` information.
-- Added a rule for component map names validation.
+- Added the `spec-components-invalid-map-name` rule for component map names validation.
 - Added a new lint `--format` option: `summary`.
 - Added notification about the new version being available.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,16 +7,16 @@ tocMaxDepth: 2
 ## 1.0.0-beta.109 (2022-09-08)
 ### Features
 
-- Added rfc7007 rule.
-- Improved error message by adding `referenced from` information.
-- Added a rule for component names validation.
+- Added rfc7807 problem details rule.
+- Improved error messages by adding `referenced from` information.
+- Added a rule for component map names validation.
 - Added a new `--format` option: `summary`.
 
 
 ### Fixes
 
-- Fixed an issue with multiline strings in literal mode.
-- Fixed an issue with multiline markdown with windows-style new lines.
+- Fixed an issue with multi-line strings in literal mode.
+- Fixed an issue with multi-line Markdown with Windows-style new lines.
 - Fixed a Header object spec to require `content` or `schema`.
 - Fixed a error message for `operation-4xx-response` rule.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,7 @@ tocMaxDepth: 2
 
 - Fixed an issue with multi-line strings in literal mode.
 - Fixed an issue with multi-line Markdown with Windows-style new lines.
-- Fixed a Header object spec to require `content` or `schema`.
+- Fixed the Header object type to require `content` or `schema`.
 - Fixed a error message for `operation-4xx-response` rule.
 - Fixed an issue with `paths` not being correctly handled by the `join` command.
 - Fixed the `operation-security-defined` rule to check the security on the root and in each operation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,6 @@ tocMaxDepth: 2
 - Improved error messages by adding `referenced from` information.
 - Added the `spec-components-invalid-map-name` rule for component map names validation.
 - Added a new lint `--format` option: `summary`.
-- Added notification about the new version being available.
 
 
 ### Fixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ tocMaxDepth: 2
 - Improved error messages by adding `referenced from` information.
 - Added a rule for component map names validation.
 - Added a new `--format` option: `summary`.
+- Added notification about the new version being available.
 
 
 ### Fixes
@@ -19,10 +20,14 @@ tocMaxDepth: 2
 - Fixed an issue with multi-line Markdown with Windows-style new lines.
 - Fixed a Header object spec to require `content` or `schema`.
 - Fixed a error message for `operation-4xx-response` rule.
+- Fixed an issue with `paths` not being correctly handled by the `join` command.
+- Fixed the `operation-security-defined` rule to check the security on the root and in each operation.
 
 ### Changes
 
 - Renamed 'DefinitionRoot', 'ServerVariableMap', 'PathMap', 'CallbackMap', 'MediaTypeMap', 'ExampleMap', 'EncodingMap', 'HeaderMap', and 'LinkMap' definition node types.
+- Removed the `styleguide` object from the configuration file.
+- Renamed the `operation-security-defined` rule to `security-defined`.
 
 ## 1.0.0-beta.108 (2022-08-22)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ tocMaxDepth: 2
 - Fixed a Header object spec to require `content` or `schema`.
 - Fixed a error message for `operation-4xx-response` rule.
 
+### Changes
+
+- Renamed 'DefinitionRoot', 'ServerVariableMap', 'PathMap', 'CallbackMap', 'MediaTypeMap', 'ExampleMap', 'EncodingMap', 'HeaderMap', and 'LinkMap' definition node types.
 
 ## 1.0.0-beta.108 (2022-08-22)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ tocMaxDepth: 2
 - Added rfc7807 problem details rule.
 - Improved error messages by adding `referenced from` information.
 - Added a rule for component map names validation.
-- Added a new `--format` option: `summary`.
+- Added a new lint `--format` option: `summary`.
 - Added notification about the new version being available.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.108",
+  "version": "1.0.0-beta.109",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.108",
+      "version": "1.0.0-beta.109",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9057,7 +9057,7 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.108",
+      "version": "1.0.0-beta.109",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "1.0.0-beta.108",
@@ -9094,7 +9094,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.108",
+      "version": "1.0.0-beta.109",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9060,7 +9060,7 @@
       "version": "1.0.0-beta.109",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.108",
+        "@redocly/openapi-core": "1.0.0-beta.109",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -10070,7 +10070,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.108",
+        "@redocly/openapi-core": "1.0.0-beta.109",
         "@types/yargs": "16.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.108",
+  "version": "1.0.0-beta.109",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
     "Andriy Leliv <andriy@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.108",
+    "@redocly/openapi-core": "1.0.0-beta.109",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.108",
+  "version": "1.0.0-beta.109",
   "description": "",
   "license": "MIT",
   "bin": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.108",
+  "version": "1.0.0-beta.109",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.108",
+      "version": "1.0.0-beta.109",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.108",
+  "version": "1.0.0-beta.109",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?

### Features

- Added rfc7807 problem details rule. (#816)
- Improved error messages by adding `referenced from` information. (https://github.com/Redocly/redocly-cli/pull/835)
- Added a rule for component map names validation. (#815)
- Added a new `--format` option: `summary`. (#860)

### Fixes

- Fixed an issue with multi-line strings in literal mode. (#822)
- Fixed an issue with multi-line Markdown with Windows-style new lines. (#827)
- Fixed a Header object spec to require `content` or `schema`. (#830)
- Fixed a error message for `operation-4xx-response` rule (closes https://github.com/Redocly/redocly-cli/issues/840).
- Fixed an issue with `paths` not being correctly handled by the `join` command. (#778)
- Fixed the `operation-security-defined` rule to check the security on the root and in each operation. (#862)


### Changes

- Renamed 'DefinitionRoot', 'ServerVariableMap', 'PathMap', 'CallbackMap', 'MediaTypeMap', 'ExampleMap', 'EncodingMap', 'HeaderMap', and 'LinkMap' definition node types. (#852)
- Removed the `styleguide` object from the configuration file. (#847)
- Renamed the `operation-security-defined` rule to `security-defined`. (#862)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
