### PR TITLE
fix: response-contains-header force toLowerCase on comparison

### DIFF
--- a/packages/core/src/rules/common/__tests__/operation-2xx-response.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-2xx-response.test.ts
@@ -88,4 +88,41 @@ describe('Oas3 operation-2xx-response', () => {
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should report even if the responses are null', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.0.0
+          paths:
+            '/test/':
+              put:
+                responses: null
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'operation-2xx-response': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1test~1/put/responses",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Operation must have at least one \`2XX\` response.",
+          "ruleId": "operation-2xx-response",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/src/rules/common/__tests__/operation-4xx-response.test.ts
+++ b/packages/core/src/rules/common/__tests__/operation-4xx-response.test.ts
@@ -127,4 +127,41 @@ describe('Oas3 operation-4xx-response', () => {
       ]
     `);
   });
+
+  it('should report even if the responses are null', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.0.0
+          paths:
+            '/test/':
+              put:
+                responses: null
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'operation-2xx-response': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1test~1/put/responses",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Operation must have at least one \`2XX\` response.",
+          "ruleId": "operation-2xx-response",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/src/rules/common/operation-2xx-response.ts
+++ b/packages/core/src/rules/common/operation-2xx-response.ts
@@ -4,7 +4,7 @@ import { UserContext } from '../../walk';
 export const Operation2xxResponse: Oas3Rule | Oas2Rule = () => {
   return {
     ResponsesMap(responses: Record<string, object>, { report }: UserContext) {
-      const codes = Object.keys(responses);
+      const codes = Object.keys(responses || {});
       if (!codes.some((code) => code === 'default' || /2[Xx0-9]{2}/.test(code))) {
         report({
           message: 'Operation must have at least one `2XX` response.',

--- a/packages/core/src/rules/common/operation-4xx-response.ts
+++ b/packages/core/src/rules/common/operation-4xx-response.ts
@@ -4,7 +4,7 @@ import { UserContext } from '../../walk';
 export const Operation4xxResponse: Oas3Rule | Oas2Rule = () => {
   return {
     ResponsesMap(responses: Record<string, object>, { report }: UserContext) {
-      const codes = Object.keys(responses);
+      const codes = Object.keys(responses || {});
 
       if (!codes.some((code) => /4[Xx0-9]{2}/.test(code))) {
         report({

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -17,7 +17,7 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
             [];
           for (const expectedHeader of expectedHeaders) {
             if (
-              !response.headers ||
+              !response?.headers ||
               !Object.keys(response?.headers).some(
                 (key) => key.toLowerCase() === expectedHeader.toLowerCase()
               )

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -16,7 +16,12 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
             names[getMatchingStatusCodeRange(key).toLowerCase()] ||
             [];
           for (const expectedHeader of expectedHeaders) {
-            if (!response.headers?.[expectedHeader]) {
+            if (
+              !response.headers ||
+              !Object.keys(response?.headers).some(
+                (key) => key.toLowerCase() === expectedHeader.toLowerCase()
+              )
+            ) {
               report({
                 message: `Response object must contain a "${expectedHeader}" header.`,
                 location: location.child('headers').key(),

--- a/packages/core/src/rules/common/response-contains-header.ts
+++ b/packages/core/src/rules/common/response-contains-header.ts
@@ -19,7 +19,7 @@ export const ResponseContainsHeader: Oas3Rule | Oas2Rule = (options) => {
             if (
               !response?.headers ||
               !Object.keys(response?.headers).some(
-                (key) => key.toLowerCase() === expectedHeader.toLowerCase()
+                (header) => header.toLowerCase() === expectedHeader.toLowerCase()
               )
             ) {
               report({

--- a/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
@@ -334,4 +334,56 @@ describe('Oas3 response-contains-header', () => {
     });
     expect(results).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should report even if the response is null', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.0.0
+          paths:
+            '/test/':
+              put:
+                responses: 
+                  '200': null
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+          names: { '2XX': ['X-Test-Header'] },
+        },
+      }),
+    });
+
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1test~1/put/responses/200/headers",
+              "reportOnKey": true,
+              "source": Source {
+                "absoluteRef": "foobar.yaml",
+                "body": "openapi: 3.0.0
+      paths:
+        '/test/':
+          put:
+            responses: 
+              '200': null",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "Response object must contain a \\"X-Test-Header\\" header.",
+          "ruleId": "response-contains-header",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/response-contains-header.test.ts
@@ -270,4 +270,68 @@ describe('Oas3 response-contains-header', () => {
     });
     expect(results).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should not report response object containing header name upper cased', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '200':
+                description: successful operation
+                headers:
+                  X-Test-Header:
+                    description: calls per hour allowed by the user
+                    schema:
+                      type: integer
+                      format: int32
+		`);
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+          names: { '2XX': ['x-test-header'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report response object containing header name in the rule upper cased', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.3
+      info:
+        version: 3.0.0
+      paths:
+        /store/subscribe:
+          post:
+            responses:
+              '200':
+                description: successful operation
+                headers:
+                  x-test-header:
+                    description: calls per hour allowed by the user
+                    schema:
+                      type: integer
+                      format: int32
+		`);
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'response-contains-header': {
+          severity: 'error',
+          names: { '2XX': ['X-Test-Header'] },
+        },
+      }),
+    });
+    expect(results).toMatchInlineSnapshot(`Array []`);
+  });
 });


### PR DESCRIPTION
## What/Why/How?
In the `response-contains-header` rule we need to force toLowerCase on comparison for accurate results. 

## Reference
Closes  #824

## Testing
Locally.

## Screenshots (optional)
N/a

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
