### PR TITLE
fix: path parameter not defined

### DIFF
--- a/packages/core/src/rules/common/path-params-defined.ts
+++ b/packages/core/src/rules/common/path-params-defined.ts
@@ -37,13 +37,14 @@ export const PathParamsDefined: Oas3Rule | Oas2Rule = () => {
         },
         leave(_op: object, { report, location }: UserContext) {
           for (const templateParam of Array.from(pathTemplateParams.keys())) {
-            if (!definedOperationParams.has(templateParam)) {
-              if (!definedPathParams.has(templateParam)) {
-                report({
-                  message: `The operation does not define the path parameter \`{${templateParam}}\` expected by path \`${currentPath}\`.`,
-                  location: location.child(['parameters']).key(), // report on operation
-                });
-              }
+            if (
+              !definedOperationParams.has(templateParam) &&
+              !definedPathParams.has(templateParam)
+            ) {
+              report({
+                message: `The operation does not define the path parameter \`{${templateParam}}\` expected by path \`${currentPath}\`.`,
+                location: location.child(['parameters']).key(), // report on operation
+              });
             }
           }
         },


### PR DESCRIPTION
## What/Why/How?
If parameters ware not defined in the other operation but exist in first lint did not catch error.
For example 
```yaml

paths:
  /case/{a}:
    get:
      parameters: 
        - name: a
          in: path
          schema: 
            type: number 
      summary: Case GET 
      description: Should not fail cause parameters exist
      responses:
        '200':
          description: Successful operation

    post: 
      summary: Case POST
      description: Should fail cause no parameters
      responses:
        '200':
          description: Successful operation
```
<img width="411" alt="Screenshot 2022-09-26 at 16 04 04" src="https://user-images.githubusercontent.com/52038205/192283750-06901ec2-8221-47eb-8d07-0dee3bc43f53.png">


## Reference
Closes #211 

## Testing

## Screenshots (optional)
Now it throw appropriate error
<img width="678" alt="Screenshot 2022-09-26 at 16 04 46" src="https://user-images.githubusercontent.com/52038205/192284014-f5ed06c5-a33d-4149-8e1d-5bb1d84b6fe4.png">

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
