### PR TITLE
fix: add keep-url-references 

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -280,7 +280,7 @@ yargs
           description: 'Keep absolute url references.',
           type: 'boolean',
           alias: 'k',
-        }
+        },
       }),
     (argv) => {
       process.env.REDOCLY_CLI_COMMAND = 'bundle';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -276,6 +276,11 @@ yargs
           type: 'boolean',
           default: false,
         },
+        'keep-url-references': {
+          description: 'Keep absolute url references.',
+          type: 'boolean',
+          alias: 'k',
+        }
       }),
     (argv) => {
       process.env.REDOCLY_CLI_COMMAND = 'bundle';


### PR DESCRIPTION
## What/Why/How?

There was added [`keep-url-references`](https://github.com/Redocly/redocly-cli/pull/688) flag for the `bundle` command but not as argument for cli

## Reference
Close #888
## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
