### PR TITLE
fix: detect api from the list by the root file match

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { Totals } from '@redocly/openapi-core';
-import { isSubdir, pathToFilename, printConfigLintTotals } from '../utils';
+import { getFallbackApisOrExit, isSubdir, pathToFilename, printConfigLintTotals } from '../utils';
 import { red, yellow } from 'colorette';
 
 jest.mock('os');
@@ -48,6 +48,19 @@ describe('pathToFilename', () => {
   it('should use correct path separator', () => {
     const processedPath = pathToFilename('/user/createWithList', '_');
     expect(processedPath).toEqual('user_createWithList');
+  });
+});
+
+describe('getFallbackApisOrExit', () => {
+  it('should find alias by filename', async () => {
+    const entry = await getFallbackApisOrExit(['./test.yaml'], {
+      apis: {
+        main: {
+          root: 'test.yaml',
+        },
+      },
+    } as any);
+    expect(entry).toEqual([{ path: './test.yaml', alias: 'main' }]);
   });
 });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -48,7 +48,13 @@ function isNotEmptyArray<T>(args?: T[]): boolean {
 function getAliasOrPath(config: Config, aliasOrPath: string): Entrypoint {
   return config.apis[aliasOrPath]
     ? { path: config.apis[aliasOrPath]?.root, alias: aliasOrPath }
-    : { path: aliasOrPath };
+    : {
+        path: aliasOrPath,
+        // find alias by path, take the first match
+        alias: Object.entries(config.apis).find(([_alias, api]) => {
+          return path.resolve(api.root) === path.resolve(aliasOrPath);
+        })?.[0] ?? undefined,
+      };
 }
 
 async function expandGlobsInEntrypoints(args: string[], config: Config) {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -51,9 +51,10 @@ function getAliasOrPath(config: Config, aliasOrPath: string): Entrypoint {
     : {
         path: aliasOrPath,
         // find alias by path, take the first match
-        alias: Object.entries(config.apis).find(([_alias, api]) => {
-          return path.resolve(api.root) === path.resolve(aliasOrPath);
-        })?.[0] ?? undefined,
+        alias:
+          Object.entries(config.apis).find(([_alias, api]) => {
+            return path.resolve(api.root) === path.resolve(aliasOrPath);
+          })?.[0] ?? undefined,
       };
 }
 

--- a/resources/.redocly.yaml
+++ b/resources/.redocly.yaml
@@ -1,29 +1,7 @@
-apiDefinitions:
-  main: ./petstore-with-errors.yaml
-lint:
-  plugins:
-    - './local-plugin.js'
-
-  extends:
-    - recommended
-    - local/all
-  rules:
-    operation-2xx-response: warn
-    no-invalid-media-type-examples: error
-    # operation-description: error
-    path-http-verbs-order: error
-    boolean-parameter-prefixes: off
-  preprocessors:
-    # local/duplicate-description: on
-  decorators:
-    # local/inject-x-stats: on
-referenceDocs:
-  showConsole: true
-  layout:
-    scope: section
-  routingStrategy: browser
-  theme:
-    rightPanel:
-      backgroundColor: '#263238'
-    links:
-      color: '#6CC496'
+apis:
+  repro@bug:
+    root: ./pets.yaml
+    decorators: {}
+    extends: []
+extends:
+  - recommended


### PR DESCRIPTION
## What/Why/How?

If `redocly-cli lint` was run with path to the file as argument it was not detecting proper overrides from `apis` config.

## Reference

Found it while fixing https://github.com/Redocly/redocly-cli/issues/899

## Testing

Added a unit test.

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
