### PR TITLE
Fix: Outdated image name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To build and run with a local image, run the following from the project root:
 
 ```
 docker build -t redocly-cli .
-docker run --rm -v $PWD:/spec redocly/openapi-cli lint path-to-root-file.yaml
+docker run --rm -v $PWD:/spec redocly/cli lint path-to-root-file.yaml
 ```
 
 ## [Read the docs](https://redocly.com/docs/cli/)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To build and run with a local image, run the following from the project root:
 
 ```
 docker build -t redocly-cli .
-docker run --rm -v $PWD:/spec redocly-cli lint path-to-root-file.yaml
+docker run --rm -v $PWD:/spec redocly/openapi-cli lint path-to-root-file.yaml
 ```
 
 ## [Read the docs](https://redocly.com/docs/cli/)


### PR DESCRIPTION
## What/Why/How?

Given command didn't work; using current image name now.