### PR TITLE
chore: v1.0.0-beta.113

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@ toc:
 
 # Redocly CLI changelog
 
+## 1.0.0-beta.113 (2022-11-15)
+
+### Changes
+
+- Added missing OAS2 and OAS3 list types.
+- Removed the feature where we add the `recommended` ruleset fallback when there is a config defined.
+- Now we don't show an error when discriminator is used with `allOf` keyword.
+
+### Fixes
+
+- Fixed an issue with undefined `process.cwd` in browser environment.
+- Fixed an issue with `$anchors` in OpenAPI documents are not properly parsed.
+
 ## 1.0.0-beta.112 (2022-11-01)
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9798,6 +9798,31 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
+    "packages/cli/node_modules/@redocly/openapi-core": {
+      "version": "1.0.0-beta.112",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.112.tgz",
+      "integrity": "sha512-VNJPQwLUvTtgsMrd4CAPnl6zJWvggHE50LCOhnQAReyo4Em7HAGYYo9v920HbIgZ5LCB6Y/f5QUTINrgYPaTkg==",
+      "dependencies": {
+        "@redocly/ajv": "^8.11.0",
+        "@types/node": "^14.11.8",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "lodash.isequal": "^4.5.0",
+        "minimatch": "^5.0.1",
+        "node-fetch": "^2.6.1",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "packages/cli/node_modules/@types/node": {
+      "version": "14.18.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
+    },
     "packages/cli/node_modules/@types/yargs": {
       "version": "16.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.2.tgz",
@@ -10885,6 +10910,28 @@
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
           "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+        },
+        "@redocly/openapi-core": {
+          "version": "1.0.0-beta.112",
+          "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.112.tgz",
+          "integrity": "sha512-VNJPQwLUvTtgsMrd4CAPnl6zJWvggHE50LCOhnQAReyo4Em7HAGYYo9v920HbIgZ5LCB6Y/f5QUTINrgYPaTkg==",
+          "requires": {
+            "@redocly/ajv": "^8.11.0",
+            "@types/node": "^14.11.8",
+            "colorette": "^1.2.0",
+            "js-levenshtein": "^1.1.6",
+            "js-yaml": "^4.1.0",
+            "lodash.isequal": "^4.5.0",
+            "minimatch": "^5.0.1",
+            "node-fetch": "^2.6.1",
+            "pluralize": "^8.0.0",
+            "yaml-ast-parser": "0.0.43"
+          }
+        },
+        "@types/node": {
+          "version": "14.18.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+          "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
         },
         "@types/yargs": {
           "version": "16.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9750,7 +9750,7 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "1.0.0-beta.112",
@@ -9857,7 +9857,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "description": "",
   "license": "MIT",
   "bin": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?
Bump version to `v1.0.0-beta.113`.

The release includes:
- $anchors in openapi documents are not properly parsed (#836)
- Added list types (https://github.com/Redocly/redocly-cli/pull/928)
- Undefined process.cwd in browser environment (#922)
- Do not add the recommended ruleset fallback when there is a config (#923)
-  Ignore discriminator error (#931)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
