### PR TITLE
chore: v1.0.0-beta.113

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ toc:
 
 - Fixed an issue with undefined `process.cwd` in browser environment.
 - Fixed an issue with `$anchors` in OpenAPI documents are not properly parsed.
+- Fixed an issue with the `spec` rule not reporting on `nullable` in Schema object that don't have a `type` sibling.
 
 ## 1.0.0-beta.112 (2022-11-01)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@ toc:
 
 # Redocly CLI changelog
 
+## 1.0.0-beta.113 (2022-11-15)
+
+### Changes
+
+- Added missing OAS2 and OAS3 list types.
+- Removed the feature where we add the `recommended` ruleset fallback when there is a config defined.
+- Now we don't show an error when discriminator is used with `allOf` keyword.
+
+### Fixes
+
+- Fixed an issue with undefined `process.cwd` in browser environment.
+- Fixed an issue with `$anchors` in OpenAPI documents are not properly parsed.
+
 ## 1.0.0-beta.112 (2022-11-01)
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9750,10 +9750,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.112",
+        "@redocly/openapi-core": "1.0.0-beta.113",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -9857,7 +9857,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
@@ -10850,7 +10850,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.112",
+        "@redocly/openapi-core": "1.0.0-beta.113",
         "@types/configstore": "^5.0.1",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -33,7 +33,7 @@
     "Roman Hotsiy <roman@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.112",
+    "@redocly/openapi-core": "1.0.0-beta.113",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.112",
+      "version": "1.0.0-beta.113",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.112",
+  "version": "1.0.0-beta.113",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?
Bump version to `v1.0.0-beta.113`.

The release includes:
- $anchors in openapi documents are not properly parsed (#836)
- Added list types (https://github.com/Redocly/redocly-cli/pull/928)
- Undefined process.cwd in browser environment (#922)
- Do not add the recommended ruleset fallback when there is a config (#923)
-  Ignore discriminator error (#931)
- Nullable in schema object must have a type sibling (#938)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
