### PR TITLE
docs: remove default `recommended` fallback when there is a config file

### DIFF
--- a/docs/configuration/index.mdx
+++ b/docs/configuration/index.mdx
@@ -83,15 +83,15 @@ features.openapi:
 Use `extends` to list built-in configurations and other configuration files as the base settings.
 If you don't [override this base configuration](#priority-and-overrides), it is used for all APIs specified in your configuration file.
 
-If you omit the `extends` list or if you don't have a Redocly configuration file, Redocly CLI automatically uses the `recommended` configuration.
+If you don't have a Redocly configuration file, Redocly CLI automatically uses the `recommended` configuration.
 To override the default settings, you can either configure different settings for specific rules in the `rules` object, or create your own configuration files and reference them in the `extends` list.
 
 
 :::warning Important
 
-The behavior automatically defaulting to the `recommended` configuration is deprecated, and will change in the stable Redocly CLI release.
+The previous behavior (automatically defaulting to the `recommended` configuration) was deprecated.
 
-After the change, `extends` will have to be explicitly defined in the main configuration file for any extended configuration to apply.
+The `extends` field has to be explicitly defined in the main configuration file for any extended configuration to apply.
 
 :::
 


### PR DESCRIPTION
## What/Why/How?

Updated docs in regards to https://github.com/Redocly/redocly-cli/pull/923

## Reference




## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
