### PR TITLE
chore: v1.0.0-beta.115

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ toc:
 ### Changes
 
 - Renamed the Docker image on [Docker Hub](https://hub.docker.com/repository/docker/redocly/cli).
+- Changed assertions errors grouping.
+- Removed orphaned git submodule `public_api_docs`.
 
 ## 1.0.0-beta.114 (2022-11-18)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ toc:
 
 # Redocly CLI changelog
 
+
+## 1.0.0-beta.115 (2022-11-29)
+
+### Features
+
+- Added support for [`any`]() type in assertions.
+
+### Changes
+
+- Renamed the Docker image on [Docker Hub](https://hub.docker.com/repository/docker/redocly/cli).
+
 ## 1.0.0-beta.114 (2022-11-18)
 
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ toc:
 
 ### Features
 
-- Added support for [`any`]() type in assertions.
+- Added support for [`any`](./rules/custom-rules.md#any-example) type in assertions.
 
 ### Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.114",
+  "version": "1.0.0-beta.115",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.114",
+      "version": "1.0.0-beta.115",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9750,10 +9750,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.114",
+      "version": "1.0.0-beta.115",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.114",
+        "@redocly/openapi-core": "1.0.0-beta.115",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -9857,7 +9857,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.114",
+      "version": "1.0.0-beta.115",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
@@ -10850,7 +10850,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.114",
+        "@redocly/openapi-core": "1.0.0-beta.115",
         "@types/configstore": "^5.0.1",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.114",
+  "version": "1.0.0-beta.115",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.114",
+  "version": "1.0.0-beta.115",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -33,7 +33,7 @@
     "Roman Hotsiy <roman@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.114",
+    "@redocly/openapi-core": "1.0.0-beta.115",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.113",
+  "version": "1.0.0-beta.115",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.113",
+      "version": "1.0.0-beta.115",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.114",
+  "version": "1.0.0-beta.115",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?
 v1.0.0-beta.115 release:

- feat: add support for any type in assertions (#948)
- fix: outdated Docker image name (#949)
- chore: fix assertion messages grouping (#950)
- chore: remove orphaned git submodule public_api_docs (#934)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
