### PR TITLE
feat(cli/login): add the ability to pass a token via the login cli

### DIFF
--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -33,6 +33,7 @@ Option | Type | Description
 --region, -r | string | Specify which region to use when logging in. Supported values: `us`, `eu`. Read more about [configuring the region](../configuration/index.mdx).
 --verbose | boolean | Include additional output.
 --version | boolean | Show version number.
+--token | string | Provide a token to be used in logging in.
 
 ## Examples
 

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -11,10 +11,14 @@ export function promptClientToken(domain: string) {
   );
 }
 
-export async function handleLogin(argv: { verbose?: boolean; region?: Region }) {
+export async function handleLogin(argv: { verbose?: boolean; region?: Region; token?: string }) {
   const region = argv.region || (await loadConfig()).region;
   const client = new RedoclyClient(region);
-  const clientToken = await promptClientToken(client.domain);
+
+  let clientToken = argv.token;
+  if (!clientToken) {
+    clientToken = await promptClientToken(client.domain);
+  }
   process.stdout.write(gray('\n  Logging in...\n'));
   await client.login(clientToken, argv.verbose);
   process.stdout.write(green('  Authorization confirmed. ✅\n\n'));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -301,6 +301,11 @@ yargs
           alias: 'r',
           choices: regionChoices,
         },
+        token: {
+          description: 'Specify an access token.',
+          alias: 't',
+          type: 'string',
+        },
       }),
     (argv) => {
       process.env.REDOCLY_CLI_COMMAND = 'login';


### PR DESCRIPTION
added the ability to pass a --token flag for the redocly login cli