### PR TITLE
fix: spec-components-invalid-map-name not applied for all examples

### DIFF
--- a/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
@@ -214,4 +214,92 @@ describe('Oas3 spec-components-invalid-map-name', () => {
 
     expect(results).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should report about invalid keys inside nested examples', async () => {
+    const document = parseYamlToDocument(outdent`
+      openapi: 3.0.0
+      info:
+        version: 3.0.0
+      components:
+        parameters:
+          my Param:
+            name: param
+            description: param
+            in: path
+            examples:
+              invalid identifier:
+                description: 'Some description'
+                value: 21 
+		`);
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'spec-components-invalid-map-name': 'error',
+      }),
+    });
+
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/components/parameters/my Param",
+              "reportOnKey": true,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.0
+      info:
+        version: 3.0.0
+      components:
+        parameters:
+          my Param:
+            name: param
+            description: param
+            in: path
+            examples:
+              invalid identifier:
+                description: 'Some description'
+                value: 21 ",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "The map key in parameters \\"my Param\\" does not match the regular expression \\"^[a-zA-Z0-9\\\\.\\\\-_]+$\\"",
+          "ruleId": "spec-components-invalid-map-name",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/components/parameters/my Param/examples/invalid identifier",
+              "reportOnKey": true,
+              "source": Source {
+                "absoluteRef": "",
+                "body": "openapi: 3.0.0
+      info:
+        version: 3.0.0
+      components:
+        parameters:
+          my Param:
+            name: param
+            description: param
+            in: path
+            examples:
+              invalid identifier:
+                description: 'Some description'
+                value: 21 ",
+                "mimeType": undefined,
+              },
+            },
+          ],
+          "message": "The map key in examples \\"invalid identifier\\" does not match the regular expression \\"^[a-zA-Z0-9\\\\.\\\\-_]+$\\"",
+          "ruleId": "spec-components-invalid-map-name",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
+++ b/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
@@ -68,7 +68,7 @@ export const SpecComponentsInvalidMapName: Oas3Rule = () => {
     ExampleMap: {
       Example(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'examples');
-      }
+      },
     },
   };
 };

--- a/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
+++ b/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
@@ -20,34 +20,55 @@ export const SpecComponentsInvalidMapName: Oas3Rule = () => {
   }
 
   return {
-    Components: {
-      Parameter(_node, { key, report, location }: UserContext) {
-        validateKey(key, report, location, 'parameters');
-      },
-      Response(_node, { key, report, location }: UserContext) {
-        validateKey(key, report, location, 'responses');
-      },
+    NamedSchemas: {
       Schema(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'schemas');
       },
+    },
+    NamedParameters: {
+      Parameter(_node, { key, report, location }: UserContext) {
+        validateKey(key, report, location, 'parameters');
+      },
+    },
+    NamedResponses: {
+      Response(_node, { key, report, location }: UserContext) {
+        validateKey(key, report, location, 'responses');
+      },
+    },
+    NamedExamples: {
       Example(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'examples');
       },
+    },
+    NamedRequestBodies: {
       RequestBody(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'requestBodies');
       },
+    },
+    NamedHeaders: {
       Header(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'headers');
       },
+    },
+    NamedSecuritySchemes: {
       SecurityScheme(_node, { key, report, location }: UserContext) {
-        validateKey(key, report, location, 'securitySchemas');
+        validateKey(key, report, location, 'securitySchemes');
       },
+    },
+    NamedLinks: {
       Link(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'links');
       },
+    },
+    NamedCallbacks: {
       Callback(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'callbacks');
       },
+    },
+    ExampleMap: {
+      Example(_node, { key, report, location }: UserContext) {
+        validateKey(key, report, location, 'examples');
+      }
     },
   };
 };


### PR DESCRIPTION
## What/Why/How?
Fix an issue where the rule `spec-components-invalid-map-name` is not applied for all examples and adjust the logic behind the rule in general.

## Reference
Resolves #959

## Testing
Locally.

## Screenshots (optional)
N/a

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
