### PR TITLE
fix: spec rule error on extension additional properties

### DIFF
--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -487,7 +487,7 @@ describe('Oas3.1 spec', () => {
   it('should not report on SpecExtension with additionalProperties', async () => {
     const document = parseYamlToDocument(
       outdent`
-      openapi: 3.0.0
+      openapi: 3.1.0
       info:
         x-logo:
           url: 'https://redocly.github.io/redoc/example-logo.svg'

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -516,7 +516,7 @@ describe('Oas3.1 spec', () => {
               "source": "foobar.yaml",
             },
           ],
-          "message": "The field \`paths\` must be present on this level.",
+          "message": "Must contain at least one of the following fields: paths, components, webhooks.",
           "ruleId": "spec",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -308,6 +308,56 @@ describe('Oas3 spec', () => {
       ]
     `);
   });
+
+  it('should not report on SpecExtension with additionalProperties', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      openapi: 3.0.0
+      x-foo:
+        prop: bar
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ spec: 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The field \`paths\` must be present on this level.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The field \`info\` must be present on this level.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
 });
 
 describe('Oas3.1 spec', () => {
@@ -432,5 +482,74 @@ describe('Oas3.1 spec', () => {
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it('should not report on SpecExtension with additionalProperties', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      openapi: 3.0.0
+      info:
+        x-logo:
+          url: 'https://redocly.github.io/redoc/example-logo.svg'
+          backgroundColor: '#FFFFFF'
+          altText: 'Example logo'
+      x-foo:
+        prop: bar
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ spec: 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The field \`paths\` must be present on this level.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/info",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The field \`title\` must be present on this level.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/info",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The field \`version\` must be present on this level.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
   });
 });

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -66,6 +66,7 @@ export function mapOf(typeName: string) {
 export const SpecExtension: NormalizedNodeType = {
   name: 'SpecExtension',
   properties: {},
+  additionalProperties: null
 };
 
 export function normalizeTypes(

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -66,7 +66,7 @@ export function mapOf(typeName: string) {
 export const SpecExtension: NormalizedNodeType = {
   name: 'SpecExtension',
   properties: {},
-  additionalProperties: null
+  additionalProperties: null,
 };
 
 export function normalizeTypes(

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -66,6 +66,7 @@ export function mapOf(typeName: string) {
 export const SpecExtension: NormalizedNodeType = {
   name: 'SpecExtension',
   properties: {},
+  // skip validation of additional properties for unknown extensions
   additionalProperties: null,
 };
 

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -38,6 +38,7 @@ const Info: NodeType = {
     summary: { type: 'string' },
     contact: 'Contact',
     license: 'License',
+    'x-logo': 'Logo',
   },
   required: ['title', 'version'],
   extensionsPrefix: 'x-',


### PR DESCRIPTION
## What/Why/How?
Add support for `x-logo` type to the 3.1 spec version. 
Allow additional properties for the SpecExtension type. 

## Reference
https://redoc-ly.slack.com/archives/C02UHE7EL3E/p1672741829392659

## Testing
Locally.

## Screenshots (optional)
N/a

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
