### PR TITLE
fix: resolve refs inside spec extensions

### DIFF
--- a/packages/core/src/rules/__tests__/no-unresolved-refs.test.ts
+++ b/packages/core/src/rules/__tests__/no-unresolved-refs.test.ts
@@ -165,4 +165,35 @@ describe('oas3 boolean-parameter-prefixes', () => {
       ]
     `);
   });
+
+  it('should not report on refs inside specification extensions', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          requestBodies:
+            a:
+              content:
+                application/json:
+                  schema:
+                    type: object
+        x-webhooks:
+          test:
+            put:
+              requestBody:
+                $ref: '#/components/requestBodies/a'
+      `,
+      path.join(__dirname, 'foobar.yaml')
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'no-unresolved-refs': 'error',
+      }),
+    });
+
+    expect(replaceSourceWithRef(results, __dirname)).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -67,7 +67,7 @@ export const SpecExtension: NormalizedNodeType = {
   name: 'SpecExtension',
   properties: {},
   // skip validation of additional properties for unknown extensions
-  additionalProperties: null,
+  additionalProperties: { resolvable: true },
 };
 
 export function normalizeTypes(


### PR DESCRIPTION
## What/Why/How?
Resolve an issue where refs aren't resolved inside specification extensions while linting.

## Reference
https://redoc-ly.slack.com/archives/C02UHE7EL3E/p1672777257007459

## Testing
Locally

## Screenshots (optional)
N/a

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
