### PR TITLE
docs: rename features.openapi and features.mockServer in config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ toc:
 
 # Redocly CLI changelog
 
-## 1.0.0-beta.121 (2023-01-24)
+## 1.0.0-beta.121 (2023-01-25)
 
 ### Changes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,25 @@ toc:
 
 # Redocly CLI changelog
 
+## Next
+
+### Changes
+
+- Moved and renamed the `features.openapi` and `features.mockServer` into the `theme` object with the names `openapi` and `mockServer`.
+
+Before:
+```yaml
+features.openapi: {}
+features.mockServer: {}
+```
+
+After:
+```yaml
+theme:
+  openapi: {}
+  mockServer: {}
+```
+
 ## 1.0.0-beta.119 (2023-01-03)
 
 ### Fixes

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -15,7 +15,7 @@ Apart from uploading your API definition file, the `push` command can automatica
 
 - the [Redocly configuration file](/docs/cli/configuration/index.mdx) and any configuration files referenced in the `extends` list.
 - the `package.json` file (if it exists) from the folder where you're executing the `push` command. Redocly Workflows will use the `@redocly/cli` version specified in `package.json`.
-- the HTML template and the full contents of the folder specified as the `features.openapi > htmlTemplate` parameter in the Redocly configuration file.
+- the HTML template and the full contents of the folder specified as the `theme > openapi > htmlTemplate` parameter in the Redocly configuration file.
 
 :::attention
 

--- a/docs/configuration/api.yaml
+++ b/docs/configuration/api.yaml
@@ -111,15 +111,18 @@ additionalProperties:
                   - off
                 description: The severity level if the problem occurs.
             additionalProperties: true
-    features.openapi:
+    theme:
       type: object
-      description: >-
-        Defines theming and functionality for an API definition.
-        Supports the same format and options as the [global `features.openapi` object](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
-        API-level configuration will always override global configuration.
-    features.mockServer:
-      type: object
-      description: |-
-        Defines mock server behavior for an API definition.
-        Supports the same format and options as the [global `features.mockServer` object](#featuresmockserver-object).
-        API-level configuration will always override global configuration.
+      properties:
+        openapi:
+          type: object
+          description: >-
+            Defines theming and functionality for an API definition.
+            Supports the same format and options as the [global `openapi` object](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
+            API-level configuration will always override global configuration.
+        mockServer:
+          type: object
+          description: >-
+            Defines mock server behavior for an API definition.
+            Supports the same format and options as the [global `mockServer` object](#featuresmockserver-object).
+            API-level configuration will always override global configuration.

--- a/docs/configuration/index.mdx
+++ b/docs/configuration/index.mdx
@@ -67,15 +67,17 @@ apis:
     root: ./openapi/external.yaml
     labels:
       - external
-    features.openapi:
-      hideLogo: true
+    theme:
+      openapi:
+        hideLogo: true
 
-features.openapi:
-  schemaExpansionLevel: 2
-  generateCodeSamples:
-    languages:
-      - lang: curl
-      - lang: Python
+theme:
+  openapi:
+    schemaExpansionLevel: 2
+    generateCodeSamples:
+      languages:
+        - lang: curl
+        - lang: Python
 ```
 
 ### `extends` list
@@ -250,7 +252,8 @@ apis:
     root: ./openapi/openapi.yaml
     labels:
       - production
-    features.openapi: {}
+    theme:
+      openapi: {}
 ```
 
 :::warning Important
@@ -273,16 +276,19 @@ On the other hand, if you run the command without specifying any aliases, it app
 redocly lint
 ```
 
+### theme object
 
-### features.mockServer object
+The `theme` object configures OpenAPI features, mock server features, and others.
 
-You can apply `features.mockServer` to individual APIs as well as at the global level.
+#### mockServer object
+
+You can apply `mockServer` to individual APIs as well as at the global level.
 In case of conflict, API takes priority.
 
 The API registry supports [the mock server feature](../../api-registry/guides/mock-server-quickstart.md) and allows project owners to enable it for all branches per API version.
 When the mock server is enabled for an API, you can send test requests to it from any API client.
 
-The `features.mockServer` object allows additional configuration of the mock server behavior.
+The `mockServer` object is a property of the `theme` object and allows additional configuration of the mock server behavior.
 This object is optional.
 
 #### Fixed properties
@@ -296,11 +302,11 @@ This object is optional.
 </StyledContent>
 
 
-### features.openapi object
+#### openapi object
 
-The `features.openapi` object configures features and theming for API documentation generated from OpenAPI definitions.
+The `openapi` object is a property of the `theme` object and configures features and theming for API documentation generated from OpenAPI definitions.
 
-If you need to apply different theming and functionality to individual APIs, add the `features.openapi` property to the appropriate API in the `apis` object, and use the same options as the global `features.openapi`.
+If you need to apply different theming and functionality to individual APIs, add the theme `openapi` property to the appropriate API in the `apis` and `theme` object, and use the same options as the global `openapi` object.
 
 Find the full list of supported options on the [Reference docs configuration page](../../api-reference-docs/configuration/functionality.mdx).
 

--- a/docs/configuration/schema.yaml
+++ b/docs/configuration/schema.yaml
@@ -149,18 +149,21 @@ properties:
                       - off
                     description: The severity level if the problem occurs.
                 additionalProperties: true
-        features.openapi:
+        theme:
           type: object
-          description: >-
-            Defines theming and functionality for an API definition.
-            Supports the same format and options as the [global `features.openapi` object](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
-            API-level configuration will always override global configuration.
-        features.mockServer:
-          type: object
-          description: |-
-            Defines mock server behavior for an API definition.
-            Supports the same format and options as the global `features.mockServer` object.
-            API-level configuration will always override global configuration.
+          properties:
+            openapi:
+              type: object
+              description: >-
+                Defines theming and functionality for an API definition.
+                Supports the same format and options as the [global `openapi` object](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
+                API-level configuration will always override global configuration.
+            mockServer:
+              type: object
+              description: >-
+                Defines mock server behavior for an API definition.
+                Supports the same format and options as the global `mockServer` object.
+                API-level configuration will always override global configuration.
   preprocessors:
     type: object
     title: Preprocessors object
@@ -246,29 +249,32 @@ properties:
                 - off
               description: The severity level if the problem occurs.
           additionalProperties: true
-  features.mockServer:
+  theme:
     type: object
-    description: Lets you toggle features that control how mock servers behave.
     properties:
-      errorIfForcedExampleNotFound:
+      mockServer:
+        type: object
+        description: Lets you toggle features that control how mock servers behave.
+        properties:
+          errorIfForcedExampleNotFound:
+            description: >-
+              You can force specific examples to appear in the response by adding the optional `x-redocly-response-body-example` header to your requests.
+              If you pass an example ID that can't be found in the API definition, the mock server will return any other example unless `errorIfForcedExampleNotFound` is `true`.
+              Then the mock server will return an error instead.
+            type: boolean
+            default: false
+          strictExamples:
+            description: >-
+              By default, the mock server automatically enhances responses with heuristics, such as substituting response fields with request parameter values.
+              If you set `strictExamples:true`, examples are returned in the response unmodified, and exactly how they are described in the OpenAPI definition.
+            type: boolean
+            default: false
+      openapi:
+        type: object
         description: >-
-          You can force specific examples to appear in the response by adding the optional `x-redocly-response-body-example` header to your requests.
-          If you pass an example ID that can't be found in the API definition, the mock server will return any other example unless `errorIfForcedExampleNotFound` is `true`.
-          Then the mock server will return an error instead.
-        type: boolean
-        default: false
-      strictExamples:
-        description: >-
-          By default, the mock server automatically enhances responses with heuristics, such as substituting response fields with request parameter values.
-          If you set `strictExamples:true`, examples are returned in the response unmodified, and exactly how they are described in the OpenAPI definition.
-        type: boolean
-        default: false
-  features.openapi:
-    type: object
-    description: >-
-      Configuration options supported by Redocly for rendering OpenAPI into web pages.
-      Used when previewing or building the docs.
-      See the [list of options supported](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
+          Configuration options supported by Redocly for rendering OpenAPI into web pages.
+          Used when previewing or building the docs.
+          See the [list of options supported](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
   region:
     type: string
     enum:


### PR DESCRIPTION
## What/Why/How?

See #982 

## Reference

Docs for #982 
