### PR TITLE
fix: resolve nested refs inside spec extensions

### DIFF
--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -276,7 +276,11 @@ export async function resolveDocument(opts: {
         if (propType === undefined) propType = type.additionalProperties;
         if (typeof propType === 'function') propType = propType(propValue, propName);
         if (propType === undefined) propType = unknownType;
-        if (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) {
+        if (
+          type.extensionsPrefix &&
+          propName.startsWith(type.extensionsPrefix) &&
+          propType === unknownType
+        ) {
           propType = SpecExtension;
         }
 

--- a/packages/core/src/rules/__tests__/fixtures/code-sample.php
+++ b/packages/core/src/rules/__tests__/fixtures/code-sample.php
@@ -1,0 +1,9 @@
+$form = new \PetStore\Entities\Pet();
+$form->setPetType("Dog");
+$form->setName("Rex");
+// set other fields
+try {
+    $pet = $client->pets()->create($form);
+} catch (UnprocessableEntityException $e) {
+    var_dump($e->getErrors());
+}

--- a/packages/core/src/rules/__tests__/no-unresolved-refs.test.ts
+++ b/packages/core/src/rules/__tests__/no-unresolved-refs.test.ts
@@ -196,4 +196,33 @@ describe('oas3 boolean-parameter-prefixes', () => {
 
     expect(replaceSourceWithRef(results, __dirname)).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should not report on nested refs inside specification extensions', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        x-test:
+          prop:
+            $ref: 'fixtures/ref.yaml'
+        paths:
+          '/test':
+            get:
+              x-codeSamples:
+                - lang: PHP
+                  source:
+                    $ref: 'fixtures/code-sample.php'
+      `,
+      path.join(__dirname, 'foobar.yaml')
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({
+        'no-unresolved-refs': 'error',
+      }),
+    });
+
+    expect(replaceSourceWithRef(results, __dirname)).toMatchInlineSnapshot(`Array []`);
+  });
 });


### PR DESCRIPTION
## What/Why/How?
Resolve an issue with nested refs not resolved and throwing an error from the no-unresolved-refs rule.

## Reference
N/a

## Testing
Locally.

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
