### PR TITLE
chore: v1.0.0-beta.120

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ toc:
 
 # Redocly CLI changelog
 
+## 1.0.0-beta.120 (2023-01-05)
+
+### Fixes
+
+- Fixed an issue where `$refs` weren't resolved inside specification extensions.
+
 ## 1.0.0-beta.119 (2023-01-03)
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.119",
+  "version": "1.0.0-beta.120",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.119",
+      "version": "1.0.0-beta.120",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9750,10 +9750,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.119",
+      "version": "1.0.0-beta.120",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.119",
+        "@redocly/openapi-core": "1.0.0-beta.120",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -9857,7 +9857,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.119",
+      "version": "1.0.0-beta.120",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
@@ -10850,7 +10850,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.119",
+        "@redocly/openapi-core": "1.0.0-beta.120",
         "@types/configstore": "^5.0.1",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.119",
+  "version": "1.0.0-beta.120",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.119",
+  "version": "1.0.0-beta.120",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -33,7 +33,7 @@
     "Roman Hotsiy <roman@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.119",
+    "@redocly/openapi-core": "1.0.0-beta.120",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.119",
+  "version": "1.0.0-beta.120",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.119",
+      "version": "1.0.0-beta.120",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.119",
+  "version": "1.0.0-beta.120",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?
v1.0.0-beta.120 release:
- fix: resolve refs inside spec extensions (#981)
- fix: resolve nested refs inside spec extensions (#985)
- chore(deps): bump json5 from 2.2.1 to 2.2.3 (#980)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
