### PR TITLE
docs: add missing guide to the list on the cli guides page

### DIFF
--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -29,5 +29,8 @@ Learn how to work with Redocly CLI.
     <WideTile to="./change-token-url.md" header="Change the OAuth2 token URL">
       How to change the OAuth2 token URL.
     </WideTile>
+    <WideTile to="./hide-specification-extensions.md" header="Hide OpenAPI specification extensions">
+      How to create a custom decorator to hide OpenAPI specification extensions.
+    </WideTile>
   </Flex>
 </div>


### PR DESCRIPTION
## What/Why/How?

The guide was added to the sidebar (in the linked PR). This PR adds the guide to the index list (tiles) on the https://redocly.com/docs/cli/guides/ page

## Reference

Related to Redocly/marketing-site-portal#1032

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
