### PR TITLE
fix: ignore case when inferring file extension from codeSample lang prop

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,4 +1,10 @@
-import { getFallbackApisOrExit, isSubdir, pathToFilename, printConfigLintTotals } from '../utils';
+import {
+  getFallbackApisOrExit,
+  isSubdir,
+  pathToFilename,
+  printConfigLintTotals,
+  langToExt,
+} from '../utils';
 import { ResolvedApi, Totals, isAbsoluteUrl } from '@redocly/openapi-core';
 import { red, yellow } from 'colorette';
 import { existsSync } from 'fs';
@@ -234,5 +240,24 @@ describe('getFallbackApisOrExit', () => {
         path: 'https://someLinkt/petstore.yaml?main',
       },
     ]);
+  });
+});
+
+describe('langToExt', () => {
+  it.each([
+    ['php', '.php'],
+    ['c#', '.cs'],
+    ['shell', '.sh'],
+    ['curl', '.sh'],
+    ['bash', '.sh'],
+    ['javascript', '.js'],
+    ['js', '.js'],
+    ['python', '.py'],
+  ])('should infer file extension from lang - %s', (lang, expected) => {
+    expect(langToExt(lang)).toBe(expected);
+  });
+
+  it('should ignore case when inferring file extension', () => {
+    expect(langToExt('JavaScript')).toBe('.js');
   });
 });

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -13,6 +13,7 @@ import {
   writeYaml,
   exitWithError,
   escapeLanguageName,
+  langToExt,
 } from '../../utils';
 import { isString, isObject, isEmptyObject } from '../../js-utils';
 import {
@@ -104,20 +105,6 @@ function validateDefinitionFileName(fileName: string) {
       'File does not conform to the OpenAPI Specification. OpenAPI version is not specified'
     );
   return true;
-}
-
-function langToExt(lang: string) {
-  const langObj: any = {
-    php: '.php',
-    'c#': '.cs',
-    shell: '.sh',
-    curl: '.sh',
-    bash: '.sh',
-    javascript: '.js',
-    js: '.js',
-    python: '.py',
-  };
-  return langObj[lang];
 }
 
 function traverseDirectoryDeep(directory: string, callback: any, componentsFiles: object) {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -122,6 +122,20 @@ export function escapeLanguageName(lang: string) {
   return lang.replace(/#/g, '_sharp').replace(/\//, '_').replace(/\s/g, '');
 }
 
+export function langToExt(lang: string) {
+  const langObj: any = {
+    php: '.php',
+    'c#': '.cs',
+    shell: '.sh',
+    curl: '.sh',
+    bash: '.sh',
+    javascript: '.js',
+    js: '.js',
+    python: '.py',
+  };
+  return langObj[lang.toLowerCase()];
+}
+
 export class CircularJSONNotSupportedError extends Error {
   constructor(public originalError: Error) {
     super(originalError.message);


### PR DESCRIPTION
## What/Why/How?

### What
Ignore case when inferring file extension from codeSample lang property.

### Why
Considering the following `x-codeSamples` operation definition:
```yaml
@oas [get] /foobar
x-codeSamples:
  - lang: JavaScript
    source: |
       const foo = 'bar';
```

When establishing the `sampleFileName`, `x-codeSample.lang` is used to infer the file extension. The above will yield a filename `getundefined` since `JavaScript` is not lowercase.

### How
The method `langToExt` shall convert `lang` to lowercase before attempting to infer the file extension against its map of known languages.

`langToExt` has been moved to `utils` to simplify unit testing.

## Reference
sampleFineName
https://github.com/Redocly/redocly-cli/blob/4dc87c3f1820b0b21000708f53aa088afc99c3c8/packages/cli/src/commands/split/index.ts#L306-L312

langToExt
https://github.com/Redocly/redocly-cli/blob/4dc87c3f1820b0b21000708f53aa088afc99c3c8/packages/cli/src/commands/split/index.ts#L109-L121


## Testing

Added unit testing around `langToExt` method.

## Screenshots (optional)
n/a

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
  - no impact 
- [x] Code follows company security practices and guidelines
