### PR TITLE
feat: new decorator info-override

### DIFF
--- a/__tests__/bundle/info-override/.redocly.yaml
+++ b/__tests__/bundle/info-override/.redocly.yaml
@@ -1,0 +1,8 @@
+apis:
+  main:
+    root: ./main.yaml
+
+decorators:
+  info-override:
+    title: Updated title
+    x-vendor: custom extension

--- a/__tests__/bundle/info-override/main.yaml
+++ b/__tests__/bundle/info-override/main.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+servers:
+  - url: //petstore.swagger.io/v2
+    description: Default server
+info:
+  title: Example OpenAPI 3 definition.
+  version: 1.0.0
+  description: some description
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  contact:
+    name: qa
+    url: https://swagger.io/specification/#definitions
+    email: email@redoc.ly
+
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: example
+      summary: summary example
+      responses:
+        '200':
+          description: example description

--- a/__tests__/bundle/info-override/snapshot.js
+++ b/__tests__/bundle/info-override/snapshot.js
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle info-description-override 1`] = `
+openapi: 3.0.0
+servers:
+  - url: //petstore.swagger.io/v2
+    description: Default server
+info:
+  title: Updated title
+  version: 1.0.0
+  description: |
+    This is a test API description.
+
+    # Heading test
+
+    Body [test](#) content.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: qa
+    url: https://swagger.io/specification/#definitions
+    email: email@redoc.ly
+  x-vendor: custom extension
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: example
+      summary: summary example
+      responses:
+        '200':
+          description: example description
+components: {}
+
+Woohoo! Your OpenAPI definitions are valid. 🎉
+
+bundling ./main.yaml...
+📦 Created a bundle for ./main.yaml at stdout <test>ms.
+
+`;

--- a/__tests__/bundle/info-override/snapshot.js
+++ b/__tests__/bundle/info-override/snapshot.js
@@ -8,12 +8,7 @@ servers:
 info:
   title: Updated title
   version: 1.0.0
-  description: |
-    This is a test API description.
-
-    # Heading test
-
-    Body [test](#) content.
+  description: some description
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/__tests__/bundle/info-override/snapshot.js
+++ b/__tests__/bundle/info-override/snapshot.js
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`E2E bundle info-description-override 1`] = `
+exports[`E2E bundle info-override 1`] = `
 openapi: 3.0.0
 servers:
   - url: //petstore.swagger.io/v2

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -15,6 +15,7 @@ They are commonly used to add, remove, or change content.
 
 ### Changing descriptions
 - [info-description-override](./decorators/info-description-override.md)
+- [info-override](./decorators/info-override.md)
 - [operation-description-override](./decorators/operation-description-override.md)
 - [tag-description-override](./decorators/tag-description-override.md)
 

--- a/docs/decorators/info-override.md
+++ b/docs/decorators/info-override.md
@@ -1,0 +1,40 @@
+# info-override
+
+Extends the info object with the designated value.
+
+## API design principles
+
+Sometimes developers generate OpenAPI and the info object need to be improved after the fact.
+This generally happens when you have no permission to edit the source.
+This decorator provides a way to "overlay" a new info section over the source so that as the source changes you won't lose your modifications.
+
+
+## Configuration
+
+|Option|Type|Description|
+|---|---|---|
+|_additionalProperties_|any|**REQUIRED.** Any properties from the OpenAPI info object.|
+
+Example of a configuration:
+
+```yaml
+decorators:
+  info-description-override:
+    title: Updated title
+    x-meta: Custom metadata
+```
+
+## Examples
+
+![info-override](https://user-images.githubusercontent.com/3975738/214524591-328377a5-9004-4222-8040-57e49e07604a.png)
+
+## Related decorators
+
+- [info-description-override](./info-description-override.md)
+- [operation-description-override](./operation-description-override.md)
+- [tag-description-override](./tag-description-override.md)
+
+## Resources
+
+- [Decorator source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/decorators/common/info-description-override.ts)
+- [Blog post about Overlays](../../../blog/openapi-overlays.md)

--- a/packages/core/src/decorators/common/info-override.ts
+++ b/packages/core/src/decorators/common/info-override.ts
@@ -5,9 +5,7 @@ export const InfoOverride: Oas3Decorator | Oas2Decorator = (newInfo) => {
     Info: {
       leave(info) {
         if (typeof newInfo !== 'object' || Array.isArray(newInfo) || newInfo === null) {
-          throw new Error(
-            `"info-override" decorator should be called with an object`
-          );
+          throw new Error(`"info-override" decorator should be called with an object`);
         }
         Object.assign(info, newInfo);
       },

--- a/packages/core/src/decorators/common/info-override.ts
+++ b/packages/core/src/decorators/common/info-override.ts
@@ -1,0 +1,16 @@
+import { Oas3Decorator, Oas2Decorator } from '../../visitors';
+
+export const InfoOverride: Oas3Decorator | Oas2Decorator = (newInfo) => {
+  return {
+    Info: {
+      leave(info) {
+        if (typeof newInfo !== 'object' || Array.isArray(newInfo) || newInfo === null) {
+          throw new Error(
+            `"info-override" decorator should be called with an object`
+          );
+        }
+        Object.assign(info, newInfo);
+      },
+    },
+  };
+};

--- a/packages/core/src/decorators/common/info-override.ts
+++ b/packages/core/src/decorators/common/info-override.ts
@@ -7,7 +7,8 @@ export const InfoOverride: Oas3Decorator | Oas2Decorator = (newInfo) => {
         if (typeof newInfo !== 'object' || Array.isArray(newInfo) || newInfo === null) {
           throw new Error(`"info-override" decorator should be called with an object`);
         }
-        Object.assign(info, newInfo);
+        const { severity: _, ...rest } = newInfo;
+        Object.assign(info, rest);
       },
     },
   };

--- a/packages/core/src/decorators/oas2/index.ts
+++ b/packages/core/src/decorators/oas2/index.ts
@@ -3,6 +3,7 @@ import { RegistryDependencies } from '../common/registry-dependencies';
 import { OperationDescriptionOverride } from '../common/operation-description-override';
 import { TagDescriptionOverride } from '../common/tag-description-override';
 import { InfoDescriptionOverride } from '../common/info-description-override';
+import { InfoOverride } from '../common/info-override';
 import { RemoveXInternal } from '../common/remove-x-internal';
 import { FilterIn } from '../common/filters/filter-in';
 import { FilterOut } from '../common/filters/filter-out';
@@ -12,6 +13,7 @@ export const decorators = {
   'operation-description-override': OperationDescriptionOverride as Oas2Decorator,
   'tag-description-override': TagDescriptionOverride as Oas2Decorator,
   'info-description-override': InfoDescriptionOverride as Oas2Decorator,
+  'info-override': InfoOverride as Oas2Decorator,
   'remove-x-internal': RemoveXInternal as Oas2Decorator,
   'filter-in': FilterIn as Oas2Decorator,
   'filter-out': FilterOut as Oas2Decorator,

--- a/packages/core/src/decorators/oas3/index.ts
+++ b/packages/core/src/decorators/oas3/index.ts
@@ -3,6 +3,7 @@ import { RegistryDependencies } from '../common/registry-dependencies';
 import { OperationDescriptionOverride } from '../common/operation-description-override';
 import { TagDescriptionOverride } from '../common/tag-description-override';
 import { InfoDescriptionOverride } from '../common/info-description-override';
+import { InfoOverride } from '../common/info-override';
 import { RemoveXInternal } from '../common/remove-x-internal';
 import { FilterIn } from '../common/filters/filter-in';
 import { FilterOut } from '../common/filters/filter-out';
@@ -13,6 +14,7 @@ export const decorators = {
   'operation-description-override': OperationDescriptionOverride as Oas3Decorator,
   'tag-description-override': TagDescriptionOverride as Oas3Decorator,
   'info-description-override': InfoDescriptionOverride as Oas3Decorator,
+  'info-override': InfoOverride as Oas3Decorator,
   'remove-x-internal': RemoveXInternal as Oas3Decorator,
   'filter-in': FilterIn as Oas3Decorator,
   'filter-out': FilterOut as Oas3Decorator,


### PR DESCRIPTION
## What/Why/How?

This decorator will merge/override additional properties into the info object.

With this decorator you cannot remove some properties from info. Do we need another decorator or some option in this to switch from "merge" to "complete replace" behaviour?

Thoughs?

## Testing

Added tests.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
