### PR TITLE
chore: v1.0.0-beta.121

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ toc:
 
 - Added custom output file option to the `join` command.
 - Added an option to include webhooks to [operation-4xx-response](./rules/operations-4xx-response.md) rule.
+- Added a new built-in decorator [info-override](./decorators/info-override.md).
 
 ### Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ toc:
 
 ## 1.0.0-beta.121 (2023-01-25)
 
+### Features
+
+- Added custom output file option to join command
+- Added an option to include webhooks to operation-4xx-response rule
+
+### Fixes
+
+- Ignored case when inferring file extension from codeSample lang property
+
 ### Changes
 
 - Moved and renamed the `features.openapi` and `features.mockServer` into the `theme` object with the names `openapi` and `mockServer`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ toc:
 - Added custom output file option to the `join` command.
 - Added an option to include webhooks to [operation-4xx-response](./rules/operations-4xx-response.md) rule.
 - Added a new built-in decorator [info-override](./decorators/info-override.md).
+- Added support for `/` as a separator which puts paths into subdirectories for each path segment with the [split command](./commands/split.md).
 
 ### Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,12 +9,12 @@ toc:
 
 ### Features
 
-- Added custom output file option to join command
-- Added an option to include webhooks to operation-4xx-response rule
+- Added custom output file option to the `join` command.
+- Added an option to include webhooks to [operation-4xx-response](./rules/operations-4xx-response.md) rule.
 
 ### Fixes
 
-- Ignored case when inferring file extension from codeSample lang property
+- Ignored case when inferring file extension from code sample `lang` property.
 
 ### Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.120",
+  "version": "1.0.0-beta.121",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.120",
+      "version": "1.0.0-beta.121",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9575,10 +9575,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.120",
+      "version": "1.0.0-beta.121",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.120",
+        "@redocly/openapi-core": "1.0.0-beta.121",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -9621,7 +9621,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.120",
+      "version": "1.0.0-beta.121",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
@@ -10584,7 +10584,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.120",
+        "@redocly/openapi-core": "1.0.0-beta.121",
         "@types/configstore": "^5.0.1",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.120",
+  "version": "1.0.0-beta.121",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.120",
+  "version": "1.0.0-beta.121",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -33,7 +33,7 @@
     "Roman Hotsiy <roman@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.120",
+    "@redocly/openapi-core": "1.0.0-beta.121",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.120",
+  "version": "1.0.0-beta.121",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.120",
+      "version": "1.0.0-beta.121",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.120",
+  "version": "1.0.0-beta.121",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?

v1.0.0-beta.121 release:

 - join: add custom output file option(https://github.com/Redocly/redocly-cli/pull/987)
 - add an option to include webhooks to operation-4xx-response rule(https://github.com/Redocly/redocly-cli/pull/990)
 - fix: ignore case when inferring file extension from codeSample lang prop(https://github.com/Redocly/redocly-cli/pull/991)
 - chore: rename features.openapi to theme.openapi for build docs (https://github.com/Redocly/redocly-cli/pull/892)
 - chore: rename features.openapi and features.mockServer to theme (https://github.com/Redocly/redocly-cli/pull/995)
 - fix: push destination parsing (#890) 
 -  feat: new decorator info-override (https://github.com/Redocly/redocly-cli/pull/999)
 -  fix: support / separator in split command (https://github.com/Redocly/redocly-cli/pull/997)
 
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
