### PR TITLE
fix: fix destination name validation

### DIFF
--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -202,6 +202,37 @@ describe('getDestinationProps', () => {
       version: 'v1',
     });
   });
+  it('should return organizationId from destination string', () => {
+    expect(getDestinationProps('@test-org/main@main-v1', undefined)).toEqual({
+      organizationId: 'test-org',
+      name: 'main',
+      version: 'main-v1',
+    });
+  });
+
+  it('should return organizationId, version and empty name from destination string', () => {
+    expect(getDestinationProps('@test_org/@main_v1', undefined)).toEqual({
+      organizationId: 'test_org',
+      name: '',
+      version: 'main_v1',
+    });
+  });
+
+  it('should validate organizationId with space and version with dot', () => {
+    expect(getDestinationProps('@test org/simple_name@main.v1', undefined)).toEqual({
+      organizationId: 'test org',
+      name: 'simple_name',
+      version: 'main.v1',
+    });
+  });
+
+  it('should not work with "@" in destination name', () => {
+    expect(getDestinationProps('@test org/simple@name@main.v1', undefined)).toEqual({
+      organizationId: undefined,
+      name: undefined,
+      version: undefined,
+    });
+  });
 });
 
 describe('getApiRoot', () => {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -302,7 +302,7 @@ function hashFiles(filePaths: { filePath: string }[]) {
 }
 
 function validateDestination(destination: string) {
-  const regexp = /^(@(?<organizationId>\w+)\/)?(?<name>.*)@(?<version>[\w\.\-\_]+)$/;
+  const regexp = /^(@(?<organizationId>[\w\-\s]+)\/)?(?<name>[^@]*)@(?<version>[\w\.\-]+)$/;
 
   return destination?.match(regexp)?.groups;
 }


### PR DESCRIPTION
## What/Why/How?

Fix problem with symbols in organization id for the `push` command.
Disallow `@` in destination name;

## Reference
https://github.com/Redocly/redocly-cli/pull/890
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
