### PR TITLE
fix: do not fail the push command when organization is provided via redocly.yaml

### DIFF
--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -122,13 +122,13 @@ describe('push', () => {
 
     expect(exitWithError).toBeCalledTimes(1);
     expect(exitWithError).toBeCalledWith(
-        `No organization provided, please use the right format: ${yellow(
-            '<@organization-id/api-name@api-version>'
-        )} or specify the 'organization' field in the config file.`
+      `No organization provided, please use the right format: ${yellow(
+        '<@organization-id/api-name@api-version>'
+      )} or specify the 'organization' field in the config file.`
     );
   });
 
-  it('pushes with organization in config', async () => {
+  it('push should work with organization in config', async () => {
     (loadConfigAndHandleErrors as jest.Mock).mockImplementation(() => {
       return { ...ConfigFixture, organization: 'test_org' };
     });
@@ -157,7 +157,7 @@ describe('push', () => {
     });
   });
 
-  it('push should works if destination not provided and api in config is provided', async () => {
+  it('push should work if destination not provided and api in config is provided', async () => {
     (loadConfigAndHandleErrors as jest.Mock).mockImplementation(() => {
       return {
         ...ConfigFixture,

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -58,7 +58,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   const batchId = argv['batch-id'];
   const batchSize = argv['batch-size'];
 
-  if (!validateDestination(destination)) {
+  if (destination && !DESTINATION_REGEX.test(destination)) {
     exitWithError(
       `Destination argument value is not valid, please use the right format: ${yellow(
         '<@organization-id/api-name@api-version>'
@@ -98,6 +98,11 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   }
 
   const apis = api ? { [`${name}@${version}`]: { root: api } } : config.apis;
+  if (!Object.keys(apis).length) {
+    exitWithError(
+      `Api not found. Please make sure you have provided the correct data in the config file.`
+    );
+  }
 
   for (const [apiNameAndVersion, { root: api }] of Object.entries(apis)) {
     const resolvedConfig = getMergedConfig(config, apiNameAndVersion);
@@ -299,10 +304,6 @@ function hashFiles(filePaths: { filePath: string }[]) {
   const sum = createHash('sha256');
   filePaths.forEach((file) => sum.update(fs.readFileSync(file.filePath)));
   return sum.digest('hex');
-}
-
-function validateDestination(destination?: string): boolean {
-  return destination ? DESTINATION_REGEX.test(destination) : false;
 }
 
 function parseDestination(


### PR DESCRIPTION
## What/Why/How?

- Do not fail the push command when organization is provided via redocly.yaml
- Add more tests for push command

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
