### PR TITLE
fix: spacing of path items in stats output

### DIFF
--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -29,7 +29,7 @@ const statsAccumulator: StatsAccumulator = {
   schemas: { metric: '📈 Schemas', total: 0, color: 'white' },
   parameters: { metric: '👉 Parameters', total: 0, color: 'yellow', items: new Set() },
   links: { metric: '🔗 Links', total: 0, color: 'cyan', items: new Set() },
-  pathItems: { metric: '➡️ Path Items', total: 0, color: 'green' },
+  pathItems: { metric: '➡️  Path Items', total: 0, color: 'green' },
   operations: { metric: '👷 Operations', total: 0, color: 'yellow' },
   tags: { metric: '🔖 Tags', total: 0, color: 'white', items: new Set() },
 };


### PR DESCRIPTION
## What/Why/How?

I noticed that `redocly stats` has a funny spacing in its output, where the "Path Items" entry is too close to its emoji

![stat-layout](https://user-images.githubusercontent.com/172607/224970702-7b92131b-3e28-4235-888f-a36dcede719b.png)

## Reference

## Testing

`npm test` works, and the output looks correct when I use my local branch

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
