### PR TITLE
build-docs command output success message to stdout

### DIFF
--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -47,7 +47,7 @@ export const handlerBuildCommand = async (argv: BuildDocsArgv) => {
     mkdirSync(dirname(options.output), { recursive: true });
     writeFileSync(options.output, pageHTML);
     const sizeInKiB = Math.ceil(Buffer.byteLength(pageHTML) / 1024);
-    process.stderr.write(
+    process.stdout.write(
       `\n🎉 bundled successfully in: ${options.output} (${sizeInKiB} KiB) [⏱ ${elapsed}].\n`
     );
   } catch (e) {


### PR DESCRIPTION
## What/Why/How?

Hello.
I wondered why it wasn't outputting to stdout during execution, and when I looked at the source, it was outputting to stderr, so I fixed it.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
