### PR TITLE
docs: add docs for reworked assertionFn and new rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -71,6 +71,7 @@ The *Special rules* group contains rules that may apply to multiple objects or t
 - [response-contains-header](./rules/response-contains-header.md)
 - [response-contains-property](./rules/response-contains-property.md)
 - [scalar-property-missing-example](./rules/scalar-property-missing-example.md)
+- [required-min-length-string-type-property](./rules/required-min-length-string-type-property.md)
 
 ### Servers
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -71,7 +71,7 @@ The *Special rules* group contains rules that may apply to multiple objects or t
 - [response-contains-header](./rules/response-contains-header.md)
 - [response-contains-property](./rules/response-contains-property.md)
 - [scalar-property-missing-example](./rules/scalar-property-missing-example.md)
-- [required-min-length-string-type-property](./rules/required-min-length-string-type-property.md)
+- [required-string-property-missing-min-length](./rules/required-string-property-missing-min-length.md)
 
 ### Servers
 

--- a/docs/rules/custom-rules.md
+++ b/docs/rules/custom-rules.md
@@ -263,7 +263,7 @@ Property | Type | Description
 -- | -- | --
 value | `string` \| [`string`] | Value that appears at the corresponding location.
 options | `object` | Options that is described in the configuration file.
-location | `Location Object` | Location in the source document. See [Location Object](../resources/custom-plugins.md#location-object)
+assertionProperties | `object` | Assertion Properties contains 3 properties: `baseLocation`, `rawValue` and `ctx`. Base location (`baseLocation`) is corresponding to the Location in the source document, see [Location Object](../resources/custom-plugins.md#location-object). Raw value contains the original value that appears at at the corresponding location. Context (`ctx`) is corresponding to the [Context object](../resources/custom-plugins.md#the-context-object) that contains additional data and functionality.
 **Return**
 problems | [`Problem`] | List of problems. An empty list means all checks are valid.
 
@@ -300,12 +300,17 @@ assert/operation-summary-check:
 module.exports = {
   id: 'local',
   assertions: {
-    checkWordsStarts: (value, options, location) => {
+    checkWordsStarts: (value, options, assertionProperties) => {
       const regexp = new RegExp(`^${options.words.join('|')}`);
       if (regexp.test(value)) {
         return [];
       }
-      return [{ message: 'Operation summary should start with an active verb', location }];
+      return [
+        { 
+          message: 'Operation summary should start with an active verb', 
+          location: assertionProperties.baseLocation 
+        }
+      ];
     },
     checkWordsCount: (value, options, location) => {
       const words = value.split(' ');
@@ -313,7 +318,10 @@ module.exports = {
         return [];
       }
       return [
-        { message: `Operation summary should contain at least ${options.min} words`, location },
+        { 
+          message: `Operation summary should contain at least ${options.min} words`, 
+          location: assertionProperties.baseLocation  
+        }
       ];
     },
   },

--- a/docs/rules/custom-rules.md
+++ b/docs/rules/custom-rules.md
@@ -263,7 +263,7 @@ Property | Type | Description
 -- | -- | --
 value | `string` \| [`string`] | Value that appears at the corresponding location.
 options | `object` | Options that is described in the configuration file.
-assertionProperties | `object` | Assertion Properties contains 3 properties: `baseLocation`, `rawValue` and `ctx`. Base location (`baseLocation`) is corresponding to the Location in the source document, see [Location Object](../resources/custom-plugins.md#location-object). Raw value contains the original value that appears at at the corresponding location. Context (`ctx`) is corresponding to the [Context object](../resources/custom-plugins.md#the-context-object) that contains additional data and functionality.
+assertionContext | `object` | Assertion Context contains 3 properties: `baseLocation`, `rawValue`, and `ctx`. Base location (`baseLocation`) corresponds to the location in the source document. (See [Location Object](../resources/custom-plugins.md#location-object).) Raw value is the original value that appears at at the corresponding location. Context (`ctx`) corresponds to the [Context object](../resources/custom-plugins.md#the-context-object) that contains additional data and functionality.
 **Return**
 problems | [`Problem`] | List of problems. An empty list means all checks are valid.
 
@@ -300,7 +300,7 @@ assert/operation-summary-check:
 module.exports = {
   id: 'local',
   assertions: {
-    checkWordsStarts: (value, options, assertionProperties) => {
+    checkWordsStarts: (value, options, assertionContext) => {
       const regexp = new RegExp(`^${options.words.join('|')}`);
       if (regexp.test(value)) {
         return [];
@@ -308,7 +308,7 @@ module.exports = {
       return [
         { 
           message: 'Operation summary should start with an active verb', 
-          location: assertionProperties.baseLocation 
+          location: assertionContext.baseLocation 
         }
       ];
     },
@@ -320,7 +320,7 @@ module.exports = {
       return [
         { 
           message: `Operation summary should contain at least ${options.min} words`, 
-          location: assertionProperties.baseLocation  
+          location: assertionContext.baseLocation  
         }
       ];
     },

--- a/docs/rules/custom-rules.md
+++ b/docs/rules/custom-rules.md
@@ -263,7 +263,7 @@ Property | Type | Description
 -- | -- | --
 value | `string` \| [`string`] | Value that appears at the corresponding location.
 options | `object` | Options that is described in the configuration file.
-assertionContext | `object` | Assertion Context contains 3 properties: `baseLocation`, `rawValue`, and `ctx`. Base location (`baseLocation`) corresponds to the location in the source document. (See [Location Object](../resources/custom-plugins.md#location-object).) Raw value is the original value that appears at at the corresponding location. Context (`ctx`) corresponds to the [Context object](../resources/custom-plugins.md#the-context-object) that contains additional data and functionality.
+assertionContext | `object` | Assertion Context contains 3 properties: `baseLocation`, `rawValue`, and `ctx`. Base location (`baseLocation`) corresponds to the location in the source document. (See [Location Object](../resources/custom-plugins.md#location-object)). Raw value is the original value that appears at the corresponding location. Context (`ctx`) corresponds to the [Context object](../resources/custom-plugins.md#the-context-object) that contains additional data and functionality.
 **Return**
 problems | [`Problem`] | List of problems. An empty list means all checks are valid.
 

--- a/docs/rules/custom-rules.md
+++ b/docs/rules/custom-rules.md
@@ -263,7 +263,7 @@ Property | Type | Description
 -- | -- | --
 value | `string` \| [`string`] | Value that appears at the corresponding location.
 options | `object` | Options that is described in the configuration file.
-assertionContext | `object` | Assertion Context contains 3 properties: `baseLocation`, `rawValue`, and `ctx`. Base location (`baseLocation`) corresponds to the location in the source document. (See [Location Object](../resources/custom-plugins.md#location-object)). Raw value is the original value that appears at the corresponding location. Context (`ctx`) corresponds to the [Context object](../resources/custom-plugins.md#the-context-object) that contains additional data and functionality.
+ctx | `object` | Context object corresponds to the [Context object](../resources/custom-plugins.md#the-context-object) and extended by 2 properties: `baseLocation`, and `rawValue`. Base location (`baseLocation`) corresponds to the location in the source document for current assertion. (See [Location Object](../resources/custom-plugins.md#location-object)). Raw value is the original value that appears at the corresponding assertion location. 
 **Return**
 problems | [`Problem`] | List of problems. An empty list means all checks are valid.
 
@@ -300,7 +300,7 @@ assert/operation-summary-check:
 module.exports = {
   id: 'local',
   assertions: {
-    checkWordsStarts: (value, options, assertionContext) => {
+    checkWordsStarts: (value, options, ctx) => {
       const regexp = new RegExp(`^${options.words.join('|')}`);
       if (regexp.test(value)) {
         return [];
@@ -308,11 +308,11 @@ module.exports = {
       return [
         { 
           message: 'Operation summary should start with an active verb', 
-          location: assertionContext.baseLocation 
+          location: ctx.baseLocation 
         }
       ];
     },
-    checkWordsCount: (value, options, location) => {
+    checkWordsCount: (value, options, ctx) => {
       const words = value.split(' ');
       if (words.length >= options.min) {
         return [];
@@ -320,7 +320,7 @@ module.exports = {
       return [
         { 
           message: `Operation summary should contain at least ${options.min} words`, 
-          location: assertionContext.baseLocation  
+          location: ctx.baseLocation  
         }
       ];
     },

--- a/docs/rules/custom-rules.md
+++ b/docs/rules/custom-rules.md
@@ -263,7 +263,7 @@ Property | Type | Description
 -- | -- | --
 value | `string` \| [`string`] | Value that appears at the corresponding location.
 options | `object` | Options that is described in the configuration file.
-ctx | `object` | Context object corresponds to the [Context object](../resources/custom-plugins.md#the-context-object) and extended by 2 properties: `baseLocation`, and `rawValue`. Base location (`baseLocation`) corresponds to the location in the source document for current assertion. (See [Location Object](../resources/custom-plugins.md#location-object)). Raw value is the original value that appears at the corresponding assertion location. 
+ctx | `object` | `ctx` object extends the [Context object](../resources/custom-plugins.md#the-context-object) with two properties: `baseLocation`, and `rawValue`. Base location (`baseLocation`) contains the location in the source document for current assertion. (See [Location Object](../resources/custom-plugins.md#location-object)). Raw value is the original assertion value. 
 **Return**
 problems | [`Problem`] | List of problems. An empty list means all checks are valid.
 

--- a/docs/rules/required-min-length-string-type-property.md
+++ b/docs/rules/required-min-length-string-type-property.md
@@ -1,0 +1,90 @@
+# required-min-length-string-type-property
+
+Requires that every property in the API definition with type `string` that are required also to have `minLength`. 
+
+|OAS|Compatibility|
+|---|---|
+|2.0|✅|
+|3.0|✅|
+|3.1|✅|
+
+## API design principles
+
+The `minLength` property is useful in scenarios where you need to specify a minimum length requirement for a string or to check if the string is not empty, especially if the property is marked as `required`. It helps to prevent errors or unexpected behavior in your application that may result from having strings that are too short or even empty. By setting a minimum length, you can ensure that the string has enough characters to be useful in your application. Overall, using the `minLength` property for string type properties in OAS definitions is a best practice for ensuring data integrity and improving the overall quality of the API.
+
+## Configuration
+
+To configure the rule, add it to the `rules` object in your configuration file.
+Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
+
+```yaml
+rules:
+  required-min-length-string-type-property:
+    severity: error
+```
+
+## Configuration
+
+
+|Option|Type|Description|
+|---|---|---|
+|severity|string|Possible values: `off`, `warn`, `error`. Default `off` (in `recommended` configuration). |
+
+An example configuration:
+
+```yaml
+rules:
+  required-min-length-string-type-property: error
+```
+
+## Examples
+
+
+Given this configuration:
+
+```yaml
+rules:
+  required-min-length-string-type-property: error
+```
+
+Example of an **incorrect** schema:
+
+```yaml Bad example
+schemas:
+  User:
+    type: object
+    required:
+        - name 
+    properties:
+      name:
+        description: User name
+        type: string
+        
+```
+
+Example of a **correct** schema:
+
+
+```yaml Good example
+schemas:
+  User:
+    type: object
+    required:
+        - name 
+    properties:
+      name:
+        description: User name
+        type: string
+        minLength: 2
+```
+
+## Related rules
+
+- [no-invalid-schema-examples](./no-invalid-schema-examples.md)
+- [response-contains-property](./response-contains-property.md)
+- [custom rules](./custom-rules.md)
+
+## Resources
+
+- [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/common/required-min-length-string-type-property.ts)
+- [Schema docs](https://redocly.com/docs/openapi-visual-reference/schemas/)

--- a/docs/rules/required-min-length-string-type-property.md
+++ b/docs/rules/required-min-length-string-type-property.md
@@ -1,6 +1,6 @@
 # required-min-length-string-type-property
 
-Requires that every property in the API definition with type `string` that are required also to have `minLength`. 
+Requires that every required property in the API definition with type `string` has a `minLength`. 
 
 |OAS|Compatibility|
 |---|---|
@@ -82,7 +82,7 @@ schemas:
 
 - [no-invalid-schema-examples](./no-invalid-schema-examples.md)
 - [response-contains-property](./response-contains-property.md)
-- [custom rules](./custom-rules.md)
+- [Custom rules](./custom-rules.md)
 
 ## Resources
 

--- a/docs/rules/required-string-property-missing-min-length.md
+++ b/docs/rules/required-string-property-missing-min-length.md
@@ -1,4 +1,4 @@
-# required-min-length-string-type-property
+# required-string-property-missing-min-length
 
 Requires that every required property in the API definition with type `string` has a `minLength`. 
 
@@ -10,7 +10,7 @@ Requires that every required property in the API definition with type `string` h
 
 ## API design principles
 
-The `minLength` property is useful in scenarios where you need to specify a minimum length requirement for a string or to check if the string is not empty, especially if the property is marked as `required`. It helps to prevent errors or unexpected behavior in your application that may result from having strings that are too short or even empty. By setting a minimum length, you can ensure that the string has enough characters to be useful in your application. Overall, using the `minLength` property for string type properties in OAS definitions is a best practice for ensuring data integrity and improving the overall quality of the API.
+The `minLength` keyword constrains string values. When a property of type `string` is `required`, defining the `minLength` helps prevent common mistakes, such as empty strings. Use the `minLength` property as a best practice to ensure data integrity and enhances the overall quality of the API.
 
 ## Configuration
 
@@ -19,7 +19,7 @@ Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
 
 ```yaml
 rules:
-  required-min-length-string-type-property:
+  required-string-property-missing-min-length:
     severity: error
 ```
 
@@ -34,7 +34,7 @@ An example configuration:
 
 ```yaml
 rules:
-  required-min-length-string-type-property: error
+  required-string-property-missing-min-length: error
 ```
 
 ## Examples
@@ -44,7 +44,7 @@ Given this configuration:
 
 ```yaml
 rules:
-  required-min-length-string-type-property: error
+  required-string-property-missing-min-length: error
 ```
 
 Example of an **incorrect** schema:
@@ -86,5 +86,5 @@ schemas:
 
 ## Resources
 
-- [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/common/required-min-length-string-type-property.ts)
+- [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/common/required-string-property-missing-min-length.ts)
 - [Schema docs](https://redocly.com/docs/openapi-visual-reference/schemas/)


### PR DESCRIPTION
## What/Why/How?
Updated docs for Assertions : 
- Add new property `assertionsProperties` that can be accessible in the `customFn`  instead of the Location. Now location is posted in the assertionsProperties as baseLocation propertie.

New rule: 'required-min-length-string-type-property'.
-  Requires that every property in the API definition with type `string` that are required also to have `minLength`

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
