### PR TITLE
fix: handle $ref in the joining path parameters

### DIFF
--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -159,6 +159,7 @@ describe('E2E', () => {
         'two-files-with-no-errors',
         'fails-if-component-conflicts',
         'multiple-tags-in-same-files',
+        'references-in-parameters',
       ];
 
       test.each(testDirNames)('test: %s', (dir) => {

--- a/__tests__/join/references-in-parameters/bar.yaml
+++ b/__tests__/join/references-in-parameters/bar.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Example API
+  description: This is an example API.
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+paths:
+  /users/{userId}/orders/{orderId}:
+    parameters:
+      - $ref: "#/components/parameters/userIdParam"
+      - $ref: "#/components/parameters/orderIdParam"
+    get:
+      summary: Get an order by ID for a specific user
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not found
+components:
+  parameters:
+    userIdParam:
+      name: userId
+      in: path
+      description: ID of the user
+      required: true
+      schema:
+        type: integer
+    orderIdParam:
+      name: orderId
+      in: path
+      description: ID of the order
+      required: true
+      schema:
+        type: integer

--- a/__tests__/join/references-in-parameters/foo.yaml
+++ b/__tests__/join/references-in-parameters/foo.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.0
+info:
+  title: Example API
+  description: This is an example API.
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+paths:
+  /users/{userId}/products/{productId}:
+    parameters:
+      - $ref: "#/components/parameters/userIdParam"
+      - $ref: "#/components/parameters/productIdParam"
+    get:
+      summary: Get a product by ID for a specific user
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not found
+  /users/{userId}/orders/{orderId}/items/{itemId}:
+    parameters:
+      - $ref: "#/components/parameters/userIdParam"
+      - $ref: "#/components/parameters/orderIdParam"
+      - $ref: "#/components/parameters/itemIdParam"
+    get:
+      summary: Get an item by ID for a specific order and user
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not found
+components:
+  parameters:
+    userIdParam:
+      name: userId
+      in: path
+      description: ID of the user
+      required: true
+      schema:
+        type: integer
+    productIdParam:
+      name: productId
+      in: path
+      description: ID of the product
+      required: true
+      schema:
+        type: integer
+    orderIdParam:
+      name: orderId
+      in: path
+      description: ID of the order
+      required: true
+      schema:
+        type: integer
+    itemIdParam:
+      name: itemId
+      in: path
+      description: ID of the item
+      required: true
+      schema:
+        type: integer

--- a/__tests__/join/references-in-parameters/snapshot.js
+++ b/__tests__/join/references-in-parameters/snapshot.js
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E join without options test: references-in-parameters 1`] = `
+
+openapi: 3.0.0
+info:
+  title: Example API
+  description: This is an example API.
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+paths:
+  /users/{userId}/products/{productId}:
+    parameters:
+      - $ref: '#/components/parameters/userIdParam'
+      - $ref: '#/components/parameters/productIdParam'
+    get:
+      summary: Get a product by ID for a specific user
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+      tags:
+        - b_other
+  /users/{userId}/orders/{orderId}/items/{itemId}:
+    parameters:
+      - $ref: '#/components/parameters/userIdParam'
+      - $ref: '#/components/parameters/orderIdParam'
+      - $ref: '#/components/parameters/itemIdParam'
+    get:
+      summary: Get an item by ID for a specific order and user
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+      tags:
+        - b_other
+  /users/{userId}/orders/{orderId}:
+    parameters:
+      - $ref: '#/components/parameters/userIdParam'
+      - $ref: '#/components/parameters/orderIdParam'
+    get:
+      summary: Get an order by ID for a specific user
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+      tags:
+        - a_other
+tags:
+  - name: b_other
+    x-displayName: other
+  - name: a_other
+    x-displayName: other
+x-tagGroups:
+  - name: b
+    tags:
+      - b_other
+  - name: a
+    tags:
+      - a_other
+components:
+  parameters:
+    userIdParam:
+      name: userId
+      in: path
+      description: ID of the user
+      required: true
+      schema:
+        type: integer
+    productIdParam:
+      name: productId
+      in: path
+      description: ID of the product
+      required: true
+      schema:
+        type: integer
+    orderIdParam:
+      name: orderId
+      in: path
+      description: ID of the order
+      required: true
+      schema:
+        type: integer
+    itemIdParam:
+      name: itemId
+      in: path
+      description: ID of the item
+      required: true
+      schema:
+        type: integer
+
+openapi.yaml: join processed in <test>ms
+
+
+`;

--- a/__tests__/join/references-in-parameters/snapshot.js
+++ b/__tests__/join/references-in-parameters/snapshot.js
@@ -22,7 +22,7 @@ paths:
         '404':
           description: Not found
       tags:
-        - b_other
+        - foo_other
   /users/{userId}/orders/{orderId}/items/{itemId}:
     parameters:
       - $ref: '#/components/parameters/userIdParam'
@@ -36,7 +36,7 @@ paths:
         '404':
           description: Not found
       tags:
-        - b_other
+        - foo_other
   /users/{userId}/orders/{orderId}:
     parameters:
       - $ref: '#/components/parameters/userIdParam'
@@ -49,19 +49,19 @@ paths:
         '404':
           description: Not found
       tags:
-        - a_other
+        - bar_other
 tags:
-  - name: b_other
+  - name: foo_other
     x-displayName: other
-  - name: a_other
+  - name: bar_other
     x-displayName: other
 x-tagGroups:
-  - name: b
+  - name: foo
     tags:
-      - b_other
-  - name: a
+      - foo_other
+  - name: bar
     tags:
-      - a_other
+      - bar_other
 components:
   parameters:
     userIdParam:

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -426,7 +426,6 @@ export async function handleJoin(argv: JoinArgv, packageVersion: string) {
 
         for (const pathParameter of joinedDef.paths[path]
           .parameters as Referenced<Oas3Parameter>[]) {
-
           // Compare $ref only if both are reference objects
           if (isRef(pathParameter) && isRef(parameter)) {
             if (pathParameter['$ref'] === parameter['$ref']) {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -5,7 +5,7 @@ import { Oas3Types } from './types/oas3';
 import { Oas2Types } from './types/oas2';
 import { Oas3_1Types } from './types/oas3_1';
 import { NormalizedNodeType, normalizeTypes, NodeType } from './types';
-import {WalkContext, walkDocument, UserContext, ResolveResult, NormalizedProblem} from './walk';
+import { WalkContext, walkDocument, UserContext, ResolveResult, NormalizedProblem } from './walk';
 import { detectOpenAPI, openAPIMajor, OasMajorVersion } from './oas-types';
 import { isAbsoluteUrl, isRef, Location, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
@@ -69,9 +69,9 @@ export type BundleResult = {
   problems: NormalizedProblem[];
   fileDependencies: Set<string>;
   rootType: NormalizedNodeType;
-  refTypes?:  Map<string, NormalizedNodeType>;
-  visitorsData:  Record<string, Record<string, unknown>>;
-}
+  refTypes?: Map<string, NormalizedNodeType>;
+  visitorsData: Record<string, Record<string, unknown>>;
+};
 
 export async function bundleDocument(opts: {
   document: Document;

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -5,7 +5,7 @@ import { Oas3Types } from './types/oas3';
 import { Oas2Types } from './types/oas2';
 import { Oas3_1Types } from './types/oas3_1';
 import { NormalizedNodeType, normalizeTypes, NodeType } from './types';
-import { WalkContext, walkDocument, UserContext, ResolveResult } from './walk';
+import {WalkContext, walkDocument, UserContext, ResolveResult, NormalizedProblem} from './walk';
 import { detectOpenAPI, openAPIMajor, OasMajorVersion } from './oas-types';
 import { isAbsoluteUrl, isRef, Location, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
@@ -64,6 +64,15 @@ export async function bundle(opts: {
 
 type BundleContext = WalkContext;
 
+export type BundleResult = {
+  bundle: Document;
+  problems: NormalizedProblem[];
+  fileDependencies: Set<string>;
+  rootType: NormalizedNodeType;
+  refTypes?:  Map<string, NormalizedNodeType>;
+  visitorsData:  Record<string, Record<string, unknown>>;
+}
+
 export async function bundleDocument(opts: {
   document: Document;
   config: StyleguideConfig;
@@ -73,7 +82,7 @@ export async function bundleDocument(opts: {
   skipRedoclyRegistryRefs?: boolean;
   removeUnusedComponents?: boolean;
   keepUrlRefs?: boolean;
-}) {
+}): Promise<BundleResult> {
   const {
     document,
     config,


### PR DESCRIPTION
## What/Why/How?

Handle $ref in the joining path parameters

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/1018

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
