### PR TITLE
fix: decorator name in a docs example

### DIFF
--- a/docs/decorators/info-override.md
+++ b/docs/decorators/info-override.md
@@ -19,7 +19,7 @@ Example of a configuration:
 
 ```yaml
 decorators:
-  info-description-override:
+  info-override:
     title: Updated title
     x-meta: Custom metadata
 ```


### PR DESCRIPTION
## What/Why/How?

I noticed a mismatch between a decorator name and the code example in the docs. The example works when I use it like this.

## Reference

https://redocly.com/docs/cli/decorators/info-override/

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
