### PR TITLE
fix: resolve external oas attributes with if refs exist in array

### DIFF
--- a/__tests__/bundle/resolve-refs-from-x-attributes/.redocly.yaml
+++ b/__tests__/bundle/resolve-refs-from-x-attributes/.redocly.yaml
@@ -1,0 +1,7 @@
+apis:
+  main:
+    root: ./openapi.yaml
+decorators:
+  plugin/resolve-x: on
+plugins:
+  - "./plugin.js"

--- a/__tests__/bundle/resolve-refs-from-x-attributes/external.yaml
+++ b/__tests__/bundle/resolve-refs-from-x-attributes/external.yaml
@@ -1,0 +1,4 @@
+Test1:
+  name: test 1
+Test2:
+  name: test 2

--- a/__tests__/bundle/resolve-refs-from-x-attributes/openapi.yaml
+++ b/__tests__/bundle/resolve-refs-from-x-attributes/openapi.yaml
@@ -1,0 +1,8 @@
+openapi: 3.0.3
+info:
+  title: foo
+  version: 1.0
+  x-attributes:
+    - $ref: external.yaml#/Test1
+  test-attributes:
+    - $ref: external.yaml#/Test2

--- a/__tests__/bundle/resolve-refs-from-x-attributes/plugin.js
+++ b/__tests__/bundle/resolve-refs-from-x-attributes/plugin.js
@@ -1,0 +1,13 @@
+const ResolveX = require('./resolve-x.decorator');
+const id = 'plugin';
+
+const decorators = {
+  oas3: {
+    'resolve-x': ResolveX,
+  },
+};
+
+module.exports = {
+  id,
+  decorators,
+};

--- a/__tests__/bundle/resolve-refs-from-x-attributes/resolve-x.decorator.js
+++ b/__tests__/bundle/resolve-refs-from-x-attributes/resolve-x.decorator.js
@@ -1,0 +1,15 @@
+module.exports = ResolveX;
+
+function ResolveX() {
+  return {
+    Info: {
+      leave(info, ctx) {
+        const xAttribute = ctx.resolve(info['x-attributes'][0]).node;
+        info['x-attributes'][0].resolved = xAttribute;
+
+        const testAttribute = ctx.resolve(info['test-attributes'][0]).node;
+        info['test-attributes'][0].resolved = testAttribute;
+      },
+    },
+  };
+}

--- a/__tests__/bundle/resolve-refs-from-x-attributes/snapshot.js
+++ b/__tests__/bundle/resolve-refs-from-x-attributes/snapshot.js
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle resolve-refs-from-x-attributes 1`] = `
+openapi: 3.0.3
+info:
+  title: foo
+  version: 1
+  x-attributes:
+    - $ref: external.yaml#/Test1
+      resolved:
+        name: test 1
+  test-attributes:
+    - $ref: external.yaml#/Test2
+      resolved:
+        name: test 2
+components: {}
+
+Woohoo! Your OpenAPI definitions are valid. 🎉
+
+bundling ./openapi.yaml...
+📦 Created a bundle for ./openapi.yaml at stdout <test>ms.
+
+`;

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -261,7 +261,7 @@ export async function resolveDocument(opts: {
       if (Array.isArray(node)) {
         const itemsType = type.items;
         // we continue resolving unknown types, but stop early on known scalars
-        if (type !== unknownType && itemsType === undefined) {
+        if (type !== unknownType && type !== SpecExtension && itemsType === undefined) {
           return;
         }
         for (let i = 0; i < node.length; i++) {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -261,7 +261,7 @@ export async function resolveDocument(opts: {
       if (Array.isArray(node)) {
         const itemsType = type.items;
         // we continue resolving unknown types, but stop early on known scalars
-        if (type !== unknownType && type !== SpecExtension && itemsType === undefined) {
+        if (itemsType === undefined && type !== unknownType && type !== SpecExtension) {
           return;
         }
         for (let i = 0; i < node.length; i++) {


### PR DESCRIPTION
## What/Why/How?

Fixed a bug where context.resolve() did not work when applied to nodes belonging to external oas (x-) attributes that contain an array.

## Reference
Closes: https://github.com/Redocly/redocly-cli/issues/992
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
