### PR TITLE
chore: renamed misspelled built-in rule function - `RequiredStringPropertyMissingMunLength`

### DIFF
--- a/packages/core/src/rules/common/required-string-property-missing-min-length.ts
+++ b/packages/core/src/rules/common/required-string-property-missing-min-length.ts
@@ -3,7 +3,7 @@ import { Oas3Schema, Oas3_1Schema } from '../../typings/openapi';
 import { Oas2Schema } from 'core/src/typings/swagger';
 import { Oas3Rule } from 'core/src/visitors';
 
-export const RequiredStringPropertyMissingMunLength: Oas3Rule = () => {
+export const RequiredStringPropertyMissingMinLength: Oas3Rule = () => {
   let skipSchemaProperties: boolean;
   let requiredPropertiesSet: Set<string>;
 

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -39,7 +39,7 @@ import { PathSegmentPlural } from '../common/path-segment-plural';
 import { ResponseContainsHeader } from '../common/response-contains-header';
 import { ResponseContainsProperty } from './response-contains-property';
 import { ScalarPropertyMissingExample } from '../common/scalar-property-missing-example';
-import { RequiredStringPropertyMissingMunLength } from '../common/required-string-property-missing-min-length';
+import { RequiredStringPropertyMissingMinLength } from '../common/required-string-property-missing-min-length';
 
 export const rules = {
   spec: OasSpec as Oas2Rule,
@@ -83,7 +83,7 @@ export const rules = {
   'response-contains-header': ResponseContainsHeader as Oas2Rule,
   'response-contains-property': ResponseContainsProperty as Oas2Rule,
   'scalar-property-missing-example': ScalarPropertyMissingExample,
-  'required-string-property-missing-min-length': RequiredStringPropertyMissingMunLength,
+  'required-string-property-missing-min-length': RequiredStringPropertyMissingMinLength,
 };
 
 export const preprocessors = {};

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -49,7 +49,7 @@ import { ResponseContainsProperty } from './response-contains-property';
 import { ScalarPropertyMissingExample } from '../common/scalar-property-missing-example';
 import { SpecComponentsInvalidMapName } from './spec-components-invalid-map-name';
 import { Operation4xxProblemDetailsRfc7807 } from './operation-4xx-problem-details-rfc7807';
-import { RequiredStringPropertyMissingMunLength } from '../common/required-string-property-missing-min-length';
+import { RequiredStringPropertyMissingMinLength } from '../common/required-string-property-missing-min-length';
 
 export const rules = {
   spec: OasSpec,
@@ -103,7 +103,7 @@ export const rules = {
   'response-contains-property': ResponseContainsProperty,
   'scalar-property-missing-example': ScalarPropertyMissingExample,
   'spec-components-invalid-map-name': SpecComponentsInvalidMapName,
-  'required-string-property-missing-min-length': RequiredStringPropertyMissingMunLength,
+  'required-string-property-missing-min-length': RequiredStringPropertyMissingMinLength,
 } as Oas3RuleSet;
 
 export const preprocessors = {};


### PR DESCRIPTION
fixes: #1050

- [ x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ x] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
