### PR TITLE
fix: push doesn't recognize API definitions with a space

### DIFF
--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -213,7 +213,7 @@ describe('push', () => {
       'batch-size': 2,
     });
 
-    expect(encodeURIComponentSpy).toHaveReturnedWith("my%20test%20api")
+    expect(encodeURIComponentSpy).toHaveReturnedWith('my%20test%20api');
     expect(redoclyClient.registryApi.pushApi).toBeCalledTimes(1);
   });
 });

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -194,6 +194,28 @@ describe('push', () => {
       'Api not found. Please make sure you have provided the correct data in the config file.'
     );
   });
+
+  it('push should work and encode name with spaces', async () => {
+    const encodeURIComponentSpy = jest.spyOn(global, 'encodeURIComponent');
+    (loadConfigAndHandleErrors as jest.Mock).mockImplementation(() => {
+      return {
+        ...ConfigFixture,
+        organization: 'test_org',
+        apis: { 'my test api@v1': { root: 'path' } },
+      };
+    });
+    await handlePush({
+      upsert: true,
+      destination: 'my test api@v1',
+      branchName: 'test',
+      public: true,
+      'batch-id': '123',
+      'batch-size': 2,
+    });
+
+    expect(encodeURIComponentSpy).toHaveReturnedWith("my%20test%20api")
+    expect(redoclyClient.registryApi.pushApi).toBeCalledTimes(1);
+  });
 });
 
 describe('transformPush', () => {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -109,6 +109,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
     resolvedConfig.styleguide.skipDecorators(argv['skip-decorator']);
 
     const [name, version = DEFAULT_VERSION] = apiNameAndVersion.split('@');
+    const encodedName = encodeURIComponent(name);
     try {
       let rootFilePath = '';
       const filePaths: string[] = [];
@@ -127,7 +128,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
       for (const file of filesToUpload.files) {
         const { signedUploadUrl, filePath } = await client.registryApi.prepareFileUpload({
           organizationId,
-          name,
+          name: encodedName,
           version,
           filesHash,
           filename: file.keyOnS3,
@@ -162,7 +163,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
 
       await client.registryApi.pushApi({
         organizationId,
-        name,
+        name: encodedName,
         version,
         rootFilePath,
         filePaths,
@@ -318,7 +319,6 @@ export function getDestinationProps(
 ) {
   const groups = destination && parseDestination(destination);
   if (groups) {
-    groups.name && (groups.name = encodeURIComponent(groups.name));
     return {
       organizationId: groups.organizationId || organization,
       name: groups.name,


### PR DESCRIPTION
## What/Why/How?
Fix problem with encoding name in push command
## Reference
Closes: https://github.com/Redocly/redocly-cli/issues/1031
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
