### PR TITLE
feat: add whiteLabel options for preview by default

### DIFF
--- a/packages/cli/src/commands/preview-docs/index.ts
+++ b/packages/cli/src/commands/preview-docs/index.ts
@@ -142,6 +142,7 @@ export async function previewDocs(
       ...referenceDocs,
       useCommunityEdition: argv['use-community-edition'] || referenceDocs?.useCommunityEdition,
       licenseKey: process.env.REDOCLY_LICENSE_KEY || referenceDocs?.licenseKey,
+      whiteLabel: true,
     };
     return resolvedConfig;
   }


### PR DESCRIPTION
## What/Why/How?
Enable whiteLabel options for preview docs by default.
## Reference

## Testing

## Screenshots (optional)
<img width="285" alt="Screenshot 2023-05-09 at 11 18 47" src="https://user-images.githubusercontent.com/14113673/237037200-1b9524ed-5212-4a0d-b226-0e551ad30873.png">

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
