### PR TITLE
fix: handle htmlTemplate option for build-docs command

### DIFF
--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -37,7 +37,7 @@ export function getObjectOrJSON(
       break;
     default: {
       if (config) {
-        process.stderr.write(`Found ${config.configFile} and using theme.openapi options`);
+        process.stderr.write(`Found ${config.configFile} and using theme.openapi options\n`);
 
         return config.theme.openapi ? config.theme.openapi : {};
       }
@@ -70,7 +70,11 @@ export async function getPageHTML(
   const state = await store.toJS();
   const css = sheet.getStyleTags();
 
-  templateFileName = templateFileName ? templateFileName : join(__dirname, './template.hbs');
+  templateFileName = templateFileName
+    ? templateFileName
+    : redocOptions?.htmlTemplate
+    ? redocOptions.htmlTemplate as string
+    : join(__dirname, './template.hbs');
   const template = compile(readFileSync(templateFileName).toString());
   return template({
     redocHTML: `

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -73,7 +73,7 @@ export async function getPageHTML(
   templateFileName = templateFileName
     ? templateFileName
     : redocOptions?.htmlTemplate
-    ? redocOptions.htmlTemplate as string
+    ? (redocOptions.htmlTemplate as string)
     : join(__dirname, './template.hbs');
   const template = compile(readFileSync(templateFileName).toString());
   return template({


### PR DESCRIPTION
## What/Why/How?
related to https://github.com/Redocly/redoc/issues/2290
handle htmlTemplate option for build-docs command.

## Reference

## Testing
redocly.yaml
```yaml
theme:
  openapi:
    htmlTemplate: resources/redocly.html # this setting is ignored
    theme:
      sidebar:
        backgroundColor: '#f2f2f2'
```
resources/redocly.html
```html
<!DOCTYPE html>
<html>

<head>
  <meta charset="utf8" />
  <title>Test</title>
  <!-- needed for adaptive design -->
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <style>
    body {
      padding: 0;
      margin: 0;
    }
  </style>
  {{{redocHead}}}
  {{#unless disableGoogleFont}}<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">{{/unless}}
</head>

<body>
  <div>Custom template</div>
  {{{redocHTML}}}
</body>

</html>
```
## Screenshots (optional)
<img width="1512" alt="Screenshot 2023-05-09 at 11 58 41" src="https://user-images.githubusercontent.com/14113673/237047530-5e52f788-7c7f-4da6-8357-5a0b5ba3166c.png">

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
