### PR TITLE
fix: define default allowedValues in the all ruleset for mime-type rules

### DIFF
--- a/packages/core/src/config/all.ts
+++ b/packages/core/src/config/all.ts
@@ -36,7 +36,14 @@ export default {
       severity: 'error',
       patterns: [],
     },
-    'request-mime-type': 'error',
+    'request-mime-type': {
+      severity: 'error',
+      allowedValues: ['application/json']
+    },
+    'response-mime-type': {
+      severity: 'error',
+      allowedValues: ['application/json']
+    },
     spec: 'error',
     'no-invalid-schema-examples': 'error',
     'no-invalid-parameter-examples': 'error',

--- a/packages/core/src/config/all.ts
+++ b/packages/core/src/config/all.ts
@@ -38,11 +38,11 @@ export default {
     },
     'request-mime-type': {
       severity: 'error',
-      allowedValues: ['application/json']
+      allowedValues: ['application/json'],
     },
     'response-mime-type': {
       severity: 'error',
-      allowedValues: ['application/json']
+      allowedValues: ['application/json'],
     },
     spec: 'error',
     'no-invalid-schema-examples': 'error',


### PR DESCRIPTION
## What/Why/How?

Define default allowedValues in the `all` ruleset for request/response-mime-type rules

## Reference
Closes: https://github.com/Redocly/redocly-cli/issues/464
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
