### PR TITLE
fix: duplicated components created when referencing from components

### DIFF
--- a/__tests__/bundle/no-duplicated-components/.redocly.yaml
+++ b/__tests__/bundle/no-duplicated-components/.redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./openapi.yaml

--- a/__tests__/bundle/no-duplicated-components/Test.yaml
+++ b/__tests__/bundle/no-duplicated-components/Test.yaml
@@ -1,0 +1,1 @@
+type: object

--- a/__tests__/bundle/no-duplicated-components/openapi.yaml
+++ b/__tests__/bundle/no-duplicated-components/openapi.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+paths:
+  /path:
+    $ref: './paths/path.yaml'
+components:
+  schemas:
+    Test:
+      $ref: './Test.yaml'

--- a/__tests__/bundle/no-duplicated-components/paths/path.yaml
+++ b/__tests__/bundle/no-duplicated-components/paths/path.yaml
@@ -1,0 +1,6 @@
+get:
+  requestBody:
+    content:
+      'application/json':
+        schema:
+          $ref: ../Test.yaml

--- a/__tests__/bundle/no-duplicated-components/snapshot.js
+++ b/__tests__/bundle/no-duplicated-components/snapshot.js
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle no-duplicated-components 1`] = `
+openapi: 3.1.0
+paths:
+  /path:
+    get:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Test'
+components:
+  schemas:
+    Test:
+      type: object
+
+bundling ./openapi.yaml...
+📦 Created a bundle for ./openapi.yaml at stdout <test>ms.
+
+`;

--- a/__tests__/bundle/no-self-referenced-components/.redocly.yaml
+++ b/__tests__/bundle/no-self-referenced-components/.redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./openapi.yaml

--- a/__tests__/bundle/no-self-referenced-components/openapi.yaml
+++ b/__tests__/bundle/no-self-referenced-components/openapi.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+paths:
+  /pets/{petId}:
+    $ref: './paths/Pet.yaml'
+components:
+  schemas:
+    $ref: './schemas/_index.yaml'
+  parameters:
+    $ref: './parameters/_index.yaml'

--- a/__tests__/bundle/no-self-referenced-components/parameters/PetId.yaml
+++ b/__tests__/bundle/no-self-referenced-components/parameters/PetId.yaml
@@ -1,0 +1,4 @@
+name: petId
+in: path
+schema:
+  type: string

--- a/__tests__/bundle/no-self-referenced-components/parameters/_index.yaml
+++ b/__tests__/bundle/no-self-referenced-components/parameters/_index.yaml
@@ -1,0 +1,2 @@
+PetId:
+  $ref: './PetId.yaml'

--- a/__tests__/bundle/no-self-referenced-components/paths/Pet.yaml
+++ b/__tests__/bundle/no-self-referenced-components/paths/Pet.yaml
@@ -1,0 +1,9 @@
+get:
+  parameters:
+    - $ref: '../parameters/PetId.yaml'
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Pet.yaml'

--- a/__tests__/bundle/no-self-referenced-components/schemas/Pet.yaml
+++ b/__tests__/bundle/no-self-referenced-components/schemas/Pet.yaml
@@ -1,0 +1,1 @@
+type: object

--- a/__tests__/bundle/no-self-referenced-components/schemas/_index.yaml
+++ b/__tests__/bundle/no-self-referenced-components/schemas/_index.yaml
@@ -1,0 +1,2 @@
+Pet:
+  $ref: './Pet.yaml'

--- a/__tests__/bundle/no-self-referenced-components/snapshot.js
+++ b/__tests__/bundle/no-self-referenced-components/snapshot.js
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle no-self-referenced-components 1`] = `
+openapi: 3.0.3
+paths:
+  /pets/{petId}:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/PetId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+  parameters:
+    PetId:
+      name: petId
+      in: path
+      schema:
+        type: string
+
+bundling ./openapi.yaml...
+📦 Created a bundle for ./openapi.yaml at stdout <test>ms.
+
+`;

--- a/__tests__/bundle/no-self-referenced-or-duplicated-components/.redocly.yaml
+++ b/__tests__/bundle/no-self-referenced-or-duplicated-components/.redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./openapi.yaml

--- a/__tests__/bundle/no-self-referenced-or-duplicated-components/components/schemas.yaml
+++ b/__tests__/bundle/no-self-referenced-or-duplicated-components/components/schemas.yaml
@@ -1,0 +1,3 @@
+schemas:
+  myObject:
+    $ref: ../folder/myObject.v2.schema.yaml

--- a/__tests__/bundle/no-self-referenced-or-duplicated-components/folder/myObject.v2.schema.yaml
+++ b/__tests__/bundle/no-self-referenced-or-duplicated-components/folder/myObject.v2.schema.yaml
@@ -1,0 +1,1 @@
+type: object

--- a/__tests__/bundle/no-self-referenced-or-duplicated-components/openapi.yaml
+++ b/__tests__/bundle/no-self-referenced-or-duplicated-components/openapi.yaml
@@ -1,0 +1,3 @@
+openapi: 3.0.3
+components:
+  $ref: ./components/schemas.yaml

--- a/__tests__/bundle/no-self-referenced-or-duplicated-components/snapshot.js
+++ b/__tests__/bundle/no-self-referenced-or-duplicated-components/snapshot.js
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle no-self-referenced-or-duplicated-components 1`] = `
+openapi: 3.0.3
+components:
+  schemas:
+    myObject.v2.schema:
+      type: object
+
+bundling ./openapi.yaml...
+📦 Created a bundle for ./openapi.yaml at stdout <test>ms.
+
+`;

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -223,6 +223,7 @@ function makeBundleVisitor(
   keepUrlRefs: boolean
 ) {
   let components: Record<string, Record<string, any>>;
+  let rootLocation: Location;
 
   const visitor: Oas3Visitor | Oas2Visitor = {
     ref: {
@@ -264,7 +265,8 @@ function makeBundleVisitor(
       },
     },
     Root: {
-      enter(root: any) {
+      enter(root: any, ctx: any) {
+        rootLocation = ctx.location;
         if (version === OasMajorVersion.Version3) {
           components = root.components = root.components || {};
         } else if (version === OasMajorVersion.Version2) {
@@ -342,7 +344,7 @@ function makeBundleVisitor(
   ) {
     if (
       isRef(node) &&
-      ctx.resolve(node).location?.absolutePointer === target.location.absolutePointer
+      ctx.resolve(node, rootLocation.absolutePointer).location?.absolutePointer === target.location.absolutePointer
     ) {
       return true;
     }

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -344,7 +344,8 @@ function makeBundleVisitor(
   ) {
     if (
       isRef(node) &&
-      ctx.resolve(node, rootLocation.absolutePointer).location?.absolutePointer === target.location.absolutePointer
+      ctx.resolve(node, rootLocation.absolutePointer).location?.absolutePointer ===
+        target.location.absolutePointer
     ) {
       return true;
     }


### PR DESCRIPTION
## What/Why/How?

We were incorrectly resolving the components pointer. It should get resolved from the root, instead we were resolving from the current node location which breaks if the file is in the folder.

## Reference

Fixes #658, fixes #290

## Testing

Tests needed.

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
