### PR TITLE
fix: avoid different result depending on option arguments position

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ const version = require('../package.json').version;
 yargs
   .version('version', 'Show version number.', version)
   .help('help', 'Show help.')
+  .parserConfiguration({ 'greedy-arrays': false })
   .command(
     'stats [api]',
     'Gathering statistics for a document.',


### PR DESCRIPTION
## What/Why/How?

Changes greedy arrays option to false in **yargs**.
This eliminates dependency on position of arguments, e.g. those commands will produce the same result: 

```bash
redocly lint --skip-rule=operation-4xx-response openapi.yaml

redocly lint openapi.yaml --skip-rule=operation-4xx-response
```

To pass an array of values you will have to explicitly point to the option, e.g.: 

```bash 
redocly lint --skip-rule=operation-4xx-response --skip-rule=operation-2xx-response openapi.yaml
```

The change affects **ALL** options behaviour: `--skip-rule`, `--skip-decorator`, `--skip-preprocessor`, `--extends` and `--files`.

Additional motivation is that **yargs** is going to make this behaviour default in next versions ([link](https://github.com/yargs/yargs-parser/blob/main/README.md#greedy-arrays)).

## Reference

Closes https://github.com/Redocly/redocly-cli/issues/1063

Related docs: [link](https://github.com/Redocly/redocly-cli/pull/1084)

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
