### PR TITLE
Add MLC for link checking

### DIFF
--- a/.github/workflows/mlc-link-check.yaml
+++ b/.github/workflows/mlc-link-check.yaml
@@ -1,0 +1,17 @@
+name: Check links
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Markup Link Checker (mlc)
+        uses: becheran/mlc@v0.16.1
+        with:
+          args: ./docs

--- a/.mlc.toml
+++ b/.mlc.toml
@@ -1,4 +1,7 @@
-# List of links which will be ignored
-ignore-links=["../*"]
+# Ignore these links, we can't check them from this subproject
+ignore-links=["../../*", "/docs/*",
+	# skip this, it redirects to user login
+	"https://github.com/Redocly/redocly-cli/issues/*"
+]
 # Path to the root folder used to resolve all relative paths
 root-dir="./docs"

--- a/.mlc.toml
+++ b/.mlc.toml
@@ -1,0 +1,4 @@
+# List of links which will be ignored
+ignore-links=["../*"]
+# Path to the root folder used to resolve all relative paths
+root-dir="./docs"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -373,7 +373,7 @@ and later in the official project GitHub repository.
 The change also affects the CLI commands. The legacy name `openapi` will remain supported for a while, but we strongly recommend you use the new name `redocly`.
 (To illustrate, if you previously used `openapi lint`, now you should use `redocly lint`).
 
-If you encounter any issues and suspect they may be related to this change, let us know by [reporting an issue](https://github.com/Redocly/openapi-cli/issues).
+If you encounter any issues and suspect they may be related to this change, let us know by [reporting an issue](https://github.com/Redocly/redocly-cli/issues).
 
 :::
 

--- a/docs/commands/build-docs.md
+++ b/docs/commands/build-docs.md
@@ -26,7 +26,7 @@ api | string | Path to the API definition filename or alias that you want to gen
 --cdn | boolean | Uses the CDN pointing to the latest version of Redoc. If not enabled, the Redoc version is selected from Redocly CLI's associated dependency (and to update Redoc requires updating the CLI and building the docs again). The default value is `false`.
 --template, -t | string | Uses custom [Handlebars](https://handlebarsjs.com/) templates to render your OpenAPI definition.
 --templateOptions | string | Adds template options you want to pass to your custom Handlebars template. To add options, use dot notation.
---theme.openapi | string | Customizes your output using [Redoc functionality options](https://redocly.com/docs/api-reference-docs/configuration/functionality) or [Redoc theming options](https://redocly.com/docs/api-reference-docs/configuration/theming).
+--theme.openapi | string | Customizes your output using [Redoc functionality options](https://redocly.com/docs/api-reference-docs/configuration/functionality/) or [Redoc theming options](https://redocly.com/docs/api-reference-docs/configuration/theming/).
 --config | string | Specifies path to the [configuration file](#custom-configuration-file).
 --help | boolean | Shows help.
 --version | boolean | Shows version number.

--- a/docs/commands/preview-docs.md
+++ b/docs/commands/preview-docs.md
@@ -4,7 +4,7 @@
 
 With this command, you can generate documentation previews for API definitions on your local machine.
 
-If you have a license key or API key, you will get a preview of the premium [Redocly API reference docs](https://redocly.com/reference-docs). If you don't, you will get a preview of [Redoc community edition](https://redocly.com/redoc).
+If you have a license key or API key, you will get a preview of the premium [Redocly API reference docs](https://redocly.com/reference/). If you don't, you will get a preview of [Redoc community edition](https://redocly.com/redoc/).
 
 :::success Tip
 To preview docs using the premium Redocly API reference docs, you must first authenticate to the API registry with the [`login`](./login.md) command.

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -62,8 +62,8 @@ To authenticate to the API registry, you can use several approaches:
   Treat the API keys as secrets and work with them accordingly. Consult the documentation for your CI system to learn more about handling secrets:
 
   - [Travis CI documentation](https://docs.travis-ci.com/user/environment-variables/)
-  - [CircleCI documentation](https://circleci.com/docs/2.0/env-vars/)
-  - [GitHub Actions documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)
+  - [CircleCI documentation](https://circleci.com/docs/env-vars/)
+  - [GitHub Actions documentation](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
   - [Jenkins documentation](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials)
 
 ## Usage

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ Running `redocly --version` will confirm that the installation was successful, a
 
 ## Use `npx` at runtime
 
-[npx](https://docs.npmjs.com/cli/v9/commands/npx) is npm's package runner. It will install and run a command without installing it globally. You might use this where you can't install a new command, or in a CI context where the command is only used a handful of times.
+[npx](https://docs.npmjs.com/cli/v9/commands/npx/) is npm's package runner. It will install and run a command without installing it globally. You might use this where you can't install a new command, or in a CI context where the command is only used a handful of times.
 
 ```shell Command
 npx @redocly/cli <command> [options]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ There's also an [openapi-starter](https://github.com/Redocly/openapi-starter) re
 
 ### Preview API documentation
 
-Redocly CLI has support for showing a preview of [Redoc](https://redocly.com/redoc) rendering your API docs, which updates when the API description updates. 
+Redocly CLI has support for showing a preview of [Redoc](https://redocly.com/redoc/) rendering your API docs, which updates when the API description updates.
 Run the command:
 
 ```bash


### PR DESCRIPTION
Ignores relative links since we can only check those from the main
website project.

## What/Why/How?

It's difficult to know when we're breaking links in our docs - this will automatically check on each pull request

## Reference

Uses MLC (https://github.com/becheran/mlc)

And its GitHub action (https://github.com/marketplace/actions/markup-link-checker-mlc)

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
