### PR TITLE
fix: handle syntax errors from plugins

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -16,7 +16,6 @@ import {
   isAbsoluteUrl,
   ResolveError,
   YamlParseError,
-  Oas3Definition,
 } from '@redocly/openapi-core';
 import { blue, red, yellow } from 'colorette';
 import { existsSync } from 'fs';
@@ -395,6 +394,20 @@ describe('handleErrors', () => {
     expect(process.stderr.write).toHaveBeenCalledWith(
       `Detected circular reference which can't be converted to JSON.\n` +
         `Try to use ${blue('yaml')} output or remove ${blue('--dereferenced')}.\n\n`
+    );
+  });
+
+  it('should handle SyntaxError', () => {
+    const testError = new SyntaxError('Unexpected identifier');
+    testError.stack = 'test stack';
+    try {
+      handleError(testError);
+    } catch (e) {
+      expect(e).toEqual(testError);
+    }
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Syntax error: Unexpected identifier test stack\n'
     );
   });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -225,7 +225,7 @@ export function pluralize(label: string, num: number) {
   return num === 1 ? `${label}` : `${label}s`;
 }
 
-export function handleError(e: Error, ref: string) {
+export function handleError(e: Error, ref?: string) {
   switch (e.constructor) {
     case ResolveError:
       return exitWithError(`Failed to resolve api definition at ${ref}:\n\n  - ${e.message}.`);
@@ -239,9 +239,14 @@ export function handleError(e: Error, ref: string) {
       );
       return process.exit(1);
     }
+    case SyntaxError:
+      process.stderr.write(red(`Syntax error: ${e.message} ${e.stack?.split('\n\n')?.[0]}\n`));
+      return process.exit(1);
     default: {
-      process.stderr.write(`Something went wrong when processing ${ref}:\n\n  - ${e.message}.\n\n`);
-      process.exitCode = 1;
+      process.stderr.write(
+        red(`Something went wrong when processing ${ref}:\n\n  - ${e.message}.\n\n`)
+      );
+      process.exit(1);
       throw e;
     }
   }
@@ -392,7 +397,7 @@ export async function loadConfigAndHandleErrors(
   try {
     return await loadConfig(options);
   } catch (e) {
-    exitWithError(e.message);
+    handleError(e);
     return new Config({ apis: {}, styleguide: {} });
   }
 }

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -89,6 +89,9 @@ export function resolvePlugins(
             __non_webpack_require__(absoltePluginPath)
           : require(absoltePluginPath);
       } catch (e) {
+        if (e instanceof SyntaxError) {
+          throw e;
+        }
         throw new Error(`Failed to load plugin "${plugin}". Please provide a valid path`);
       }
     }


### PR DESCRIPTION
## What/Why/How?

Handle syntax errors from custom plugins

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/1091

## Testing

## Screenshots (optional)
![Знімок екрана 2023-05-25 о 11 25 20](https://github.com/Redocly/redocly-cli/assets/106662428/1bf647cb-7bed-480d-888e-67551b395fad)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
