### PR TITLE
fix: apply regular expression only to fixed fields under components

### DIFF
--- a/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
@@ -1,4 +1,4 @@
-import { makeConfig, parseYamlToDocument, replaceSourceWithRef } from '../../../../__tests__/utils';
+import { makeConfig, parseYamlToDocument } from '../../../../__tests__/utils';
 import { outdent } from 'outdent';
 import { lintDocument } from '../../../lint';
 import { BaseResolver } from '../../../resolve';

--- a/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
@@ -215,7 +215,7 @@ describe('Oas3 spec-components-invalid-map-name', () => {
     expect(results).toMatchInlineSnapshot(`Array []`);
   });
 
-  it('should does not report about invalid keys inside nested examples', async () => {
+  it('should not report invalid keys inside nested examples', async () => {
     const document = parseYamlToDocument(outdent`
       openapi: 3.0.0
       info:

--- a/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
@@ -215,7 +215,7 @@ describe('Oas3 spec-components-invalid-map-name', () => {
     expect(results).toMatchInlineSnapshot(`Array []`);
   });
 
-  it('should report about invalid keys inside nested examples', async () => {
+  it('should does not report about invalid keys inside nested examples', async () => {
     const document = parseYamlToDocument(outdent`
       openapi: 3.0.0
       info:
@@ -266,95 +266,6 @@ describe('Oas3 spec-components-invalid-map-name', () => {
             },
           ],
           "message": "The map key in parameters \\"my Param\\" does not match the regular expression \\"^[a-zA-Z0-9\\\\.\\\\-_]+$\\"",
-          "ruleId": "spec-components-invalid-map-name",
-          "severity": "error",
-          "suggest": Array [],
-        },
-        Object {
-          "location": Array [
-            Object {
-              "pointer": "#/components/parameters/my Param/examples/invalid identifier",
-              "reportOnKey": true,
-              "source": Source {
-                "absoluteRef": "",
-                "body": "openapi: 3.0.0
-      info:
-        version: 3.0.0
-      components:
-        parameters:
-          my Param:
-            name: param
-            description: param
-            in: path
-            examples:
-              invalid identifier:
-                description: 'Some description'
-                value: 21 ",
-                "mimeType": undefined,
-              },
-            },
-          ],
-          "message": "The map key in examples \\"invalid identifier\\" does not match the regular expression \\"^[a-zA-Z0-9\\\\.\\\\-_]+$\\"",
-          "ruleId": "spec-components-invalid-map-name",
-          "severity": "error",
-          "suggest": Array [],
-        },
-      ]
-    `);
-  });
-
-  it('should report about invalid key only inside components', async () => {
-    const document = parseYamlToDocument(outdent`
-      openapi: 3.0.0
-      info:
-        version: 3.0.0
-      paths:
-        /bikes:
-          get:
-            tags:
-              - Bikes
-            summary: List bikes
-            description: List all bikes
-            operationId: getBike
-            parameters:
-              my-param:
-                name: param
-                description: param
-                in: path
-                examples:
-                  valid identifier:
-                    description: 'Some description'
-                    value: 21   
-      components:
-        parameters:
-          my-param:
-            name: param
-            description: param
-            in: path
-            examples:
-              invalid identifier:
-                description: 'Some description'
-                value: 21 
-		`);
-    const results = await lintDocument({
-      externalRefResolver: new BaseResolver(),
-      document,
-      config: await makeConfig({
-        'spec-components-invalid-map-name': 'error',
-      }),
-    });
-
-    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "location": Array [
-            Object {
-              "pointer": "#/components/parameters/my-param/examples/invalid identifier",
-              "reportOnKey": true,
-              "source": "",
-            },
-          ],
-          "message": "The map key in examples \\"invalid identifier\\" does not match the regular expression \\"^[a-zA-Z0-9\\\\.\\\\-_]+$\\"",
           "ruleId": "spec-components-invalid-map-name",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec-components-invalid-map-name.test.ts
@@ -227,7 +227,7 @@ describe('Oas3 spec-components-invalid-map-name', () => {
             description: param
             in: path
             examples:
-              invalid identifier:
+              valid identifier:
                 description: 'Some description'
                 value: 21 
 		`);
@@ -258,7 +258,7 @@ describe('Oas3 spec-components-invalid-map-name', () => {
             description: param
             in: path
             examples:
-              invalid identifier:
+              valid identifier:
                 description: 'Some description'
                 value: 21 ",
                 "mimeType": undefined,

--- a/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
+++ b/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
@@ -35,6 +35,11 @@ export const SpecComponentsInvalidMapName: Oas3Rule = () => {
         validateKey(key, report, location, 'responses');
       },
     },
+    NamedExamples: {
+      Example(_node, { key, report, location }: UserContext) {
+        validateKey(key, report, location, 'examples');
+      },
+    },
     NamedRequestBodies: {
       RequestBody(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'requestBodies');
@@ -58,11 +63,6 @@ export const SpecComponentsInvalidMapName: Oas3Rule = () => {
     NamedCallbacks: {
       Callback(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'callbacks');
-      },
-    },
-    Components: {
-      Example(_node, { key, report, location }: UserContext) {
-        validateKey(key, report, location, 'examples');
       },
     },
   };

--- a/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
+++ b/packages/core/src/rules/oas3/spec-components-invalid-map-name.ts
@@ -35,11 +35,6 @@ export const SpecComponentsInvalidMapName: Oas3Rule = () => {
         validateKey(key, report, location, 'responses');
       },
     },
-    NamedExamples: {
-      Example(_node, { key, report, location }: UserContext) {
-        validateKey(key, report, location, 'examples');
-      },
-    },
     NamedRequestBodies: {
       RequestBody(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'requestBodies');
@@ -65,7 +60,7 @@ export const SpecComponentsInvalidMapName: Oas3Rule = () => {
         validateKey(key, report, location, 'callbacks');
       },
     },
-    ExampleMap: {
+    Components: {
       Example(_node, { key, report, location }: UserContext) {
         validateKey(key, report, location, 'examples');
       },


### PR DESCRIPTION
## What/Why/How?

 Apply regular expression `^[a-zA-Z0-9\.\-_]+$` only to fixed fields under components

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/1104

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
