### PR TITLE
docs: add docs for spec-strict-refs rule

### DIFF
--- a/docs/rules/built-in-rules.md
+++ b/docs/rules/built-in-rules.md
@@ -22,6 +22,7 @@ Build [configurable rules](./configurable-rules.md) if the rule you need isn't l
 - [security-defined](./security-defined.md): Security rules must be defined, either globally or per-operation
 - [spec](./spec.md): Conform to the declared OpenAPI specification version
 - [spec-components-invalid-map-name](./spec-components-invalid-map-name.md): Use only alphanumeric and basic punctuation as key names in the components section
+- [spec-ref-validation](./spec-ref-validation.md) Restricts the usage of the `$ref` keyword.
 
 ### Info
 

--- a/docs/rules/built-in-rules.md
+++ b/docs/rules/built-in-rules.md
@@ -22,7 +22,7 @@ Build [configurable rules](./configurable-rules.md) if the rule you need isn't l
 - [security-defined](./security-defined.md): Security rules must be defined, either globally or per-operation
 - [spec](./spec.md): Conform to the declared OpenAPI specification version
 - [spec-components-invalid-map-name](./spec-components-invalid-map-name.md): Use only alphanumeric and basic punctuation as key names in the components section
-- [spec-ref-validation](./spec-ref-validation.md) Restricts the usage of the `$ref` keyword.
+- [spec-strict-refs](./spec-strict-refs.md) Restricts the usage of the `$ref` keyword.
 
 ### Info
 

--- a/docs/rules/spec-ref-validation.md
+++ b/docs/rules/spec-ref-validation.md
@@ -1,0 +1,99 @@
+# spec-rule-validation
+
+Restricts the usage of the `$ref` keyword.
+
+|OAS|Compatibility|
+|---|---|
+|2.0|✅|
+|3.0|✅|
+|3.1|✅|
+
+## API design principles
+
+This rule is for spec correctness.
+
+Allows to use the `$ref` keyword exclusively for references to elements that may be inside the component section
+
+List of elements with which the `$ref` can be used:
+
+- Schema
+- Response
+- Parameter
+- Example
+- RequestBody
+- Header
+- SecurityScheme
+- Link
+- Callback
+- PathItem
+
+## Configuration
+
+To configure the rule, add it to the `rules` object in your configuration file.
+Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
+
+```yaml
+rules:
+  spec-ref-validation: error
+```
+
+## Configuration
+
+
+|Option|Type|Description|
+|---|---|---|
+|severity|string|Possible values: `off`, `warn`, `error`. |
+
+An example configuration:
+
+```yaml
+rules:
+  spec-ref-validation: error
+```
+
+## Examples
+
+Given this configuration:
+
+```yaml
+rules:
+  spec-ref-validation: error
+```
+
+Example of **incorrect** use of `$ref`:
+
+```yaml Example
+responses:
+'200':
+  description: successful operation
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          $ref: './properties.yaml'
+          name:
+            type: string
+```
+
+Example of **correct** use of `$ref`:
+
+```yaml Example
+responses:
+'200':
+  description: successful operation
+  content:
+    application/json:
+      schema:
+        $ref: './properties.yaml'
+```
+
+## Related rules
+
+- [configurable rules](./configurable-rules.md)
+- [spec](./spec.md)
+
+## Resources
+
+- [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/common/spec-ref-validation.ts)
+- [Components docs](https://redocly.com/docs/openapi-visual-reference/reference/)

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -31,7 +31,7 @@ The following is a list of elements the `$ref` can be used with according to the
 
 ## Configuration
 
-To configure the rule, add it to the `rules` object in your configuration file.
+To configure the rule, add it to the `rules` object in your configuration file, and
 Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
 
 ```yaml

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -10,7 +10,7 @@ Checks that `$ref` is only used in the locations permitted by the OpenAPI specif
 
 ## API design principles
 
-This rule is for spec correctness.
+This rule ensures adherence to OpenAPI specification standards.
 
 Allows to use the `$ref` keyword exclusively for references to elements that may be inside the component section.
 

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -1,6 +1,6 @@
 # spec-strict-refs
 
-Check that `$ref` is only used in the locations permitted by the OpenAPI specification.
+Checks that `$ref` is only used in the locations permitted by the OpenAPI specification.
 
 | OAS | Compatibility |
 | --- | ------------- |
@@ -12,11 +12,11 @@ Check that `$ref` is only used in the locations permitted by the OpenAPI specifi
 
 This rule is for spec correctness.
 
-Allows to use the `$ref` keyword exclusively for references to elements that may be inside the component section
+Allows to use the `$ref` keyword exclusively for references to elements that may be inside the component section.
 
-It can be useful when other tools are integrated into the API workflow, that demand strict adherence to the specifications.
+It can be useful when other tools are integrated into the API workflow that demands strict adherence to the specifications.
 
-List of elements with which the `$ref` can be used:
+List of elements the `$ref` can be used with:
 
 - Schema
 - Response
@@ -65,28 +65,28 @@ Example of **incorrect** use of `$ref`:
 
 ```yaml Example
 responses:
-'200':
-  description: successful operation
-  content:
-    application/json:
-      schema:
-        type: object
-        properties:
-          $ref: './properties.yaml'
-          name:
-            type: string
+  '200':
+    description: successful operation
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            $ref: './properties.yaml'
+            name:
+              type: string
 ```
 
 Example of **correct** use of `$ref`:
 
 ```yaml Example
 responses:
-'200':
-  description: successful operation
-  content:
-    application/json:
-      schema:
-        $ref: './properties.yaml'
+  '200':
+    description: successful operation
+    content:
+      application/json:
+        schema:
+          $ref: './properties.yaml'
 ```
 
 ## Related rules

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -32,7 +32,7 @@ The following is a list of elements the `$ref` can be used with according to the
 ## Configuration
 
 To configure the rule, add it to the `rules` object in your configuration file, and
-Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
+set the desired [severity](/docs/cli/rules.md#severity-settings).
 
 ```yaml
 rules:

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -16,7 +16,7 @@ It limits  use of the `$ref` keyword to only references for elements that may be
 
 It can be useful when other tools are integrated into the API workflow that demands strict adherence to the specifications.
 
-List of elements the `$ref` can be used with:
+The following is a list of elements the `$ref` can be used with according to the OpenAPI specification:
 
 - Schema
 - Response

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -12,7 +12,7 @@ Checks that `$ref` is only used in the locations permitted by the OpenAPI specif
 
 This rule ensures adherence to OpenAPI specification standards.
 
-It limits  use of the `$ref` keyword to only references for elements that may be inside the component section.
+It limits use of the `$ref` keyword to only references for elements that may be inside the component section.
 
 This rule is useful when other tools are integrated into the API workflow that demand strict adherence to the specifications.
 
@@ -34,9 +34,9 @@ The following is a list of elements the `$ref` can be used with according to the
 To configure the rule, add it to the `rules` object in your configuration file, and
 set the desired [severity](/docs/cli/rules.md#severity-settings).
 
-| Option   | Type   | Description                              |
-| -------- | ------ | ---------------------------------------- |
-| severity | string | Possible values: `off`, `warn`, `error`. |
+| Option   | Type   | Description                                                                              |
+| -------- | ------ | ---------------------------------------------------------------------------------------- |
+| severity | string | Possible values: `off`, `warn`, `error`. Default `off` (in `recommended` configuration). |
 
 An example configuration:
 

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -1,18 +1,20 @@
 # spec-strict-refs
 
-Restricts the usage of the `$ref` keyword.
+Check that `$ref` is only used in the locations permitted by the OpenAPI specification.
 
-|OAS|Compatibility|
-|---|---|
-|2.0|✅|
-|3.0|✅|
-|3.1|✅|
+| OAS | Compatibility |
+| --- | ------------- |
+| 2.0 | ✅            |
+| 3.0 | ✅            |
+| 3.1 | ✅            |
 
 ## API design principles
 
 This rule is for spec correctness.
 
 Allows to use the `$ref` keyword exclusively for references to elements that may be inside the component section
+
+It can be useful when other tools are integrated into the API workflow, that demand strict adherence to the specifications.
 
 List of elements with which the `$ref` can be used:
 
@@ -39,10 +41,9 @@ rules:
 
 ## Configuration
 
-
-|Option|Type|Description|
-|---|---|---|
-|severity|string|Possible values: `off`, `warn`, `error`. |
+| Option   | Type   | Description                              |
+| -------- | ------ | ---------------------------------------- |
+| severity | string | Possible values: `off`, `warn`, `error`. |
 
 An example configuration:
 

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -14,7 +14,7 @@ This rule ensures adherence to OpenAPI specification standards.
 
 It limits  use of the `$ref` keyword to only references for elements that may be inside the component section.
 
-It can be useful when other tools are integrated into the API workflow that demands strict adherence to the specifications.
+This rule is useful when other tools are integrated into the API workflow that demand strict adherence to the specifications.
 
 The following is a list of elements the `$ref` can be used with according to the OpenAPI specification:
 

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -34,13 +34,6 @@ The following is a list of elements the `$ref` can be used with according to the
 To configure the rule, add it to the `rules` object in your configuration file, and
 set the desired [severity](/docs/cli/rules.md#severity-settings).
 
-```yaml
-rules:
-  spec-strict-refs: error
-```
-
-## Configuration
-
 | Option   | Type   | Description                              |
 | -------- | ------ | ---------------------------------------- |
 | severity | string | Possible values: `off`, `warn`, `error`. |

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -12,7 +12,7 @@ Checks that `$ref` is only used in the locations permitted by the OpenAPI specif
 
 This rule ensures adherence to OpenAPI specification standards.
 
-Allows to use the `$ref` keyword exclusively for references to elements that may be inside the component section.
+It limits  use of the `$ref` keyword to only references for elements that may be inside the component section.
 
 It can be useful when other tools are integrated into the API workflow that demands strict adherence to the specifications.
 

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -1,4 +1,4 @@
-# spec-rule-validation
+# spec-strict-refs
 
 Restricts the usage of the `$ref` keyword.
 
@@ -34,7 +34,7 @@ Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
 
 ```yaml
 rules:
-  spec-ref-validation: error
+  spec-strict-refs: error
 ```
 
 ## Configuration
@@ -48,7 +48,7 @@ An example configuration:
 
 ```yaml
 rules:
-  spec-ref-validation: error
+  spec-strict-refs: error
 ```
 
 ## Examples
@@ -57,7 +57,7 @@ Given this configuration:
 
 ```yaml
 rules:
-  spec-ref-validation: error
+  spec-strict-refs: error
 ```
 
 Example of **incorrect** use of `$ref`:
@@ -95,5 +95,5 @@ responses:
 
 ## Resources
 
-- [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/common/spec-ref-validation.ts)
+- [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/common/spec-strict-refs.ts)
 - [Components docs](https://redocly.com/docs/openapi-visual-reference/reference/)

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -54,7 +54,7 @@ rules:
 
 ## Examples
 
-Given this configuration:
+Given the following configuration:
 
 ```yaml
 rules:


### PR DESCRIPTION
## What/Why/How?

Add docs for spec-strict-refs rule

## Reference
https://github.com/Redocly/redocly-cli/pull/1112
## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
