### PR TITLE
feat: Remote plugins

### DIFF
--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -45,7 +45,7 @@ export const yamlSerializer = {
   },
 };
 
-export function makeConfigForRuleset(
+export async function makeConfigForRuleset(
   rules: Oas3RuleSet,
   plugin?: Partial<Plugin>,
   version: string = 'oas3'
@@ -55,7 +55,7 @@ export function makeConfigForRuleset(
   Object.keys(rules).forEach((name) => {
     rulesConf[`${ruleId}/${name}`] = 'error';
   });
-  const plugins = resolvePlugins([
+  const plugins = await resolvePlugins([
     {
       ...plugin,
       id: ruleId,

--- a/packages/core/src/__tests__/config/config-resolvers.test.ts
+++ b/packages/core/src/__tests__/config/config-resolvers.test.ts
@@ -1,0 +1,46 @@
+jest.mock('node-fetch');
+
+import fetch, {Response} from 'node-fetch';
+import { mocked } from 'ts-jest/utils';
+
+import { resolvePlugins } from '../../config';
+
+describe('config-resolvers', () => {
+  it('loads plugin from local file system', async () => {
+    const path = __dirname + '/../fixtures/redocly-plugin.js';
+
+    const plugins = await resolvePlugins([path]);
+
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].id).toEqual('getyourguide');
+    expect(plugins[0].rules).toBeDefined();
+    expect(plugins[0].rules?.oas3).toBeDefined();
+  });
+
+  it('loads plugin from remote url', async () => {
+    mocked(fetch).mockReturnValue(Promise.resolve({ text: () => Promise.resolve(`
+const UniqueSchemaName = function UniqueSchemaName() {
+    return {};
+};
+const id = 'getyourguide';
+
+const rules = {
+    oas3: {
+        'unique-schema-name': UniqueSchemaName,
+    },
+};
+
+module.exports = {
+    id,
+    rules,
+};
+    `)}) as Promise<Response>);
+
+    const plugins = await resolvePlugins(['https://example.com/getyourguide.js']);
+
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].id).toEqual('getyourguide');
+    expect(plugins[0].rules).toBeDefined();
+    expect(plugins[0].rules?.oas3).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/config/config-resolvers.test.ts
+++ b/packages/core/src/__tests__/config/config-resolvers.test.ts
@@ -1,6 +1,6 @@
 jest.mock('node-fetch');
 
-import fetch, {Response} from 'node-fetch';
+import fetch, { Response } from 'node-fetch';
 import { mocked } from 'ts-jest/utils';
 
 import { resolvePlugins } from '../../config';
@@ -18,7 +18,10 @@ describe('config-resolvers', () => {
   });
 
   it('loads plugin from remote url', async () => {
-    mocked(fetch).mockReturnValue(Promise.resolve({ text: () => Promise.resolve(`
+    mocked(fetch).mockReturnValue(
+      Promise.resolve({
+        text: () =>
+          Promise.resolve(`
 const UniqueSchemaName = function UniqueSchemaName() {
     return {};
 };
@@ -34,7 +37,9 @@ module.exports = {
     id,
     rules,
 };
-    `)}) as Promise<Response>);
+    `),
+      }) as Promise<Response>
+    );
 
     const plugins = await resolvePlugins(['https://example.com/getyourguide.js']);
 

--- a/packages/core/src/__tests__/fixtures/redocly-plugin.js
+++ b/packages/core/src/__tests__/fixtures/redocly-plugin.js
@@ -1,0 +1,15 @@
+const UniqueSchemaName = function UniqueSchemaName() {
+    return {};
+};
+const id = 'getyourguide';
+
+const rules = {
+    oas3: {
+        'unique-schema-name': UniqueSchemaName,
+    },
+};
+
+module.exports = {
+    id,
+    rules,
+};

--- a/packages/core/src/__tests__/fixtures/redocly-plugin.js
+++ b/packages/core/src/__tests__/fixtures/redocly-plugin.js
@@ -1,15 +1,15 @@
 const UniqueSchemaName = function UniqueSchemaName() {
-    return {};
+  return {};
 };
 const id = 'getyourguide';
 
 const rules = {
-    oas3: {
-        'unique-schema-name': UniqueSchemaName,
-    },
+  oas3: {
+    'unique-schema-name': UniqueSchemaName,
+  },
 };
 
 module.exports = {
-    id,
-    rules,
+  id,
+  rules,
 };

--- a/packages/core/src/__tests__/walk.test.ts
+++ b/packages/core/src/__tests__/walk.test.ts
@@ -53,7 +53,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(testRuleSet.test).toBeCalledTimes(1);
@@ -121,7 +121,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(testRuleSet.test).toBeCalledTimes(1);
@@ -184,7 +184,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -264,7 +264,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet, undefined, 'oas2'),
+      config: await makeConfigForRuleset(testRuleSet, undefined, 'oas2'),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -345,7 +345,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -417,7 +417,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -489,7 +489,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -556,7 +556,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -610,7 +610,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -666,7 +666,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -708,7 +708,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -763,7 +763,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -849,7 +849,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -928,7 +928,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -1000,7 +1000,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -1044,7 +1044,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -1109,7 +1109,7 @@ describe('walk order', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`
@@ -1197,7 +1197,7 @@ describe('context.report', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(results).toHaveLength(3);
@@ -1277,7 +1277,7 @@ describe('context.report', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(results).toHaveLength(4);
@@ -1385,7 +1385,7 @@ describe('context.resolve', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
   });
 });
@@ -1434,7 +1434,7 @@ describe('type extensions', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet, {
+      config: await makeConfigForRuleset(testRuleSet, {
         typeExtension: {
           oas3(types, version) {
             expect(version).toEqual(oas);
@@ -1528,7 +1528,7 @@ describe('ignoreNextRules', () => {
     await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfigForRuleset(testRuleSet),
+      config: await makeConfigForRuleset(testRuleSet),
     });
 
     expect(calls).toMatchInlineSnapshot(`

--- a/packages/core/src/benchmark/benches/lint-with-many-rules.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-many-rules.bench.ts
@@ -25,9 +25,9 @@ for (let i = 0; i < 50; i++) {
   };
 }
 
-const config = makeConfigForRuleset(ruleset);
-export function measureAsync() {
-  return lintDocument({
+export async function measureAsync() {
+  const config = await makeConfigForRuleset(ruleset);
+  return await lintDocument({
     externalRefResolver: new BaseResolver(),
     document: rebillyDocument,
     config,

--- a/packages/core/src/benchmark/benches/lint-with-nested-rule.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-nested-rule.bench.ts
@@ -29,9 +29,9 @@ const visitor = {
     };
   },
 };
-const config = makeConfigForRuleset(visitor);
-export function measureAsync() {
-  return lintDocument({
+export async function measureAsync() {
+  const config = await makeConfigForRuleset(visitor);
+  return await lintDocument({
     externalRefResolver: new BaseResolver(),
     document: rebillyDocument,
     config,

--- a/packages/core/src/benchmark/benches/lint-with-no-rules.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-no-rules.bench.ts
@@ -10,9 +10,9 @@ const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
   rebillyDefinitionRef
 );
-const config = makeConfigForRuleset({});
-export function measureAsync() {
-  return lintDocument({
+export async function measureAsync() {
+  const config = await makeConfigForRuleset({});
+  return await lintDocument({
     externalRefResolver: new BaseResolver(),
     document: rebillyDocument,
     config,

--- a/packages/core/src/benchmark/benches/lint-with-top-level-rule-report.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-top-level-rule-report.bench.ts
@@ -11,23 +11,22 @@ const rebillyDocument = parseYamlToDocument(
   readFileSync(rebillyDefinitionRef, 'utf-8'),
   rebillyDefinitionRef
 );
+export async function measureAsync() {
+  const config = await makeConfigForRuleset({
+    test: () => {
+      return {
+        Schema(schema, ctx) {
+          if (schema.type === 'number') {
+            ctx.report({
+              message: 'type number is not allowed',
+            });
+          }
+        },
+      };
+    },
+  });
 
-const config = makeConfigForRuleset({
-  test: () => {
-    return {
-      Schema(schema, ctx) {
-        if (schema.type === 'number') {
-          ctx.report({
-            message: 'type number is not allowed',
-          });
-        }
-      },
-    };
-  },
-});
-
-export function measureAsync() {
-  return lintDocument({
+  return await lintDocument({
     externalRefResolver: new BaseResolver(),
     document: rebillyDocument,
     config,

--- a/packages/core/src/benchmark/benches/lint-with-top-level-rule.bench.ts
+++ b/packages/core/src/benchmark/benches/lint-with-top-level-rule.bench.ts
@@ -11,20 +11,20 @@ const rebillyDocument = parseYamlToDocument(
   rebillyDefinitionRef
 );
 
-const config = makeConfigForRuleset({
-  test: () => {
-    let count = 0;
-    return {
-      Schema() {
-        count++;
-        if (count === -1) throw new Error('Disable optimization');
-      },
-    };
-  },
-});
+export async function measureAsync() {
+  const config = await makeConfigForRuleset({
+    test: () => {
+      let count = 0;
+      return {
+        Schema() {
+          count++;
+          if (count === -1) throw new Error('Disable optimization');
+        },
+      };
+    },
+  });
 
-export function measureAsync() {
-  return lintDocument({
+  return await lintDocument({
     externalRefResolver: new BaseResolver(),
     document: rebillyDocument,
     config,

--- a/packages/core/src/benchmark/utils.ts
+++ b/packages/core/src/benchmark/utils.ts
@@ -12,7 +12,7 @@ export function parseYamlToDocument(body: string, absoluteRef: string = ''): Doc
   };
 }
 
-export function makeConfigForRuleset(rules: Oas3RuleSet, plugin?: Partial<Plugin>) {
+export async function makeConfigForRuleset(rules: Oas3RuleSet, plugin?: Partial<Plugin>) {
   const rulesConf: Record<string, RuleConfig> = {};
   const ruleId = 'test';
   Object.keys(rules).forEach((name) => {

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -120,7 +120,7 @@ export async function lintConfig(opts: { document: Document; severity?: ProblemS
     oasVersion: OasVersion.Version3_0,
     visitorsData: {},
   };
-  const plugins = resolvePlugins([defaultPlugin]);
+  const plugins = await resolvePlugins([defaultPlugin]);
   const config = new StyleguideConfig({
     plugins,
     rules: { spec: 'error' },

--- a/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
@@ -5,11 +5,13 @@ import { StyleguideConfig, defaultPlugin, resolvePlugins, resolvePreset } from '
 
 import { BaseResolver } from '../../../../resolve';
 
-describe('Oas3 Structural visitor basic', async () => {
+async function buildConfig() {
   const plugins = await resolvePlugins([defaultPlugin]);
   const presets = resolvePreset('all', plugins);
-  const allConfig = new StyleguideConfig({ ...presets, plugins });
+  return new StyleguideConfig({ ...presets, plugins });
+}
 
+describe('Oas3 Structural visitor basic', () => {
   it('should report wrong types', async () => {
     const document = parseYamlToDocument(
       outdent`
@@ -42,7 +44,7 @@ describe('Oas3 Structural visitor basic', async () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: allConfig,
+      config: await buildConfig(),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
@@ -176,7 +178,7 @@ describe('Oas3 Structural visitor basic', async () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: allConfig,
+      config: await buildConfig(),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
@@ -247,7 +249,7 @@ describe('Oas3 Structural visitor basic', async () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: allConfig,
+      config: await buildConfig(),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`

--- a/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/spec/spec.test.ts
@@ -5,10 +5,11 @@ import { StyleguideConfig, defaultPlugin, resolvePlugins, resolvePreset } from '
 
 import { BaseResolver } from '../../../../resolve';
 
-const plugins = resolvePlugins([defaultPlugin]);
-const pressets = resolvePreset('all', plugins);
-const allConfig = new StyleguideConfig({ ...pressets, plugins });
-describe('Oas3 Structural visitor basic', () => {
+describe('Oas3 Structural visitor basic', async () => {
+  const plugins = await resolvePlugins([defaultPlugin]);
+  const presets = resolvePreset('all', plugins);
+  const allConfig = new StyleguideConfig({ ...presets, plugins });
+
   it('should report wrong types', async () => {
     const document = parseYamlToDocument(
       outdent`


### PR DESCRIPTION
## What/Why/How?
### What
Add support for remote plugins

### Why
Because they were not supported yet and that way one can use the same custom plugin in multiple places without copy paste. 😄 

### How
Using fetch to load the plugin and temporarily storing it locally.

In `.redocly.yaml` one can specify the plugin like this now:
```
plugins:
  - 'https://raw.githubusercontent.com/your-company/redocly-plugins/main/redocly-plugin.js'
```

### Limitations
No support for protected URLs.

## Reference

## Testing

Added 2 tests:
- Verify old behaviour (loading from local file) still works
- Verify new behaviour (loading from url) works by mocking node-fetch

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
