### PR TITLE
Docs: fix example of command to combine files

### DIFF
--- a/docs/file-management.md
+++ b/docs/file-management.md
@@ -52,7 +52,7 @@ When you have multiple APIs but want to publish a single definition file, the [`
 Use the command to combine files like this:
 
 ```
-redocly bundle api1.yaml api2.yaml -o apis-combined.yaml
+redocly join api1.yaml api2.yaml -o apis-combined.yaml
 ```
 
 Supply as many API descriptions as you need to; the first one is used for the `info` and other metadata, endpoints from the following files are then added to the OpenAPI description.


### PR DESCRIPTION
## What/Why/How?
The example command uses `bundle` in the documentation about combining OpenAPI files. I guess the correct one should be `join`.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
