### PR TITLE
fix: docker build-docs failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN mv -- "$(npm pack packages/cli/)" redocly-cli.tgz && \
 
 # npm pack in the previous RUN command does not include these assets
 RUN cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/default.hbs && \
-	  cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/hot.js
+	  cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/hot.js && \
+		cp packages/cli/src/commands/build-docs/template.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/build-docs/template.hbs
 
 # Clean up to reduce image size
 RUN npm cache clean --force && rm -rf /build


### PR DESCRIPTION
## What/Why/How?

The `build-docs` is currently crashing in Docker because it cannot find a template file.

## Reference


Fixes: https://github.com/Redocly/redocly-cli/issues/1041

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
