### PR TITLE
feat: update push command

### DIFF
--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -32,7 +32,7 @@ describe('push', () => {
         destination: '@org/my-api@1.0.0',
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 2,
       },
       ConfigFixture as any
@@ -54,7 +54,7 @@ describe('push', () => {
     });
   });
 
-  it('fails if batchId value is an empty string', async () => {
+  it('fails if jobId value is an empty string', async () => {
     await handlePush(
       {
         upsert: true,
@@ -62,7 +62,7 @@ describe('push', () => {
         destination: '@org/my-api@1.0.0',
         branchName: 'test',
         public: true,
-        'batch-id': ' ',
+        'job-id': ' ',
         'batch-size': 2,
       },
       ConfigFixture as any
@@ -79,7 +79,7 @@ describe('push', () => {
         destination: '@org/my-api@1.0.0',
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 1,
       },
       ConfigFixture as any
@@ -89,14 +89,9 @@ describe('push', () => {
   });
 
   it('push with --files', async () => {
-    // (loadConfigAndHandleErrors as jest.Mock).mockImplementation(({ files }) => {
-    //   return { ...ConfigFixture, files };
-    // });
-
     const mockConfig = { ...ConfigFixture, files: ['./resouces/1.md', './resouces/2.md'] } as any;
 
-    //@ts-ignore
-    fs.statSync.mockImplementation(() => {
+    (fs.statSync as jest.Mock).mockImplementation(() => {
       return { isDirectory: () => false, size: 10 };
     });
 
@@ -131,7 +126,7 @@ describe('push', () => {
         destination: 'test@v1',
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 2,
       },
       ConfigFixture as any
@@ -139,9 +134,7 @@ describe('push', () => {
 
     expect(exitWithError).toBeCalledTimes(1);
     expect(exitWithError).toBeCalledWith(
-      `No organization provided, please use the right format: ${yellow(
-        '<@organization-id/api-name@api-version>'
-      )} or specify the 'organization' field in the config file.`
+      `No organization provided, please use --organization option or specify the 'organization' field in the config file.`
     );
   });
 
@@ -154,7 +147,7 @@ describe('push', () => {
         destination: 'my-api@1.0.0',
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 2,
       },
       mockConfig
@@ -175,7 +168,7 @@ describe('push', () => {
     });
   });
 
-  it('push should work if destination not provided and api in config is provided', async () => {
+  it('push should work if destination not provided but api in config is provided', async () => {
     const mockConfig = {
       ...ConfigFixture,
       organization: 'test_org',
@@ -185,10 +178,9 @@ describe('push', () => {
     await handlePush(
       {
         upsert: true,
-        api: 'spec.json',
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 2,
       },
       mockConfig
@@ -197,7 +189,7 @@ describe('push', () => {
     expect(redoclyClient.registryApi.pushApi).toBeCalledTimes(1);
   });
 
-  it('push should fail if destination and apis not provided', async () => {
+  it('push should fail if apis not provided', async () => {
     const mockConfig = { organization: 'test_org', apis: {} } as any;
 
     await handlePush(
@@ -205,7 +197,7 @@ describe('push', () => {
         upsert: true,
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 2,
       },
       mockConfig
@@ -214,6 +206,49 @@ describe('push', () => {
     expect(exitWithError).toBeCalledTimes(1);
     expect(exitWithError).toHaveBeenLastCalledWith(
       'Api not found. Please make sure you have provided the correct data in the config file.'
+    );
+  });
+
+  it('push should fail if destination not provided', async () => {
+    const mockConfig = { organization: 'test_org', apis: {} } as any;
+
+    await handlePush(
+      {
+        upsert: true,
+        api: 'api.yaml',
+        branchName: 'test',
+        public: true,
+        'job-id': '123',
+        'batch-size': 2,
+      },
+      mockConfig
+    );
+
+    expect(exitWithError).toBeCalledTimes(1);
+    expect(exitWithError).toHaveBeenLastCalledWith(
+      'No destination provided, please use --destination option to provide destination.'
+    );
+  });
+
+  it('push should fail if destination format is not valid', async () => {
+    const mockConfig = { organization: 'test_org', apis: {} } as any;
+
+    await handlePush(
+      {
+        upsert: true,
+        destination: 'name/v1',
+        branchName: 'test',
+        public: true,
+        'job-id': '123',
+        'batch-size': 2,
+      },
+      mockConfig
+    );
+
+    expect(exitWithError).toHaveBeenCalledWith(
+      `Destination argument value is not valid, please use the right format: ${yellow(
+        '<api-name@api-version>'
+      )}`
     );
   });
 
@@ -232,7 +267,7 @@ describe('push', () => {
         destination: 'my test api@v1',
         branchName: 'test',
         public: true,
-        'batch-id': '123',
+        'job-id': '123',
         'batch-size': 2,
       },
       mockConfig
@@ -328,6 +363,29 @@ describe('transformPush', () => {
       {
         destination: '@testing_org/main@v1',
         api: 'alias',
+      },
+      {}
+    );
+  });
+  it('should use --job-id option firstly', () => {
+    const cb = jest.fn();
+    transformPush(cb)(
+      {
+        'batch-id': 'b-123',
+        'job-id': 'j-123',
+        maybeApiOrDestination: 'test',
+        maybeDestination: 'main@v1',
+        branch: 'test',
+        destination: 'main@v1',
+      },
+      {} as any
+    );
+    expect(cb).toBeCalledWith(
+      {
+        'job-id': 'j-123',
+        api: 'test',
+        branchName: 'test',
+        destination: 'main@v1',
       },
       {}
     );

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -350,21 +350,21 @@ describe('transformPush', () => {
       {}
     );
   });
-    it('should work for a api only', () => {
-        const cb = jest.fn();
-        transformPush(cb)(
-            {
-                maybeApiOrDestination: 'test.yaml',
-            },
-            {} as any
-        );
-        expect(cb).toBeCalledWith(
-            {
-                api: 'test.yaml',
-            },
-            {}
-        );
-    });
+  it('should work for a api only', () => {
+    const cb = jest.fn();
+    transformPush(cb)(
+      {
+        maybeApiOrDestination: 'test.yaml',
+      },
+      {} as any
+    );
+    expect(cb).toBeCalledWith(
+      {
+        api: 'test.yaml',
+      },
+      {}
+    );
+  });
   it('should accept aliases for the old syntax', () => {
     const cb = jest.fn();
     transformPush(cb)(

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -283,7 +283,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        maybeApiOrDestination: 'openapi.yaml',
+        api: 'openapi.yaml',
         maybeDestination: '@testing_org/main@v1',
       },
       {} as any
@@ -300,7 +300,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        maybeApiOrDestination: 'openapi.yaml',
+        api: 'openapi.yaml',
         maybeDestination: '@testing_org/main@v1',
         maybeBranchName: 'other',
       },
@@ -319,7 +319,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        maybeApiOrDestination: 'openapi.yaml',
+        api: 'openapi.yaml',
         maybeDestination: '@testing_org/main@v1',
         maybeBranchName: 'other',
         branch: 'priority-branch',
@@ -339,7 +339,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        maybeApiOrDestination: '@testing_org/main@v1',
+        api: '@testing_org/main@v1',
       },
       {} as any
     );
@@ -354,7 +354,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        maybeApiOrDestination: 'test.yaml',
+        api: 'test.yaml',
       },
       {} as any
     );
@@ -369,7 +369,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        maybeApiOrDestination: 'alias',
+        api: 'alias',
         maybeDestination: '@testing_org/main@v1',
       },
       {} as any
@@ -388,7 +388,7 @@ describe('transformPush', () => {
       {
         'batch-id': 'b-123',
         'job-id': 'j-123',
-        maybeApiOrDestination: 'test',
+        api: 'test',
         maybeDestination: 'main@v1',
         branch: 'test',
         destination: 'main@v1',

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -350,6 +350,21 @@ describe('transformPush', () => {
       {}
     );
   });
+    it('should work for a api only', () => {
+        const cb = jest.fn();
+        transformPush(cb)(
+            {
+                maybeApiOrDestination: 'test.yaml',
+            },
+            {} as any
+        );
+        expect(cb).toBeCalledWith(
+            {
+                api: 'test.yaml',
+            },
+            {}
+        );
+    });
   it('should accept aliases for the old syntax', () => {
     const cb = jest.fn();
     transformPush(cb)(

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -376,8 +376,7 @@ export const transformPush =
       );
     }
 
-    let api = maybeApiOrDestination,
-      destination;
+    let api, destination;
     if (maybeDestination) {
       process.stderr.write(
         yellow(
@@ -393,6 +392,8 @@ export const transformPush =
         )
       );
       destination = maybeApiOrDestination;
+    } else if (maybeApiOrDestination && !DESTINATION_REGEX.test(maybeApiOrDestination)) {
+      api = maybeApiOrDestination
     }
 
     destination = rest.destination || destination;

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -358,22 +358,21 @@ export const transformPush =
       );
     }
 
-    let api = maybeApiOrDestination;
-    let destination = maybeDestination;
-
+    let api, destination;
     if (maybeDestination) {
       process.stderr.write(
           yellow(
               'Deprecation warning: Do not use the second parameter as a destination. Please use a separate --destination and --organization instead.\n\n'
           )
       );
+      api = maybeApiOrDestination;
+      destination = maybeDestination;
     } else if (maybeApiOrDestination && DESTINATION_REGEX.test(maybeApiOrDestination)) {
       process.stderr.write(
           yellow(
               'Deprecation warning: Do not use the first parameter as a destination. Please use a separate --destination and --organization options instead.\n\n'
           )
       );
-      api = undefined;
       destination = maybeApiOrDestination;
     }
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -339,8 +339,7 @@ export function getDestinationProps(
   }
 }
 
-type BarePushArgs = Omit<PushOptions, 'api' | 'destination' | 'branchName'> & {
-  maybeApiOrDestination?: string;
+type BarePushArgs = Omit<PushOptions, 'destination' | 'branchName'> & {
   maybeDestination?: string;
   maybeBranchName?: string;
   branch?: string;
@@ -351,7 +350,7 @@ export const transformPush =
   (callback: typeof handlePush) =>
   (
     {
-      maybeApiOrDestination,
+      api: maybeApiOrDestination,
       maybeDestination,
       maybeBranchName,
       branch,
@@ -377,14 +376,14 @@ export const transformPush =
       );
     }
 
-    let api, destination;
+    let apiFile, destination;
     if (maybeDestination) {
       process.stderr.write(
         yellow(
           'Deprecation warning: Do not use the second parameter as a destination. Please use a separate --destination and --organization instead.\n\n'
         )
       );
-      api = maybeApiOrDestination;
+      apiFile = maybeApiOrDestination;
       destination = maybeDestination;
     } else if (maybeApiOrDestination && DESTINATION_REGEX.test(maybeApiOrDestination)) {
       process.stderr.write(
@@ -394,7 +393,7 @@ export const transformPush =
       );
       destination = maybeApiOrDestination;
     } else if (maybeApiOrDestination && !DESTINATION_REGEX.test(maybeApiOrDestination)) {
-      api = maybeApiOrDestination;
+      apiFile = maybeApiOrDestination;
     }
 
     destination = rest.destination || destination;
@@ -403,7 +402,7 @@ export const transformPush =
       {
         ...rest,
         destination,
-        api,
+        api: apiFile,
         branchName: branch ?? maybeBranchName,
         'job-id': jobId || batchId,
       },

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -87,6 +87,7 @@ export async function handlePush(argv: PushOptions, config: Config): Promise<voi
     );
   }
 
+  // Ensure that a destination for the api is provided.
   if (!name && api) {
     return exitWithError(
       `No destination provided, please use --destination option to provide destination.`
@@ -393,7 +394,7 @@ export const transformPush =
       );
       destination = maybeApiOrDestination;
     } else if (maybeApiOrDestination && !DESTINATION_REGEX.test(maybeApiOrDestination)) {
-      api = maybeApiOrDestination
+      api = maybeApiOrDestination;
     }
 
     destination = rest.destination || destination;

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -87,7 +87,7 @@ export async function handlePush(argv: PushOptions, config: Config): Promise<voi
     );
   }
 
-  if ((!name || !version) && api) {
+  if (!name && api) {
     return exitWithError(
       `No destination provided, please use --destination option to provide destination.`
     );
@@ -187,12 +187,13 @@ export async function handlePush(argv: PushOptions, config: Config): Promise<voi
       }
 
       if (error.message === 'API_VERSION_NOT_FOUND') {
-        exitWithError(`The definition version ${blue(name)}/${blue(
-          version
-        )} does not exist in organization ${blue(organizationId)}!\n${yellow(
-          'Suggestion:'
-        )} please use ${blue('-u')} or ${blue('--upsert')} to create definition.
-        `);
+        exitWithError(
+          `The definition version ${blue(
+            `${name}@${version}`
+          )} does not exist in organization ${blue(organizationId)}!\n${yellow(
+            'Suggestion:'
+          )} please use ${blue('-u')} or ${blue('--upsert')} to create definition.\n\n`
+        );
       }
 
       throw error;
@@ -375,7 +376,8 @@ export const transformPush =
       );
     }
 
-    let api, destination;
+    let api = maybeApiOrDestination,
+      destination;
     if (maybeDestination) {
       process.stderr.write(
         yellow(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -126,14 +126,17 @@ yargs
       commandWrapper(handleJoin)(argv);
     }
   )
+
   .command(
-    'push [maybeApiOrDestination] [maybeDestination] [maybeBranchName]',
+    'push [api] [maybeDestination] [maybeBranchName])',
     'Push an API definition to the Redocly API registry.',
     (yargs) =>
       yargs
-        .positional('maybeApiOrDestination', { type: 'string' })
+        .usage('push [api]')
+        .positional('api', { type: 'string' })
         .positional('maybeDestination', { type: 'string' })
-        .positional('maybeBranchName', { type: 'string' })
+        .hide('maybeDestination')
+        .hide('maybeBranchName')
         .option({
           organization: { type: 'string', alias: 'o' },
           destination: { type: 'string', alias: 'd' },
@@ -145,6 +148,7 @@ yargs
             type: 'string',
             requiresArg: true,
             deprecated: true,
+            hidden: true,
           },
           'job-id': {
             description:
@@ -174,6 +178,7 @@ yargs
           },
         })
         .deprecateOption('batch-id', 'use --job-id')
+        .deprecateOption('maybeDestination')
         .implies('job-id', 'batch-size')
         .implies('batch-id', 'batch-size')
         .implies('batch-size', 'job-id'),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -139,6 +139,12 @@ yargs
           destination: { type: 'string', alias: 'd' },
           branch: { type: 'string', alias: 'b' },
           upsert: { type: 'boolean', alias: 'u' },
+          'batch-id': {
+            description:
+              'Specifies the ID of the CI job that the current push will be associated with. (Deprecated)',
+            type: 'string',
+            requiresArg: true,
+          },
           'job-id': {
             description:
               'Specifies the ID of the CI job that the current push will be associated with.',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -172,11 +172,12 @@ yargs
             array: true,
             type: 'string',
           },
-          config: {
-            description: 'Specify path to the config file.',
-            requiresArg: true,
-            type: 'string',
-          },
+          // TODO: fix resolving links in config
+          // config: {
+          //   description: 'Specify path to the config file.',
+          //   requiresArg: true,
+          //   type: 'string',
+          // },
         })
         .deprecateOption('batch-id', 'use --job-id')
         .implies('job-id', 'batch-size')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -138,10 +138,30 @@ yargs
         .hide('maybeDestination')
         .hide('maybeBranchName')
         .option({
-          organization: { type: 'string', alias: 'o' },
-          destination: { type: 'string', alias: 'd' },
-          branch: { type: 'string', alias: 'b' },
-          upsert: { type: 'boolean', alias: 'u' },
+          organization: {
+            description:
+              'Name of the organization to push to.',
+            type: 'string',
+            alias: 'o'
+          },
+          destination: {
+            description:
+              'API name and version in the format `name@version`.',
+            type: 'string',
+            alias: 'd'
+          },
+          branch: {
+            description:
+              'Branch name to push to.',
+            type: 'string',
+            alias: 'b'
+          },
+          upsert: { 
+            description:
+              'Create the specified API version if it doesn\'t exist, update if it does exist.',
+            type: 'boolean', 
+            alias: 'u'
+          },
           'batch-id': {
             description:
               'Specifies the ID of the CI job that the current push will be associated with.',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -172,12 +172,6 @@ yargs
             array: true,
             type: 'string',
           },
-          // TODO: fix resolving links in config
-          // config: {
-          //   description: 'Specify path to the config file.',
-          //   requiresArg: true,
-          //   type: 'string',
-          // },
         })
         .deprecateOption('batch-id', 'use --job-id')
         .implies('job-id', 'batch-size')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -139,28 +139,25 @@ yargs
         .hide('maybeBranchName')
         .option({
           organization: {
-            description:
-              'Name of the organization to push to.',
+            description: 'Name of the organization to push to.',
             type: 'string',
-            alias: 'o'
+            alias: 'o',
           },
           destination: {
-            description:
-              'API name and version in the format `name@version`.',
+            description: 'API name and version in the format `name@version`.',
             type: 'string',
-            alias: 'd'
+            alias: 'd',
           },
           branch: {
-            description:
-              'Branch name to push to.',
+            description: 'Branch name to push to.',
             type: 'string',
-            alias: 'b'
+            alias: 'b',
           },
-          upsert: { 
+          upsert: {
             description:
-              'Create the specified API version if it doesn\'t exist, update if it does exist.',
-            type: 'boolean', 
-            alias: 'u'
+              "Create the specified API version if it doesn't exist, update if it does exist.",
+            type: 'boolean',
+            alias: 'u',
           },
           'batch-id': {
             description:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -135,9 +135,11 @@ yargs
         .positional('maybeDestination', { type: 'string' })
         .positional('maybeBranchName', { type: 'string' })
         .option({
+          organization: { type: 'string', alias: 'o' },
+          destination: { type: 'string', alias: 'd' },
           branch: { type: 'string', alias: 'b' },
           upsert: { type: 'boolean', alias: 'u' },
-          'batch-id': {
+          'job-id': {
             description:
               'Specifies the ID of the CI job that the current push will be associated with.',
             type: 'string',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,7 +127,7 @@ yargs
     }
   )
   .command(
-    'push [api]',
+    'push [maybeApiOrDestination] [maybeDestination] [maybeBranchName]',
     'Push an API definition to the Redocly API registry.',
     (yargs) =>
       yargs

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -128,7 +128,7 @@ yargs
   )
 
   .command(
-    'push [api] [maybeDestination] [maybeBranchName])',
+    'push [api] [maybeDestination] [maybeBranchName]',
     'Push an API definition to the Redocly API registry.',
     (yargs) =>
       yargs

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,7 +127,7 @@ yargs
     }
   )
   .command(
-    'push [maybeApiOrDestination] [maybeDestination] [maybeBranchName]',
+    'push [api]',
     'Push an API definition to the Redocly API registry.',
     (yargs) =>
       yargs
@@ -141,9 +141,10 @@ yargs
           upsert: { type: 'boolean', alias: 'u' },
           'batch-id': {
             description:
-              'Specifies the ID of the CI job that the current push will be associated with. (Deprecated)',
+              'Specifies the ID of the CI job that the current push will be associated with.',
             type: 'string',
             requiresArg: true,
+            deprecated: true,
           },
           'job-id': {
             description:
@@ -177,8 +178,10 @@ yargs
             type: 'string',
           },
         })
+        .deprecateOption('batch-id', 'use --job-id')
+        .implies('job-id', 'batch-size')
         .implies('batch-id', 'batch-size')
-        .implies('batch-size', 'batch-id'),
+        .implies('batch-size', 'job-id'),
     (argv) => {
       process.env.REDOCLY_CLI_COMMAND = 'push';
       commandWrapper(transformPush(handlePush))(argv);


### PR DESCRIPTION
## What/Why/How?

- Add new options `--organization` and `--destination`.
- Mark `maybeApiOrDestination` and `maybeDestination` as deprecated
- Rename `job-id` option and mark `batch-id` as deprecated

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/1032

## Testing

## Screenshots (optional)
<img width="678" alt="Знімок екрана 2023-06-26 о 17 18 49" src="https://github.com/Redocly/redocly-cli/assets/106662428/fa8788ef-b1f4-47dc-bb11-16b19a307d65">

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
