### PR TITLE
chore: v1.0.0-beta.129

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,9 +18,9 @@ toc:
 
 ### Changes
 
-- Changed the `push` command interface.
+- Streamlined the `push` command interface. The previous syntax also continues to work.
 - Improved Redocly configuration validation.
-- Documentation adn messaging corrections.
+- Documentation and messaging corrections.
 
 ## 1.0.0-beta.128 (2023-06-07)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,23 @@ toc:
 
 # Redocly CLI changelog
 
+
+## 1.0.0-beta.129 (2023-06-26)
+
+### Features
+
+- Added telemetry.
+### Fixes
+
+- Fixed build-docs command not working in Docker.
+- Other stability fixes and improvements.
+
+### Changes
+
+- Changed the `push` command interface.
+- Improved Redocly configuration validation.
+- Documentation adn messaging corrections.
+
 ## 1.0.0-beta.128 (2023-06-07)
 
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ toc:
 
 ### Features
 
-- Added telemetry.
+- Added product metrics collection.
 ### Fixes
 
 - Fixed build-docs command not working in Docker.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.128",
+  "version": "1.0.0-beta.129",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.128",
+      "version": "1.0.0-beta.129",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9577,10 +9577,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.0.0-beta.128",
+      "version": "1.0.0-beta.129",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.128",
+        "@redocly/openapi-core": "1.0.0-beta.129",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -9614,6 +9614,11 @@
         "node": ">=12.0.0"
       }
     },
+    "packages/cli/node_modules/@types/node": {
+      "version": "14.18.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
+      "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA=="
+    },
     "packages/cli/node_modules/@types/yargs": {
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.5.tgz",
@@ -9625,7 +9630,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.128",
+      "version": "1.0.0-beta.129",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
@@ -10588,7 +10593,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.128",
+        "@redocly/openapi-core": "1.0.0-beta.129",
         "@types/configstore": "^5.0.1",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",
@@ -10613,6 +10618,10 @@
         "yargs": "17.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
+          "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA=="
+        },
         "@types/yargs": {
           "version": "17.0.5",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.128",
+  "version": "1.0.0-beta.129",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/cli",
-  "version": "1.0.0-beta.128",
+  "version": "1.0.0-beta.129",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -33,7 +33,7 @@
     "Roman Hotsiy <roman@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.128",
+    "@redocly/openapi-core": "1.0.0-beta.129",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.128",
+  "version": "1.0.0-beta.129",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?

Release v1.0.0-beta.129.

This includes the following:
-  #1123
- #1130
- #1132
- #1133
- #1136
- #1137

## Reference

The related docs changes to be merged: 
- https://github.com/Redocly/redocly-cli/pull/1139


## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
