### PR TITLE
fix: pass files from '--files' option to config

### DIFF
--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -2,7 +2,8 @@ import { loadConfigAndHandleErrors, sendTelemetry } from '../utils';
 import * as process from 'process';
 import { commandWrapper } from '../wrapper';
 import { handleLint } from '../commands/lint';
-import nodeFetch from 'node-fetch';
+import { Arguments } from 'yargs';
+import { handlePush, PushOptions } from '../commands/push';
 
 jest.mock('node-fetch');
 jest.mock('../utils', () => ({
@@ -39,5 +40,18 @@ describe('commandWrapper', () => {
     expect(handleLint).toHaveBeenCalledTimes(1);
 
     expect(sendTelemetry).toHaveBeenCalledTimes(0);
+  });
+
+  it('should pass files from arguments to config', async () => {
+    const filesToPush = ['test1.yaml', 'test2.yaml'];
+
+    const loadConfigMock = loadConfigAndHandleErrors as jest.Mock<any, any>;
+
+    const argv = {
+      files: filesToPush,
+    } as Arguments<PushOptions>;
+
+    await commandWrapper(handlePush)(argv);
+    expect(loadConfigMock).toHaveBeenCalledWith(expect.objectContaining({ files: filesToPush }));
   });
 });

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -20,7 +20,7 @@ export function commandWrapper<T extends CommandOptions>(
         configPath: argv.config,
         customExtends: argv.extends as string[] | undefined,
         region: argv.region as Region,
-        files: argv.file as string[] | undefined,
+        files: argv.files as string[] | undefined,
         processRawConfig: lintConfigCallback(argv as T & Record<string, undefined>, version),
       })) as Config;
       telemetry = config.telemetry;


### PR DESCRIPTION
## What/Why/How?

Fix problem with `--files` option in `push` command

## Reference

Related: https://github.com/Redocly/redocly-cli/issues/1148

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
