### PR TITLE
fix: add timeout for unnecessary calls

### DIFF
--- a/packages/cli/src/__tests__/fetch-with-timeout.test.ts
+++ b/packages/cli/src/__tests__/fetch-with-timeout.test.ts
@@ -1,0 +1,35 @@
+import fetchWithTimeout from '../fetch-with-timeout';
+import nodeFetch from 'node-fetch';
+
+jest.mock('node-fetch');
+
+describe('fetchWithTimeout', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use bare node-fetch if AbortController is not available', async () => {
+    // @ts-ignore
+    global.AbortController = undefined;
+    // @ts-ignore
+    global.setTimeout = jest.fn();
+    await fetchWithTimeout('url', { method: 'GET' });
+
+    expect(nodeFetch).toHaveBeenCalledWith('url', { method: 'GET' });
+
+    expect(global.setTimeout).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call node-fetch with signal if AbortController is  available', async () => {
+    global.AbortController = jest.fn().mockImplementation(() => ({ signal: 'something' }));
+    // @ts-ignore
+    global.setTimeout = jest.fn();
+
+    global.clearTimeout = jest.fn();
+    await fetchWithTimeout('url');
+
+    expect(global.setTimeout).toHaveBeenCalledTimes(1);
+    expect(nodeFetch).toHaveBeenCalledWith('url', { signal: 'something' });
+    expect(global.clearTimeout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/fetch-with-timeout.ts
+++ b/packages/cli/src/fetch-with-timeout.ts
@@ -1,0 +1,17 @@
+import nodeFetch from 'node-fetch';
+
+const TIMEOUT = 3000;
+
+export default async (url: string, options = {}) => {
+  if (!AbortController) {
+    return nodeFetch(url, options);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, TIMEOUT);
+  const res = await nodeFetch(url, { signal: controller.signal, ...options });
+  clearTimeout(timeout);
+  return res;
+};

--- a/packages/cli/src/update-version-notifier.ts
+++ b/packages/cli/src/update-version-notifier.ts
@@ -2,7 +2,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { existsSync, writeFileSync, readFileSync, statSync } from 'fs';
 import { compare } from 'semver';
-import fetch from 'node-fetch';
+import fetch from './fetch-with-timeout';
 import { cyan, green, yellow } from 'colorette';
 import { cleanColors } from './utils';
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import fetch from './fetch-with-timeout';
 import { basename, dirname, extname, join, resolve, relative, isAbsolute } from 'path';
 import { blue, gray, green, red, yellow } from 'colorette';
 import { performance } from 'perf_hooks';


### PR DESCRIPTION
## What/Why/How?

Adding fetch request timeout to prevent hanging the tool when executing commands. 

## Reference

https://github.com/Redocly/redocly-cli/issues/1146

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
