### PR TITLE
fix: correctly validate schema `type: null`

### DIFF
--- a/__tests__/lint/oas3.1/openapi.yaml
+++ b/__tests__/lint/oas3.1/openapi.yaml
@@ -228,7 +228,7 @@ components:
           type: 'null'
         tag:
           type:
-            - null
+            - 'null'
             - string
             - integer
           examples:
@@ -287,11 +287,6 @@ components:
             - string
             - 'null'
         eleven:
-          description: x-nullable string
-          type:
-            - string
-            - null
-        twelve:
           description: file/binary
     person:
       type: object
@@ -322,7 +317,7 @@ components:
           description: location can be null, set using `nullable` property thats supported by OpenAPI `3.0.x`
           type:
             - string
-            - null
+            - 'null' 
         age:
           description: Age of Person
           type: integer

--- a/__tests__/lint/oas3.1/openapi.yaml
+++ b/__tests__/lint/oas3.1/openapi.yaml
@@ -317,7 +317,7 @@ components:
           description: location can be null, set using `nullable` property thats supported by OpenAPI `3.0.x`
           type:
             - string
-            - 'null' 
+            - 'null'
         age:
           description: Age of Person
           type: integer

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -455,7 +455,7 @@ describe('Oas3.1 spec', () => {
     `);
   });
 
-  it('should not report about unknown type', async () => {
+  it('should report about `type: null` and not report `type: "null"`', async () => {
     const document = parseYamlToDocument(
       outdent`
       openapi: 3.1.0
@@ -468,10 +468,18 @@ describe('Oas3.1 spec', () => {
           url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
       components:
         schemas:
-          TestSchema:
-            title: TestSchema
-            description: Property name's description
+          WrongType:
             type: null
+          CorrectType:
+            type: "null"
+          WrongArrayType:
+            type:
+              - null
+              - string
+          CorrectArrayType:
+            type:
+              - 'null'
+              - string
         `
     );
 
@@ -481,7 +489,54 @@ describe('Oas3.1 spec', () => {
       config: await makeConfig({ spec: 'error' }),
     });
 
-    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/components/schemas/WrongType/type",
+              "reportOnKey": false,
+              "source": "",
+            },
+          ],
+          "message": "\`type\` can be one of the following only: \\"object\\", \\"array\\", \\"string\\", \\"number\\", \\"integer\\", \\"boolean\\", \\"null\\".",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [
+            "object",
+            "array",
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null",
+          ],
+        },
+        Object {
+          "from": undefined,
+          "location": Array [
+            Object {
+              "pointer": "#/components/schemas/WrongArrayType/type/0",
+              "reportOnKey": false,
+              "source": "",
+            },
+          ],
+          "message": "\`type\` can be one of the following only: \\"object\\", \\"array\\", \\"string\\", \\"number\\", \\"integer\\", \\"boolean\\", \\"null\\".",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [
+            "object",
+            "array",
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null",
+          ],
+        },
+      ]
+    `);
   });
 
   it('should not report on SpecExtension with additionalProperties', async () => {

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -70,6 +70,8 @@ export function validateDefinedAndNonEmpty(fieldName: string, value: any, ctx: U
 }
 
 export function getSuggest(given: string, variants: string[]): string[] {
+  if (given === null) return variants;
+
   if (typeof given !== 'string' || !variants.length) return [];
 
   const distances: Array<{ variant: string; distance: number }> = [];
@@ -157,7 +159,7 @@ export function validateSchemaEnumType(
   if (!schemaEnum) {
     return;
   }
-  if (!schemaEnum.includes(propertyValue === null ? 'null' : propertyValue)) {
+  if (!schemaEnum.includes(propertyValue)) {
     report({
       location,
       message: `\`${propName}\` can be one of the following only: ${schemaEnum


### PR DESCRIPTION
## What/Why/How?

This fixes wrong type validation (broken in **beta.111**).

Since then, we didn't recognise `type: null` being an error:

```yaml

WrongType:
     type: null

```

Whilst the `null` should be a string:

```yaml

CorrectType:
     type: "null"
```

## Reference

The original MR: https://github.com/Redocly/redocly-cli/pull/891

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
