### PR TITLE
docs: update docker installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,7 +38,7 @@ npx @redocly/cli@latest lint petstore.yaml
 
 Redocly CLI is available as a pre-built Docker image in [Docker Hub](https://hub.docker.com/r/redocly/cli) and [GitHub Packages](https://github.com/Redocly/redocly-cli/pkgs/container/cli).
 
-If you have [Docker](https://docs.docker.com/get-docker/) installed, pull the image with the following command:
+Install [Docker](https://docs.docker.com/get-docker/) if you don't have it already, then pull the image with the following command:
 
 ```shell Docker Hub
 docker pull redocly/cli

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,6 +36,18 @@ npx @redocly/cli@latest lint petstore.yaml
 
 ## <a id="docker"></a>Run commands inside Docker
 
+Redocly CLI is available as a pre-built Docker image in [Docker Hub](https://hub.docker.com/r/redocly/cli) and [GitHub Packages](https://github.com/Redocly/redocly-cli/pkgs/container/redocly-cli).
+
+If you have [Docker](https://docs.docker.com/get-docker/) installed, pull the image with the following command:
+
+```shell Docker Hub
+docker pull redocly/cli
+```
+
+```shell GitHub Packages
+docker pull ghcr.io/redocly/redocly-cli
+```
+
 To give a Docker container access to your OpenAPI definition files, you need to mount the containing directory as a volume. Assuming the definition is in the current working directory, the command to use is:
 
 ```shell Example with lint command

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ npx @redocly/cli@latest lint petstore.yaml
 
 ## <a id="docker"></a>Run commands inside Docker
 
-Redocly CLI is available as a pre-built Docker image in [Docker Hub](https://hub.docker.com/r/redocly/cli) and [GitHub Packages](https://github.com/Redocly/redocly-cli/pkgs/container/redocly-cli).
+Redocly CLI is available as a pre-built Docker image in [Docker Hub](https://hub.docker.com/r/redocly/cli) and [GitHub Packages](https://github.com/Redocly/redocly-cli/pkgs/container/cli).
 
 If you have [Docker](https://docs.docker.com/get-docker/) installed, pull the image with the following command:
 
@@ -45,7 +45,7 @@ docker pull redocly/cli
 ```
 
 ```shell GitHub Packages
-docker pull ghcr.io/redocly/redocly-cli
+docker pull ghcr.io/redocly/cli
 ```
 
 To give a Docker container access to your OpenAPI definition files, you need to mount the containing directory as a volume. Assuming the definition is in the current working directory, the command to use is:


### PR DESCRIPTION
## What/Why/How?

Update docker installation guide, add option to pull image from GitHub packages.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
