### PR TITLE
chore: fix failing on node 14-

### DIFF
--- a/packages/cli/src/fetch-with-timeout.ts
+++ b/packages/cli/src/fetch-with-timeout.ts
@@ -3,7 +3,7 @@ import nodeFetch from 'node-fetch';
 const TIMEOUT = 3000;
 
 export default async (url: string, options = {}) => {
-  if (!AbortController) {
+  if (!global.AbortController) {
     return nodeFetch(url, options);
   }
 


### PR DESCRIPTION
## What/Why/How?

Using `global.AbortController` to prevent failing when there's no AbortController in NodeJS.

## Reference

Hotfix for https://github.com/Redocly/redocly-cli/pull/1150

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
