### PR TITLE
chore: remove cdn option from build-docs

### DIFF
--- a/docs/commands/build-docs.md
+++ b/docs/commands/build-docs.md
@@ -23,7 +23,6 @@ api | string | Path to the API definition filename or alias that you want to gen
 --output, -o | string | Sets the path and name of the output file. The default value is `redoc-static.html`.
 --title | string | Sets the page title.
 --disableGoogleFont | boolean | Disables Google fonts. The default value is `false`.
---cdn | boolean | Uses the CDN pointing to the latest version of Redoc. If not enabled, the Redoc version is selected from Redocly CLI's associated dependency (and to update Redoc requires updating the CLI and building the docs again). The default value is `false`.
 --template, -t | string | Uses custom [Handlebars](https://handlebarsjs.com/) templates to render your OpenAPI definition.
 --templateOptions | string | Adds template options you want to pass to your custom Handlebars template. To add options, use dot notation.
 --theme.openapi | string | Customizes your output using [Redoc functionality options](https://redocly.com/docs/api-reference-docs/configuration/functionality/) or [Redoc theming options](https://redocly.com/docs/api-reference-docs/configuration/theming/).

--- a/packages/cli/src/__tests__/commands/build-docs.test.ts
+++ b/packages/cli/src/__tests__/commands/build-docs.test.ts
@@ -11,7 +11,6 @@ jest.mock('../../utils');
 
 const config = {
   output: '',
-  cdn: false,
   title: 'Test',
   disableGoogleFont: false,
   templateFileName: '',
@@ -47,7 +46,6 @@ describe('build-docs', () => {
     await handlerBuildCommand(
       {
         o: '',
-        cdn: false,
         title: 'test',
         disableGoogleFont: false,
         template: '',

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -18,7 +18,6 @@ export const handlerBuildCommand = async (argv: BuildDocsArgv, configFromFile: C
 
   const options = {
     output: argv.o,
-    cdn: argv.cdn,
     title: argv.title,
     disableGoogleFont: argv.disableGoogleFont,
     templateFileName: argv.template,

--- a/packages/cli/src/commands/build-docs/types.ts
+++ b/packages/cli/src/commands/build-docs/types.ts
@@ -1,6 +1,5 @@
 export type BuildDocsOptions = {
   watch?: boolean;
-  cdn?: boolean;
   output?: string;
   title?: string;
   disableGoogleFont?: boolean;
@@ -14,7 +13,6 @@ export type BuildDocsOptions = {
 export type BuildDocsArgv = {
   api: string;
   o: string;
-  cdn: boolean;
   title?: string;
   disableGoogleFont?: boolean;
   template?: string;

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -51,7 +51,6 @@ export async function getPageHTML(
   api: any,
   pathToApi: string,
   {
-    cdn,
     title,
     disableGoogleFont,
     templateFileName,
@@ -87,9 +86,7 @@ export async function getPageHTML(
 
       </script>`,
     redocHead:
-      (cdn
-        ? '<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>'
-        : `<script src="https://cdn.redoc.ly/redoc/v${redocCurrentVersion}/bundles/redoc.standalone.js"></script>`) +
+      `<script src="https://cdn.redoc.ly/redoc/v${redocCurrentVersion}/bundles/redoc.standalone.js"></script>` +
       css,
     title: title || api.info.title || 'ReDoc documentation',
     disableGoogleFont,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -451,11 +451,6 @@ yargs
             type: 'boolean',
             default: false,
           },
-          cdn: {
-            describe: 'Do not include Redoc source code into html page, use link to CDN instead',
-            type: 'boolean',
-            default: false,
-          },
           t: {
             alias: 'template',
             describe: 'Path to handlebars page template, see https://git.io/vh8fP for the example',


### PR DESCRIPTION
## What/Why/How?

Removes the `cdn` option from `build-docs` command to avoid  dependencies discrepancy between Redoc and Redocly CLI. 

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
