### PR TITLE
fix: use proxy env variables and abort-controller package to prevent hanging behind proxies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,6 +1919,17 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -3570,6 +3581,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -9604,6 +9623,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "1.0.0-beta.131",
+        "abort-controller": "^3.0.0",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -9636,11 +9656,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "packages/cli/node_modules/@types/node": {
-      "version": "14.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
-      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
     },
     "packages/cli/node_modules/@types/yargs": {
       "version": "17.0.5",
@@ -10623,6 +10638,7 @@
         "@types/semver": "^7.5.0",
         "@types/styled-components": "^5.1.1",
         "@types/yargs": "17.0.5",
+        "abort-controller": "^3.0.0",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -10641,27 +10657,6 @@
         "yargs": "17.0.1"
       },
       "dependencies": {
-        "@redocly/openapi-core": {
-          "version": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.130.tgz",
-          "integrity": "sha512-P24AcEw06s002JZsG6f79/oqEJm3vRj4RySPHjHiJA4JXugbI7Msx4shmIX2PaGsxCLo2aKK/QlDK/0TYDqkrA==",
-          "requires": {
-            "@redocly/ajv": "^8.11.0",
-            "@types/node": "^14.11.8",
-            "colorette": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "js-yaml": "^4.1.0",
-            "lodash.isequal": "^4.5.0",
-            "minimatch": "^5.0.1",
-            "node-fetch": "^2.6.1",
-            "pluralize": "^8.0.0",
-            "yaml-ast-parser": "0.0.43"
-          }
-        },
-        "@types/node": {
-          "version": "14.18.53",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
-          "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
-        },
         "@types/yargs": {
           "version": "17.0.5",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.5.tgz",
@@ -11301,6 +11296,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "8.8.0",
@@ -12559,6 +12562,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,29 +35,30 @@
   ],
   "dependencies": {
     "@redocly/openapi-core": "1.0.0-beta.131",
+    "abort-controller": "^3.0.0",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",
     "handlebars": "^4.7.6",
+    "mobx": "^6.0.4",
     "portfinder": "^1.0.26",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "redoc": "~2.0.0",
     "semver": "^7.5.2",
     "simple-websocket": "^9.0.0",
-    "yargs": "17.0.1",
-    "mobx": "^6.0.4",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "yargs": "17.0.1"
   },
   "devDependencies": {
     "@types/configstore": "^5.0.1",
     "@types/react": "^17.0.8",
     "@types/react-dom": "^17.0.5",
+    "@types/semver": "^7.5.0",
     "@types/styled-components": "^5.1.1",
     "@types/yargs": "17.0.5",
-    "@types/semver": "^7.5.0",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/cli/src/__tests__/fetch-with-timeout.test.ts
+++ b/packages/cli/src/__tests__/fetch-with-timeout.test.ts
@@ -1,3 +1,4 @@
+import AbortController from 'abort-controller';
 import fetchWithTimeout from '../fetch-with-timeout';
 import nodeFetch from 'node-fetch';
 
@@ -8,20 +9,7 @@ describe('fetchWithTimeout', () => {
     jest.clearAllMocks();
   });
 
-  it('should use bare node-fetch if AbortController is not available', async () => {
-    // @ts-ignore
-    global.AbortController = undefined;
-    // @ts-ignore
-    global.setTimeout = jest.fn();
-    await fetchWithTimeout('url', { method: 'GET' });
-
-    expect(nodeFetch).toHaveBeenCalledWith('url', { method: 'GET' });
-
-    expect(global.setTimeout).toHaveBeenCalledTimes(0);
-  });
-
-  it('should call node-fetch with signal if AbortController is  available', async () => {
-    global.AbortController = jest.fn().mockImplementation(() => ({ signal: 'something' }));
+  it('should call node-fetch with signal', async () => {
     // @ts-ignore
     global.setTimeout = jest.fn();
 
@@ -29,7 +17,7 @@ describe('fetchWithTimeout', () => {
     await fetchWithTimeout('url');
 
     expect(global.setTimeout).toHaveBeenCalledTimes(1);
-    expect(nodeFetch).toHaveBeenCalledWith('url', { signal: 'something' });
+    expect(nodeFetch).toHaveBeenCalledWith('url', { signal:  (new AbortController()).signal });
     expect(global.clearTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/__tests__/fetch-with-timeout.test.ts
+++ b/packages/cli/src/__tests__/fetch-with-timeout.test.ts
@@ -17,7 +17,7 @@ describe('fetchWithTimeout', () => {
     await fetchWithTimeout('url');
 
     expect(global.setTimeout).toHaveBeenCalledTimes(1);
-    expect(nodeFetch).toHaveBeenCalledWith('url', { signal:  (new AbortController()).signal });
+    expect(nodeFetch).toHaveBeenCalledWith('url', { signal: new AbortController().signal });
     expect(global.clearTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/fetch-with-timeout.ts
+++ b/packages/cli/src/fetch-with-timeout.ts
@@ -1,12 +1,10 @@
 import nodeFetch from 'node-fetch';
+import AbortController from 'abort-controller';
 
 const TIMEOUT = 3000;
 
 export default async (url: string, options = {}) => {
   try {
-    if (!global.AbortController) {
-      return nodeFetch(url, options);
-    }
     const controller = new AbortController();
     const timeout = setTimeout(() => {
       controller.abort();

--- a/packages/cli/src/update-version-notifier.ts
+++ b/packages/cli/src/update-version-notifier.ts
@@ -13,7 +13,11 @@ const SPACE_TO_BORDER = 4;
 
 const INTERVAL_TO_CHECK = 1000 * 60 * 60 * 12;
 const SHOULD_NOT_NOTIFY =
-  process.env.NODE_ENV === 'test' || process.env.CI || !!process.env.LAMBDA_TASK_ROOT;
+  process.env.NODE_ENV === 'test' ||
+  process.env.CI ||
+  !!process.env.LAMBDA_TASK_ROOT ||
+  process.env.HTTP_PROXY ||
+  process.env.HTTPS_PROXY;
 
 export const notifyUpdateCliVersion = () => {
   if (SHOULD_NOT_NOTIFY) {

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -31,7 +31,12 @@ export function commandWrapper<T extends CommandOptions>(
     } catch (err) {
       // Do nothing
     } finally {
-      if (process.env.REDOCLY_TELEMETRY !== 'off' && telemetry !== 'off') {
+      if (
+        process.env.REDOCLY_TELEMETRY !== 'off' &&
+        telemetry !== 'off' &&
+        !process.env.HTTP_PROXY &&
+        !process.env.HTTPS_PROXY
+      ) {
         await sendTelemetry(argv, code, hasConfig);
       }
       process.once('beforeExit', () => {


### PR DESCRIPTION
## What/Why/How?

While working behind proxy,  HTTP_PROXY or HTTPS_PROXY environment variables might be used to detect this and skip  unnecessary http calls. 
Also, added `abort-controller` package to ensure consistent usage throughout different nodeJS versions.  

## Reference

Related to https://github.com/Redocly/redocly-cli/issues/1146

## Testing

IN PROGRESS. Trying to replicate the original issue...

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
