### PR TITLE
feat: run custom rules without plugin-Id

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -198,7 +198,7 @@ export class StyleguideConfig {
   getRuleSettings(ruleId: string, oasVersion: OasVersion): RuleSettings {
     this._usedRules.add(ruleId);
     this._usedVersions.add(oasVersion);
-    const settings = this.rules[oasVersion][ruleId] || 'off';
+    const settings = this.getSettings(this.rules[oasVersion], ruleId);
     if (typeof settings === 'string') {
       return {
         severity: settings,
@@ -212,7 +212,7 @@ export class StyleguideConfig {
     this._usedRules.add(ruleId);
     this._usedVersions.add(oasVersion);
 
-    const settings = this.preprocessors[oasVersion][ruleId] || 'off';
+    const settings = this.getSettings(this.preprocessors[oasVersion], ruleId);
     if (typeof settings === 'string') {
       return {
         severity: settings === 'on' ? 'error' : settings,
@@ -225,7 +225,7 @@ export class StyleguideConfig {
   getDecoratorSettings(ruleId: string, oasVersion: OasVersion): RuleSettings {
     this._usedRules.add(ruleId);
     this._usedVersions.add(oasVersion);
-    const settings = this.decorators[oasVersion][ruleId] || 'off';
+    const settings = this.getSettings(this.decorators[oasVersion], ruleId);
     if (typeof settings === 'string') {
       return {
         severity: settings === 'on' ? 'error' : settings,
@@ -233,6 +233,22 @@ export class StyleguideConfig {
     } else {
       return { severity: 'error', ...settings };
     }
+  }
+
+  private getSettings<T>(
+    entity: Record<string, T>,
+    ruleId: string,
+  ) {
+    if (entity[ruleId]) return entity[ruleId];
+
+    if (ruleId.match('.*/.*')) {
+      const fullRuleName = Object.keys(entity).filter(
+        (key) => ruleId.split('/')[1] === key
+      );
+      return entity[fullRuleName[0]] || 'off';
+    }
+
+    return 'off';
   }
 
   getUnusedRules() {


### PR DESCRIPTION
## What/Why/How?

Run rules from plugins even if the `plugin-id ` is not specified (Search by name)

The warning from the config file will still be displayed if the `plugin- id` is not specified
## Reference

## Testing

## Screenshots (optional)
![Screenshot 2023-07-13 at 11 15 19](https://github.com/Redocly/redocly-cli/assets/106662428/c54b9c29-958d-4609-b549-6ebae74b6239)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
