### PR TITLE
fix: remove assertions severity from default rulesets

### DIFF
--- a/.changeset/great-impalas-explain.md
+++ b/.changeset/great-impalas-explain.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed empty custom rules having severity in default rulesets.

--- a/packages/core/src/config/__tests__/__snapshots__/config-resolvers.test.ts.snap
+++ b/packages/core/src/config/__tests__/__snapshots__/config-resolvers.test.ts.snap
@@ -36,7 +36,6 @@ Object {
   "preprocessors": Object {},
   "recommendedFallback": false,
   "rules": Object {
-    "assertions": "warn",
     "boolean-parameter-prefixes": "error",
     "component-name-unique": "off",
     "info-contact": "off",

--- a/packages/core/src/config/all.ts
+++ b/packages/core/src/config/all.ts
@@ -18,7 +18,6 @@ export default {
     'operation-description': 'error',
     'operation-2xx-response': 'error',
     'operation-4xx-response': 'error',
-    assertions: 'error',
     'operation-operationId': 'error',
     'operation-summary': 'error',
     'operation-operationId-unique': 'error',

--- a/packages/core/src/config/minimal.ts
+++ b/packages/core/src/config/minimal.ts
@@ -17,7 +17,6 @@ export default {
     'operation-description': 'off',
     'operation-2xx-response': 'warn',
     'operation-4xx-response': 'off',
-    assertions: 'warn',
     'operation-operationId': 'warn',
     'operation-summary': 'warn',
     'operation-operationId-unique': 'warn',

--- a/packages/core/src/config/recommended.ts
+++ b/packages/core/src/config/recommended.ts
@@ -16,7 +16,6 @@ export default {
     'path-parameters-defined': 'error',
     'operation-description': 'off',
     'operation-2xx-response': 'warn',
-    assertions: 'warn',
     'operation-4xx-response': 'warn',
     'operation-operationId': 'warn',
     'operation-summary': 'error',


### PR DESCRIPTION
## What/Why/How?

We expose default severity levels for `assertions` in our predefined rulesets what doesn't make too much sense as we don't have any default assertions. And once someone adds an assertion to their **redocly.yaml**, we use `error` as a default severity regardless of the defined in the ruleset. 

Also it contradicts with our current types as we expect the `assertions` field to be of type `Assertion[]`: https://github.com/Redocly/redocly-cli/blob/2e02eda23ba173633db8820fd6d38d65967856b9/packages/core/src/rules/common/assertions/index.ts#L28



## Reference

## Testing

- [x] Locally
- [x] Portal

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
