### PR TITLE
docs: fix typo in 'where' example

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -91,13 +91,13 @@ rule/no-pdf-in-ok-response:
   where:
     - subject:
         type: Operation
-        filterByParentKeys:
+        filterInParentKeys:
           - put
       assertions:
         defined: true
     - subject:
         type: Response
-        filterByParentKeys:
+        filterInParentKeys:
           - '201'
           - '200'
       assertions:


### PR DESCRIPTION
## What/Why/How?

- Replaced `filterByParentKeys` by `filterInParentKeys`

## Reference

## Testing

## Screenshots (optional)
<img width="1371" alt="Screenshot 2023-08-02 at 14 50 35" src="https://github.com/Redocly/redocly-cli/assets/4423716/d80f5a76-9776-4751-9f4f-dfaabf313eea">

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
