### PR TITLE
chore: fix release pipeline

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,11 +22,11 @@ Hi! We're really excited that you are interested in contributing to Redocly CLI.
 Before submitting a pull request, please make sure the following is done:
 
 1. Fork the repository and create your branch from `main`.
-2. Run `npm install` in the repository root.
-3. If you’ve fixed a bug or added code that should be tested, don't forget to add tests!
-4. Ensure the test suite passes (`npm test`). Tip: `npm test -- --watch TestName` is helpful in development.
-5. Format your code with prettier (`npm run prettier`).
-6. Each feat/fix PR should also contain a changeset (to create one, run `npx changeset`). Please describe what you've done in this PR using sentence case (you can refer to our [changelog](https://redocly.com/docs/cli/changelog/)). This produces a file in `.changeset` folder. Please commit this file along with your changes.
+1. Run `npm install` in the repository root.
+1. If you’ve fixed a bug or added code that should be tested, don't forget to add tests!
+1. Ensure the test suite passes (`npm test`). Tip: `npm test -- --watch TestName` is helpful in development.
+1. Format your code with prettier (`npm run prettier`).
+1. Each feat/fix PR should also contain a changeset (to create one, run `npx changeset`; if your changes are scoped to `packages/core` but also affect Redocly CLI behavior, please include the `@redocly/cli` package as well). Please describe what you've done in this PR using sentence case (you can refer to our [changelog](https://redocly.com/docs/cli/changelog/)). This produces a file in `.changeset` folder. Please commit this file along with your changes.
 
 ## Development Setup
 
@@ -198,4 +198,7 @@ E2E tests are sensitive to any additional output (like `console.log`) in the sou
 
 ## Release flow
 
-We use [Changesets](https://github.com/changesets/changesets) flow. After merging a PR with a changeset, the release PR is automatically created. Merging that PR triggers the release process.
+We use [Changesets](https://github.com/changesets/changesets) flow.
+After merging a PR with a changeset, the release PR is automatically created.
+
+If the pipelines are not starting, close and reopen the PR. Merging that PR triggers the release process.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,19 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-      - run: npm ci
-      - run: npm test
-
   release:
-    needs: [test]
     name: Release
     runs-on: ubuntu-latest
     outputs:
@@ -98,13 +86,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Get version
+        id: get_version
+        run: |
+          value="$(cat packages/cli/package.json | jq -r '.version')"
+          echo "value=$value" >> "$GITHUB_OUTPUT"
+
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v4
         with:
           images: |
             redocly/cli
             ghcr.io/redocly/cli
+          tags: |
+            ${{ steps.get_version.outputs.value }}
+            latest
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -149,7 +146,7 @@ jobs:
         run: npm i -g @redocly/cli@latest
       - name: Test version from NPM
         run: |
-          expected_version="$(cat package.json | jq -r '.version')"
+          expected_version="$(cat packages/cli/package.json | jq -r '.version')"
           actual_version="$(redocly --version)"
           if [[ $expected_version == $actual_version  ]]; then
             echo "The version is correct. Actual version: $actual_version"
@@ -164,7 +161,7 @@ jobs:
         run: docker pull redocly/cli:latest
       - name: Test docker image
         run: |
-          expected_version="$(cat package.json | jq -r '.version')"
+          expected_version="$(cat packages/cli/package.json | jq -r '.version')"
           actual_version="$(docker run --rm redocly/cli --version)"
           if [[ $expected_version == $actual_version  ]]; then
             echo "The version is correct. Actual version: $actual_version"

--- a/scripts/archive-and-upload-bundle.js
+++ b/scripts/archive-and-upload-bundle.js
@@ -1,6 +1,6 @@
 const yargs = require('yargs');
 const { execSync } = require('child_process');
-const package = require('../package.json');
+const package = require('../packages/cli/package.json');
 
 const version = package.version;
 const fileName = `openapi-cli.${version}.tar.gz`;


### PR DESCRIPTION
## What/Why/How?

Fixes release pipeline for Dockerhub + Github packages (was publishing version `main` instead of the actual version), and S3 (was publishing v1.0 instead of the actual one).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
