### PR TITLE
chore: format cli/src/commands/join.ts

### DIFF
--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -29,7 +29,12 @@ import {
   sortTopLevelKeysForOas,
 } from '../utils';
 import { isObject, isString, keysOf } from '../js-utils';
-import { Oas3Parameter, Oas3PathItem, Oas3Server, Oas3_1Definition } from '@redocly/openapi-core/lib/typings/openapi';
+import {
+  Oas3Parameter,
+  Oas3PathItem,
+  Oas3Server,
+  Oas3_1Definition,
+} from '@redocly/openapi-core/lib/typings/openapi';
 import { OPENAPI3_METHOD } from './split/types';
 import { BundleResult } from '@redocly/openapi-core/lib/bundle';
 
@@ -141,7 +146,7 @@ export async function handleJoin(argv: JoinOptions, config: Config, packageVersi
     }
   }
 
-  let oasVersion : OasVersion | null = null;
+  let oasVersion: OasVersion | null = null;
   for (const document of documents) {
     try {
       const version = detectOpenAPI(document.parsed);


### PR DESCRIPTION
## What/Why/How?

This file is throwing off `prettier:check`.

Since this is just formatting, not creating a changeset file.

- [X] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
