### PR TITLE
Fix/wrong location in no trailing slash rule

### DIFF
--- a/.changeset/loud-forks-speak.md
+++ b/.changeset/loud-forks-speak.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed the wrong location pointer when reporting on the 'no-path-trailing-slash' rule.

--- a/packages/core/src/rules/common/__tests__/no-path-trailing-slash.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-path-trailing-slash.test.ts
@@ -41,6 +41,48 @@ describe('no-path-trailing-slash', () => {
     `);
   });
 
+  it('should report on trailing slash in path on key when referencing', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        paths:
+          '/bad/':
+            $ref: '#/components/pathItems/MyItem'
+        components:
+          pathItems:
+            MyItem:
+              get:
+                summary: List all pets
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'no-path-trailing-slash': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1bad~1",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "\`/bad/\` should not have a trailing slash.",
+          "ruleId": "no-path-trailing-slash",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+
+
   it('should not report on if no trailing slash in path', async () => {
     const document = parseYamlToDocument(
       outdent`

--- a/packages/core/src/rules/common/__tests__/no-path-trailing-slash.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-path-trailing-slash.test.ts
@@ -82,7 +82,6 @@ describe('no-path-trailing-slash', () => {
     `);
   });
 
-
   it('should not report on if no trailing slash in path', async () => {
     const document = parseYamlToDocument(
       outdent`

--- a/packages/core/src/rules/common/no-path-trailing-slash.ts
+++ b/packages/core/src/rules/common/no-path-trailing-slash.ts
@@ -3,11 +3,11 @@ import { UserContext } from '../../walk';
 
 export const NoPathTrailingSlash: Oas3Rule | Oas2Rule = () => {
   return {
-    PathItem(_path: any, { report, key, location }: UserContext) {
+    PathItem(_path: any, { report, key, rawLocation }: UserContext) {
       if ((key as string).endsWith('/') && key !== '/') {
         report({
           message: `\`${key}\` should not have a trailing slash.`,
-          location: location.key(),
+          location: rawLocation.key(),
         });
       }
     },


### PR DESCRIPTION
## What/Why/How?

Fixed the wrong location pointer when reporting on the 'no-path-trailing-slash' rule. Previously it was pointing on a value instead of a key when using $refs.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
