### PR TITLE
chore: rollback the wrong openapi-core version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12703,10 +12703,10 @@
     },
     "packages/cli": {
       "name": "@redocly/cli",
-      "version": "1.1.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.1.0",
+        "@redocly/openapi-core": "1.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -12751,7 +12751,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.1.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
@@ -14355,7 +14355,7 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.1.0",
+        "@redocly/openapi-core": "1.0.2",
         "@types/configstore": "^5.0.1",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",


### PR DESCRIPTION
## What/Why/How?

Rollbacking the wrong `openapi-core` version in package-lock.json.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
