### PR TITLE
chore: do not comment on a PR created from a fork

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -33,14 +33,8 @@ jobs:
           CI: true
           REDOCLY_TELEMETRY: off
 
-      # Test:
-      - run: |
-          echo ${{ github.repository }}
-          echo ${{ github.event.pull_request.head.repo.full_name }}
-          echo ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-
       - name: Comment PR
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}        
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: benchmark_check.md

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -32,13 +32,15 @@ jobs:
         env:
           CI: true
           REDOCLY_TELEMETRY: off
+
       # Test:
       - run: |
           echo ${{ github.repository }}
-          echo ${{ github.event.repository.full_name }}
+          echo ${{ github.event.pull_request.head.repo.full_name }}
+          echo ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Comment PR
-        if: github.repository == github.event.repository.full_name
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}        
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: benchmark_check.md


### PR DESCRIPTION
## What/Why/How?

Fix identifying a fork PR
Notice the [performance pipeline](https://github.com/Redocly/redocly-cli/actions/runs/5866521606/job/15905481387?pr=1231) not failing.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
