### PR TITLE
chore: replace stale dependencies

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -130,32 +130,6 @@ jobs:
           node-version: 14
       - run: bash ./__tests__/smoke/run-smoke.sh "npm i redoc redocly-cli.tgz" "npm run"
 
-  run-smoke--npm--node-12:
-    needs: prepare-smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: __tests__/smoke/
-          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 12
-      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redocly-cli.tgz" "npm run"
-
-  run-smoke--npm--node-12--redoc:
-    needs: prepare-smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: __tests__/smoke/
-          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 12
-      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redoc redocly-cli.tgz" "npm run"
-
   run-smoke--yarn--node-20:
     needs: prepare-smoke
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -12696,7 +12696,7 @@
         "typescript": "^4.0.3"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "packages/cli/node_modules/@types/yargs": {
@@ -12734,7 +12734,7 @@
         "typescript": "^4.0.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "packages/core/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2056,13 +2056,20 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
       "dependencies": {
-        "@types/minimatch": "*",
+        "@types/minimatch": "^5.1.2",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/glob/node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -2209,7 +2216,8 @@
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -3020,14 +3028,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/asynckit": {
@@ -5377,6 +5377,11 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.0.1.tgz",
+      "integrity": "sha512-R5pcVO8Z1+pVDu8Ml3xaJCEkBiiy1VQN9za0YqH8GIi1nIqD4IzQhzY6dDzMRtdS1lyiGlucRzm8IN8wtLIXng=="
+    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -5446,20 +5451,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob-promise": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
-      "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
-      "dependencies": {
-        "@types/glob": "*"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "glob": "*"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -8150,17 +8141,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mobx": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.2.tgz",
@@ -8982,27 +8962,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/portfinder": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
-      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
-      "dependencies": {
-        "async": "^2.6.4",
-        "debug": "^3.2.7",
-        "mkdirp": "^0.5.6"
-      },
-      "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/portfinder/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/posix-character-classes": {
@@ -12710,11 +12669,10 @@
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
+        "get-port-please": "^3.0.1",
         "glob": "^7.1.6",
-        "glob-promise": "^3.4.0",
         "handlebars": "^4.7.6",
         "mobx": "^6.0.4",
-        "portfinder": "^1.0.26",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "redoc": "~2.0.0",
@@ -12729,6 +12687,7 @@
       },
       "devDependencies": {
         "@types/configstore": "^5.0.1",
+        "@types/glob": "^8.1.0",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",
         "@types/semver": "^7.5.0",
@@ -14357,6 +14316,7 @@
       "requires": {
         "@redocly/openapi-core": "1.0.2",
         "@types/configstore": "^5.0.1",
+        "@types/glob": "^8.1.0",
         "@types/react": "^17.0.8",
         "@types/react-dom": "^17.0.5",
         "@types/semver": "^7.5.0",
@@ -14365,11 +14325,10 @@
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
+        "get-port-please": "^3.0.1",
         "glob": "^7.1.6",
-        "glob-promise": "^3.4.0",
         "handlebars": "^4.7.6",
         "mobx": "^6.0.4",
-        "portfinder": "^1.0.26",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "redoc": "~2.0.0",
@@ -14515,12 +14474,21 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
       "requires": {
-        "@types/minimatch": "*",
+        "@types/minimatch": "^5.1.2",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+          "dev": true
+        }
       }
     },
     "@types/graceful-fs": {
@@ -14661,7 +14629,8 @@
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -15282,14 +15251,6 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -17109,6 +17070,11 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-port-please": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.0.1.tgz",
+      "integrity": "sha512-R5pcVO8Z1+pVDu8Ml3xaJCEkBiiy1VQN9za0YqH8GIi1nIqD4IzQhzY6dDzMRtdS1lyiGlucRzm8IN8wtLIXng=="
+    },
     "get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -17173,14 +17139,6 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.3"
-      }
-    },
-    "glob-promise": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
-      "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
-      "requires": {
-        "@types/glob": "*"
       }
     },
     "glob-to-regexp": {
@@ -19190,14 +19148,6 @@
       "integrity": "sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==",
       "dev": true
     },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
-    },
     "mobx": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.2.tgz",
@@ -19793,26 +19743,6 @@
       "integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
       "requires": {
         "@babel/runtime": "^7.17.8"
-      }
-    },
-    "portfinder": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
-      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
-      "requires": {
-        "async": "^2.6.4",
-        "debug": "^3.2.7",
-        "mkdirp": "^0.5.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "posix-character-classes": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "redocly": "bin/cli.js"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "engineStrict": true,
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,26 +38,26 @@
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",
+    "get-port-please": "^3.0.1",
     "glob": "^7.1.6",
-    "glob-promise": "^3.4.0",
     "handlebars": "^4.7.6",
-    "portfinder": "^1.0.26",
-    "redoc": "~2.0.0",
-    "semver": "^7.5.2",
-    "simple-websocket": "^9.0.0",
-    "yargs": "17.0.1",
     "mobx": "^6.0.4",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "styled-components": "^5.1.1"
+    "redoc": "~2.0.0",
+    "semver": "^7.5.2",
+    "simple-websocket": "^9.0.0",
+    "styled-components": "^5.1.1",
+    "yargs": "17.0.1"
   },
   "devDependencies": {
     "@types/configstore": "^5.0.1",
+    "@types/glob": "^8.1.0",
     "@types/react": "^17.0.8",
     "@types/react-dom": "^17.0.5",
+    "@types/semver": "^7.5.0",
     "@types/styled-components": "^5.1.1",
     "@types/yargs": "17.0.5",
-    "@types/semver": "^7.5.0",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/cli/src/__tests__/commands/build-docs.test.ts
+++ b/packages/cli/src/__tests__/commands/build-docs.test.ts
@@ -26,10 +26,6 @@ jest.mock('handlebars', () => ({
   compile: jest.fn(() => jest.fn(() => '<html></html>')),
 }));
 
-jest.mock('mkdirp', () => ({
-  sync: jest.fn(),
-}));
-
 describe('build-docs', () => {
   it('should return correct html and call function for ssr', async () => {
     const result = await getPageHTML({}, '../some-path/openapi.yaml', {

--- a/packages/cli/src/assert-node-version.ts
+++ b/packages/cli/src/assert-node-version.ts
@@ -9,9 +9,9 @@ try {
 
   if (!semver.satisfies(process.version, version)) {
     process.stderr.write(
-        yellow(
-            `\n⚠️ Warning: failed to satisfy expected node version. Expected: "${version}", Current "${process.version}"\n\n`
-        )
+      yellow(
+        `\n⚠️ Warning: failed to satisfy expected node version. Expected: "${version}", Current "${process.version}"\n\n`
+      )
     );
   }
 } catch (e) {

--- a/packages/cli/src/assert-node-version.ts
+++ b/packages/cli/src/assert-node-version.ts
@@ -1,8 +1,19 @@
+import * as semver from 'semver';
 import * as path from 'path';
-import { exitWithError } from './utils';
+import * as process from 'process';
+import { yellow } from 'colorette';
 
 try {
-  require('assert-node-version')(path.join(__dirname, '../'));
-} catch (err) {
-  exitWithError(err.message);
+  const { engines } = require(path.join(__dirname, '../package.json'));
+  const version = engines.node;
+
+  if (!semver.satisfies(process.version, version)) {
+    process.stderr.write(
+        yellow(
+            `\n⚠️ Warning: failed to satisfy expected node version. Expected: "${version}", Current "${process.version}"\n\n`
+        )
+    );
+  }
+} catch (e) {
+  // Do nothing
 }

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -1,6 +1,6 @@
 import { compile } from 'handlebars';
 import * as colorette from 'colorette';
-import * as portfinder from 'portfinder';
+import { getPort } from 'get-port-please';
 import { readFileSync, promises as fsPromises } from 'fs';
 import * as path from 'path';
 
@@ -143,7 +143,7 @@ export default async function startPreviewServer(
     console.timeEnd(colorette.dim(`GET ${request.url}`));
   };
 
-  const wsPort = await portfinder.getPortPromise({ port: 32201 });
+  const wsPort = await getPort({ portRange: [32201, 32301 ] });
 
   const server = startHttpServer(port, host, handler);
   server.on('listening', () => {

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -143,7 +143,7 @@ export default async function startPreviewServer(
     console.timeEnd(colorette.dim(`GET ${request.url}`));
   };
 
-  const wsPort = await getPort({ portRange: [32201, 32301 ] });
+  const wsPort = await getPort({ portRange: [32201, 32301] });
 
   const server = startHttpServer(port, host, handler);
   server.on('listening', () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -2,7 +2,7 @@ import fetch from './fetch-with-timeout';
 import { basename, dirname, extname, join, resolve, relative, isAbsolute } from 'path';
 import { blue, gray, green, red, yellow } from 'colorette';
 import { performance } from 'perf_hooks';
-import * as glob from 'glob'
+import * as glob from 'glob';
 import * as fs from 'fs';
 import * as readline from 'readline';
 import { Writable } from 'stream';

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -2,7 +2,7 @@ import fetch from './fetch-with-timeout';
 import { basename, dirname, extname, join, resolve, relative, isAbsolute } from 'path';
 import { blue, gray, green, red, yellow } from 'colorette';
 import { performance } from 'perf_hooks';
-import * as glob from 'glob-promise';
+import * as glob from 'glob'
 import * as fs from 'fs';
 import * as readline from 'readline';
 import { Writable } from 'stream';
@@ -96,7 +96,7 @@ async function expandGlobsInEntrypoints(args: string[], config: ConfigApis) {
     await Promise.all(
       (args as string[]).map(async (aliasOrPath) => {
         return glob.hasMagic(aliasOrPath) && !isAbsoluteUrl(aliasOrPath)
-          ? (await glob(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
+          ? (await glob.__promisify__(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
           : getAliasOrPath(config, aliasOrPath);
       })
     )

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "engineStrict": true,
   "license": "MIT",


### PR DESCRIPTION
## What/Why/How?

- Set minimal `Node.js` version to 14
- Remove unsupported `assert-node-version` and `glob-promise` dependencies
- Replace `portfinder` with `get-port-please` package

## Reference
https://github.com/orgs/Redocly/projects/12/views/5?pane=issue&itemId=35308489
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
