### PR TITLE
Add `ignoreCase` for `tags-alphabetical` rule

### DIFF
--- a/.changeset/forty-onions-deliver.md
+++ b/.changeset/forty-onions-deliver.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Added ignoreCase option for tags-alphabetical rule

--- a/.changeset/forty-onions-deliver.md
+++ b/.changeset/forty-onions-deliver.md
@@ -1,6 +1,6 @@
 ---
-'@redocly/openapi-core': patch
-'@redocly/cli': patch
+'@redocly/openapi-core': minor
+'@redocly/cli': minor
 ---
 
-Added ignoreCase option for tags-alphabetical rule
+Added `ignoreCase` option for `tags-alphabetical` rule.

--- a/docs/rules/tags-alphabetical.md
+++ b/docs/rules/tags-alphabetical.md
@@ -33,6 +33,7 @@ This rule is intended to prevent bikeshedding and diffuse tension between teamma
 |Option|Type|Description|
 |---|---|---|
 |severity|string|Possible values: `off`, `warn`, `error`. Default `off` (in `recommended` configuration). |
+|ignoreCase|boolean|Possible values: `true`, `false`. Default `false` (in `recommended` configuration). |
 
 An example configuration:
 

--- a/packages/core/src/rules/common/__tests__/tags-alphabetical.test.ts
+++ b/packages/core/src/rules/common/__tests__/tags-alphabetical.test.ts
@@ -61,4 +61,62 @@ describe('Oas3 tags-alphabetical', () => {
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
   });
+
+  it('should report on tags object if not sorted alphabetically not ignoring case', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.0.0
+          paths: {}
+          tags:
+            - name: a
+            - name: B
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'tags-alphabetical': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/tags/0",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The \`tags\` array should be in alphabetical order.",
+          "ruleId": "tags-alphabetical",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+
+  it('should not report on tags object if sorted alphabetically ignoring case', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      openapi: 3.0.0
+      paths: {}
+      tags:
+        - name: a
+        - name: B
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'tags-alphabetical': { severity: 'error', ignoreCase: true } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/packages/core/src/rules/common/tags-alphabetical.ts
+++ b/packages/core/src/rules/common/tags-alphabetical.ts
@@ -1,14 +1,14 @@
 import { Oas3Rule, Oas2Rule } from '../../visitors';
-import { Oas2Definition } from '../../typings/swagger';
-import { Oas3Definition } from '../../typings/openapi';
+import { Oas2Definition, Oas2Tag } from '../../typings/swagger';
+import { Oas3Definition, Oas3Tag } from '../../typings/openapi';
 import { UserContext } from '../../walk';
 
-export const TagsAlphabetical: Oas3Rule | Oas2Rule = () => {
+export const TagsAlphabetical: Oas3Rule | Oas2Rule = ({ ignoreCase = false }) => {
   return {
     Root(root: Oas2Definition | Oas3Definition, { report, location }: UserContext) {
       if (!root.tags) return;
       for (let i = 0; i < root.tags.length - 1; i++) {
-        if (root.tags[i].name > root.tags[i + 1].name) {
+        if (getTagName(root.tags[i], ignoreCase) > getTagName(root.tags[i + 1], ignoreCase)) {
           report({
             message: 'The `tags` array should be in alphabetical order.',
             location: location.child(['tags', i]),
@@ -18,3 +18,7 @@ export const TagsAlphabetical: Oas3Rule | Oas2Rule = () => {
     },
   };
 };
+
+function getTagName(tag: Oas2Tag | Oas3Tag, ignoreCase: boolean): string {
+  return ignoreCase ? tag.name.toLowerCase() : tag.name;
+}


### PR DESCRIPTION
## What/Why/How?

For human perception, case doesn't really make a huge difference, especially when trying to find an item on the list. We used to have a custom assertion to do the same thing, but with an `ignoreCase` option to achieve the goal (see referenced PR).

## Reference

https://github.com/Rebilly/api-definitions/pull/1590

## Testing

Test cases were added to cover the option.

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
