### PR TITLE
chore: send release message even if post release smokes fail

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,6 +138,7 @@ jobs:
       - deploy
       - dockerhub
     name: Test released version
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -145,6 +146,7 @@ jobs:
       - name: Install CLI from npm
         run: npm i -g @redocly/cli@latest
       - name: Test version from NPM
+        continue-on-error: true
         run: |
           expected_version="$(cat packages/cli/package.json | jq -r '.version')"
           actual_version="$(redocly --version)"
@@ -152,7 +154,6 @@ jobs:
             echo "The version is correct. Actual version: $actual_version"
           else
             echo "The version is incorrect. Expected: $expected_version, actual: $actual_version"
-            exit 1
           fi
           redocly lint https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml --format=stylish
           redocly bundle https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml -o bundled.json
@@ -160,6 +161,7 @@ jobs:
       - name: Pull docker image
         run: docker pull redocly/cli:latest
       - name: Test docker image
+        continue-on-error: true
         run: |
           expected_version="$(cat packages/cli/package.json | jq -r '.version')"
           actual_version="$(docker run --rm redocly/cli --version)"
@@ -167,7 +169,6 @@ jobs:
             echo "The version is correct. Actual version: $actual_version"
           else
             echo "The version is incorrect. Expected: $expected_version, actual: $actual_version"
-            exit 1
           fi
           docker run --rm redocly/cli lint https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml
           docker run --rm redocly/cli bundle https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml --output=bundled.yaml
@@ -178,7 +179,7 @@ jobs:
       - release
       - post-release-smoke-checks
     if: needs.release.outputs.published == 'true'
-    name: Post the Release Message
+    name: Send the Release Message to Slack
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -196,7 +197,7 @@ jobs:
       - name: Write release message to file
         run: node scripts/write-release-message.js
 
-      - name: Post to a Slack channel
+      - name: Send to a Slack channel
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
         with:


### PR DESCRIPTION
## What/Why/How?

Post-release smokes are somewhat flaky by design. It's ok that they might fail sometimes. Anyways, we need to send a release message. This MR allows it to work that way even if some post-release smokes fail. 

## Reference

## Testing

During the next release. 

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
