### PR TITLE
fix(docs): update example

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -488,7 +488,7 @@ rules:
   rule/operation-summary-contains-test:
     subject:
       type: Operation
-      property: The summary
+      property: summary
     assertions:
       notPattern: /^The/
 ```

--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -485,7 +485,7 @@ The following example asserts that the operation summary doesn't start with "The
 
 ```yaml
 rules:
-  rule/operation-summary-contains-test:
+  rule/operation-summary-does-not-start-with-the:
     subject:
       type: Operation
       property: summary


### PR DESCRIPTION
## What/Why/How?

`notPattern` rule defined an invalid type of `property: The summary`

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
