### PR TITLE
fix: fix $ref resolution when used with $id

### DIFF
--- a/packages/core/src/__tests__/resolve.test.ts
+++ b/packages/core/src/__tests__/resolve.test.ts
@@ -428,4 +428,53 @@ describe('collect refs', () => {
 
     expect(Array.from(resolvedRefs.values()).pop()!.error).toBeInstanceOf(Error);
   });
+
+  it('should handle $id correctly', async () => {
+    const cwd = path.join(__dirname, 'fixtures/resolve');
+    const rootDocument = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            Local:
+              type: string
+            LocalRef:
+              $ref: "#/components/schemas/Local"
+            External:
+              $id: "http://example.com/external.yaml"
+              $defs:
+                Id:
+                  type: string
+                  format: uuid
+              properties:
+                foo:
+                  $ref: "#/$defs/Id"
+                bar:
+                  $ref: "test.yaml"
+      `,
+      path.join(cwd, 'foobar')
+    );
+
+    const resolvedRefs = await resolveDocument({
+      rootDocument,
+      externalRefResolver: new BaseResolver(),
+      rootType: normalizeTypes(Oas3Types).Root,
+    });
+
+    expect(
+      Array.from(resolvedRefs.keys()).map(
+        (ref) => (ref.startsWith('http:') && ref) || ref.substring(cwd.length + 1)
+      )
+    ).toEqual([
+      'foobar::#/components/schemas/Local',
+      'http://example.com/external.yaml::#/$defs/Id',
+      'http://example.com/external.yaml::test.yaml',
+    ]);
+
+    expect(Array.from(resolvedRefs.values()).map((info) => info.node)).toEqual([
+      {type: 'string'},
+      {type: 'string', format: 'uuid'},
+      undefined, // unresolved ref
+    ]);
+  });
 });

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -251,6 +251,19 @@ export async function resolveDocument(opts: {
         return;
       }
 
+      if (node.$id && node.$id !== nodeAbsoluteRef) {
+        const nestedDocument = {
+          source: new Source(
+            node.$id,
+            rootNodeDocument.source.body,
+            rootNodeDocument.source.mimeType
+          ),
+          parsed: node,
+        };
+        resolveRefsInParallel(node, nestedDocument, '', type);
+        return;
+      }
+
       const nodeId = `${type.name}::${nodeAbsoluteRef}`;
       if (seedNodes.has(nodeId)) {
         return;

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -125,7 +125,7 @@ export function walkDocument<T>(opts: {
     key: string | number
   ) {
     const resolve: ResolveFn = (ref, from = currentLocation.source.absoluteRef) => {
-      if (!isRef(ref)) return { location, node: ref };
+      if (!isRef(ref)) return { location: currentLocation, node: ref };
       const refId = makeRefId(from, ref.$ref);
       const resolvedRef = resolvedRefMap.get(refId);
       if (!resolvedRef) {
@@ -147,6 +147,14 @@ export function walkDocument<T>(opts: {
 
     const rawLocation = location;
     let currentLocation = location;
+
+    if (node?.$id) {
+      currentLocation = new Location(
+        new Source(node.$id, location.source.body, location.source.mimeType),
+        location.pointer
+      );
+    }
+
     const { node: resolvedNode, location: resolvedLocation, error } = resolve(node);
     const enteredContexts: Set<VisitorLevelContext> = new Set();
 


### PR DESCRIPTION
## What/Why/How?

Potential fix for https://github.com/Redocly/redocly-cli/issues/1233

I'll fill in more details later.

## Reference

https://github.com/Redocly/redocly-cli/issues/1233

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
