### PR TITLE
fix: use separate resolvers for each file in join

### DIFF
--- a/.changeset/dull-ducks-beam.md
+++ b/.changeset/dull-ducks-beam.md
@@ -3,4 +3,4 @@
 '@redocly/cli': patch
 ---
 
-Fixed an issue with nested refs in the join command
+Fixed an issue with nested refs in the `join` command.

--- a/.changeset/dull-ducks-beam.md
+++ b/.changeset/dull-ducks-beam.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed an issue with nested refs in the join command

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -162,6 +162,7 @@ describe('E2E', () => {
         'multiple-tags-in-same-files',
         'references-in-parameters',
         'ignore-decorators',
+        'multi-references-to-one-file',
       ];
 
       test.each(testDirNames)('test: %s', (dir) => {

--- a/__tests__/join/multi-references-to-one-file/bar.yaml
+++ b/__tests__/join/multi-references-to-one-file/bar.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+tags:
+  - name: CreateBar
+    description: Create a new Bar
+paths:
+  /bar/:
+    post:
+      summary: Create a single bar
+      operationId: createBar
+      responses:
+        '200':
+          description: One single bar
+          content:
+            application/json:
+              schema:
+                $ref: './nested/Response.yaml'

--- a/__tests__/join/multi-references-to-one-file/foo.yaml
+++ b/__tests__/join/multi-references-to-one-file/foo.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: Sample API
+  description: My sample api
+  version: 0.0.1
+  license:
+    name: 'Internal'
+    url: 'https://mycompany.com/license'
+tags:
+  - name: GetSingleFoo
+    description: Get a single foo
+  - name: Foo
+    description: All foo operations
+paths:
+  /foo/{id}:
+    get:
+      summary: Returns a single foo
+      operationId: getFoo
+      responses:
+        '200':
+          description: One single Food
+          content:
+            application/json:
+              schema:
+                $ref: './nested/Response.yaml'

--- a/__tests__/join/multi-references-to-one-file/nested/FooObject.yaml
+++ b/__tests__/join/multi-references-to-one-file/nested/FooObject.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  x:
+    type: string
+  y:
+    type: string

--- a/__tests__/join/multi-references-to-one-file/nested/Response.yaml
+++ b/__tests__/join/multi-references-to-one-file/nested/Response.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: string
+    format: uuid
+  name:
+    type: string
+  description:
+    type: string
+  subFoo:
+    $ref: './FooObject.yaml'

--- a/__tests__/join/multi-references-to-one-file/snapshot.js
+++ b/__tests__/join/multi-references-to-one-file/snapshot.js
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E join without options test: multi-references-to-one-file 1`] = `
+
+openapi: 3.0.3
+info:
+  title: Sample API
+  description: My sample api
+  version: 0.0.1
+  license:
+    name: Internal
+    url: https://mycompany.com/license
+tags:
+  - name: GetSingleFoo
+    description: Get a single foo
+    x-displayName: GetSingleFoo
+  - name: Foo
+    description: All foo operations
+    x-displayName: Foo
+  - name: foo_other
+    x-displayName: other
+  - name: CreateBar
+    description: Create a new Bar
+    x-displayName: CreateBar
+  - name: bar_other
+    x-displayName: other
+paths:
+  /foo/{id}:
+    get:
+      summary: Returns a single foo
+      operationId: getFoo
+      responses:
+        '200':
+          description: One single Food
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      tags:
+        - foo_other
+  /bar/:
+    post:
+      summary: Create a single bar
+      operationId: createBar
+      responses:
+        '200':
+          description: One single bar
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      tags:
+        - bar_other
+components:
+  schemas:
+    FooObject:
+      type: object
+      properties:
+        x:
+          type: string
+        'y':
+          type: string
+    Response:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        subFoo:
+          $ref: '#/components/schemas/FooObject'
+x-tagGroups:
+  - name: foo
+    tags:
+      - GetSingleFoo
+      - Foo
+      - foo_other
+    description: My sample api
+  - name: bar
+    tags:
+      - CreateBar
+      - bar_other
+
+openapi.yaml: join processed in <test>ms
+
+
+`;

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -124,7 +124,7 @@ export async function handleJoin(argv: JoinOptions, config: Config, packageVersi
       bundleDocument({
         document,
         config: config.styleguide,
-        externalRefResolver,
+        externalRefResolver: new BaseResolver(config.resolve),
       }).catch((e) => {
         exitWithError(`${e.message}: ${blue(document.source.absoluteRef)}`);
       })

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -157,6 +157,7 @@ export class BaseResolver {
 
     const cachedDocument = this.cache.get(absoluteRef);
     if (cachedDocument) {
+      // return copy of a node from the cache instead of a reference
       return cachedDocument.then((document) => JSON.parse(JSON.stringify(document)));
     }
 

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -157,8 +157,7 @@ export class BaseResolver {
 
     const cachedDocument = this.cache.get(absoluteRef);
     if (cachedDocument) {
-      // return copy of a node from the cache instead of a reference
-      return cachedDocument.then((document) => JSON.parse(JSON.stringify(document)));
+      return cachedDocument;
     }
 
     const doc = this.loadExternalRef(absoluteRef).then((source) => {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -157,7 +157,7 @@ export class BaseResolver {
 
     const cachedDocument = this.cache.get(absoluteRef);
     if (cachedDocument) {
-      return cachedDocument;
+      return cachedDocument.then((document) => JSON.parse(JSON.stringify(document)));
     }
 
     const doc = this.loadExternalRef(absoluteRef).then((source) => {


### PR DESCRIPTION
## What/Why/How?
Fixed an issue with nested refs in the join command

The problem occurs when two files have a reference to one file, and this file contains another references

When we resolve multiple documents with one `BaseResolver`, we share a common cache. When we try to resolve an already cached document, we get a reference to the node in the cache
The bundle visitor mutates the node, which can be a reference to the cache . Therefore, for the next document, the values in the cache will have already been changed and the node may be invalid for this document, since it will contain a reference to the component section, not to the file.

Solution: Use a separate `BaseResolver` (with its own cache) for each file during  `bundle`

## Reference
 https://github.com/Redocly/redocly-cli/issues/1268
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
