### PR TITLE
fix(types): update unevaluatedItems type defintion

### DIFF
--- a/.changeset/slow-lemons-accept.md
+++ b/.changeset/slow-lemons-accept.md
@@ -3,4 +3,4 @@
 '@redocly/openapi-core': major
 ---
 
-fix(types): update `unevaluatedItems` type definition to resolve either boolean or object schema per JSON Schema 2019-09 specification
+Updated `unevaluatedItems` type definition to resolve either boolean or object schema per JSON Schema 2019-09 specification.

--- a/.changeset/slow-lemons-accept.md
+++ b/.changeset/slow-lemons-accept.md
@@ -1,0 +1,6 @@
+---
+'@redocly/cli': major
+'@redocly/openapi-core': major
+---
+
+fix(types): update `unevaluatedItems` type definition to resolve either boolean or object schema per JSON Schema 2019-09 specification

--- a/.changeset/slow-lemons-accept.md
+++ b/.changeset/slow-lemons-accept.md
@@ -1,6 +1,6 @@
 ---
-'@redocly/cli': major
-'@redocly/openapi-core': major
+'@redocly/cli': patch
+'@redocly/openapi-core': patch
 ---
 
 Updated `unevaluatedItems` type definition to resolve either boolean or object schema per JSON Schema 2019-09 specification.

--- a/packages/core/src/types/asyncapi.ts
+++ b/packages/core/src/types/asyncapi.ts
@@ -390,7 +390,13 @@ const Schema: NodeType = {
     maxContains: { type: 'integer', minimum: 0 },
     patternProperties: { type: 'object' },
     propertyNames: 'Schema',
-    unevaluatedItems: 'Schema',
+    unevaluatedItems: (value: unknown) => {
+      if (typeof value === 'boolean') {
+        return { type: 'boolean' };
+      } else {
+        return 'Schema';
+      }
+    },
     unevaluatedProperties: (value: unknown) => {
       if (typeof value === 'boolean') {
         return { type: 'boolean' };

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -137,7 +137,13 @@ const Schema: NodeType = {
     maxContains: { type: 'integer', minimum: 0 },
     patternProperties: { type: 'object' },
     propertyNames: 'Schema',
-    unevaluatedItems: 'Schema',
+    unevaluatedItems: (value: unknown) => {
+      if (typeof value === 'boolean') {
+        return { type: 'boolean' };
+      } else {
+        return 'Schema';
+      }
+    },
     unevaluatedProperties: (value: unknown) => {
       if (typeof value === 'boolean') {
         return { type: 'boolean' };


### PR DESCRIPTION
Per JSON Schema 2019-09+ spec. this annotation keyword can be any valid JSON Schema schema. e.g. `boolean` or `schema` https://json-schema.org/draft/2019-09/json-schema-core#unevaluatedItems

partially fixes #1233

## What/Why/How?

The type definition for `unevaulatedItems` was incorrect per the JSON Schema 2019-09 specification

## Reference

https://json-schema.org/draft/2019-09/json-schema-core#unevaluatedItems

## Testing

## Screenshots (optional)

## Check yourself

- [ x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
