### PR TITLE
fix: use same host for websocket server as for http server when previewing locally

### DIFF
--- a/.changeset/strange-insects-jog.md
+++ b/.changeset/strange-insects-jog.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': patch
+---
+
+The --host/-h argument provided for the preview http server, is now also used by the ws server.

--- a/.changeset/strange-insects-jog.md
+++ b/.changeset/strange-insects-jog.md
@@ -2,4 +2,4 @@
 '@redocly/cli': patch
 ---
 
-The --host/-h argument provided for the preview http server, is now also used by the ws server.
+The `--host/-h` argument in the `preview-docs` command is now also used by the WebSocket server for hot reloading.

--- a/packages/cli/src/commands/preview-docs/preview-server/hot.js
+++ b/packages/cli/src/commands/preview-docs/preview-server/hot.js
@@ -1,13 +1,29 @@
 (function run() {
   const Socket = window.SimpleWebsocket;
   const port = window.__OPENAPI_CLI_WS_PORT;
+  const host = window.__OPENAPI_CLI_WS_HOST;
 
   let socket;
 
   reconnect();
 
+  function getFormattedHost() {
+    // Use localhost when bound to all interfaces
+    if (host === '::' || host === '0.0.0.0') {
+      return 'localhost';
+    }
+
+    // Other IPv6 addresses must be wrapped in brackets
+    if (host.includes("::")) {
+      return `[${host}]`
+    }
+
+    // Otherwise return as-is
+    return host
+  }
+
   function reconnect() {
-    socket = new Socket(`ws://127.0.0.1:${port}`);
+    socket = new Socket(`ws://${getFormattedHost()}:${port}`);
     socket.on('connect', () => {
       socket.send('{"type": "ping"}');
     });
@@ -29,13 +45,14 @@
 
     socket.on('close', () => {
       socket.destroy();
-      console.log('Connection lost, trying to reconnect in 4s');
+      console.log('[hot] Connection lost, trying to reconnect in 4s');
       setTimeout(() => {
         reconnect();
       }, 4000);
     });
 
     socket.on('error', () => {
+      console.log('[hot] Error connecting to hot reloading server')
       socket.destroy();
     });
   }

--- a/packages/cli/src/commands/preview-docs/preview-server/hot.js
+++ b/packages/cli/src/commands/preview-docs/preview-server/hot.js
@@ -14,12 +14,12 @@
     }
 
     // Other IPv6 addresses must be wrapped in brackets
-    if (host.includes("::")) {
-      return `[${host}]`
+    if (host.includes('::')) {
+      return `[${host}]`;
     }
 
     // Otherwise return as-is
-    return host
+    return host;
   }
 
   function reconnect() {
@@ -52,7 +52,7 @@
     });
 
     socket.on('error', () => {
-      console.log('[hot] Error connecting to hot reloading server')
+      console.log('[hot] Error connecting to hot reloading server');
       socket.destroy();
     });
   }

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -12,7 +12,8 @@ function getPageHTML(
   htmlTemplate: string,
   redocOptions: object = {},
   useRedocPro: boolean,
-  wsPort: number
+  wsPort: number,
+  host: string
 ) {
   let templateSrc = readFileSync(htmlTemplate, 'utf-8');
 
@@ -28,6 +29,7 @@ function getPageHTML(
   <script>
     window.__REDOC_EXPORT = '${useRedocPro ? 'RedoclyReferenceDocs' : 'Redoc'}';
     window.__OPENAPI_CLI_WS_PORT = ${wsPort};
+    window.__OPENAPI_CLI_WS_HOST = "${host}";
   </script>
   <script src="/simplewebsocket.min.js"></script>
   <script src="/hot.js"></script>
@@ -67,7 +69,7 @@ export default async function startPreviewServer(
 
     if (request.url?.endsWith('/') || path.extname(request.url!) === '') {
       respondWithGzip(
-        getPageHTML(htmlTemplate || defaultTemplate, getOptions(), useRedocPro, wsPort),
+        getPageHTML(htmlTemplate || defaultTemplate, getOptions(), useRedocPro, wsPort, host),
         request,
         response,
         {
@@ -143,7 +145,7 @@ export default async function startPreviewServer(
     console.timeEnd(colorette.dim(`GET ${request.url}`));
   };
 
-  const wsPort = await getPort({ portRange: [32201, 32301] });
+  const wsPort = await getPort({ port: 32201, portRange: [32201, 32301], host });
 
   const server = startHttpServer(port, host, handler);
   server.on('listening', () => {
@@ -152,5 +154,5 @@ export default async function startPreviewServer(
     );
   });
 
-  return startWsServer(wsPort);
+  return startWsServer(wsPort, host);
 }

--- a/packages/cli/src/commands/preview-docs/preview-server/server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/server.ts
@@ -62,8 +62,8 @@ export function startHttpServer(port: number, host: string, handler: http.Reques
   return http.createServer(handler).listen(port, host);
 }
 
-export function startWsServer(port: number) {
-  const socketServer = new SocketServer({ port, clientTracking: true });
+export function startWsServer(port: number, host: string) {
+  const socketServer = new SocketServer({ port, host, clientTracking: true });
 
   socketServer.on('connection', (socket: any) => {
     socket.on('data', (data: string) => {


### PR DESCRIPTION
## What/Why/How?
Today the WS server used for hot reloading is initialized without specifying a host. But in the `hot.js` file, `127.0.0.1` is hardcoded as the host it should connect to. This breaks in some cases, such as when the websocket server binds to ipv6, and therefore isn't available on `127.0.0.1`.

This PR changes it so that the host provided via `--host` or `-h` is passed on to the WS server as well, not only to the http server. It also adds this host as a global variable, alongside the `wsPort` variable, so that `hot.js` can pick up the correct host when connecting to the websocket; instead of the hardcoded host today.

## Testing
No tests seem to exist for the preview-server functionality and I have not added any. Instead I have tested manually with a variety of commonly used hosts (`::`, `0.0.0.0`, `::1`, `localhost`, `127.0.0.1`) to confirm that they work.

## Check yourself

- [X] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
