### PR TITLE
OAS3_1 types `SchemaProperties` updated per JSON Schema draft 2020-12

### DIFF
--- a/.changeset/short-poets-sleep.md
+++ b/.changeset/short-poets-sleep.md
@@ -1,0 +1,9 @@
+---
+'@redocly/openapi-core': patch
+---
+
+OpenAPI 3.1.x defaults to JSON Schema draft 2020-12 and the value of property names defined in `properties` was updated since OpenAPI 3.0.x and JSON Schema draft-04.
+
+In the new JSON Schema specification, each property value within a `properties` schema accepts a `boolean` or `object` schema.
+
+https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1

--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -402,7 +402,24 @@ describe('lint', () => {
       config: await makeConfig({ spec: 'error' }),
     });
 
-    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "from": undefined,
+          "location": [
+            {
+              "pointer": "#/components/callbacks/resultCallback/{$url}/post/requestBody/content/application~1json/schema/properties/test",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Property \`test\` is not expected here.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
   });
 
   it('should ignore error because ignore file passed', async () => {

--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -402,24 +402,7 @@ describe('lint', () => {
       config: await makeConfig({ spec: 'error' }),
     });
 
-    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
-      [
-        {
-          "from": undefined,
-          "location": [
-            {
-              "pointer": "#/components/callbacks/resultCallback/{$url}/post/requestBody/content/application~1json/schema/properties/test",
-              "reportOnKey": true,
-              "source": "foobar.yaml",
-            },
-          ],
-          "message": "Property \`test\` is not expected here.",
-          "ruleId": "spec",
-          "severity": "error",
-          "suggest": [],
-        },
-      ]
-    `);
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
   });
 
   it('should ignore error because ignore file passed', async () => {

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -181,6 +181,18 @@ const Schema: NodeType = {
   extensionsPrefix: 'x-',
 };
 
+const SchemaProperties: NodeType = {
+  properties: {
+    propertyName: (value: any) => {
+      if (typeof value === 'boolean') {
+        return { type: 'boolean' };
+      } else {
+        return 'Schema';
+      }
+    },
+  },
+};
+
 const SecurityScheme: NodeType = {
   properties: {
     type: { enum: ['apiKey', 'http', 'oauth2', 'openIdConnect', 'mutualTLS'] },
@@ -256,6 +268,7 @@ export const Oas3_1Types: Record<string, NodeType> = {
   Info,
   Root,
   Schema,
+  SchemaProperties,
   License,
   Components,
   NamedPathItems: mapOf('PathItem'),

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -182,14 +182,13 @@ const Schema: NodeType = {
 };
 
 const SchemaProperties: NodeType = {
-  properties: {
-    propertyName: (value: any) => {
-      if (typeof value === 'boolean') {
-        return { type: 'boolean' };
-      } else {
-        return 'Schema';
-      }
-    },
+  properties: {},
+  additionalProperties: (value: any) => {
+    if (typeof value === 'boolean') {
+      return { type: 'boolean' };
+    } else {
+      return 'Schema';
+    }
   },
 };
 


### PR DESCRIPTION
## What/Why/How?

OpenAPI 3.1.x defaults to JSON Schema draft 2020-12 and the value of property names defined in `properties` was updated since OpenAPI 3.0.x and JSON Schema draft-04. 

In the new JSON Schema specification, each property value within a `properties` schema accepts a `boolean` or `object` schema.

fixes #1296 

## Reference
https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
