### PR TITLE
fix: improve browser detection when running with Bun

### DIFF
--- a/.changeset/twelve-kids-tan.md
+++ b/.changeset/twelve-kids-tan.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed incorrect browser detection by removing check for 'self' as Bun also exposes it by default. 

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,5 +1,5 @@
 export const isBrowser =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  typeof window !== 'undefined' || typeof self !== 'undefined' || typeof process === 'undefined'; // main and worker thread
+  typeof window !== 'undefined' || typeof process === 'undefined'; // main and worker thread
 export const env = isBrowser ? {} : process.env || {};


### PR DESCRIPTION
## What/Why/How?

Bun exposes self by default and the validation from https://github.com/Redocly/redocly-cli/blob/eadf29f6a89f49136ce097e665f6b92a8c4ecec1/packages/core/src/env.ts#L4 wrongly assumes isBrowser is true

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
