### PR TITLE
feat: create new rule to enforce array parameters format

### DIFF
--- a/.changeset/silver-singers-glow.md
+++ b/.changeset/silver-singers-glow.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": minor
+"@redocly/cli": minor
+---
+
+Added new rule `array-parameter-serialization` to enforce array parameters format.

--- a/.changeset/silver-singers-glow.md
+++ b/.changeset/silver-singers-glow.md
@@ -3,4 +3,4 @@
 "@redocly/cli": minor
 ---
 
-Added new rule `array-parameter-serialization` to enforce array parameters format.
+Added new rule `array-parameter-serialization` to require that serialization parameters `style` and `explode` are present on array parameters.

--- a/docs/rules/array-parameter-serialization.md
+++ b/docs/rules/array-parameter-serialization.md
@@ -105,6 +105,5 @@ paths:
 
 ## Resources
 
-- [Rule source for OAS 2.0](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/oas2/boolean-parameter-prefixes.ts)
-- [Rule source for OAS 3.0 and 3.1](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/oas3/boolean-parameter-prefixes.ts)
+- [Rule source for OAS 3.0 and 3.1](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/oas3/array-parameter-serialization.ts)
 - [OpenAPI Parameter](https://redocly.com/docs/openapi-visual-reference/parameter/) docs

--- a/docs/rules/array-parameter-serialization.md
+++ b/docs/rules/array-parameter-serialization.md
@@ -1,0 +1,110 @@
+---
+slug: /docs/cli/rules/array-parameter-serialization
+---
+
+# array-parameter-serialization
+
+Enforces the inclusion of `style` and `explode` fields for parameters with array type or parameters with a schema that includes `items` or `prefixItems`.
+
+| OAS | Compatibility |
+| --- | ------------- |
+| 2.0 | ❌            |
+| 3.0 | ✅            |
+| 3.1 | ✅            |
+
+```mermaid
+flowchart TD
+
+root ==> Paths --> PathItem --> Operation --> Parameter --enforces style and explode fields for array types--> Schema
+PathItem --> Parameter
+NamedParameter --> Parameter
+
+root ==> components
+
+subgraph components
+NamedParameter
+end
+
+style Parameter fill:#codaf9,stroke:#0044d4,stroke-width:5px
+style Schema fill:#codaf9,stroke:#0044d4,stroke-width:5px
+```
+
+## API design principles
+
+Specifying serialization details consistently helps developers understand how to interact with the API effectively.
+
+## Configuration
+
+| Option   | Type     | Description                                                                                                                      |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| severity | string   | Possible values: `off`, `warn`, `error`. Default `off`.                                                                          |
+| in       | [string] | List of valid parameter locations where the rule should be enforced. By default the rule applies to parameters in all locations. |
+
+An example configuration:
+
+```yaml
+rules:
+  array-parameter-serialization:
+    severity: error
+    in:
+      - query
+      - header
+```
+
+## Examples
+
+Given this configuration:
+
+```yaml
+rules:
+  array-parameter-serialization:
+    severity: error
+    in:
+      - query
+```
+
+Example of **incorrect** parameter:
+
+```yaml
+paths:
+  /example:
+    get:
+      parameters:
+        - name: exampleArray
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+```
+
+Example of **correct** parameter:
+
+```yaml
+paths:
+  /example:
+    get:
+      parameters:
+        - name: exampleArray
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+```
+
+## Related rules
+
+- [configurable rules](./configurable-rules.md)
+- [boolean-parameter-prefixes](./boolean-parameter-prefixes.md)
+- [no-invalid-parameter-examples](./no-invalid-parameter-examples.md)
+- [parameter-description](./parameter-description.md)
+- [operation-parameters-unique](./operation-parameters-unique.md)
+
+## Resources
+
+- [Rule source for OAS 2.0](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/oas2/boolean-parameter-prefixes.ts)
+- [Rule source for OAS 3.0 and 3.1](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/oas3/boolean-parameter-prefixes.ts)
+- [OpenAPI Parameter](https://redocly.com/docs/openapi-visual-reference/parameter/) docs

--- a/packages/core/src/config/__tests__/__snapshots__/config-resolvers.test.ts.snap
+++ b/packages/core/src/config/__tests__/__snapshots__/config-resolvers.test.ts.snap
@@ -21,6 +21,7 @@ exports[`resolveConfig should ignore minimal from the root and read local file 1
   "oas3_0Decorators": {},
   "oas3_0Preprocessors": {},
   "oas3_0Rules": {
+    "array-parameter-serialization": "off",
     "boolean-parameter-prefixes": "error",
     "component-name-unique": "off",
     "no-empty-servers": "error",
@@ -40,6 +41,7 @@ exports[`resolveConfig should ignore minimal from the root and read local file 1
   "oas3_1Decorators": {},
   "oas3_1Preprocessors": {},
   "oas3_1Rules": {
+    "array-parameter-serialization": "off",
     "boolean-parameter-prefixes": "error",
     "component-name-unique": "off",
     "no-empty-servers": "error",
@@ -125,6 +127,7 @@ exports[`resolveStyleguideConfig should resolve extends with local file config w
   "oas3_0Decorators": {},
   "oas3_0Preprocessors": {},
   "oas3_0Rules": {
+    "array-parameter-serialization": "off",
     "boolean-parameter-prefixes": "error",
     "component-name-unique": "off",
     "no-empty-servers": "error",
@@ -144,6 +147,7 @@ exports[`resolveStyleguideConfig should resolve extends with local file config w
   "oas3_1Decorators": {},
   "oas3_1Preprocessors": {},
   "oas3_1Rules": {
+    "array-parameter-serialization": "off",
     "boolean-parameter-prefixes": "error",
     "component-name-unique": "off",
     "no-empty-servers": "error",

--- a/packages/core/src/config/all.ts
+++ b/packages/core/src/config/all.ts
@@ -78,6 +78,7 @@ const all: PluginStyleguideConfig<'built-in'> = {
     'component-name-unique': 'error',
     'response-contains-property': 'error',
     'spec-components-invalid-map-name': 'error',
+    'array-parameter-serialization': 'error',
   },
   oas3_1Rules: {
     'no-invalid-media-type-examples': 'error',
@@ -101,6 +102,7 @@ const all: PluginStyleguideConfig<'built-in'> = {
     'component-name-unique': 'error',
     'response-contains-property': 'error',
     'spec-components-invalid-map-name': 'error',
+    'array-parameter-serialization': 'error',
   },
   async2Rules: {
     'channels-kebab-case': 'error',

--- a/packages/core/src/config/minimal.ts
+++ b/packages/core/src/config/minimal.ts
@@ -66,6 +66,7 @@ const minimal: PluginStyleguideConfig<'built-in'> = {
     'request-mime-type': 'off',
     'response-contains-property': 'off',
     'response-mime-type': 'off',
+    'array-parameter-serialization': 'off',
   },
   oas3_1Rules: {
     'no-invalid-media-type-examples': 'warn',
@@ -83,6 +84,7 @@ const minimal: PluginStyleguideConfig<'built-in'> = {
     'request-mime-type': 'off',
     'response-contains-property': 'off',
     'response-mime-type': 'off',
+    'array-parameter-serialization': 'off',
   },
   async2Rules: {
     'channels-kebab-case': 'off',

--- a/packages/core/src/config/recommended-strict.ts
+++ b/packages/core/src/config/recommended-strict.ts
@@ -66,6 +66,7 @@ const recommendedStrict: PluginStyleguideConfig<'built-in'> = {
     'request-mime-type': 'off',
     'response-contains-property': 'off',
     'response-mime-type': 'off',
+    'array-parameter-serialization': 'off',
   },
   oas3_1Rules: {
     'no-invalid-media-type-examples': 'error',
@@ -83,6 +84,7 @@ const recommendedStrict: PluginStyleguideConfig<'built-in'> = {
     'request-mime-type': 'off',
     'response-contains-property': 'off',
     'response-mime-type': 'off',
+    'array-parameter-serialization': 'off',
   },
   async2Rules: {
     'channels-kebab-case': 'off',

--- a/packages/core/src/config/recommended.ts
+++ b/packages/core/src/config/recommended.ts
@@ -66,6 +66,7 @@ const recommended: PluginStyleguideConfig<'built-in'> = {
     'request-mime-type': 'off',
     'response-contains-property': 'off',
     'response-mime-type': 'off',
+    'array-parameter-serialization': 'off',
   },
   oas3_1Rules: {
     'no-invalid-media-type-examples': 'warn',
@@ -83,6 +84,7 @@ const recommended: PluginStyleguideConfig<'built-in'> = {
     'request-mime-type': 'off',
     'response-contains-property': 'off',
     'response-mime-type': 'off',
+    'array-parameter-serialization': 'off',
   },
   async2Rules: {
     'channels-kebab-case': 'off',

--- a/packages/core/src/rules/oas3/__tests__/array-parameter-serialization.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/array-parameter-serialization.test.ts
@@ -98,22 +98,28 @@ describe('oas3 array-parameter-serialization', () => {
   it('should report on parameter without type but with items', async () => {
     const document = parseYamlToDocument(
       outdent`
-        openapi: 3.0.0
-        paths:
-          '/test':
-            parameters:
-            - name: a
-              in: query
-              schema:
-                items:
-                  type: string
-            - name: b
-              in: header
-              schema:
-                type: array
-                items:
-                  type: string     
-      `,
+        openapi: 3.1.0
+        paths: 
+          /test:
+            parameters: 
+              - name: test only type, path level
+                in: query
+                schema:
+                  type: array # no items
+            get: 
+              parameters: 
+                - name: test only items, operation level
+                  in: header
+                  items: # no type
+                    type: string
+        components: 
+          parameters:
+            TestParameter: 
+              in: cookie
+              name: test only prefixItems, components level
+              prefixItems: # no type or items
+                - type: number    
+              `,
       'foobar.yaml'
     );
     const results = await lintDocument({
@@ -133,7 +139,7 @@ describe('oas3 array-parameter-serialization', () => {
               "source": "foobar.yaml",
             },
           ],
-          "message": "Parameter \`a\` should have \`style\` and \`explode \` fields",
+          "message": "Parameter \`test only type, path level\` should have \`style\` and \`explode \` fields",
           "ruleId": "array-parameter-serialization",
           "severity": "error",
           "suggest": [],

--- a/packages/core/src/rules/oas3/array-parameter-serialization.ts
+++ b/packages/core/src/rules/oas3/array-parameter-serialization.ts
@@ -1,0 +1,43 @@
+import { Oas3Rule, Oas3Visitor } from '../../visitors';
+import { isRef } from '../../ref-utils';
+import { Oas3_1Schema, Oas3Parameter } from '../../typings/openapi';
+
+export type ArrayParameterSerializationOptions = {
+  in?: string[];
+};
+
+export const ArrayParameterSerialization: Oas3Rule = (
+  options: ArrayParameterSerializationOptions
+): Oas3Visitor => {
+  return {
+    Parameter: {
+      leave(node: Oas3Parameter, ctx) {
+        if (!node.schema) {
+          return;
+        }
+        const schema = isRef(node.schema)
+          ? ctx.resolve<Oas3_1Schema>(node.schema).node
+          : (node.schema as Oas3_1Schema);
+
+        if (schema && shouldReportMissingStyleAndExplode(node, schema, options)) {
+          ctx.report({
+            message: `Parameter \`${node.name}\` should have \`style\` and \`explode \` fields`,
+            location: ctx.location,
+          });
+        }
+      },
+    },
+  };
+};
+
+function shouldReportMissingStyleAndExplode(
+  node: Oas3Parameter,
+  schema: Oas3_1Schema,
+  options: ArrayParameterSerializationOptions
+) {
+  return (
+    (schema.type === 'array' || schema.items || schema.prefixItems) &&
+    (!node.style || !node.explode) &&
+    (!options.in || (node.in && options.in?.includes(node.in)))
+  );
+}

--- a/packages/core/src/rules/oas3/array-parameter-serialization.ts
+++ b/packages/core/src/rules/oas3/array-parameter-serialization.ts
@@ -37,7 +37,7 @@ function shouldReportMissingStyleAndExplode(
 ) {
   return (
     (schema.type === 'array' || schema.items || schema.prefixItems) &&
-    (!node.style || !node.explode) &&
+    (node.style === undefined || node.explode === undefined) &&
     (!options.in || (node.in && options.in?.includes(node.in)))
   );
 }

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -52,6 +52,7 @@ import { Operation4xxProblemDetailsRfc7807 } from './operation-4xx-problem-detai
 import { RequiredStringPropertyMissingMinLength } from '../common/required-string-property-missing-min-length';
 import { SpecStrictRefs } from '../common/spec-strict-refs';
 import { ComponentNameUnique } from './component-name-unique';
+import { ArrayParameterSerialization } from './array-parameter-serialization';
 
 export const rules: Oas3RuleSet<'built-in'> = {
   spec: Spec,
@@ -108,6 +109,7 @@ export const rules: Oas3RuleSet<'built-in'> = {
   'required-string-property-missing-min-length': RequiredStringPropertyMissingMinLength,
   'spec-strict-refs': SpecStrictRefs,
   'component-name-unique': ComponentNameUnique,
+  'array-parameter-serialization': ArrayParameterSerialization,
 };
 
 export const preprocessors = {};

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -77,6 +77,7 @@ const builtInOAS3Rules = [
   'response-contains-property',
   'response-mime-type',
   'spec-components-invalid-map-name',
+  'array-parameter-serialization',
 ] as const;
 
 export type BuiltInOAS3RuleId = typeof builtInOAS3Rules[number];

--- a/packages/core/src/typings/openapi.ts
+++ b/packages/core/src/typings/openapi.ts
@@ -156,6 +156,7 @@ export interface Oas3Schema {
 export type Oas3_1Schema = Oas3Schema & {
   type?: string | string[];
   examples?: any[];
+  prefixItems?: Oas3_1Schema[];
 };
 
 export interface Oas3_1Definition extends Oas3Definition {


### PR DESCRIPTION
## What/Why/How?

Create new rule `array-parameter-serialization` rule to enforce array parameters format.

This Rule enforces to define  fields `explode` and `style` for parameter if param's schema type is `array` or has `items` or `preffixItems`

## Reference

## Testing
https://github.com/Redocly/redocly-cli/issues/1317
## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
