### PR TITLE
docs: Add a cookbook mention to the configurable rules page

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -656,4 +656,3 @@ rules:
 ## Find and share examples
 
 Configurable rules allow such flexibility, but they can be complex to start with. To help you along the way, take a look at the [Redocly CLI Cookbook](https://github.com/Redocly/redocly-cli-cookbook#readme) where our community goes to share its best examples. Choose from the menu available, and don't forget to share your own rules too.
-

--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -652,3 +652,8 @@ rules:
         - name
         - description
 ```
+
+## Find and share examples
+
+Configurable rules allow such flexibility, but they can be complex to start with. To help you along the way, take a look at the [Redocly CLI Cookbook](https://github.com/Redocly/redocly-cli-cookbook#readme) where our community goes to share its best examples. Choose from the menu available, and don't forget to share your own rules too.
+


### PR DESCRIPTION
## What/Why/How?

Adding a signpost to the cookbook to signpost to more configurable rules examples.

(this minor change is also to test if we can publish docs)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
