### PR TITLE
chore: adjust the clean command and remove redundant changeset

### DIFF
--- a/.changeset/bright-steaks-walk.md
+++ b/.changeset/bright-steaks-walk.md
@@ -1,5 +1,0 @@
----
-"@redocly/cli": patch
----
-
-Support standalone docs development to facilitate more contributors, add docs quality checks to CI.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier": "npx prettier --write \"**/*.{ts,js,yaml,json,md}\"",
     "prettier:check": "npx prettier --check \"**/*.{ts,js,yaml,json,md}\"",
     "eslint": "eslint packages/**",
-    "clean": "rm -rf packages/**/lib packages/**/node_modules packages/**/*.tsbuildinfo package-lock.json node_modules",
+    "clean": "rm -rf packages/**/lib packages/**/node_modules packages/**/*.tsbuildinfo package-lock.json node_modules dist",
     "watch": "tsc -b tsconfig.build.json --watch ",
     "compile": "tsc -b tsconfig.build.json",
     "prepare": "npm run compile",


### PR DESCRIPTION
## What/Why/How?

Adjusting the `npm run clean` command to clear the dist/ folder as well.
Removing a redundant changeset.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
