### PR TITLE
chore: deprecate lint option in the join command

### DIFF
--- a/.changeset/new-books-cross.md
+++ b/.changeset/new-books-cross.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Deprecated `--lint` option in the `join` command. The options are marked for removal in a future release. Use the [lint command](https://redocly.com/docs/cli/commands/lint/) separately to lint your APIs.

--- a/docs/commands/join.md
+++ b/docs/commands/join.md
@@ -35,13 +35,18 @@ redocly join --version
 
 ## Options
 
+{% admonition type="warning" name="Important" %}
+The `--lint` option is deprecated and is marked for removal in future releases.
+Use the [lint command](./lint.md) separately to lint your APIs before bundling.
+{% /admonition %}
+
 | Option                             | Type     | Description                                                                                                                                                                                                |
 | ---------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | apis                               | [string] | **REQUIRED.** 1. Array of paths to API description files that you want to join. At least two input files are required.<br />2. A wildcard pattern to match API description files within a specific folder. |
 | --config                           | string   | Specify path to the [config file](../configuration/index.md).                                                                                                                                              |
 | --decorate                         | boolean  | Run decorators.                                                                                                                                                                                            |
 | --help                             | boolean  | Show help.                                                                                                                                                                                                 |
-| --lint                             | boolean  | Lint API description files.                                                                                                                                                                                |
+| --lint (**Deprecated**)            | boolean  | Lint API description files.                                                                                                                                                                                |
 | --lint-config                      | string   | Specify the severity level for the configuration file. <br/> **Possible values:** `warn`, `error`, `off`. Default value is `warn`.                                                                         |
 | --output, -o                       | string   | Name for the joined output file. Defaults to `openapi.yaml` or `openapi.json` (Depends on the extension of the first input file). **If the file already exists, it's overwritten.**                        |
 | --prefix-components-with-info-prop | string   | Prefix components with property value from info object. See the [prefix-components-with-info-prop section](#prefix-components-with-info-prop) below.                                                       |

--- a/docs/commands/join.md
+++ b/docs/commands/join.md
@@ -37,7 +37,7 @@ redocly join --version
 
 {% admonition type="warning" name="Important" %}
 The `--lint` option is deprecated and is marked for removal in future releases.
-Use the [lint command](./lint.md) separately to lint your APIs before bundling.
+Use the [lint command](./lint.md) separately to lint your APIs before joining.
 {% /admonition %}
 
 | Option                             | Type     | Description                                                                                                                                                                                                |

--- a/packages/cli/src/__mocks__/utils.ts
+++ b/packages/cli/src/__mocks__/utils.ts
@@ -19,3 +19,4 @@ export const checkIfRulesetExist = jest.fn();
 export const sortTopLevelKeysForOas = jest.fn((document) => document);
 export const getAndValidateFileExtension = jest.fn((fileName: string) => fileName.split('.').pop());
 export const writeToFileByExtension = jest.fn();
+export const checkForDeprecatedOptions = jest.fn();

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -23,6 +23,7 @@ import type { OutputExtensions, Skips, Totals } from '../types';
 import { performance } from 'perf_hooks';
 import { blue, gray, green, yellow } from 'colorette';
 import { writeFileSync } from 'fs';
+import { checkForDeprecatedOptions } from '../utils';
 
 export type BundleOptions = {
   apis?: string[];
@@ -47,8 +48,15 @@ export async function handleBundle(argv: BundleOptions, config: Config, version:
   const apis = await getFallbackApisOrExit(argv.apis, config);
   const totals: Totals = { errors: 0, warnings: 0, ignored: 0 };
   const maxProblems = argv['max-problems'];
+  const deprecatedOptions: Array<keyof BundleOptions> = [
+    'lint',
+    'format',
+    'skip-rule',
+    'extends',
+    'max-problems',
+  ];
 
-  checkForDeprecatedOptions(argv);
+  checkForDeprecatedOptions(argv, deprecatedOptions);
 
   for (const { path, alias } of apis) {
     try {
@@ -175,25 +183,5 @@ export async function handleBundle(argv: BundleOptions, config: Config, version:
 
   if (!(totals.errors === 0 || argv.force)) {
     throw new Error('Bundle failed.');
-  }
-}
-
-function checkForDeprecatedOptions(argv: BundleOptions) {
-  const deprecatedOptions: Array<keyof BundleOptions> = [
-    'lint',
-    'format',
-    'skip-rule',
-    'extends',
-    'max-problems',
-  ];
-
-  for (const option of deprecatedOptions) {
-    if (argv[option]) {
-      process.stderr.write(
-        yellow(
-          `[WARNING] "${option}" option is deprecated and will be removed in a future release. \n\n`
-        )
-      );
-    }
   }
 }

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -29,6 +29,7 @@ import {
   sortTopLevelKeysForOas,
   getAndValidateFileExtension,
   writeToFileByExtension,
+  checkForDeprecatedOptions,
 } from '../utils';
 import { isObject, isString, keysOf } from '../js-utils';
 import {
@@ -65,7 +66,6 @@ export type JoinOptions = {
   'without-x-tag-groups'?: boolean;
   output?: string;
   config?: string;
-  extends?: undefined;
   'lint-config'?: RuleSeverity;
 };
 
@@ -75,6 +75,8 @@ export async function handleJoin(argv: JoinOptions, config: Config, packageVersi
   if (argv.apis.length < 2) {
     return exitWithError(`At least 2 apis should be provided. \n\n`);
   }
+
+  checkForDeprecatedOptions(argv, ['lint'] as Array<keyof JoinOptions>);
 
   const fileExtension = getAndValidateFileExtension(argv.output || argv.apis[0]);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,7 +101,7 @@ yargs
           demandOption: true,
         })
         .option({
-          lint: { description: 'Lint definitions', type: 'boolean', default: false },
+          lint: { description: 'Lint definitions', type: 'boolean', default: false, hidden: true },
           decorate: { description: 'Run decorators', type: 'boolean', default: false },
           preprocess: { description: 'Run preprocessors', type: 'boolean', default: false },
           'prefix-tags-with-info-prop': {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -626,3 +626,17 @@ export function cleanArgs(args: CommandOptions) {
 export function cleanRawInput(argv: string[]) {
   return argv.map((entry) => entry.split('=').map(cleanString).join('=')).join(' ');
 }
+
+export function checkForDeprecatedOptions<T>(argv: T, deprecatedOptions: Array<keyof T>) {
+  for (const option of deprecatedOptions) {
+    if (argv[option]) {
+      process.stderr.write(
+        yellow(
+          `[WARNING] "${String(
+            option
+          )}" option is deprecated and will be removed in a future release. \n\n`
+        )
+      );
+    }
+  }
+}


### PR DESCRIPTION
## What/Why/How?

Add deprecate warning for the `--lint` option in the `join` command.

## Reference

Related: https://github.com/Redocly/redocly-cli/issues/1250

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
