### PR TITLE
docs: Minor fix to code sample from website feedback

### DIFF
--- a/docs/custom-plugins/custom-rules.md
+++ b/docs/custom-plugins/custom-rules.md
@@ -38,7 +38,7 @@ The `ctx` object here holds all the context, which can be used to give more situ
 Adding this as part of a plugin requires you to add it to the `rules` part of the plugin object, under the relevant document type. The example rule here is intended to be used with OpenAPI, so the plugin code in `plugins/my-rules.js` is as follows:
 
 ```js
-const OpIdNotTest = require('./rules/opid-not-test.js');
+const OperationIdNotTest = require('./rules/opid-not-test.js');
 
 module.exports = {
   id: 'my-rules',


### PR DESCRIPTION
## What/Why/How?

We got a feedback item about an incorrectly named import in a code sample. This fixes it.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
