### PR TITLE
docs: explain using refs in a config file

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -231,7 +231,7 @@ Therefore, only the header from the first match is used in the request.
 ### Split up the configuration file
 
 As your config file grows, you may want to split it into multiple parts.
-That is possible by using references in a config similar to how they are used in OpenAPI descriptions:
+Splitting a config file is possible by using references in a config similar to how they are used in OpenAPI descriptions:
 
 ```yaml
 extends:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -227,3 +227,23 @@ resolve:
 
 The first match takes priority when a URL matches multiple patterns.
 Therefore, only the header from the first match is used in the request.
+
+### Split up the configuration file
+
+As your config file grows, you may want to split it into multiple parts.
+That is possible by using references in a config similar to how they are used in OpenAPI descriptions:
+
+```yaml
+extends:
+  - recommended
+
+theme:
+  openapi:
+    $ref: ./openapi-theme.yaml
+  mockServer:
+    $ref: ./mockserver.yaml
+```
+
+{% admonition type="attention" %}
+When using the `push` command with `$ref`s in a config file, all referenced files should explicitly upload using the `--files` option
+{% /admonition %}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -245,5 +245,5 @@ theme:
 ```
 
 {% admonition type="attention" %}
-When using the `push` command with `$ref`s in a config file, all referenced files should explicitly upload using the `--files` option
+When using the `push` command with a config file that includes `$ref`s, all referenced files are explicitly uploaded using the `--files` option.
 {% /admonition %}


### PR DESCRIPTION
## What/Why/How?

Added docs for $refs in the config file: https://github.com/Redocly/redocly-cli/pull/1345.

Merge this alongside [the release](https://github.com/Redocly/redocly-cli/pull/1361).

## Reference


## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
