### PR TITLE
docs: fix typo in the migration guide

### DIFF
--- a/docs/guides/migrate-from-swagger-cli.md
+++ b/docs/guides/migrate-from-swagger-cli.md
@@ -74,7 +74,7 @@ Both commands have additional options; here's a quick reference on how to replac
 
 - Keep `-o` or replace `--outfile` with `--output` to direct the command output to a filename.
 - Replace the `-t` or `--type` argument with `--ext` for the file type to output. Redocly CLI also detects the correct format from the output filename, so this option isn't needed for file output, but can be useful if outputting to stdout.
-- Replace `-r` or `--dereference` with `-r` or `--dereferenced` to output a file with all `$ref`s resolved.
+- Replace `-r` or `--dereference` with `-d` or `--dereferenced` to output a file with all `$ref`s resolved.
 
 ## Get the best from Redocly CLI
 


### PR DESCRIPTION
Fixed typo in the migration guide