### PR TITLE
docs: Add a note about expected newlines in multiline markdown fields

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -493,6 +493,11 @@ rules:
       notPattern: /^The/
 ```
 
+Take care using `notPattern` with multiline Markdown values such as
+`description` fields. These may end with a newline rather than the character
+you expect. Use the trimmed notations (`|-` or `>-`) or take account of this in
+your pattern.
+
 ### `pattern` example
 
 The following example asserts that the operation summary contains "test".
@@ -506,6 +511,10 @@ rules:
     assertions:
       pattern: /test/
 ```
+
+Take care using `pattern` with multiline Markdown values such as `description`
+fields. These may end with a newline rather than the character you expect. Use
+the trimmed notations (`|-` or `>-`) or take account of this in your pattern.
 
 ### `ref` example
 


### PR DESCRIPTION
## What/Why/How?

Fixes #649 by adding a clarifying note that markdown fields may have trailing newlines.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
