### PR TITLE
feat: Improve CLI help output

### DIFF
--- a/__tests__/bundle/bundle-lint-format/emptyFormatValue-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/emptyFormatValue-snapshot.js
@@ -4,7 +4,7 @@ exports[`E2E bundle lint format bundle lint: no format parameter or empty value 
 
 index.ts bundle [apis...]
 
-Bundle definition.
+Bundle a multi-file API description to a single file.
 
 Positionals:
   apis                                                     [array] [default: []]
@@ -12,7 +12,7 @@ Positionals:
 Options:
       --version                   Show version number.                 [boolean]
       --help                      Show help.                           [boolean]
-  -o, --output                                                          [string]
+  -o, --output                    Output file.                          [string]
       --ext                       Bundle file extension.
                                                 [choices: "json", "yaml", "yml"]
       --skip-preprocessor         Ignore certain preprocessors.          [array]

--- a/__tests__/lint-config/invalid-lint-config-severity/snapshot.js
+++ b/__tests__/lint-config/invalid-lint-config-severity/snapshot.js
@@ -4,7 +4,7 @@ exports[`E2E lint-config test with option: { dirName: 'invalid-lint-config-sever
 
 index.ts lint [apis...]
 
-Lint definition.
+Lint an API description.
 
 Positionals:
   apis                                                     [array] [default: []]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,7 +53,7 @@ yargs
     }
   )
   .command(
-    'split --outDir [directory] [api]',
+    'split [api]',
     'Split an API description into a multi-file structure.',
     (yargs) =>
       yargs
@@ -124,7 +124,7 @@ yargs
             type: 'boolean',
           },
           output: {
-            description: 'Output file',
+            description: 'Output file.',
             alias: 'o',
             type: 'string',
           },
@@ -292,8 +292,8 @@ yargs
       yargs.positional('apis', { array: true, type: 'string', demandOption: true }).options({
         output: {
           type: 'string',
-          description: 'Output file',
-          alias: 'o'
+          description: 'Output file.',
+          alias: 'o',
         },
         format: {
           description: 'Use a specific output format.',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,7 +53,7 @@ yargs
     }
   )
   .command(
-    'split [api]',
+    'split --outDir [directory] [api]',
     'Split an API description into a multi-file structure.',
     (yargs) =>
       yargs
@@ -92,7 +92,7 @@ yargs
   )
   .command(
     'join [apis...]',
-    'Join definitions [experimental].',
+    'Join multiple API descriptions into one [experimental].',
     (yargs) =>
       yargs
         .positional('apis', {
@@ -101,7 +101,7 @@ yargs
           demandOption: true,
         })
         .option({
-          lint: { description: 'Lint definitions', type: 'boolean', default: false, hidden: true },
+          lint: { description: 'Lint descriptions', type: 'boolean', default: false, hidden: true },
           decorate: { description: 'Run decorators', type: 'boolean', default: false },
           preprocess: { description: 'Run preprocessors', type: 'boolean', default: false },
           'prefix-tags-with-info-prop': {
@@ -124,7 +124,7 @@ yargs
             type: 'boolean',
           },
           output: {
-            describe: 'Output file',
+            description: 'Output file',
             alias: 'o',
             type: 'string',
           },
@@ -228,7 +228,7 @@ yargs
   )
   .command(
     'lint [apis...]',
-    'Lint definition.',
+    'Lint an API description.',
     (yargs) =>
       yargs.positional('apis', { array: true, type: 'string', demandOption: true }).option({
         format: {
@@ -287,10 +287,14 @@ yargs
   )
   .command(
     'bundle [apis...]',
-    'Bundle definition.',
+    'Bundle a multi-file API description to a single file.',
     (yargs) =>
       yargs.positional('apis', { array: true, type: 'string', demandOption: true }).options({
-        output: { type: 'string', alias: 'o' },
+        output: {
+          type: 'string',
+          description: 'Output file',
+          alias: 'o'
+        },
         format: {
           description: 'Use a specific output format.',
           choices: ['stylish', 'codeframe', 'json', 'checkstyle'] as ReadonlyArray<OutputFormat>,
@@ -415,7 +419,7 @@ yargs
   )
   .command(
     'preview-docs [api]',
-    'Preview API reference docs for the specified definition.',
+    'Preview API reference docs for an API description.',
     (yargs) =>
       yargs.positional('api', { type: 'string' }).options({
         port: {
@@ -519,7 +523,7 @@ yargs
       commandWrapper(handlerBuildCommand)(argv as Arguments<BuildDocsArgv>);
     }
   )
-  .completion('completion', 'Generate completion script.')
+  .completion('completion', 'Generate autocomplete script for `redocly` command.')
   .demandCommand(1)
   .middleware([notifyUpdateCliVersion])
   .strict().argv;


### PR DESCRIPTION
## What/Why/How?

Fixes #1237 (or tries to) by using more consistent language and expanding descriptions show in the output of `redocly --help`.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
