### PR TITLE
docs: correct description of multiline patterns usage based on #1353

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -495,7 +495,7 @@ rules:
 
 Take care using `notPattern` with multiline Markdown values such as `description` fields.
 These may end with a newline or a space rather than the character you expect.
-Use the [double-quotated style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
+Use the [double-quoted style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
 
 ### `pattern` example
 

--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -513,7 +513,7 @@ rules:
 
 Take care using `pattern` with multiline Markdown values such as `description` fields.
 These may end with a newline or a space rather than the character you expect.
-Use the [double-quotated style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
+Use the [double-quoted style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
 
 ### `ref` example
 

--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -493,8 +493,8 @@ rules:
       notPattern: /^The/
 ```
 
-Take care using `notPattern` with multiline Markdown values such as `description` fields. 
-These may end with a newline or a space rather than the character you expect. 
+Take care using `notPattern` with multiline Markdown values such as `description` fields.
+These may end with a newline or a space rather than the character you expect.
 Use the [double-quotated style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
 
 ### `pattern` example
@@ -511,8 +511,8 @@ rules:
       pattern: /test/
 ```
 
-Take care using `pattern` with multiline Markdown values such as `description` fields. 
-These may end with a newline or a space rather than the character you expect. 
+Take care using `pattern` with multiline Markdown values such as `description` fields.
+These may end with a newline or a space rather than the character you expect.
 Use the [double-quotated style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
 
 ### `ref` example

--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -493,10 +493,9 @@ rules:
       notPattern: /^The/
 ```
 
-Take care using `notPattern` with multiline Markdown values such as
-`description` fields. These may end with a newline rather than the character
-you expect. Use the trimmed notations (`|-` or `>-`) or take account of this in
-your pattern.
+Take care using `notPattern` with multiline Markdown values such as `description` fields. 
+These may end with a newline or a space rather than the character you expect. 
+Use the [double-quotated style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
 
 ### `pattern` example
 
@@ -512,9 +511,9 @@ rules:
       pattern: /test/
 ```
 
-Take care using `pattern` with multiline Markdown values such as `description`
-fields. These may end with a newline rather than the character you expect. Use
-the trimmed notations (`|-` or `>-`) or take account of this in your pattern.
+Take care using `pattern` with multiline Markdown values such as `description` fields. 
+These may end with a newline or a space rather than the character you expect. 
+Use the [double-quotated style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
 
 ### `ref` example
 


### PR DESCRIPTION
## What/Why/How?

The description was not quite correct. Fixed based on #1351 (kudos to @jeremyfiel!).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
