### PR TITLE
chore: move TypeScript type dependencies to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12894,7 +12894,6 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
-        "@types/node": "^14.11.8",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
@@ -12909,6 +12908,7 @@
         "@types/js-yaml": "^4.0.3",
         "@types/lodash.isequal": "^4.5.5",
         "@types/minimatch": "^3.0.5",
+        "@types/node": "^14.11.8",
         "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "typescript": "^5.2.2"
@@ -15558,7 +15558,7 @@
         "@types/js-yaml": "^4.0.3",
         "@types/lodash.isequal": "^4.5.5",
         "@types/minimatch": "^3.0.5",
-        "@types/node": "^14.11.8",
+        "@types/node": "^14.18.63",
         "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "colorette": "^1.2.0",
@@ -15573,9 +15573,10 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.31.tgz",
-          "integrity": "sha512-vQAnaReSQkEDa8uwAyQby8bYGKu84R/deEc6mg5T8fX6gzCn8QW6rziSgsti1fNvsrswKUKPnVTi7uoB+u62Mw=="
+          "version": "14.18.63",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+          "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/jest": "^26.0.15",
         "@types/mark.js": "^8.11.5",
         "@types/marked": "^4.0.3",
-        "@types/node": "^17.0.31",
+        "@types/node": "^20.11.5",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
         "@typescript-eslint/parser": "^6.8.0",
         "eslint": "^8.22.0",
@@ -3767,10 +3767,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -12050,6 +12053,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -12908,7 +12917,7 @@
         "@types/js-yaml": "^4.0.3",
         "@types/lodash.isequal": "^4.5.5",
         "@types/minimatch": "^3.0.5",
-        "@types/node": "^14.11.8",
+        "@types/node": "^20.11.5",
         "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "typescript": "^5.2.2"
@@ -12917,11 +12926,6 @@
         "node": ">=14.19.0",
         "npm": ">=7.0.0"
       }
-    },
-    "packages/core/node_modules/@types/node": {
-      "version": "14.18.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.31.tgz",
-      "integrity": "sha512-vQAnaReSQkEDa8uwAyQby8bYGKu84R/deEc6mg5T8fX6gzCn8QW6rziSgsti1fNvsrswKUKPnVTi7uoB+u62Mw=="
     }
   },
   "dependencies": {
@@ -15558,7 +15562,7 @@
         "@types/js-yaml": "^4.0.3",
         "@types/lodash.isequal": "^4.5.5",
         "@types/minimatch": "^3.0.5",
-        "@types/node": "^14.18.63",
+        "@types/node": "^20.11.5",
         "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "colorette": "^1.2.0",
@@ -15570,14 +15574,6 @@
         "pluralize": "^8.0.0",
         "typescript": "^5.2.2",
         "yaml-ast-parser": "0.0.43"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.63",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-          "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-          "dev": true
-        }
       }
     },
     "@sinclair/typebox": {
@@ -15842,10 +15838,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -21977,6 +21976,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/jest": "^26.0.15",
     "@types/mark.js": "^8.11.5",
     "@types/marked": "^4.0.3",
-    "@types/node": "^17.0.31",
+    "@types/node": "^20.11.5",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
     "eslint": "^8.22.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "@types/js-yaml": "^4.0.3",
     "@types/lodash.isequal": "^4.5.5",
     "@types/minimatch": "^3.0.5",
-    "@types/node": "^14.11.8",
+    "@types/node": "^20.11.5",
     "@types/node-fetch": "^2.5.7",
     "@types/pluralize": "^0.0.29",
     "typescript": "^5.2.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.11.0",
-    "@types/node": "^14.11.8",
     "colorette": "^1.2.0",
     "js-levenshtein": "^1.1.6",
     "js-yaml": "^4.1.0",
@@ -50,6 +49,7 @@
     "@types/js-yaml": "^4.0.3",
     "@types/lodash.isequal": "^4.5.5",
     "@types/minimatch": "^3.0.5",
+    "@types/node": "^14.11.8",
     "@types/node-fetch": "^2.5.7",
     "@types/pluralize": "^0.0.29",
     "typescript": "^5.2.2"


### PR DESCRIPTION
## What/Why/How?

Currently, `@types/node` is a dependency in the `@redocly/openapi-core` package. As these are only TypeScript types, they are not needed in production and can be moved to a dev dependency.

Also, there is already a `@types/node@17.0.31` in the root package. My question would be whether the dependency there should be sufficient and whether the dependency should be changed to a more up-to-date version.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
