### PR TITLE
chore: pin Vale in GitHub action to last v2 vale version until we update to v3

### DIFF
--- a/.github/workflows/docs-tests.yaml
+++ b/.github/workflows/docs-tests.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           files: '["README.md", "docs"]'
           filter_mode: file
+          version: 2.30.0
 
   linkcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What/Why/How?

Vale has a new release (yay!) but it came with some directory structure changes and these are causing the build to fail. This pull request pins to a working version and I'll follow up with another one to handle the v3 update.

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
