### PR TITLE
feat: add markdown output format to stats command

### DIFF
--- a/.changeset/pink-waves-press.md
+++ b/.changeset/pink-waves-press.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Added markdown format option to stats command for use with GitHub job summaries.

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -494,4 +494,39 @@ describe('E2E', () => {
       expect(fs.statSync(join(testPath, 'nested/redoc-static.html')).size).toEqual(33016);
     });
   });
+
+  describe('stats', () => {
+    const folderPath = join(__dirname, 'stats');
+
+    test('stats should produce correct output (stylish format)', () => {
+      const testPath = join(folderPath, 'stats-stylish');
+      const args = getParams('../../../packages/cli/src/index.ts', 'stats', [
+        'museum.yaml',
+      ]);
+      const result = getCommandOutput(args, testPath);
+      (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
+    });
+
+    test('stats should produce correct JSON output', () => {
+      const testPath = join(folderPath, 'stats-json');
+      const args = getParams('../../../packages/cli/src/index.ts', 'stats', [
+        'museum.yaml',
+        '--format=json',
+      ]);
+      const result = getCommandOutput(args, testPath);
+      (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
+    });
+
+    test('stats should produce correct Markdown format', () => {
+      const testPath = join(folderPath, 'stats-markdown');
+      const args = getParams('../../../packages/cli/src/index.ts', 'stats', [
+        'museum.yaml',
+        '--format=markdown',
+      ]);
+      const result = getCommandOutput(args, testPath);
+      (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
+    });
+
+  });
+
 });

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -500,9 +500,7 @@ describe('E2E', () => {
 
     test('stats should produce correct output (stylish format)', () => {
       const testPath = join(folderPath, 'stats-stylish');
-      const args = getParams('../../../packages/cli/src/index.ts', 'stats', [
-        'museum.yaml',
-      ]);
+      const args = getParams('../../../packages/cli/src/index.ts', 'stats', ['museum.yaml']);
       const result = getCommandOutput(args, testPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
     });
@@ -526,7 +524,5 @@ describe('E2E', () => {
       const result = getCommandOutput(args, testPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
     });
-
   });
-
 });

--- a/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
+++ b/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
@@ -114,4 +114,7 @@ Document: openapi.yaml stats:
 👷 Operations: 2 
 🔖 Tags: 0 
 
+openapi.yaml: stats processed in <test>ms
+
+
 `;

--- a/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
+++ b/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
@@ -114,7 +114,4 @@ Document: openapi.yaml stats:
 👷 Operations: 2 
 🔖 Tags: 0 
 
-openapi.yaml: stats processed in <test>ms
-
-
 `;

--- a/__tests__/stats/stats-json/museum.yaml
+++ b/__tests__/stats/stats-json/museum.yaml
@@ -1,0 +1,1 @@
+../../../resources/museum.yaml

--- a/__tests__/stats/stats-json/snapshot.js
+++ b/__tests__/stats/stats-json/snapshot.js
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E stats stats should produce correct JSON output 1`] = `
+{
+  "refs": {
+    "metric": "🚗 References",
+    "total": 39
+  },
+  "externalDocs": {
+    "metric": "📦 External Documents",
+    "total": 0
+  },
+  "schemas": {
+    "metric": "📈 Schemas",
+    "total": 22
+  },
+  "parameters": {
+    "metric": "👉 Parameters",
+    "total": 6
+  },
+  "links": {
+    "metric": "🔗 Links",
+    "total": 0
+  },
+  "pathItems": {
+    "metric": "➡️  Path Items",
+    "total": 5
+  },
+  "operations": {
+    "metric": "👷 Operations",
+    "total": 8
+  },
+  "tags": {
+    "metric": "🔖 Tags",
+    "total": 3
+  }
+}
+
+`;

--- a/__tests__/stats/stats-markdown/museum.yaml
+++ b/__tests__/stats/stats-markdown/museum.yaml
@@ -1,0 +1,1 @@
+../../../resources/museum.yaml

--- a/__tests__/stats/stats-markdown/snapshot.js
+++ b/__tests__/stats/stats-markdown/snapshot.js
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`E2E stats stats should produce correct Markdown format 1`] = `
-- 🚗 References: 39
-- 📦 External Documents: 0
-- 📈 Schemas: 22
-- 👉 Parameters: 6
-- 🔗 Links: 0
-- ➡️  Path Items: 5
-- 👷 Operations: 8
-- 🔖 Tags: 3
+| Feature  | Count  |
+| --- | --- |
+| 🚗 References | 39 |
+| 📦 External Documents | 0 |
+| 📈 Schemas | 22 |
+| 👉 Parameters | 6 |
+| 🔗 Links | 0 |
+| ➡️  Path Items | 5 |
+| 👷 Operations | 8 |
+| 🔖 Tags | 3 |
 
 
 `;

--- a/__tests__/stats/stats-markdown/snapshot.js
+++ b/__tests__/stats/stats-markdown/snapshot.js
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E stats stats should produce correct Markdown format 1`] = `
+- 🚗 References: 39
+- 📦 External Documents: 0
+- 📈 Schemas: 22
+- 👉 Parameters: 6
+- 🔗 Links: 0
+- ➡️  Path Items: 5
+- 👷 Operations: 8
+- 🔖 Tags: 3
+
+
+`;

--- a/__tests__/stats/stats-stylish/museum.yaml
+++ b/__tests__/stats/stats-stylish/museum.yaml
@@ -1,0 +1,1 @@
+../../../resources/museum.yaml

--- a/__tests__/stats/stats-stylish/snapshot.js
+++ b/__tests__/stats/stats-stylish/snapshot.js
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E stats stats should produce correct output (stylish format) 1`] = `
+
+Document: museum.yaml stats:
+
+🚗 References: 39 
+📦 External Documents: 0 
+📈 Schemas: 22 
+👉 Parameters: 6 
+🔗 Links: 0 
+➡️  Path Items: 5 
+👷 Operations: 8 
+🔖 Tags: 3 
+
+`;

--- a/__tests__/stats/stats-stylish/snapshot.js
+++ b/__tests__/stats/stats-stylish/snapshot.js
@@ -13,4 +13,7 @@ Document: museum.yaml stats:
 👷 Operations: 8 
 🔖 Tags: 3 
 
+museum.yaml: stats processed in <test>ms
+
+
 `;

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,4 +1,3 @@
-import { performance } from 'perf_hooks';
 import * as colors from 'colorette';
 import {
   Config,

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -46,6 +46,14 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
   process.stdout.write(JSON.stringify(json, null, 2));
 }
 
+function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
+  let output = "";
+  for (const key of Object.keys(statsAccumulator)) {
+      output += "- " + statsAccumulator[key as StatsName].metric + ": " + statsAccumulator[key as StatsName].total + "\n";
+  }
+  process.stdout.write(output);
+}
+
 function printStats(statsAccumulator: StatsAccumulator, api: string, format: string) {
   switch (format) {
     case 'stylish':
@@ -54,6 +62,9 @@ function printStats(statsAccumulator: StatsAccumulator, api: string, format: str
       break;
     case 'json':
       printStatsJson(statsAccumulator);
+      break;
+    case 'markdown':
+      printStatsMarkdown(statsAccumulator);
       break;
   }
 }

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -47,9 +47,9 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
 }
 
 function printStats(statsAccumulator: StatsAccumulator, api: string, format: string) {
-  process.stderr.write(`Document: ${colors.magenta(api)} stats:\n\n`);
   switch (format) {
     case 'stylish':
+      process.stderr.write(`Document: ${colors.magenta(api)} stats:\n\n`);
       printStatsStylish(statsAccumulator);
       break;
     case 'json':
@@ -108,5 +108,4 @@ export async function handleStats(argv: StatsOptions, config: Config) {
   });
 
   printStats(statsAccumulator, path, argv.format);
-  printExecutionTime('stats', startedAt, path);
 }

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks';
 import * as colors from 'colorette';
 import {
   Config,
@@ -58,11 +59,12 @@ function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
   process.stdout.write(output);
 }
 
-function printStats(statsAccumulator: StatsAccumulator, api: string, format: string) {
+function printStats(statsAccumulator: StatsAccumulator, api: string, startedAt:number, format: string) {
   switch (format) {
     case 'stylish':
       process.stderr.write(`Document: ${colors.magenta(api)} stats:\n\n`);
       printStatsStylish(statsAccumulator);
+      printExecutionTime('stats', startedAt, api);
       break;
     case 'json':
       printStatsJson(statsAccumulator);
@@ -90,6 +92,7 @@ export async function handleStats(argv: StatsOptions, config: Config) {
     lintConfig
   );
 
+  const startedAt = performance.now();
   const ctx: WalkContext = {
     problems: [],
     oasVersion: specVersion,
@@ -121,5 +124,5 @@ export async function handleStats(argv: StatsOptions, config: Config) {
     ctx,
   });
 
-  printStats(statsAccumulator, path, argv.format);
+  printStats(statsAccumulator, path, startedAt, argv.format);
 }

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -47,9 +47,14 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
 }
 
 function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
-  let output = "";
+  let output = '';
   for (const key of Object.keys(statsAccumulator)) {
-      output += "- " + statsAccumulator[key as StatsName].metric + ": " + statsAccumulator[key as StatsName].total + "\n";
+    output +=
+      '- ' +
+      statsAccumulator[key as StatsName].metric +
+      ': ' +
+      statsAccumulator[key as StatsName].total +
+      '\n';
   }
   process.stdout.write(output);
 }

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -47,14 +47,14 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
 }
 
 function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
-  let output = '';
+  let output = '| Feature  | Count  |\n| --- | --- |\n';
   for (const key of Object.keys(statsAccumulator)) {
     output +=
-      '- ' +
+      '| ' +
       statsAccumulator[key as StatsName].metric +
-      ': ' +
+      ' | ' +
       statsAccumulator[key as StatsName].total +
-      '\n';
+      ' |\n';
   }
   process.stdout.write(output);
 }

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -91,7 +91,6 @@ export async function handleStats(argv: StatsOptions, config: Config) {
     lintConfig
   );
 
-  const startedAt = performance.now();
   const ctx: WalkContext = {
     problems: [],
     oasVersion: specVersion,

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -59,7 +59,12 @@ function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
   process.stdout.write(output);
 }
 
-function printStats(statsAccumulator: StatsAccumulator, api: string, startedAt:number, format: string) {
+function printStats(
+  statsAccumulator: StatsAccumulator,
+  api: string,
+  startedAt: number,
+  format: string
+) {
   switch (format) {
     case 'stylish':
       process.stderr.write(`Document: ${colors.magenta(api)} stats:\n\n`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,7 +46,7 @@ yargs
         },
         format: {
           description: 'Use a specific output format.',
-          choices: ['stylish', 'json'] as ReadonlyArray<OutputFormat>,
+          choices: ['stylish', 'json', 'markdown'] as ReadonlyArray<OutputFormat>,
           default: 'stylish' as OutputFormat,
         },
       }),

--- a/resources/museum.yaml
+++ b/resources/museum.yaml
@@ -1,0 +1,680 @@
+openapi: 3.1.0
+info:
+  title: Redocly Museum API
+  description: An imaginary, but delightful Museum API for interacting with museum services and information. Built with love by Redocly.
+  version: 1.0.0
+  contact:
+    email: team@redocly.com
+    url: 'https://redocly.com/docs/cli/'
+  license:
+    name: MIT
+    url: 'https://opensource.org/license/mit/ '
+servers:
+  - url: 'https://api.fake-museum-example.com/v1'
+paths:
+  /museum-hours:
+    get:
+      summary: Get museum hours
+      description: Get upcoming museum operating hours
+      operationId: getMuseumHours
+      tags:
+        - Operations
+      parameters:
+        - $ref: '#/components/parameters/StartDate'
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/PaginationLimit'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMuseumHoursResponse'
+              examples:
+                default_example:
+                  $ref: '#/components/examples/GetMuseumHoursResponseExample'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+  /special-events:
+    post:
+      summary: Create special events
+      description: Creates a new special event for the museum.
+      operationId: createSpecialEvent
+      tags:
+        - Events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSpecialEventRequest'
+            examples:
+              default_example:
+                $ref: '#/components/examples/CreateSpecialEventRequestExample'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpecialEventResponse'
+              examples:
+                default_example:
+                  $ref: '#/components/examples/CreateSpecialEventResponseExample'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+    get:
+      summary: List special events
+      description: Return a list of upcoming special events at the museum.
+      operationId: listSpecialEvents
+      tags:
+        - Events
+      parameters:
+        - $ref: '#/components/parameters/StartDate'
+        - $ref: '#/components/parameters/EndDate'
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/PaginationLimit'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSpecialEventsResponse'
+              examples:
+                default_example:
+                  $ref: '#/components/examples/ListSpecialEventsResponseExample'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+  /special-events/{eventId}:
+    get:
+      summary: Get special event
+      description: Get details about a special event.
+      operationId: getSpecialEvent
+      tags:
+        - Events
+      parameters:
+        - $ref: '#/components/parameters/EventId'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpecialEventResponse'
+              examples:
+                default_example:
+                  $ref: '#/components/examples/GetSpecialEventResponseExample'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+    patch:
+      summary: Update special event
+      description: Update the details of a special event
+      operationId: updateSpecialEvent
+      tags:
+        - Events
+      parameters:
+        - $ref: '#/components/parameters/EventId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSpecialEventRequest'
+            examples:
+              default_example:
+                $ref: '#/components/examples/UpdateSpecialEventRequestExample'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpecialEventResponse'
+              examples:
+                default_example:
+                  $ref: '#/components/examples/UpdateSpecialEventResponseExample'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+    delete:
+      summary: Delete special event
+      description: Delete a special event from the collection. Allows museum to cancel planned events.
+      operationId: deleteSpecialEvent
+      tags:
+        - Events
+      parameters:
+        - $ref: '#/components/parameters/EventId'
+      responses:
+        '204':
+          description: Success - no content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not found
+  /tickets:
+    post:
+      summary: Buy museum tickets
+      description: Purchase museum tickets for general entry or special events.
+      operationId: buyMuseumTickets
+      tags:
+        - Tickets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BuyMuseumTicketsRequest'
+            examples:
+              general_entry:
+                $ref: '#/components/examples/BuyGeneralTicketsRequestExample'
+              event_entry:
+                $ref: '#/components/examples/BuyEventTicketsRequestExample'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuyMuseumTicketsResponse'
+              examples:
+                general_entry:
+                  $ref: '#/components/examples/BuyGeneralTicketsResponseExample'
+                event_entry:
+                  $ref: '#/components/examples/BuyEventTicketsResponseExample'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+  /tickets/{ticketId}/qr:
+    get:
+      summary: Get ticket QR code
+      description: Return an image of your ticket with scannable QR code. Used for event entry.
+      operationId: getTicketCode
+      tags:
+        - Tickets
+      parameters:
+        - $ref: '#/components/parameters/TicketId'
+      responses:
+        '200':
+          description: Scannable event ticket in image format
+          content:
+            image/png:
+              schema:
+                $ref: '#/components/schemas/GetTicketCodeResponse'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+components:
+  schemas:
+    TicketType:
+      description: Type of ticket being purchased. Use `general` for regular museum entry and `event` for tickets to special events.
+      type: string
+      enum:
+        - event
+        - general
+      example: event
+    Date:
+      type: string
+      format: date
+      example: 2023-10-29
+    Email:
+      description: Email address for ticket purchaser.
+      type: string
+      format: email
+      example: museum-lover@example.com
+    Phone:
+      description: Phone number for the ticket purchaser (optional).
+      type: string
+      example: +1(234)-567-8910
+    BuyMuseumTicketsRequest:
+      description: Request payload used for purchasing museum tickets.
+      type: object
+      properties:
+        ticketType:
+          $ref: '#/components/schemas/TicketType'
+        eventId:
+          description: Unique identifier for a special event. Required if purchasing tickets for the museum's special events.
+          $ref: '#/components/schemas/EventId'
+        ticketDate:
+          description: Date that the ticket is valid for.
+          $ref: '#/components/schemas/Date'
+        email:
+          $ref: '#/components/schemas/Email'
+        phone:
+          $ref: '#/components/schemas/Phone'
+      required:
+        - ticketType
+        - ticketDate
+        - email
+    TicketMessage:
+      description: Confirmation message after a ticket purchase.
+      type: string
+      example: Museum general entry ticket purchased
+    TicketId:
+      description: Unique identifier for museum ticket. Generated when purchased.
+      type: string
+      format: uuid
+      example: a54a57ca-36f8-421b-a6b4-2e8f26858a4c
+    TicketConfirmation:
+      description: Unique confirmation code used to verify ticket purchase.
+      type: string
+      example: ticket-event-a98c8f-7eb12
+    BuyMuseumTicketsResponse:
+      description: Details for a museum ticket after a successful purchase.
+      type: object
+      properties:
+        message:
+          $ref: '#/components/schemas/TicketMessage'
+        eventName:
+          $ref: '#/components/schemas/EventName'
+        ticketId:
+          $ref: '#/components/schemas/TicketId'
+        ticketType:
+          $ref: '#/components/schemas/TicketType'
+        ticketDate:
+          description: Date the ticket is valid for.
+          $ref: '#/components/schemas/Date'
+        confirmationCode:
+          $ref: '#/components/schemas/TicketConfirmation'
+      required:
+        - message
+        - ticketId
+        - ticketType
+        - ticketDate
+        - confirmationCode
+    GetTicketCodeResponse:
+      description: An image of a ticket with a QR code used for museum or event entry.
+      type: string
+      format: binary
+    GetMuseumHoursResponse:
+      description: List of museum operating hours for consecutive days.
+      type: array
+      items:
+        $ref: '#/components/schemas/MuseumDailyHours'
+    MuseumDailyHours:
+      description: Daily operating hours for the museum.
+      type: object
+      properties:
+        date:
+          description: Date the operating hours apply to.
+          $ref: '#/components/schemas/Date'
+          example: 02-02-2022
+        timeOpen:
+          type: string
+          pattern: '^([01]\d|2[0-3]):?([0-5]\d)$'
+          description: Time the museum opens on a specific date. Uses 24 hour time format (`HH:mm`).
+          example: 09:00
+        timeClose:
+          description: Time the museum closes on a specific date. Uses 24 hour time format (`HH:mm`).
+          type: string
+          pattern: '^([01]\d|2[0-3]):?([0-5]\d)$'
+          example: 18:00
+      required:
+        - date
+        - timeOpen
+        - timeClose
+    EventId:
+      description: Identifier for a special event.
+      type: string
+      format: uuid
+      example: 3be6453c-03eb-4357-ae5a-984a0e574a54
+    EventName:
+      type: string
+      description: Name of the special event
+      example: Pirate Coding Workshop
+    EventLocation:
+      type: string
+      description: Location where the special event is held
+      example: Computer Room
+    EventDescription:
+      type: string
+      description: Description of the special event
+      example: Captain Blackbeard shares his love of the C...language. And possibly Arrrrr (R lang).
+    EventDates:
+      type: array
+      items:
+        $ref: '#/components/schemas/Date'
+      description: List of planned dates for the special event
+    EventPrice:
+      description: Price of a ticket for the special event
+      type: number
+      format: float
+      example: 25
+    CreateSpecialEventRequest:
+      description: Request payload for creating new special events at the museum.
+      properties:
+        name:
+          $ref: '#/components/schemas/EventName'
+        location:
+          $ref: '#/components/schemas/EventLocation'
+        eventDescription:
+          $ref: '#/components/schemas/EventDescription'
+        dates:
+          $ref: '#/components/schemas/EventDates'
+        price:
+          $ref: '#/components/schemas/EventPrice'
+      required:
+        - name
+        - location
+        - eventDescription
+        - dates
+        - price
+    UpdateSpecialEventRequest:
+      description: Request payload for updating an existing special event. Only included fields are updated in the event.
+      properties:
+        name:
+          $ref: '#/components/schemas/EventName'
+        location:
+          $ref: '#/components/schemas/EventLocation'
+        eventDescription:
+          $ref: '#/components/schemas/EventDescription'
+        dates:
+          $ref: '#/components/schemas/EventDates'
+        price:
+          $ref: '#/components/schemas/EventPrice'
+    ListSpecialEventsResponse:
+      description: A list of upcoming special events
+      type: array
+      items:
+        $ref: '#/components/schemas/SpecialEventResponse'
+    SpecialEventResponse:
+      description: Information about a special event.
+      properties:
+        eventId:
+          $ref: '#/components/schemas/EventId'
+        name:
+          $ref: '#/components/schemas/EventName'
+        location:
+          $ref: '#/components/schemas/EventLocation'
+        eventDescription:
+          $ref: '#/components/schemas/EventDescription'
+        dates:
+          $ref: '#/components/schemas/EventDates'
+        price:
+          $ref: '#/components/schemas/EventPrice'
+      required:
+        - eventId
+        - name
+        - location
+        - eventDescription
+        - dates
+        - price
+  securitySchemes:
+    MuseumPlaceholderAuth:
+      type: http
+      scheme: basic
+  examples:
+    BuyGeneralTicketsRequestExample:
+      summary: General entry ticket
+      value:
+        ticketType: general
+        ticketDate: 2023-09-07
+        email: todd@example.com
+    BuyEventTicketsRequestExample:
+      summary: Special event ticket
+      value:
+        ticketType: general
+        eventId: dad4bce8-f5cb-4078-a211-995864315e39
+        ticketDate: 2023-09-05
+        email: todd@example.com
+    BuyGeneralTicketsResponseExample:
+      summary: General entry ticket
+      value:
+        message: Museum general entry ticket purchased
+        ticketId: 382c0820-0530-4f4b-99af-13811ad0f17a
+        ticketType: general
+        ticketDate: 2023-09-07
+        confirmationCode: ticket-general-e5e5c6-dce78
+    BuyEventTicketsResponseExample:
+      summary: Special event ticket
+      value:
+        message: Museum special event ticket purchased
+        ticketId: b811f723-17b2-44f7-8952-24b03e43d8a9
+        eventName: Mermaid Treasure Identification and Analysis
+        ticketType: event
+        ticketDate: 2023-09-05
+        confirmationCode: ticket-event-9c55eg-8v82a
+    CreateSpecialEventRequestExample:
+      summary: Create special event
+      value:
+        name: Mermaid Treasure Identification and Analysis
+        location: Under the seaaa 🦀 🎶 🌊.
+        eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.
+        dates:
+          - 2023-09-05
+          - 2023-09-08
+        price: 0
+    CreateSpecialEventResponseExample:
+      summary: Special event created
+      value:
+        eventId: dad4bce8-f5cb-4078-a211-995864315e39
+        name: Mermaid Treasure Identification and Analysis
+        location: Under the seaaa 🦀 🎶 🌊.
+        eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.
+        dates:
+          - 2023-09-05
+          - 2023-09-08
+        price: 30
+    GetSpecialEventResponseExample:
+      summary: Get special event
+      value:
+        eventId: 6744a0da-4121-49cd-8479-f8cc20526495
+        name: Time Traveler Tea Party
+        location: Temporal Tearoom
+        eventDescription: Sip tea with important historical figures.
+        dates:
+          - 2023-11-18
+          - 2023-11-25
+          - 2023-12-02
+        price: 60
+    ListSpecialEventsResponseExample:
+      summary: List of special events
+      value:
+        - eventId: f3e0e76e-e4a8-466e-ab9c-ae36c15b8e97
+          name: Sasquatch Ballet
+          location: Seattle... probably
+          eventDescription: They're big, they're hairy, but they're also graceful. Come learn how the biggest feet can have the lightest touch.
+          dates:
+            - 2023-12-15
+            - 2023-12-22
+          price: 40
+        - eventId: 2f14374a-9c65-4ee5-94b7-fba66d893483
+          name: Solar Telescope Demonstration
+          location: Far from the sun.
+          eventDescription: Look at the sun without going blind!
+          dates:
+            - 2023-09-07
+            - 2023-09-14
+          price: 50
+        - eventId: 6aaa61ba-b2aa-4868-b803-603dbbf7bfdb
+          name: Cook like a Caveman
+          location: Fire Pit on East side
+          eventDescription: Learn to cook on an open flame.
+          dates:
+            - 2023-11-10
+            - 2023-11-17
+            - 2023-11-24
+          price: 5
+        - eventId: 602b75e1-5696-4ab8-8c7a-f9e13580f910
+          name: Underwater Basket Weaving
+          location: Rec Center Pool next door.
+          eventDescription: Learn to weave baskets underwater.
+          dates:
+            - 2023-09-12
+            - 2023-09-15
+          price: 15
+        - eventId: dad4bce8-f5cb-4078-a211-995864315e39
+          name: Mermaid Treasure Identification and Analysis
+          location: Room Sea-12
+          eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits — kindly donated by Ariel.
+          dates:
+            - 2023-09-05
+            - 2023-09-08
+          price: 30
+        - eventId: 6744a0da-4121-49cd-8479-f8cc20526495
+          name: Time Traveler Tea Party
+          location: Temporal Tearoom
+          eventDescription: Sip tea with important historical figures.
+          dates:
+            - 2023-11-18
+            - 2023-11-25
+            - 2023-12-02
+          price: 60
+        - eventId: 3be6453c-03eb-4357-ae5a-984a0e574a54
+          name: Pirate Coding Workshop
+          location: Computer Room
+          eventDescription: Captain Blackbeard shares his love of the C...language. And possibly Arrrrr (R lang).
+          dates:
+            - 2023-10-29
+            - 2023-10-30
+            - 2023-10-31
+          price: 45
+        - eventId: 9d90d29a-2af5-4206-97d9-9ea9ceadcb78
+          name: Llama Street Art Through the Ages
+          location: Auditorium
+          eventDescription: Llama street art?! Alpaca my bags -- let's go!
+          dates:
+            - 2023-10-29
+            - 2023-10-30
+            - 2023-10-31
+          price: 45
+        - eventId: a3c7b2c4-b5fb-4ef7-9322-00a919864957
+          name: The Great Parrot Debate
+          location: Outdoor Amphitheatre
+          eventDescription: See leading parrot minds discuss important geopolitical issues.
+          dates:
+            - 2023-11-03
+            - 2023-11-10
+          price: 35
+        - eventId: b92d46b7-4c5d-422b-87a5-287767e26f29
+          name: Eat a Bunch of Corn
+          location: Cafeteria
+          eventDescription: We accidentally bought too much corn. Please come eat it.
+          dates:
+            - 2023-11-10
+            - 2023-11-17
+            - 2023-11-24
+          price: 5
+    UpdateSpecialEventRequestExample:
+      summary: Update special event request
+      value:
+        location: On the beach.
+        price: 15
+    UpdateSpecialEventResponseExample:
+      summary: Update special event
+      value:
+        eventId: dad4bce8-f5cb-4078-a211-995864315e39
+        name: Mermaid Treasure Identification and Analysis
+        location: On the beach.
+        eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.
+        dates:
+          - 2023-09-05
+          - 2023-09-08
+        price: 15
+    GetMuseumHoursResponseExample:
+      summary: Get hours response
+      value:
+        - date: '2023-09-11'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-12'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-13'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-14'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-15'
+          timeOpen: '10:00'
+          timeClose: '16:00'
+        - date: '2023-09-18'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-19'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-20'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-21'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2023-09-22'
+          timeOpen: '10:00'
+          timeClose: '16:00'
+  parameters:
+    PaginationPage:
+      name: page
+      in: query
+      description: The page number to retrieve.
+      schema:
+        type: integer
+        default: 1
+        example: 2
+    PaginationLimit:
+      name: limit
+      in: query
+      description: The number of days per page.
+      schema:
+        type: integer
+        default: 10
+        maximum: 30
+        example: 15
+    EventId:
+      name: eventId
+      in: path
+      description: An identifier for a special event.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: dad4bce8-f5cb-4078-a211-995864315e39
+    StartDate:
+      name: startDate
+      in: query
+      description: The starting date to retrieve future operating hours from. Defaults to today's date.
+      schema:
+        type: string
+        format: date
+        example: 2023-02-23
+    EndDate:
+      name: endDate
+      in: query
+      description: The end of a date range to retrieve special events for. Defaults to 7 days after `startDate`.
+      schema:
+        type: string
+        format: date
+        example: 2023-04-18
+    TicketId:
+      name: ticketId
+      in: path
+      description: An identifier for a ticket to a museum event. Used to generate ticket image.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: a54a57ca-36f8-421b-a6b4-2e8f26858a4c
+tags:
+  - name: Operations
+    description: Operational information about the museum.
+  - name: Events
+    description: Special events hosted by the Museum
+  - name: Tickets
+    description: Museum tickets for general entrance or special events.
+security:
+  - MuseumPlaceholderAuth: []


### PR DESCRIPTION
## What/Why/How?

I was answering a question about JSON format output containing not-JSON elements, and I also noticed #976 requesting markdown format output that could be used in other contexts, such as [GitHub Job Sumaries](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary).

So this pull request removes the output about which file is being `stat`-ed from being displayed by default - the stylish format keeps it as that one is human readable. The execution time output is also removed, this isn't used in all commands and breaks the other file formats such as JSON.

The pull request also adds a `--format=markdown` option to the `stats` command, to produce a markdown output. The original request was for the GitHub Job Summaries, but the format is generic markdown that could also be used elsewhere.

Example:

| Feature  | Count  |
| --- | --- |
| 🚗 References | 39 |
| 📦 External Documents | 0 |
| 📈 Schemas | 22 |
| 👉 Parameters | 7 |
| 🔗 Links | 0 |
| ➡️  Path Items | 5 |
| 👷 Operations | 8 |
| 🔖 Tags | 3 |

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
