### PR TITLE
fix: extra whitespace after update notifier

### DIFF
--- a/packages/cli/src/utils/update-version-notifier.ts
+++ b/packages/cli/src/utils/update-version-notifier.ts
@@ -64,27 +64,27 @@ const renderUpdateBanner = (current: string, latest: string) => {
   const maxLength = Math.max(...messageLines.map((line) => cleanColors(line).length));
 
   const border = yellow('═'.repeat(maxLength + SPACE_TO_BORDER));
+  const extraSpaces = ' '.repeat(SPACE_TO_BORDER);
 
-  const banner = `
-    ${yellow('╔' + border + '╗')}
-    ${yellow('║' + ' '.repeat(maxLength + SPACE_TO_BORDER) + '║')}
-    ${messageLines
-      .map((line, index) => {
-        return getLineWithPadding(maxLength, line, index);
-      })
-      .join('\n')}
-    ${yellow('║' + ' '.repeat(maxLength + SPACE_TO_BORDER) + '║')}
-    ${yellow('╚' + border + '╝')}
-`;
-
+  const banner = [
+    '',
+    extraSpaces + yellow('╔' + border + '╗'),
+    extraSpaces + yellow('║' + ' '.repeat(maxLength + SPACE_TO_BORDER) + '║'),
+    messageLines.map(getLineWithPadding(maxLength, extraSpaces)).join('\n'),
+    extraSpaces + yellow('║' + ' '.repeat(maxLength + SPACE_TO_BORDER) + '║'),
+    extraSpaces + yellow('╚' + border + '╝'),
+    '',
+    '',
+  ].join('\n');
   process.stderr.write(banner);
 };
 
-const getLineWithPadding = (maxLength: number, line: string, index: number): string => {
-  const padding = ' '.repeat(maxLength - cleanColors(line).length);
-  const extraSpaces = index !== 0 ? ' '.repeat(SPACE_TO_BORDER) : '';
-  return `${extraSpaces}${yellow('║')}  ${line}${padding}  ${yellow('║')}`;
-};
+const getLineWithPadding =
+  (maxLength: number, extraSpaces: string) =>
+  (line: string): string => {
+    const padding = ' '.repeat(maxLength - cleanColors(line).length);
+    return `${extraSpaces}${yellow('║')}  ${line}${padding}  ${yellow('║')}`;
+  };
 
 const isNeedToBeCached = (): boolean => {
   try {

--- a/packages/cli/src/utils/update-version-notifier.ts
+++ b/packages/cli/src/utils/update-version-notifier.ts
@@ -75,7 +75,7 @@ const renderUpdateBanner = (current: string, latest: string) => {
       .join('\n')}
     ${yellow('║' + ' '.repeat(maxLength + SPACE_TO_BORDER) + '║')}
     ${yellow('╚' + border + '╝')}
-  `;
+`;
 
   process.stderr.write(banner);
 };


### PR DESCRIPTION
## What/Why/How?

We did a new release yesterday and I noticed that when I get the release banner, I also get slightly indented output from whichever command I was using.

## Screenshots (optional)
![Screenshot from 2024-01-24 15-46-35](https://github.com/Redocly/redocly-cli/assets/172607/8783d507-e624-4905-844e-9ab58c8406f5)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
