### PR TITLE
docs: Fix an incorrectly-formatted table in the custom function docs for configurable rules

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -203,10 +203,10 @@ Each function is called with the following parameters:
 problems | [`Problem`] | List of problems. An empty list means all checks are valid.
 
 `Problem`
-Property | Type | Description
--- | -- | --
-message | `string` \| [`string`] | Problem message that is displayed in the [lint command](../commands/lint.md) output.
-location | `Location Object` | Location in the source document. See [Location Object](../custom-plugins/custom-rules.md#location-object)
+| Property | Type | Description |
+| -- | -- | -- |
+| message | `string` \| [`string`] | Problem message that is displayed in the [lint command](../commands/lint.md) output. |
+| location | `Location Object` | Location in the source document. See [Location Object](../custom-plugins/custom-rules.md#location-object) |
 
 `redocly.yaml`
 


### PR DESCRIPTION
## What/Why/How?

Markdownlint started complaining about a table in the configurable rule documentation. This pull request fixes the reported problems (the rendering was and is fine).

## Has code been changed?

- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
