### PR TITLE
fix: resolve an issue with options in the push command

### DIFF
--- a/.changeset/thin-badgers-worry.md
+++ b/.changeset/thin-badgers-worry.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue with the `destination` option in the `push` command.
+Fixed an issue with the `push` command, when `destination` option does not work without specifying it in `redocly.yaml`.

--- a/.changeset/thin-badgers-worry.md
+++ b/.changeset/thin-badgers-worry.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue with the `destination` option in the `push` command.

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -279,73 +279,17 @@ describe('push', () => {
 });
 
 describe('transformPush', () => {
-  it('should adapt the existing syntax', () => {
-    const cb = jest.fn();
-    transformPush(cb)(
-      {
-        api: 'openapi.yaml',
-        maybeDestination: '@testing_org/main@v1',
-      },
-      {} as any
-    );
-    expect(cb).toBeCalledWith(
-      {
-        api: 'openapi.yaml',
-        destination: '@testing_org/main@v1',
-      },
-      {}
-    );
-  });
-  it('should adapt the existing syntax (including branchName)', () => {
-    const cb = jest.fn();
-    transformPush(cb)(
-      {
-        api: 'openapi.yaml',
-        maybeDestination: '@testing_org/main@v1',
-        maybeBranchName: 'other',
-      },
-      {} as any
-    );
-    expect(cb).toBeCalledWith(
-      {
-        api: 'openapi.yaml',
-        destination: '@testing_org/main@v1',
-        branchName: 'other',
-      },
-      {}
-    );
-  });
-  it('should use --branch option firstly', () => {
-    const cb = jest.fn();
-    transformPush(cb)(
-      {
-        api: 'openapi.yaml',
-        maybeDestination: '@testing_org/main@v1',
-        maybeBranchName: 'other',
-        branch: 'priority-branch',
-      },
-      {} as any
-    );
-    expect(cb).toBeCalledWith(
-      {
-        api: 'openapi.yaml',
-        destination: '@testing_org/main@v1',
-        branchName: 'priority-branch',
-      },
-      {}
-    );
-  });
   it('should work for a destination only', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        api: '@testing_org/main@v1',
+        apis: ['main@v1'],
       },
       {} as any
     );
     expect(cb).toBeCalledWith(
       {
-        destination: '@testing_org/main@v1',
+        destination: 'main@v1',
       },
       {}
     );
@@ -354,7 +298,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        api: 'test.yaml',
+        apis: ['test.yaml'],
       },
       {} as any
     );
@@ -365,31 +309,32 @@ describe('transformPush', () => {
       {}
     );
   });
-  it('should accept aliases for the old syntax', () => {
+
+  it('should use destination from option', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        api: 'alias',
-        maybeDestination: '@testing_org/main@v1',
+        apis: ['test@v1'],
+        destination: 'main@v1',
       },
       {} as any
     );
     expect(cb).toBeCalledWith(
       {
-        destination: '@testing_org/main@v1',
-        api: 'alias',
+        destination: 'main@v1',
+        api: 'test@v1',
       },
       {}
     );
   });
+
   it('should use --job-id option firstly', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
         'batch-id': 'b-123',
         'job-id': 'j-123',
-        api: 'test',
-        maybeDestination: 'main@v1',
+        apis: ['test'],
         branch: 'test',
         destination: 'main@v1',
       },

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -279,6 +279,57 @@ describe('push', () => {
 });
 
 describe('transformPush', () => {
+  it('should adapt the existing syntax', () => {
+    const cb = jest.fn();
+    transformPush(cb)(
+      {
+        apis: ['openapi.yaml', '@testing_org/main@v1'],
+      },
+      {} as any
+    );
+    expect(cb).toBeCalledWith(
+      {
+        api: 'openapi.yaml',
+        destination: '@testing_org/main@v1',
+      },
+      {}
+    );
+  });
+  it('should adapt the existing syntax (including branchName)', () => {
+    const cb = jest.fn();
+    transformPush(cb)(
+      {
+        apis: ['openapi.yaml', '@testing_org/main@v1', 'other'],
+      },
+      {} as any
+    );
+    expect(cb).toBeCalledWith(
+      {
+        api: 'openapi.yaml',
+        destination: '@testing_org/main@v1',
+        branchName: 'other',
+      },
+      {}
+    );
+  });
+  it('should use --branch option firstly', () => {
+    const cb = jest.fn();
+    transformPush(cb)(
+      {
+        apis: ['openapi.yaml', '@testing_org/main@v1', 'other'],
+        branch: 'priority-branch',
+      },
+      {} as any
+    );
+    expect(cb).toBeCalledWith(
+      {
+        api: 'openapi.yaml',
+        destination: '@testing_org/main@v1',
+        branchName: 'priority-branch',
+      },
+      {}
+    );
+  });
   it('should work for a destination only', () => {
     const cb = jest.fn();
     transformPush(cb)(
@@ -314,7 +365,7 @@ describe('transformPush', () => {
     const cb = jest.fn();
     transformPush(cb)(
       {
-        apis: ['test@v1'],
+        apis: ['test.yaml', 'test@v1'],
         destination: 'main@v1',
       },
       {} as any
@@ -322,7 +373,7 @@ describe('transformPush', () => {
     expect(cb).toBeCalledWith(
       {
         destination: 'main@v1',
-        api: 'test@v1',
+        api: 'test.yaml',
       },
       {}
     );

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -355,8 +355,6 @@ export function getDestinationProps(
 
 type BarePushArgs = Omit<PushOptions, 'destination' | 'branchName'> & {
   apis?: string[];
-  maybeDestination?: string;
-  maybeBranchName?: string;
   branch?: string;
   destination?: string;
 };


### PR DESCRIPTION
## What/Why/How?

Fixed an issue with the `push` command, when `destination` option does not work without specifying it in `redocly.yaml`.

## Reference

## Testing

## Screenshots (optional)

## Has code been changed?

- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
