### PR TITLE
chore: do not update domain env variable from code

### DIFF
--- a/packages/cli/src/__tests__/commands/push-region.test.ts
+++ b/packages/cli/src/__tests__/commands/push-region.test.ts
@@ -19,7 +19,8 @@ jest.mock('../../utils/miscellaneous');
 const mockPromptClientToken = promptClientToken as jest.MockedFunction<typeof promptClientToken>;
 
 describe('push-with-region', () => {
-  const redoclyClient = require('@redocly/openapi-core').__redoclyClient;
+  const RedoclyClient = require('@redocly/openapi-core').RedoclyClient;
+  const redoclyClient = new RedoclyClient();
   redoclyClient.isAuthorizedWithRedoclyByRegion = jest.fn().mockResolvedValue(false);
 
   beforeAll(() => {
@@ -27,7 +28,7 @@ describe('push-with-region', () => {
   });
 
   it('should call login with default domain when region is US', async () => {
-    redoclyClient.domain = 'redoc.ly';
+    RedoclyClient.domain = 'redoc.ly';
     await handlePush(
       {
         upsert: true,
@@ -38,11 +39,11 @@ describe('push-with-region', () => {
       ConfigFixture as any
     );
     expect(mockPromptClientToken).toBeCalledTimes(1);
-    expect(mockPromptClientToken).toHaveBeenCalledWith(redoclyClient.domain);
+    expect(mockPromptClientToken).toHaveBeenCalledWith(RedoclyClient.domain);
   });
 
   it('should call login with EU domain when region is EU', async () => {
-    redoclyClient.domain = 'eu.redocly.com';
+    RedoclyClient.domain = 'eu.redocly.com';
     await handlePush(
       {
         upsert: true,
@@ -53,6 +54,6 @@ describe('push-with-region', () => {
       ConfigFixture as any
     );
     expect(mockPromptClientToken).toBeCalledTimes(1);
-    expect(mockPromptClientToken).toHaveBeenCalledWith(redoclyClient.domain);
+    expect(mockPromptClientToken).toHaveBeenCalledWith(RedoclyClient.domain);
   });
 });

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -20,7 +20,7 @@ export type LoginOptions = {
 export async function handleLogin(argv: LoginOptions, config: Config) {
   const region = argv.region || config.region;
   const client = new RedoclyClient(region);
-  const clientToken = await promptClientToken(client.domain);
+  const clientToken = await promptClientToken(RedoclyClient.domain);
   process.stdout.write(gray('\n  Logging in...\n'));
   await client.login(clientToken, argv.verbose);
   process.stdout.write(green('  Authorization confirmed. ✅\n\n'));

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -62,7 +62,7 @@ export async function handlePush(argv: PushOptions, config: Config): Promise<voi
   const client = new RedoclyClient(config.region);
   const isAuthorized = await client.isAuthorizedWithRedoclyByRegion();
   if (!isAuthorized) {
-    const clientToken = await promptClientToken(client.domain);
+    const clientToken = await promptClientToken(RedoclyClient.domain);
     await client.login(clientToken);
   }
 

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -14,7 +14,7 @@ import { isAbsoluteUrl, isRef, Location, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
 import { reportUnresolvedRef } from './rules/no-unresolved-refs';
 import { isPlainObject, isTruthy } from './utils';
-import { isRedoclyRegistryURL } from './redocly';
+import { RedoclyClient } from './redocly';
 import { RemoveUnusedComponents as RemoveUnusedComponentsOas2 } from './decorators/oas2/remove-unused-components';
 import { RemoveUnusedComponents as RemoveUnusedComponentsOas3 } from './decorators/oas3/remove-unused-components';
 import { ConfigTypes } from './types/redocly-yaml';
@@ -338,7 +338,7 @@ function makeBundleVisitor(
         }
 
         // do not bundle registry URL before push, otherwise we can't record dependencies
-        if (skipRedoclyRegistryRefs && isRedoclyRegistryURL(node.$ref)) {
+        if (skipRedoclyRegistryRefs && RedoclyClient.isRedoclyRegistryURL(node.$ref)) {
           return;
         }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -29,6 +29,7 @@ import type {
 } from './types';
 import { getResolveConfig } from './utils';
 import { isAbsoluteUrl } from '../ref-utils';
+import { RedoclyClient } from '../redocly';
 
 export const IGNORE_FILE = '.redocly.lint-ignore.yaml';
 const IGNORE_BANNER =
@@ -44,7 +45,7 @@ function getDomains() {
   };
 
   // FIXME: temporary fix for our lab environments
-  const domain = env.REDOCLY_DOMAIN;
+  const domain = RedoclyClient?.domain || env.REDOCLY_DOMAIN;
   if (domain?.endsWith('.redocly.host')) {
     domains[domain.split('.')[0] as Region] = domain;
   }

--- a/packages/core/src/decorators/common/registry-dependencies.ts
+++ b/packages/core/src/decorators/common/registry-dependencies.ts
@@ -1,5 +1,5 @@
 import { UserContext } from '../../walk';
-import { isRedoclyRegistryURL } from '../../redocly';
+import { RedoclyClient } from '../../redocly';
 
 import { Oas3Decorator, Oas2Decorator } from '../../visitors';
 
@@ -16,7 +16,7 @@ export const RegistryDependencies: Oas3Decorator | Oas2Decorator = () => {
     ref(node) {
       if (node.$ref) {
         const link = node.$ref.split('#/')[0];
-        if (isRedoclyRegistryURL(link)) {
+        if (RedoclyClient.isRedoclyRegistryURL(link)) {
           registryDependencies.add(link);
         }
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,7 +41,7 @@ export {
   ResolvedApi,
 } from './config';
 
-export { RedoclyClient, isRedoclyRegistryURL } from './redocly';
+export { RedoclyClient } from './redocly';
 
 export {
   Source,

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -19,36 +19,36 @@ describe('RedoclyClient', () => {
   });
 
   it('should resolve the US domain by default', () => {
-    const client = new RedoclyClient();
-    expect(client.domain).toBe(REDOCLY_DOMAIN_US);
+    new RedoclyClient();
+    expect(RedoclyClient.domain).toBe(REDOCLY_DOMAIN_US);
   });
 
   it('should resolve domain from RedoclyDomain env', () => {
     process.env.REDOCLY_DOMAIN = testRedoclyDomain;
-    const client = new RedoclyClient();
-    expect(client.domain).toBe(testRedoclyDomain);
+    new RedoclyClient();
+    expect(RedoclyClient.domain).toBe(testRedoclyDomain);
   });
 
   it('should resolve a domain by US region', () => {
-    const client = new RedoclyClient('us');
-    expect(client.domain).toBe(REDOCLY_DOMAIN_US);
+    new RedoclyClient('us');
+    expect(RedoclyClient.domain).toBe(REDOCLY_DOMAIN_US);
   });
 
   it('should resolve a domain by EU region', () => {
-    const client = new RedoclyClient('eu');
-    expect(client.domain).toBe(REDOCLY_DOMAIN_EU);
+    new RedoclyClient('eu');
+    expect(RedoclyClient.domain).toBe(REDOCLY_DOMAIN_EU);
   });
 
   it('should resolve domain by EU region prioritizing flag over env variable', () => {
     process.env.REDOCLY_DOMAIN = testRedoclyDomain;
-    const client = new RedoclyClient('eu');
-    expect(client.domain).toBe(REDOCLY_DOMAIN_EU);
+    new RedoclyClient('eu');
+    expect(RedoclyClient.domain).toBe(REDOCLY_DOMAIN_EU);
   });
 
   it('should resolve domain by US region prioritizing flag over env variable', () => {
     process.env.REDOCLY_DOMAIN = testRedoclyDomain;
-    const client = new RedoclyClient('us');
-    expect(client.domain).toBe(REDOCLY_DOMAIN_US);
+    new RedoclyClient('us');
+    expect(RedoclyClient.domain).toBe(REDOCLY_DOMAIN_US);
   });
 
   it('should resolve domain by US region when REDOCLY_DOMAIN consists EU domain', () => {

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -15,15 +15,13 @@ export const TOKEN_FILENAME = '.redocly-config.json';
 export class RedoclyClient {
   private accessTokens: AccessTokens = {};
   private region: Region;
-  domain: string;
+  static domain: string;
   registryApi: RegistryApi;
 
   constructor(region?: Region) {
     this.region = this.loadRegion(region);
     this.loadTokens();
-    this.domain = region ? DOMAINS[region] : env.REDOCLY_DOMAIN || DOMAINS[DEFAULT_REGION];
-
-    env.REDOCLY_DOMAIN = this.domain; // isRedoclyRegistryURL depends on the value to be set
+    RedoclyClient.domain = region ? DOMAINS[region] : env.REDOCLY_DOMAIN || DOMAINS[DEFAULT_REGION];
     this.registryApi = new RegistryApi(this.accessTokens, this.region);
   }
 
@@ -169,19 +167,19 @@ export class RedoclyClient {
       unlinkSync(credentialsPath);
     }
   }
-}
 
-export function isRedoclyRegistryURL(link: string): boolean {
-  const domain = env.REDOCLY_DOMAIN || DOMAINS[DEFAULT_REGION];
+  static isRedoclyRegistryURL(link: string): boolean {
+    const domain = RedoclyClient.domain || DOMAINS[DEFAULT_REGION];
 
-  const legacyDomain = domain === 'redocly.com' ? 'redoc.ly' : domain;
+    const legacyDomain = domain === 'redocly.com' ? 'redoc.ly' : domain;
 
-  if (
-    !link.startsWith(`https://api.${domain}/registry/`) &&
-    !link.startsWith(`https://api.${legacyDomain}/registry/`)
-  ) {
-    return false;
+    if (
+      !link.startsWith(`https://api.${domain}/registry/`) &&
+      !link.startsWith(`https://api.${legacyDomain}/registry/`)
+    ) {
+      return false;
+    }
+
+    return true;
   }
-
-  return true;
 }


### PR DESCRIPTION
## What/Why/How?

Do not update `REDOCLY-DOMAIN` env variable from code, use static variable instead

## Reference

## Testing

## Screenshots (optional)

## Has code been changed?

- [ ] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
