### PR TITLE
fix: update `push-status` messages

### DIFF
--- a/packages/cli/src/cms/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/cms/commands/__tests__/push-status.test.ts
@@ -90,7 +90,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(1);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deployment succeeded.\nPreview URL: https://test-url\n'
+      '🚀 PREVIEW deploy success.\nPreview URL: https://test-url\n'
     );
   });
 
@@ -110,10 +110,10 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(2);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deployment succeeded.\nPreview URL: https://test-url\n'
+      '🚀 PREVIEW deploy success.\nPreview URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PRODUCTION deployment succeeded.\nPreview URL: https://test-url\n'
+      '🚀 PRODUCTION deploy success.\nPreview URL: https://test-url\n'
     );
   });
 
@@ -139,7 +139,7 @@ describe('handlePushStatus()', () => {
       mockConfig
     );
     expect(exitWithError).toHaveBeenCalledWith(
-      '❌ PREVIEW deployment failed.\nPreview URL: https://test-url'
+      '❌ PREVIEW deploy fail.\nPreview URL: https://test-url'
     );
   });
 
@@ -176,7 +176,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(4);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deployment succeeded.\nPreview URL: https://test-url\n'
+      '🚀 PREVIEW deploy success.\nPreview URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith('\nScorecard:');
     expect(process.stdout.write).toHaveBeenCalledWith(

--- a/packages/cli/src/cms/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/cms/commands/__tests__/push-status.test.ts
@@ -90,7 +90,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(1);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deploy success.\nPreview URL: https://test-url\n'
+      '🚀 PREVIEW deploy success.\nPREVIEW URL: https://test-url\n'
     );
   });
 
@@ -110,10 +110,10 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(2);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deploy success.\nPreview URL: https://test-url\n'
+      '🚀 PREVIEW deploy success.\nPREVIEW URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PRODUCTION deploy success.\nPreview URL: https://test-url\n'
+      '🚀 PRODUCTION deploy success.\nPRODUCTION URL: https://test-url\n'
     );
   });
 
@@ -139,7 +139,7 @@ describe('handlePushStatus()', () => {
       mockConfig
     );
     expect(exitWithError).toHaveBeenCalledWith(
-      '❌ PREVIEW deploy fail.\nPreview URL: https://test-url'
+      '❌ PREVIEW deploy fail.\nPREVIEW URL: https://test-url'
     );
   });
 
@@ -176,7 +176,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(4);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deploy success.\nPreview URL: https://test-url\n'
+      '🚀 PREVIEW deploy success.\nPREVIEW URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith('\nScorecard:');
     expect(process.stdout.write).toHaveBeenCalledWith(

--- a/packages/cli/src/cms/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/cms/commands/__tests__/push-status.test.ts
@@ -90,7 +90,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(1);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 preview deploy success.\npreview URL: https://test-url\n'
+      '🚀 Preview deploy success.\nPreview URL: https://test-url\n'
     );
   });
 
@@ -110,10 +110,10 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(2);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 preview deploy success.\npreview URL: https://test-url\n'
+      '🚀 Preview deploy success.\nPreview URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 production deploy success.\nproduction URL: https://test-url\n'
+      '🚀 Production deploy success.\nProduction URL: https://test-url\n'
     );
   });
 
@@ -139,7 +139,7 @@ describe('handlePushStatus()', () => {
       mockConfig
     );
     expect(exitWithError).toHaveBeenCalledWith(
-      '❌ preview deploy fail.\npreview URL: https://test-url'
+      '❌ Preview deploy fail.\nPreview URL: https://test-url'
     );
   });
 
@@ -176,7 +176,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(4);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 preview deploy success.\npreview URL: https://test-url\n'
+      '🚀 Preview deploy success.\nPreview URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith('\nScorecard:');
     expect(process.stdout.write).toHaveBeenCalledWith(

--- a/packages/cli/src/cms/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/cms/commands/__tests__/push-status.test.ts
@@ -90,7 +90,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(1);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deploy success.\nPREVIEW URL: https://test-url\n'
+      '🚀 preview deploy success.\npreview URL: https://test-url\n'
     );
   });
 
@@ -110,10 +110,10 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(2);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deploy success.\nPREVIEW URL: https://test-url\n'
+      '🚀 preview deploy success.\npreview URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PRODUCTION deploy success.\nPRODUCTION URL: https://test-url\n'
+      '🚀 production deploy success.\nproduction URL: https://test-url\n'
     );
   });
 
@@ -139,7 +139,7 @@ describe('handlePushStatus()', () => {
       mockConfig
     );
     expect(exitWithError).toHaveBeenCalledWith(
-      '❌ PREVIEW deploy fail.\nPREVIEW URL: https://test-url'
+      '❌ preview deploy fail.\npreview URL: https://test-url'
     );
   });
 
@@ -176,7 +176,7 @@ describe('handlePushStatus()', () => {
     );
     expect(process.stdout.write).toHaveBeenCalledTimes(4);
     expect(process.stdout.write).toHaveBeenCalledWith(
-      '🚀 PREVIEW deploy success.\nPREVIEW URL: https://test-url\n'
+      '🚀 preview deploy success.\npreview URL: https://test-url\n'
     );
     expect(process.stdout.write).toHaveBeenCalledWith('\nScorecard:');
     expect(process.stdout.write).toHaveBeenCalledWith(

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -178,13 +178,13 @@ function displayDeploymentAndBuildStatus({
       spinner.stop();
       return process.stdout.write(
         `${colors.green(
-          `🚀 ${buildType.toLocaleUpperCase()} deployment succeeded.`
+          `🚀 ${buildType.toLocaleUpperCase()} deploy success.`
         )}\n${colors.magenta('Preview URL')}: ${colors.cyan(previewUrl!)}\n`
       );
     case 'failed':
       spinner.stop();
       throw new DeploymentError(
-        `${colors.red(`❌ ${buildType.toLocaleUpperCase()} deployment failed.`)}\n${colors.magenta(
+        `${colors.red(`❌ ${buildType.toLocaleUpperCase()} deploy fail.`)}\n${colors.magenta(
           'Preview URL'
         )}: ${colors.cyan(previewUrl!)}`
       );

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -5,6 +5,7 @@ import { Spinner } from '../../utils/spinner';
 import { DeploymentError } from '../utils';
 import { yellow } from 'colorette';
 import { ReuniteApiClient, getApiKeys, getDomain } from '../api';
+import { capitalize } from '../../utils/js-utils';
 
 import type { DeploymentStatus, PushResponse, ScorecardItem } from '../api/types';
 
@@ -177,15 +178,15 @@ function displayDeploymentAndBuildStatus({
     case 'success':
       spinner.stop();
       return process.stdout.write(
-        `${colors.green(`🚀 ${buildType} deploy success.`)}\n${colors.magenta(
-          `${buildType} URL`
+        `${colors.green(`🚀 ${capitalize(buildType)} deploy success.`)}\n${colors.magenta(
+          `${capitalize(buildType)} URL`
         )}: ${colors.cyan(previewUrl!)}\n`
       );
     case 'failed':
       spinner.stop();
       throw new DeploymentError(
-        `${colors.red(`❌ ${buildType} deploy fail.`)}\n${colors.magenta(
-          `${buildType} URL`
+        `${colors.red(`❌ ${capitalize(buildType)} deploy fail.`)}\n${colors.magenta(
+          `${capitalize(buildType)} URL`
         )}: ${colors.cyan(previewUrl!)}`
       );
     case 'pending':

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -178,14 +178,14 @@ function displayDeploymentAndBuildStatus({
       spinner.stop();
       return process.stdout.write(
         `${colors.green(`🚀 ${buildType.toLocaleUpperCase()} deploy success.`)}\n${colors.magenta(
-          'Preview URL'
+          `${buildType.toLocaleUpperCase()} URL`
         )}: ${colors.cyan(previewUrl!)}\n`
       );
     case 'failed':
       spinner.stop();
       throw new DeploymentError(
         `${colors.red(`❌ ${buildType.toLocaleUpperCase()} deploy fail.`)}\n${colors.magenta(
-          'Preview URL'
+          `${buildType.toLocaleUpperCase()} URL`
         )}: ${colors.cyan(previewUrl!)}`
       );
     case 'pending':

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -177,9 +177,9 @@ function displayDeploymentAndBuildStatus({
     case 'success':
       spinner.stop();
       return process.stdout.write(
-        `${colors.green(
-          `🚀 ${buildType.toLocaleUpperCase()} deploy success.`
-        )}\n${colors.magenta('Preview URL')}: ${colors.cyan(previewUrl!)}\n`
+        `${colors.green(`🚀 ${buildType.toLocaleUpperCase()} deploy success.`)}\n${colors.magenta(
+          'Preview URL'
+        )}: ${colors.cyan(previewUrl!)}\n`
       );
     case 'failed':
       spinner.stop();

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -177,15 +177,15 @@ function displayDeploymentAndBuildStatus({
     case 'success':
       spinner.stop();
       return process.stdout.write(
-        `${colors.green(`🚀 ${buildType.toLocaleUpperCase()} deploy success.`)}\n${colors.magenta(
-          `${buildType.toLocaleUpperCase()} URL`
+        `${colors.green(`🚀 ${buildType} deploy success.`)}\n${colors.magenta(
+          `${buildType} URL`
         )}: ${colors.cyan(previewUrl!)}\n`
       );
     case 'failed':
       spinner.stop();
       throw new DeploymentError(
-        `${colors.red(`❌ ${buildType.toLocaleUpperCase()} deploy fail.`)}\n${colors.magenta(
-          `${buildType.toLocaleUpperCase()} URL`
+        `${colors.red(`❌ ${buildType} deploy fail.`)}\n${colors.magenta(
+          `${buildType} URL`
         )}: ${colors.cyan(previewUrl!)}`
       );
     case 'pending':

--- a/packages/cli/src/utils/js-utils.ts
+++ b/packages/cli/src/utils/js-utils.ts
@@ -17,5 +17,8 @@ export function keysOf<T>(obj: T) {
 }
 
 export function capitalize(s: string) {
-  return s[0].toUpperCase() + s.slice(1);
+  if (s?.length > 0) {
+    return s[0].toUpperCase() + s.slice(1);
+  }
+  return s;
 }

--- a/packages/cli/src/utils/js-utils.ts
+++ b/packages/cli/src/utils/js-utils.ts
@@ -15,3 +15,7 @@ export function keysOf<T>(obj: T) {
   if (!obj) return [];
   return Object.keys(obj) as (keyof T)[];
 }
+
+export function capitalize(s: string) {
+  return s[0].toUpperCase() + s.slice(1);
+}


### PR DESCRIPTION
## What/Why/How?

Fix the wording and eliminate uppercase for messages in both the `push-status` and `push` commands.

## Reference

## Testing

## Screenshots (optional)

## Has code been changed?

- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
