### PR TITLE
docs: try updating the markdownlint tool version

### DIFF
--- a/.github/workflows/docs-tests.yaml
+++ b/.github/workflows/docs-tests.yaml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: articulate/actions-markdownlint@v1
+      - uses: DavidAnson/markdownlint-cli2-action@15
         with:
           config: .markdownlint.yaml
-          files: 'docs/**/*.md'
+          globs: |
+            docs/**/*.md
 
   vale:
     name: vale action

--- a/.github/workflows/docs-tests.yaml
+++ b/.github/workflows/docs-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@15
+      - uses: DavidAnson/markdownlint-cli2-action@v15
         with:
           config: .markdownlint.yaml
           globs: |


### PR DESCRIPTION
## What/Why/How?

We created a changelog entry with weird formatting, but the tools didn't catch it on this repo, only on the marketing repo. Try to align the tools to match.

## Reference

https://github.com/Redocly/marketing-site-portal/actions/runs/7891589237/job/21536235829?pr=1190

## Has code been changed?

- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
