### PR TITLE
docs: link no-required-schema-properties-undefined rule in sidebar

### DIFF
--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -81,6 +81,7 @@
             - page: rules/no-invalid-parameter-examples.md
             - page: rules/no-invalid-schema-examples.md
             - page: rules/no-path-trailing-slash.md
+            - page: rules/no-required-schema-properties-undefined.ts
             - page: rules/no-server-example-com.md
             - page: rules/no-server-trailing-slash.md
             - page: rules/no-server-variables-empty-enum.md


### PR DESCRIPTION
## What/Why/How?
Adding link to `no-required-schema-properties-undefined` custom rule in sidebar.

## Reference
n/a

## Testing
n/a

## Screenshots (optional)
n/a

## Has code been changed?
n/a

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
