### PR TITLE
docs: fix wrong file extension for sidebar.yaml docs

### DIFF
--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -81,7 +81,7 @@
             - page: rules/no-invalid-parameter-examples.md
             - page: rules/no-invalid-schema-examples.md
             - page: rules/no-path-trailing-slash.md
-            - page: rules/no-required-schema-properties-undefined.ts
+            - page: rules/no-required-schema-properties-undefined.md
             - page: rules/no-server-example-com.md
             - page: rules/no-server-trailing-slash.md
             - page: rules/no-server-variables-empty-enum.md


### PR DESCRIPTION
## What/Why/How?
Fix wrong file extension for sidebar.yaml docs.

## Reference
n/a

## Testing
n/a

## Screenshots (optional)
n/a

## Has code been changed?
No

- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
