### PR TITLE
chore: do not run the reqire changeset action on release branch

### DIFF
--- a/.github/workflows/require-changeset.yaml
+++ b/.github/workflows/require-changeset.yaml
@@ -2,12 +2,10 @@ name: Require Either a Changeset or a Label 'No Changeset Needed'
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches-ignore:
-      - chore/fix-reuqire-changeset # changeset-release/main
 
 jobs:
   require-changeset-or-label:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Changeset Needed') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Changeset Needed') && github.head_ref != 'chore/fix-reuqire-changeset' }}
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/require-changeset.yaml
+++ b/.github/workflows/require-changeset.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   require-changeset-or-label:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Changeset Needed') && github.head_ref != 'chore/fix-reuqire-changeset' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Changeset Needed') && github.head_ref != 'changeset-release/main' }}
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/require-changeset.yaml
+++ b/.github/workflows/require-changeset.yaml
@@ -2,6 +2,8 @@ name: Require Either a Changeset or a Label 'No Changeset Needed'
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches-ignore:
+      - chore/fix-reuqire-changeset # changeset-release/main
 
 jobs:
   require-changeset-or-label:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-console.log('Test')
+
 import './utils/assert-node-version';
 import * as yargs from 'yargs';
 import { outputExtensions, PushArguments, regionChoices } from './types';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+console.log('Test')
 import './utils/assert-node-version';
 import * as yargs from 'yargs';
 import { outputExtensions, PushArguments, regionChoices } from './types';


### PR DESCRIPTION
## What/Why/How?

We do not need to check for a changeset in the release branch. This PR skips the check when a PR was created from `changeset-release/main`.

## Reference

## Testing

## Screenshots (optional)

## Has code been changed?

- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
