### PR TITLE
fix: join command failing on null values with --prefix-components-with-info-prop option

### DIFF
--- a/.changeset/spotty-pets-doubt.md
+++ b/.changeset/spotty-pets-doubt.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue when the `join` command was failing to process schemas containing `null` values with the `--prefix-components-with-info-prop` option.'

--- a/.changeset/spotty-pets-doubt.md
+++ b/.changeset/spotty-pets-doubt.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue when the `join` command was failing to process schemas containing `null` values with the `--prefix-components-with-info-prop` option.'
+Fixed a problem where the `join` command did not process schemas containing `null` values when the `--prefix-components-with-info-prop` option was used.'

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -204,6 +204,19 @@ describe('E2E', () => {
       const lintResult = getCommandOutput(lintArgs, folderPath);
       (<any>expect(lintResult)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
     });
+
+    test('openapi json file with discriminator', () => {
+      const folderPath = join(__dirname, `split/discriminator-in-json`);
+      const file = '../../../__tests__/split/discriminator-in-json/openapi.json';
+
+      const args = getParams('../../../packages/cli/src/index.ts', 'split', [
+        file,
+        '--outDir=output',
+      ]);
+
+      const result = getCommandOutput(args, folderPath);
+      (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
+    });
   });
 
   describe('join', () => {

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -214,6 +214,16 @@ describe('E2E', () => {
         '--outDir=output',
       ]);
 
+      // run the split command and write the result to files
+      spawnSync('ts-node', args, {
+        cwd: folderPath,
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          NO_COLOR: 'TRUE',
+        },
+      });
+
       const result = getCommandOutput(args, folderPath);
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, 'snapshot.js'));
     });

--- a/__tests__/join/prefix-components-with-info-prop/bar.yaml
+++ b/__tests__/join/prefix-components-with-info-prop/bar.yaml
@@ -29,6 +29,8 @@ components:
     some-property:
       description: bar description
       type: string
+      nullable: true
+      default: null
     another-property:
       description: description
       $ref: '#/components/schemas/some-property'

--- a/__tests__/join/prefix-components-with-info-prop/snapshot.js
+++ b/__tests__/join/prefix-components-with-info-prop/snapshot.js
@@ -71,6 +71,8 @@ components:
     Bar Example OpenAPI 3 definition._some-property:
       description: bar description
       type: string
+      nullable: true
+      default: null
     Bar Example OpenAPI 3 definition._another-property:
       description: description
       $ref: '#/components/schemas/Bar Example OpenAPI 3 definition._some-property'

--- a/__tests__/split/discriminator-in-json/openapi.json
+++ b/__tests__/split/discriminator-in-json/openapi.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.server.test/v1"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SchemaWithDiscriminator"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SchemaWithNull": {
+        "type": "string",
+        "default": null,
+        "nullable": true
+      },
+      "SchemaWithRef": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "schemaType": "string",
+            "const": "foo"
+          },
+          "foo": {
+            "$ref": "#/components/schemas/SchemaWithNull"
+          }
+        }
+      },
+      "SchemaWithDiscriminator": {
+        "discriminator": {
+          "propertyName": "schemaType",
+          "mapping": {
+            "foo": "#/components/schemas/SchemaWithRef",
+            "bar": "#/components/schemas/SchemaWithNull"
+          }
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SchemaWithRef"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "schemaType": {
+                "schemaType": "string",
+                "const": "bar"
+              },
+              "bar": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/__tests__/split/discriminator-in-json/snapshot.js
+++ b/__tests__/split/discriminator-in-json/snapshot.js
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E split openapi json file with discriminator 1`] = `
+
+{
+  "type": "string",
+  "default": null,
+  "nullable": true
+}{
+  "type": "object",
+  "properties": {
+    "type": {
+      "schemaType": "string",
+      "const": "foo"
+    },
+    "foo": {
+      "$ref": "./SchemaWithNull.json"
+    }
+  }
+}{
+  "discriminator": {
+    "propertyName": "schemaType",
+    "mapping": {
+      "foo": "./SchemaWithRef.json",
+      "bar": "./SchemaWithNull.json"
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "./SchemaWithRef.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaType": {
+          "schemaType": "string",
+          "const": "bar"
+        },
+        "bar": {
+          "type": "string"
+        }
+      }
+    }
+  ]
+}{
+  "get": {
+    "responses": {
+      "200": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/SchemaWithDiscriminator"
+            }
+          }
+        }
+      }
+    }
+  }
+}{
+  "get": {
+    "responses": {
+      "200": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "../components/schemas/SchemaWithDiscriminator.json"
+            }
+          }
+        }
+      }
+    }
+  }
+}{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test",
+    "version": "<version>"
+  },
+  "servers": [
+    {
+      "url": "https://api.server.test/v1"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "$ref": "paths/test.json"
+    }
+  }
+}🪓 Document: ../../../__tests__/split/discriminator-in-json/openapi.json is successfully split
+    and all related files are saved to the directory: output 
+
+../../../__tests__/split/discriminator-in-json/openapi.json: split processed in <test>ms
+
+
+`;

--- a/packages/cli/src/__mocks__/@redocly/openapi-core.ts
+++ b/packages/cli/src/__mocks__/@redocly/openapi-core.ts
@@ -1,5 +1,5 @@
 import { ConfigFixture } from './../../__tests__/fixtures/config';
-import { firstDocument, secondDocument } from '../documents';
+import { firstDocument, secondDocument, thirdDocument } from '../documents';
 
 import type { Document } from '@redocly/openapi-core';
 
@@ -47,6 +47,9 @@ export class BaseResolver {
     )
     .mockImplementationOnce(() =>
       Promise.resolve({ source: { absoluteRef: 'ref' }, parsed: secondDocument })
+    )
+    .mockImplementationOnce(() =>
+      Promise.resolve({ source: { absoluteRef: 'ref' }, parsed: thirdDocument })
     );
 }
 

--- a/packages/cli/src/__mocks__/documents.ts
+++ b/packages/cli/src/__mocks__/documents.ts
@@ -4,7 +4,7 @@ export const firstDocument = {
   info: {
     description: 'example test',
     version: '1.0.0',
-    title: 'Swagger Petstore',
+    title: 'First API',
     termsOfService: 'http://swagger.io/terms/',
     license: {
       name: 'Apache 2.0',
@@ -36,7 +36,7 @@ export const secondDocument = {
   info: {
     description: 'example test',
     version: '1.0.0',
-    title: 'Swagger Petstore',
+    title: 'Second API',
     termsOfService: 'http://swagger.io/terms/',
     license: {
       name: 'Apache 2.0',
@@ -60,4 +60,65 @@ export const secondDocument = {
     },
   },
   components: {},
+};
+
+export const thirdDocument = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Third API',
+    version: '1.0',
+  },
+  servers: [
+    {
+      url: 'https://api.server.test/v1',
+    },
+  ],
+  paths: {},
+  components: {
+    schemas: {
+      SchemaWithNull: {
+        type: 'string',
+        default: null,
+        nullable: true,
+      },
+      SchemaWithRef: {
+        type: 'object',
+        properties: {
+          schemaType: {
+            type: 'string',
+            enum: ['foo'],
+          },
+          foo: {
+            $ref: '#/components/schemas/SchemaWithNull',
+          },
+        },
+      },
+      SchemaWithDiscriminator: {
+        discriminator: {
+          propertyName: 'schemaType',
+          mapping: {
+            foo: '#/components/schemas/SchemaWithRef',
+            bar: '#/components/schemas/SchemaWithNull',
+          },
+        },
+        oneOf: [
+          {
+            $ref: '#/components/schemas/SchemaWithRef',
+          },
+          {
+            type: 'object',
+            properties: {
+              schemaType: {
+                type: 'string',
+                enum: ['bar'],
+              },
+              bar: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
 };

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -14,7 +14,6 @@ import {
   bundleDocument,
   isRef,
 } from '@redocly/openapi-core';
-
 import {
   getFallbackApisOrExit,
   printExecutionTime,
@@ -30,7 +29,7 @@ import { isObject, isString, keysOf } from '../utils/js-utils';
 import { COMPONENTS, OPENAPI3_METHOD } from './split/types';
 import { startsWithComponents } from './split';
 
-import { Oas3Definition, Document, Oas3Tag, Referenced, RuleSeverity } from '@redocly/openapi-core';
+import type { Oas3Definition, Document, Oas3Tag, Referenced, RuleSeverity } from '@redocly/openapi-core';
 import type { BundleResult } from '@redocly/openapi-core/lib/bundle';
 import type {
   Oas3Parameter,

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -29,7 +29,13 @@ import { isObject, isString, keysOf } from '../utils/js-utils';
 import { COMPONENTS, OPENAPI3_METHOD } from './split/types';
 import { startsWithComponents } from './split';
 
-import type { Oas3Definition, Document, Oas3Tag, Referenced, RuleSeverity } from '@redocly/openapi-core';
+import type {
+  Oas3Definition,
+  Document,
+  Oas3Tag,
+  Referenced,
+  RuleSeverity,
+} from '@redocly/openapi-core';
 import type { BundleResult } from '@redocly/openapi-core/lib/bundle';
 import type {
   Oas3Parameter,
@@ -797,7 +803,7 @@ async function validateApi(
   }
 }
 
-export function crawl(object: unknown, visitor: (node: unknown) => void) {
+function crawl(object: unknown, visitor: (node: unknown) => void) {
   if (!isObject(object)) return;
   for (const key of Object.keys(object)) {
     visitor(object[key]);

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -27,7 +27,7 @@ import {
 } from '../utils/miscellaneous';
 import { isObject, isString, keysOf } from '../utils/js-utils';
 import { COMPONENTS, OPENAPI3_METHOD } from './split/types';
-import { startsWithComponents } from './split';
+import { crawl, startsWithComponents } from './split';
 
 import type {
   Oas3Definition,
@@ -803,18 +803,8 @@ async function validateApi(
   }
 }
 
-function crawl(object: unknown, visitor: (node: unknown) => void) {
-  if (!isObject(object)) return;
-  for (const key of Object.keys(object)) {
-    visitor(object[key]);
-    crawl(object[key], visitor);
-  }
-}
-
 function replace$Refs(obj: unknown, componentsPrefix: string) {
-  crawl(obj, (node: unknown) => {
-    if (!node || !isObject(node)) return;
-
+  crawl(obj, (node: Record<string, unknown>) => {
     if (node.$ref && typeof node.$ref === 'string' && startsWithComponents(node.$ref)) {
       const name = path.basename(node.$ref);
       node.$ref = node.$ref.replace(name, componentsPrefix + '_' + name);

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -4,20 +4,15 @@ import { performance } from 'perf_hooks';
 const isEqual = require('lodash.isequal');
 import {
   Config,
-  Oas3Definition,
   SpecVersion,
   BaseResolver,
-  Document,
   StyleguideConfig,
-  Oas3Tag,
   formatProblems,
   getTotals,
   lintDocument,
   detectSpec,
   bundleDocument,
-  Referenced,
   isRef,
-  RuleSeverity,
 } from '@redocly/openapi-core';
 
 import {
@@ -32,16 +27,18 @@ import {
   checkForDeprecatedOptions,
 } from '../utils/miscellaneous';
 import { isObject, isString, keysOf } from '../utils/js-utils';
-import {
+import { COMPONENTS, OPENAPI3_METHOD } from './split/types';
+import { startsWithComponents } from './split';
+
+import { Oas3Definition, Document, Oas3Tag, Referenced, RuleSeverity } from '@redocly/openapi-core';
+import type { BundleResult } from '@redocly/openapi-core/lib/bundle';
+import type {
   Oas3Parameter,
   Oas3PathItem,
   Oas3Server,
   Oas3_1Definition,
 } from '@redocly/openapi-core/lib/typings/openapi';
-import { OPENAPI3_METHOD } from './split/types';
-import { BundleResult } from '@redocly/openapi-core/lib/bundle';
 
-const COMPONENTS = 'components';
 const Tags = 'tags';
 const xTagGroups = 'x-tagGroups';
 let potentialConflictsTotal = 0;
@@ -799,10 +796,6 @@ async function validateApi(
   } catch (err) {
     handleError(err, document.parsed);
   }
-}
-
-export function startsWithComponents(node: string) {
-  return node.startsWith(`#/${COMPONENTS}/`);
 }
 
 export function crawl(object: unknown, visitor: (node: unknown) => void) {

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -1,11 +1,9 @@
 import { red, blue, yellow, green } from 'colorette';
 import * as fs from 'fs';
 import { parseYaml, slash, isRef, isTruthy } from '@redocly/openapi-core';
-import type { OasRef } from '@redocly/openapi-core';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
 const isEqual = require('lodash.isequal');
-
 import {
   printExecutionTime,
   pathToFilename,
@@ -18,6 +16,14 @@ import {
 } from '../../utils/miscellaneous';
 import { isObject, isEmptyObject } from '../../utils/js-utils';
 import {
+  OPENAPI3_COMPONENT,
+  COMPONENTS,
+  OPENAPI3_METHOD_NAMES,
+  OPENAPI3_COMPONENT_NAMES,
+} from './types';
+
+import type { OasRef } from '@redocly/openapi-core';
+import type {
   Definition,
   Oas2Definition,
   Oas3Schema,
@@ -28,10 +34,6 @@ import {
   ComponentsFiles,
   RefObject,
   Oas3PathItem,
-  OPENAPI3_COMPONENT,
-  COMPONENTS,
-  OPENAPI3_METHOD_NAMES,
-  OPENAPI3_COMPONENT_NAMES,
   Referenced,
 } from './types';
 

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -145,18 +145,17 @@ function traverseDirectoryDeepCallback(
   writeToFileByExtension(pathData, filename);
 }
 
-function crawl(object: any, visitor: any) {
+export function crawl(object: unknown, visitor: (node: Record<string, unknown>) => void) {
   if (!isObject(object)) return;
+
+  visitor(object);
   for (const key of Object.keys(object)) {
-    visitor(object, key);
     crawl(object[key], visitor);
   }
 }
 
 function replace$Refs(obj: unknown, relativeFrom: string, componentFiles = {} as ComponentsFiles) {
-  crawl(obj, (node: unknown) => {
-    if (!node || !isObject(node)) return;
-
+  crawl(obj, (node: Record<string, unknown>) => {
     if (node.$ref && typeof node.$ref === 'string' && startsWithComponents(node.$ref)) {
       replace(node as RefObject, '$ref');
     } else if (isObject(node.discriminator) && isObject(node.discriminator.mapping)) {

--- a/packages/cli/src/commands/split/types.ts
+++ b/packages/cli/src/commands/split/types.ts
@@ -28,7 +28,7 @@ export type Definition = Oas3_1Definition | Oas3Definition | Oas2Definition;
 export interface ComponentsFiles {
   [schemas: string]: any;
 }
-export interface refObj {
+export interface RefObject {
   [$ref: string]: string;
 }
 
@@ -36,8 +36,6 @@ export const COMPONENTS = 'components';
 export const PATHS = 'paths';
 export const WEBHOOKS = 'webhooks';
 export const xWEBHOOKS = 'x-webhooks';
-export const componentsPath = `#/${COMPONENTS}/`;
-
 export enum OPENAPI3_METHOD {
   get = 'get',
   put = 'put',

--- a/packages/cli/src/utils/js-utils.ts
+++ b/packages/cli/src/utils/js-utils.ts
@@ -1,4 +1,4 @@
-export function isObject(obj: any) {
+export function isObject(obj: unknown): obj is Record<string, unknown> {
   const type = typeof obj;
   return type === 'function' || (type === 'object' && !!obj);
 }


### PR DESCRIPTION
## What/Why/How?

Since 1.9.0 `join` fails when used with the --prefix-components-with-info-prop option and a schema contains `null` value.

This PR resolves the issue by moving the crawl [visitor](https://github.com/Redocly/redocly-cli/pull/1444/files#diff-e52f3b6820e3de0cd0ec76de555265a5139350fdfa3cd210402edeaa9fdd56eeR151) out of the loop. 

Also, did a small refactoring of `split` command (reusing shared things with `join`, types correction).

## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/1440


## Testing

## Screenshots (optional)

## Has code been changed?

- [ ] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
