### PR TITLE
fix: parse $refs containing the hash symbol correctly

### DIFF
--- a/.changeset/slimy-planes-deliver.md
+++ b/.changeset/slimy-planes-deliver.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed resolving $refs. Previously it was failing resolve file names that contain the hash symbol.
+Fixed resolving $refs. Previously, it was failing to correctly resolve file names that contain the hash symbol.

--- a/.changeset/slimy-planes-deliver.md
+++ b/.changeset/slimy-planes-deliver.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed resolving $refs. Previously it was failing resolve file names that contain the hash symbol.

--- a/.changeset/slimy-planes-deliver.md
+++ b/.changeset/slimy-planes-deliver.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed resolving $refs. Previously, it was failing to correctly resolve file names that contain the hash symbol.
+Fixed a bug with resolving $refs to file names that contain the hash symbol.

--- a/packages/core/src/__tests__/ref-utils.test.ts
+++ b/packages/core/src/__tests__/ref-utils.test.ts
@@ -97,13 +97,14 @@ describe('ref-utils', () => {
   });
 
   it('should parse a ref correctly', () => {
-    expect(parseRef('./info.md#/description')).toEqual({
-      uri: './info.md',
+    expect(parseRef('./info.yaml#/description')).toEqual({
+      uri: './info.yaml',
       pointer: ['description'],
     });
   });
 
   it('should parse a ref which contain a hash in the middle', () => {
+    // Here `info#description.md` is a file name
     expect(parseRef('./info#description.md')).toEqual({
       uri: './info#description.md',
       pointer: [],
@@ -111,8 +112,8 @@ describe('ref-utils', () => {
   });
 
   it('should parse a ref which ends with a hash', () => {
-    expect(parseRef('./info.md#')).toEqual({
-      uri: './info.md',
+    expect(parseRef('./info.yaml#')).toEqual({
+      uri: './info.yaml',
       pointer: [],
     });
   });

--- a/packages/core/src/__tests__/ref-utils.test.ts
+++ b/packages/core/src/__tests__/ref-utils.test.ts
@@ -96,6 +96,27 @@ describe('ref-utils', () => {
     expect(result).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should parse a ref correctly', () => {
+    expect(parseRef('./info.md#/description')).toEqual({
+      uri: './info.md',
+      pointer: ['description'],
+    });
+  });
+
+  it('should parse a ref which contain a hash in the middle', () => {
+    expect(parseRef('./info#description.md')).toEqual({
+      uri: './info#description.md',
+      pointer: [],
+    });
+  });
+
+  it('should parse a ref which ends with a hash', () => {
+    expect(parseRef('./info.md#')).toEqual({
+      uri: './info.md',
+      pointer: [],
+    });
+  });
+
   describe('refBaseName', () => {
     it('returns base name for file reference', () => {
       expect(refBaseName('../testcase/Pet.yaml')).toStrictEqual('Pet');

--- a/packages/core/src/ref-utils.ts
+++ b/packages/core/src/ref-utils.ts
@@ -43,9 +43,9 @@ export function escapePointer<T extends string | number>(fragment: T): T {
 }
 
 export function parseRef(ref: string): { uri: string | null; pointer: string[] } {
-  const [uri, pointer = ''] = ref.split('#');
+  const [uri, pointer = ''] = ref.split('#/');
   return {
-    uri: uri || null,
+    uri: (uri.endsWith('#') ? uri.slice(0, -1) : uri) || null,
     pointer: parsePointer(pointer),
   };
 }


### PR DESCRIPTION
## What/Why/How?

Since the last release, $refs has been resolved incorrectly when a file names contain the hash character. This was due to splitting URIs by '#' instead of '#/'. 

This PR reverts this change while still allowing URIs to end with '#'.

## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/1441

Corresponding docs: https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-00#idExamples

## Testing

## Screenshots (optional)

## Has code been changed?

- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
