### PR TITLE
chore: bump version

### DIFF
--- a/.changeset/sixty-jars-listen.md
+++ b/.changeset/sixty-jars-listen.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+fix: Revert "Users can run the CLI tool behind a proxy by using HTTP_PROXY or HTTPS_PROXY environment variables to configure the proxy settings" temporary.


### PR DESCRIPTION
## What/Why/How?

Bump cli and core version to resolve problem caused by https://github.com/Redocly/redocly-cli/pull/1458

## Has code been changed?

- [x] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
