### PR TITLE
fix: fix issues with https-agent-proxy for cli and openapi-core packages

### DIFF
--- a/.changeset/wild-pets-report.md
+++ b/.changeset/wild-pets-report.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Users can run the CLI tool behind a proxy by using `HTTP_PROXY` or `HTTPS_PROXY` environment variables to configure the proxy settings.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,6 +78,30 @@ To give a Docker container access to your OpenAPI description files, you need to
 docker run --rm -v $PWD:/spec redocly/cli lint openapi.yaml
 ```
 
+## Run CLI behind a proxy
+
+If you need to run the CLI tool behind a proxy, you can use the `HTTP_PROXY` and `HTTPS_PROXY` environment variables to configure the proxy settings. These environment variables are commonly used to specify the proxy server for HTTP and HTTPS traffic, respectively.
+
+### Set up Proxy Environment Variables
+
+Before running the CLI behind a proxy, make sure to set the appropriate proxy environment variables. Open a terminal and use the following commands:
+
+```bash
+# For HTTP proxy
+export HTTP_PROXY=http://your-http-proxy-server:port
+
+# For HTTPS proxy
+export HTTPS_PROXY=http://your-https-proxy-server:port
+```
+
+### Use Environment Variables with CLI Commands
+
+You can also directly include the proxy environment variables in the command itself. For example:
+
+```bash
+HTTPS_PROXY=https://your-https-proxy-server:port redocly lint --extends minimal openapi.yaml
+```
+
 ## Next steps
 
 - Set up [autocomplete for Redocly CLI](./guides/autocomplete.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12945,6 +12945,7 @@
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
         "colorette": "^1.2.0",
+        "https-proxy-agent": "^7.0.4",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "lodash.isequal": "^4.5.0",
@@ -12966,6 +12967,29 @@
       "engines": {
         "node": ">=14.19.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "packages/core/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/core/node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     }
   },
@@ -15610,6 +15634,7 @@
         "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "colorette": "^1.2.0",
+        "https-proxy-agent": "^7.0.4",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "lodash.isequal": "^4.5.0",
@@ -15618,6 +15643,25 @@
         "pluralize": "^8.0.0",
         "typescript": "^5.2.2",
         "yaml-ast-parser": "0.0.43"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+          "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        }
       }
     },
     "@sinclair/typebox": {

--- a/packages/cli/src/__mocks__/@redocly/openapi-core.ts
+++ b/packages/cli/src/__mocks__/@redocly/openapi-core.ts
@@ -21,6 +21,7 @@ export const __redoclyClient = {
 export const RedoclyClient = jest.fn(() => __redoclyClient);
 export const loadConfig = jest.fn(() => ConfigFixture);
 export const getMergedConfig = jest.fn();
+export const getProxyAgent = jest.fn();
 export const lint = jest.fn();
 export const bundle = jest.fn(() => ({ bundle: { parsed: null }, problems: null }));
 export const getTotals = jest.fn(() => ({ errors: 0 }));

--- a/packages/cli/src/cms/api/__tests__/api.client.test.ts
+++ b/packages/cli/src/cms/api/__tests__/api.client.test.ts
@@ -42,6 +42,7 @@ describe('ApiClient', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${testToken}`,
           },
+          signal: expect.any(Object),
         }
       );
 
@@ -122,6 +123,8 @@ describe('ApiClient', () => {
             type: 'CICD',
             autoMerge: true,
           }),
+          signal: expect.any(Object),
+          agent: undefined,
         }
       );
 

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -1,7 +1,7 @@
 import fetchWithTimeout from '../../utils/fetch-with-timeout';
 import fetch from 'node-fetch';
 import * as FormData from 'form-data';
-
+import { getProxyAgent } from '@redocly/openapi-core';
 import type { Response } from 'node-fetch';
 import type { ReadStream } from 'fs';
 import type {
@@ -25,7 +25,7 @@ class RemotesApiClient {
   }
 
   async getDefaultBranch(organizationId: string, projectId: string) {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/source`,
       {
         method: 'GET',
@@ -35,6 +35,10 @@ class RemotesApiClient {
         },
       }
     );
+
+    if (!response) {
+      throw new Error(`Failed to get default branch.`);
+    }
 
     try {
       const source = await this.getParsedResponse<ProjectSourceResponse>(response);
@@ -53,7 +57,7 @@ class RemotesApiClient {
       mountBranchName: string;
     }
   ): Promise<UpsertRemoteResponse> {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/remotes`,
       {
         method: 'POST',
@@ -69,6 +73,10 @@ class RemotesApiClient {
         }),
       }
     );
+
+    if (!response) {
+      throw new Error(`Failed to upsert.`);
+    }
 
     try {
       return await this.getParsedResponse<UpsertRemoteResponse>(response);
@@ -110,6 +118,7 @@ class RemotesApiClient {
           Authorization: `Bearer ${this.apiKey}`,
         },
         body: formData,
+        agent: getProxyAgent(),
       }
     );
 
@@ -121,7 +130,7 @@ class RemotesApiClient {
   }
 
   async getRemotesList(organizationId: string, projectId: string, mountPath: string) {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/remotes?filter=mountPath:/${mountPath}/`,
       {
         method: 'GET',
@@ -131,6 +140,10 @@ class RemotesApiClient {
         },
       }
     );
+
+    if (!response) {
+      throw new Error(`Failed to get remotes list.`);
+    }
 
     try {
       return await this.getParsedResponse<ListRemotesResponse>(response);
@@ -160,7 +173,7 @@ class RemotesApiClient {
     );
 
     if (!response) {
-      throw new Error(`Failed to get push status: Time is up`);
+      throw new Error(`Failed to get push status.`);
     }
 
     try {

--- a/packages/cli/src/utils/fetch-with-timeout.ts
+++ b/packages/cli/src/utils/fetch-with-timeout.ts
@@ -1,5 +1,6 @@
 import nodeFetch from 'node-fetch';
 import AbortController from 'abort-controller';
+import { getProxyAgent } from '@redocly/openapi-core';
 
 const TIMEOUT = 3000;
 
@@ -10,7 +11,11 @@ export default async (url: string, options = {}) => {
       controller.abort();
     }, TIMEOUT);
 
-    const res = await nodeFetch(url, { signal: controller.signal, ...options });
+    const res = await nodeFetch(url, {
+      signal: controller.signal,
+      ...options,
+      agent: getProxyAgent(),
+    });
     clearTimeout(timeout);
     return res;
   } catch (e) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@redocly/ajv": "^8.11.0",
     "colorette": "^1.2.0",
+    "https-proxy-agent": "^7.0.4",
     "js-levenshtein": "^1.1.6",
     "js-yaml": "^4.1.0",
     "lodash.isequal": "^4.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
     "path": "path-browserify",
     "os": false,
     "node-fetch": false,
-    "colorette": false
+    "colorette": false,
+    "https-proxy-agent": false
   },
   "homepage": "https://github.com/Redocly/redocly-cli",
   "keywords": [

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -14,7 +14,7 @@ import { isAbsoluteUrl, isRef, Location, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
 import { reportUnresolvedRef } from './rules/no-unresolved-refs';
 import { isPlainObject, isTruthy } from './utils';
-import { isRedoclyRegistryURL } from './redocly';
+import { isRedoclyRegistryURL } from './redocly/domains';
 import { RemoveUnusedComponents as RemoveUnusedComponentsOas2 } from './decorators/oas2/remove-unused-components';
 import { RemoveUnusedComponents as RemoveUnusedComponentsOas3 } from './decorators/oas3/remove-unused-components';
 import { ConfigTypes } from './types/redocly-yaml';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -10,7 +10,7 @@ import {
   Oas3RuleSet,
   Async2RuleSet,
 } from '../oas-types';
-import { isBrowser, env } from '../env';
+import { isBrowser } from '../env';
 
 import type { NodeType } from '../types';
 import type {
@@ -35,25 +35,6 @@ const IGNORE_BANNER =
   `# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.\n` +
   `# See https://redoc.ly/docs/cli/ for more information.\n`;
 
-export const DEFAULT_REGION = 'us';
-
-function getDomains() {
-  const domains: { [region in Region]: string } = {
-    us: 'redocly.com',
-    eu: 'eu.redocly.com',
-  };
-
-  // FIXME: temporary fix for our lab environments
-  const domain = env.REDOCLY_DOMAIN;
-  if (domain?.endsWith('.redocly.host')) {
-    domains[domain.split('.')[0] as Region] = domain;
-  }
-  if (domain === 'redoc.online') {
-    domains[domain as Region] = domain;
-  }
-  return domains;
-}
-
 function getIgnoreFilePath(configFile?: string): string | undefined {
   if (configFile) {
     return doesYamlFileExist(configFile)
@@ -63,9 +44,6 @@ function getIgnoreFilePath(configFile?: string): string | undefined {
     return isBrowser ? undefined : path.join(process.cwd(), IGNORE_FILE);
   }
 }
-
-export const DOMAINS = getDomains();
-export const AVAILABLE_REGIONS = Object.keys(DOMAINS) as Region[];
 
 export class StyleguideConfig {
   plugins: Plugin[];

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { RedoclyClient } from '../redocly';
 import { isEmptyObject, doesYamlFileExist } from '../utils';
 import { parseYaml } from '../js-yaml';
-import { Config, DOMAINS } from './config';
+import { Config } from './config';
 import { ConfigValidationError, transformConfig } from './utils';
 import { resolveConfig, resolveConfigFileAndRefs } from './config-resolvers';
 import { bundleConfig } from '../bundle';
@@ -12,6 +12,7 @@ import type { Document } from '../resolve';
 import type { RegionalTokenWithValidity } from '../redocly/redocly-client-types';
 import type { RawConfig, RawUniversalConfig, Region } from './types';
 import type { BaseResolver, ResolvedRefMap } from '../resolve';
+import { DOMAINS } from '../redocly/domains';
 
 async function addConfigMetadata({
   rawConfig,

--- a/packages/core/src/decorators/common/registry-dependencies.ts
+++ b/packages/core/src/decorators/common/registry-dependencies.ts
@@ -1,5 +1,5 @@
 import { UserContext } from '../../walk';
-import { isRedoclyRegistryURL } from '../../redocly';
+import { isRedoclyRegistryURL } from '../../redocly/domains';
 
 import { Oas3Decorator, Oas2Decorator } from '../../visitors';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,11 @@
-export { BundleOutputFormat, readFileFromUrl, slash, doesYamlFileExist, isTruthy } from './utils';
+export {
+  BundleOutputFormat,
+  readFileFromUrl,
+  slash,
+  doesYamlFileExist,
+  isTruthy,
+  getProxyAgent,
+} from './utils';
 export { Oas3_1Types } from './types/oas3_1';
 export { Oas3Types } from './types/oas3';
 export { Oas2Types } from './types/oas2';
@@ -41,7 +48,9 @@ export {
   ResolvedApi,
 } from './config';
 
-export { RedoclyClient, isRedoclyRegistryURL } from './redocly';
+export { RedoclyClient } from './redocly';
+
+export * from './redocly/domains';
 
 export {
   Source,

--- a/packages/core/src/redocly/__tests__/domains.test.ts
+++ b/packages/core/src/redocly/__tests__/domains.test.ts
@@ -1,0 +1,52 @@
+import { RedoclyClient } from '../../index';
+import { setRedoclyDomain, getRedoclyDomain, getDomains, AVAILABLE_REGIONS } from '../domains';
+
+describe('domains', () => {
+  const REDOCLY_DOMAIN_US = 'redocly.com';
+  const TEST_DOMAIN = 'redoclyDomain.com';
+  const TEST_LAB_DOMAIN = 'lab.redocly.host';
+  const TEST_REDOC_ONLINE_DOMAIN = 'redoc.online';
+
+  afterEach(() => {
+    delete process.env.REDOCLY_DOMAIN;
+    setRedoclyDomain('');
+  });
+
+  it('should resolve the US domain by default', () => {
+    expect(getRedoclyDomain()).toBe(REDOCLY_DOMAIN_US);
+  });
+
+  it('should resolve the US and EU regions by default', () => {
+    expect(AVAILABLE_REGIONS).toStrictEqual(['us', 'eu']);
+  });
+
+  it('should resolve the specified domain if used with setter', () => {
+    setRedoclyDomain(TEST_DOMAIN);
+    expect(getRedoclyDomain()).toBe(TEST_DOMAIN);
+  });
+
+  it('should resolve the specified domain provided in environmental variable, after initializing RedoclyClient', () => {
+    process.env.REDOCLY_DOMAIN = TEST_DOMAIN;
+    const client = new RedoclyClient();
+    expect(getRedoclyDomain()).toBe(TEST_DOMAIN);
+    expect(client.domain).toBe(TEST_DOMAIN);
+  });
+
+  it('should return correct object when redocly domain is set to lab env', () => {
+    setRedoclyDomain(TEST_LAB_DOMAIN);
+    const domains = getDomains();
+    expect(domains).toEqual({ us: 'redocly.com', eu: 'eu.redocly.com', lab: 'lab.redocly.host' });
+    expect(getRedoclyDomain()).toBe(TEST_LAB_DOMAIN);
+  });
+
+  it('should return correct object when redocly domain is set to redoc.online env', () => {
+    setRedoclyDomain(TEST_REDOC_ONLINE_DOMAIN);
+    const domains = getDomains();
+    expect(domains).toEqual({
+      us: 'redocly.com',
+      eu: 'eu.redocly.com',
+      'redoc.online': 'redoc.online',
+    });
+    expect(getRedoclyDomain()).toBe(TEST_REDOC_ONLINE_DOMAIN);
+  });
+});

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -1,3 +1,4 @@
+import { setRedoclyDomain } from '../domains';
 import { RedoclyClient } from '../index';
 
 jest.mock('node-fetch', () => ({
@@ -16,6 +17,7 @@ describe('RedoclyClient', () => {
 
   afterEach(() => {
     delete process.env.REDOCLY_DOMAIN;
+    setRedoclyDomain('');
   });
 
   it('should resolve the US domain by default', () => {
@@ -40,19 +42,19 @@ describe('RedoclyClient', () => {
   });
 
   it('should resolve domain by EU region prioritizing flag over env variable', () => {
-    process.env.REDOCLY_DOMAIN = testRedoclyDomain;
+    setRedoclyDomain(testRedoclyDomain);
     const client = new RedoclyClient('eu');
     expect(client.domain).toBe(REDOCLY_DOMAIN_EU);
   });
 
   it('should resolve domain by US region prioritizing flag over env variable', () => {
-    process.env.REDOCLY_DOMAIN = testRedoclyDomain;
+    setRedoclyDomain(testRedoclyDomain);
     const client = new RedoclyClient('us');
     expect(client.domain).toBe(REDOCLY_DOMAIN_US);
   });
 
   it('should resolve domain by US region when REDOCLY_DOMAIN consists EU domain', () => {
-    process.env.REDOCLY_DOMAIN = REDOCLY_DOMAIN_EU;
+    setRedoclyDomain(REDOCLY_DOMAIN_EU);
     const client = new RedoclyClient();
     expect(client.getRegion()).toBe('eu');
   });

--- a/packages/core/src/redocly/domains.ts
+++ b/packages/core/src/redocly/domains.ts
@@ -1,0 +1,48 @@
+import { Region } from '../config/types';
+
+let redoclyDomain = 'redocly.com';
+
+export const DEFAULT_REGION = 'us';
+
+export const DOMAINS = getDomains();
+export const AVAILABLE_REGIONS = Object.keys(DOMAINS) as Region[];
+
+export function getDomains() {
+  const domains: { [region in Region]: string } = {
+    us: 'redocly.com',
+    eu: 'eu.redocly.com',
+  };
+
+  // FIXME: temporary fix for our lab environments
+  const domain = redoclyDomain;
+  if (domain?.endsWith('.redocly.host')) {
+    domains[domain.split('.')[0] as Region] = domain;
+  }
+  if (domain === 'redoc.online') {
+    domains[domain as Region] = domain;
+  }
+  return domains;
+}
+
+export function setRedoclyDomain(domain: string) {
+  redoclyDomain = domain;
+}
+
+export function getRedoclyDomain(): string {
+  return redoclyDomain;
+}
+
+export function isRedoclyRegistryURL(link: string): boolean {
+  const domain = getRedoclyDomain() || DOMAINS[DEFAULT_REGION];
+
+  const legacyDomain = domain === 'redocly.com' ? 'redoc.ly' : domain;
+
+  if (
+    !link.startsWith(`https://api.${domain}/registry/`) &&
+    !link.startsWith(`https://api.${legacyDomain}/registry/`)
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,9 +5,10 @@ import fetch from 'node-fetch';
 import * as pluralize from 'pluralize';
 import { parseYaml } from './js-yaml';
 import { UserContext } from './walk';
-import { HttpResolveConfig } from './config';
 import { env } from './env';
 import { logger, colorize } from './logger';
+import { HttpResolveConfig } from './config';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 export { parseYaml, stringifyYaml } from './js-yaml';
 
@@ -273,4 +274,9 @@ export function nextTick() {
 
 function getUpdatedFieldName(updatedField: string, updatedObject?: string) {
   return `${typeof updatedObject !== 'undefined' ? `${updatedObject}.` : ''}${updatedField}`;
+}
+
+export function getProxyAgent() {
+  const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  return proxy ? new HttpsProxyAgent(proxy) : undefined;
 }


### PR DESCRIPTION
## What/Why/How?
Adding https-proxy-agent package to fix issues with requests when using CLI behind proxy. Create better mechanism for handling `env.REDOCLY_DOMAIN` usage in few modules. 

Now if you need to run the CLI tool behind a proxy, you can use the HTTP_PROXY and HTTPS_PROXY environment variables to configure the proxy settings.

`https-proxy-agent` package was used for `node-fetch` requests. Now we pass agent for every `fetchWithTimeout` request, as well as other regular `fetch` request.

This is a rollback of a rollback https://github.com/Redocly/redocly-cli/pull/1458 
After encountering problems with some of the packages from `https-proxy-agent` dependencies, we had to ignore this package for browser environment, by modyfing `packages/core/package.json` like so:
```
  "browser": {
    "https-proxy-agent": false
  },
```

## Reference
Resolves https://github.com/Redocly/redocly-cli/issues/1404
Fixes https://github.com/Redocly/redocly-cli/issues/529
Fixes https://github.com/Redocly/redocly-cli/issues/1146
Resolves https://github.com/Redocly/redocly-cli/pull/1433

## Testing
Fixed unit tests. Tested with few CLI commands: `push`, `lint` etc.

## Screenshots (optional)
n/a

## Has code been changed?
Yes

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines