### PR TITLE
fix: fix preview command on windows

### DIFF
--- a/.changeset/cuddly-cheetahs-teach.md
+++ b/.changeset/cuddly-cheetahs-teach.md
@@ -2,4 +2,5 @@
 "@redocly/cli": patch
 ---
 
-fix: Fixed a bug where `preview` command crashed on Windows because of incorrect NPX executable name.
+fix: Fixed a problem with the `preview` command crashing on Windows by adding operating system detection for the correct `npx` executable to use.
+

--- a/.changeset/cuddly-cheetahs-teach.md
+++ b/.changeset/cuddly-cheetahs-teach.md
@@ -3,4 +3,3 @@
 ---
 
 fix: Fixed a problem with the `preview` command crashing on Windows by adding operating system detection for the correct `npx` executable to use.
-

--- a/.changeset/cuddly-cheetahs-teach.md
+++ b/.changeset/cuddly-cheetahs-teach.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+fix: Fixed a bug where `preview` command crashed on Windows because of incorrect NPX executable name.

--- a/packages/cli/src/commands/preview-project/index.ts
+++ b/packages/cli/src/commands/preview-project/index.ts
@@ -21,12 +21,16 @@ export const previewProject = async (args: PreviewProjectOptions) => {
 
   process.stdout.write(`\nLaunching preview of ${productName} ${plan} using NPX\n\n`);
 
-  const npxExecutableName = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+  const npxExecutableName = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
-  spawn(npxExecutableName, ['-y', packageName, 'develop', `--plan=${plan}`, `--port=${port || 4000}`], {
-    stdio: 'inherit',
-    cwd: projectDir,
-  });
+  spawn(
+    npxExecutableName,
+    ['-y', packageName, 'develop', `--plan=${plan}`, `--port=${port || 4000}`],
+    {
+      stdio: 'inherit',
+      cwd: projectDir,
+    }
+  );
 };
 
 const isValidProduct = (product: string | undefined): product is Product => {

--- a/packages/cli/src/commands/preview-project/index.ts
+++ b/packages/cli/src/commands/preview-project/index.ts
@@ -21,7 +21,9 @@ export const previewProject = async (args: PreviewProjectOptions) => {
 
   process.stdout.write(`\nLaunching preview of ${productName} ${plan} using NPX\n\n`);
 
-  spawn('npx', ['-y', packageName, 'develop', `--plan=${plan}`, `--port=${port || 4000}`], {
+  const npxExecutableName = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+
+  spawn(npxExecutableName, ['-y', packageName, 'develop', `--plan=${plan}`, `--port=${port || 4000}`], {
     stdio: 'inherit',
     cwd: projectDir,
   });


### PR DESCRIPTION
## What/Why/How?

To execute an `npx` command using `spawn` on Windows, the provided executable name has to be `npx.cmd` instead of `npx`. Because this wasn't handled, the npx command was crashing on Windows with an `ENOENT` error.

## Reference

## Testing

## Screenshots (optional)

Error on Windows

![image](https://github.com/Redocly/redocly-cli/assets/22818316/93dace15-f50a-4946-a0fd-278eb3dee9d4)


## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
