### PR TITLE
fix: prevent failing in worker

### DIFF
--- a/.changeset/moody-parents-fry.md
+++ b/.changeset/moody-parents-fry.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Added a platform check so `@redocly/openapi-core` doesn't fail when running inside a worker.

--- a/.changeset/moody-parents-fry.md
+++ b/.changeset/moody-parents-fry.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Added a platform check so `@redocly/openapi-core` doesn't fail when running inside a worker.
+Added a platform check so `@redocly/openapi-core` can support running inside a worker.

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,5 +1,7 @@
 export const isBrowser =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  typeof window !== 'undefined' || typeof process === 'undefined'; // main and worker thread
+  typeof window !== 'undefined' ||
+  typeof process === 'undefined' ||
+  (process?.platform as any) === 'browser'; // main and worker thread
 export const env = isBrowser ? {} : process.env || {};


### PR DESCRIPTION
## What/Why/How?

`openapi-core` fails when running inside a worker because it doesn't recognise it's not a `node` environment` (i.e. inside a language server). Added a check for that case. 

Kudos to @jacobator

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
