### PR TITLE
fix: allow additional properties in theme.openapi

### DIFF
--- a/.changeset/old-cats-shave.md
+++ b/.changeset/old-cats-shave.md
@@ -2,4 +2,11 @@
 "@redocly/openapi-core": patch
 ---
 
-Allowed additional properties in theme.openapi config schema.
+Allowed additional properties in `theme.openapi` config schema to enable libraries that use `@redocly/openapi-core` for configuration linting to extend this part of the schema.
+
+
+
+
+
+
+

--- a/.changeset/old-cats-shave.md
+++ b/.changeset/old-cats-shave.md
@@ -3,10 +3,3 @@
 ---
 
 Allowed additional properties in `theme.openapi` config schema to enable libraries that use `@redocly/openapi-core` for configuration linting to extend this part of the schema.
-
-
-
-
-
-
-

--- a/.changeset/old-cats-shave.md
+++ b/.changeset/old-cats-shave.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Allowed additional properties in theme.openapi config schema.

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -1050,7 +1050,7 @@ const ConfigReferenceDocs: NodeType = {
     preserveOriginalExtensionsName: { type: 'boolean' },
     markdownHeadingsAnchorLevel: { type: 'number' },
   },
-  additionalProperties: { type: 'string' },
+  additionalProperties: {},
 };
 
 const ConfigMockServer: NodeType = {


### PR DESCRIPTION
## What/Why/How?

Allow additional properties in the `theme.openapi` config definition

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
