### PR TITLE
docs: add cli config reference

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -213,7 +213,7 @@ Redocly CLI supports one `http` header per URL.
 
 Here is an example for adding header definitions:
 
-```yaml
+```text
 resolve:
   http:
     headers:

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -43,13 +43,13 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 ---
 
 - rules
-- [Rules object]
+- [Rules object](./rules.md)
 - Additional rule configuration for this API.
 
 ---
 
 - decorators
-- [Decorators object]
+- [Decorators object](./decorators.md)
 - Additional decorator configuration for this API.
 
 {% /table %}

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -1,10 +1,5 @@
 # `apis`
 
-<!--Introduction
---------------------------
-Explain what the option is or does.
-For example, Developer onboarding means allowing developers to register apps and manage credentials.-->
-
 ## Introduction
 
 If your project contains multiple APIs, the `apis` configuration section allows you to set up different rules and settings for different APIs.
@@ -55,16 +50,30 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 ## Examples
 
-<!--Related options
--------------------
+The following example shows a simple `redocly.yaml` configuration file with settings for multiple APIs.
 
-Include a bulleted list of related reference documentation links.-->
+```yaml
+apis:
+  orders:
+    root: orders/openapi.yaml
+    rules:
+      tags-alphabetical: error
+      operation-operationId-unique: error
+      spec-strict-refs: error
+  newsletter:
+    root: newsletter/openapi.yaml
+    rules:
+      info-contact: off
+      operation-summary: off
+```
 
 ## Related options
 
-<!--Resources
--------------
-
-Include a bulleted list of conceptual or how-to documentation links that are related to topic referenced.-->
+- [extends](./extends.md) sets the base ruleset to use.
+- [rules](./rules.md) settings define the linting rules that are used.
+- [decorators](./decorators.md) offer some transformations for your OpenAPI documents.
 
 ## Resources
+
+- More information and examples of [per-API configuration](../apis.md).
+- List of [built-in rules](../../rules/built-in-rules.md).

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -1,0 +1,73 @@
+# `apis`
+
+<!--Introduction
+--------------------------
+Explain what the option is or does.
+For example, Developer onboarding means allowing developers to register apps and manage credentials.-->
+
+## Introduction
+
+If your project contains multiple APIs, the `apis` configuration section allows you to set up different rules and settings for different APIs.
+
+
+## Options
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- `{name}@{version}`
+- [API object](#api-object)
+- Required. Each API needs a name and optionally a version.
+
+{% /table %}
+
+### API object
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- root
+- string
+- Required. Path to the root API description file.
+
+---
+
+- rules
+- [Rules object]
+- Additional rule configuration for this API.
+
+---
+
+- decorators
+- [Decorators object]
+- Additional decorator configuration for this API.
+
+{% /table %}
+
+
+## Examples
+
+<!--Related options
+-------------------
+
+Include a bulleted list of related reference documentation links.-->
+
+## Related options
+
+<!--Resources
+-------------
+
+Include a bulleted list of conceptual or how-to documentation links that are related to topic referenced.-->
+
+## Resources
+

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -16,7 +16,7 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 - `{name}@{version}`
 - [API object](#api-object)
-- Required. Each API needs a name and optionally a version. Supports alphanumeric characters and underscores.
+- **REQUIRED**. Each API needs a name and optionally a version. Supports alphanumeric characters and underscores.
 
 {% /table %}
 
@@ -32,7 +32,7 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 - root
 - string
-- Required. Path to the root API description file.
+- **REQUIRED**. Path to the root API description file.
 
 ---
 

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -50,7 +50,7 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 - preprocessors
 - [Decorators object](./decorators.md)
-- Preprocessors run before linting, and follow the same structure as decorators. We recommend use of decorators in most cases.
+- Preprocessors run before linting, and follow the same structure as decorators. We recommend the use of decorators over preprocessors in most cases.
 
 {% /table %}
 

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -16,7 +16,7 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 - `{name}@{version}`
 - [API object](#api-object)
-- Required. Each API needs a name and optionally a version.
+- Required. Each API needs a name and optionally a version. Supports alphanumeric characters and underscores.
 
 {% /table %}
 
@@ -46,6 +46,12 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 - [Decorators object](./decorators.md)
 - Additional decorator configuration for this API.
 
+---
+
+- preprocessors
+- [Decorators object](./decorators.md)
+- Preprocessors run before linting, and follow the same structure as decorators. We recommend use of decorators in most cases.
+
 {% /table %}
 
 ## Examples
@@ -54,7 +60,7 @@ The following example shows a simple `redocly.yaml` configuration file with sett
 
 ```yaml
 apis:
-  orders:
+  orders@v3:
     root: orders/openapi.yaml
     rules:
       tags-alphabetical: error

--- a/docs/configuration/reference/apis.md
+++ b/docs/configuration/reference/apis.md
@@ -9,7 +9,6 @@ For example, Developer onboarding means allowing developers to register apps and
 
 If your project contains multiple APIs, the `apis` configuration section allows you to set up different rules and settings for different APIs.
 
-
 ## Options
 
 {% table %}
@@ -54,7 +53,6 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 {% /table %}
 
-
 ## Examples
 
 <!--Related options
@@ -70,4 +68,3 @@ Include a bulleted list of related reference documentation links.-->
 Include a bulleted list of conceptual or how-to documentation links that are related to topic referenced.-->
 
 ## Resources
-

--- a/docs/configuration/reference/decorators.md
+++ b/docs/configuration/reference/decorators.md
@@ -1,0 +1,91 @@
+# `decorators`
+
+## Introduction
+
+The `decorators` configuration section defines the transformation steps that are applied to your API description when it is bundled.
+Both the [built-in decorators](../../decorators.md) and [decorators from custom plugins](../../custom-plugins/custom-decorators.md) are configured this way.
+The `decorators` block can be used at the root of a configuration file, or inside an [API-specific section](./apis.md).
+
+## Options
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- {decorator name}
+- string _or_ [Decorator object](#decorator-object)
+- Required. You can add as many decorators as you wish. The keys must be either built-in decorators (for example `info-description-override`), or a decorator from a plugin (for example `tags-plugin/no-unused-tags`). Set the value to `on` or `off` to enable or disable a decorator, or use a [Decorator object](#decorator-object) to configure additional options for a specific decorator.
+
+{% /table %}
+
+### Decorator object
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- {additional properties}
+- any
+- Some decorators support additional configuration, check the documentation for each specific decorator to discover the values that can be used. For example the [`filter-out` decorator](../../decorators/filter-out.md) supports `property` and `value` settings for what to filter.
+
+---
+
+- severity
+- string
+- Severity level of any problems reported with this decorator. Setting this option is usually only useful for troubleshooting purposes. The value must be one of `error`, `warn`, or `off`, where `off` disables the decorator.
+
+{% /table %}
+
+## Examples
+
+This section covers some examples and common use cases.
+
+### Configure built-in decorators
+
+Pick and mix the built-in decorators in your `redocly.yaml` file as you need to.
+The following example enables the `remove-unused-components` decorator, and uses `info-override` to update the title:
+
+```yaml 
+decorators:
+  remove-unused-components: on
+  info-override:
+    title: Better title than before
+```
+
+The `info-override` decorator accepts some additional configuration.
+
+### Configure decorators from custom plugins
+
+Redocly also supports [custom plugins](../../custom-plugins/custom-rules.md) for advanced users.
+Decorators in custom plugins are also configured in the `decorators` section of the configuration file, using the plugin's module name as a prefix.
+
+The following example shows enabling a decorator called `alphabetical` from a plugin named `tag-sorting`:
+
+```yaml
+plugins:
+  - './tag-sorting.js'
+
+decorators:
+  tag-sorting/alphabetical: on
+```
+
+The example includes adding the plugin, partly to remind you that this is also needed.
+
+## Related options
+
+- [apis](./apis.md) configuration options allow setting per-API configuration in `redocly.yaml`.
+- [rules](./rules.md) settings define the linting rules that are used.
+
+## Resources
+
+- Learn more about [decorators](../../decorators.md).
+- The [Redocly CLI cookbook](https://github.com/Redocly/redocly-cli-cookbook) is a great resource for learning and sharing decorators and custom plugins.
+

--- a/docs/configuration/reference/decorators.md
+++ b/docs/configuration/reference/decorators.md
@@ -87,4 +87,5 @@ The example includes adding the plugin, partly to remind you that this is also n
 ## Resources
 
 - Learn more about [decorators](../../decorators.md).
+- To build your own decorators, you can use [custom plugins](../../custom-plugins/index.md).
 - The [Redocly CLI cookbook](https://github.com/Redocly/redocly-cli-cookbook) is a great resource for learning and sharing decorators and custom plugins.

--- a/docs/configuration/reference/decorators.md
+++ b/docs/configuration/reference/decorators.md
@@ -18,7 +18,7 @@ The `decorators` block can be used at the root of a configuration file, or insid
 
 - {decorator name}
 - string _or_ [Decorator object](#decorator-object)
-- Required. You can add as many decorators as you wish. The keys must be either built-in decorators (for example `info-description-override`), or a decorator from a plugin (for example `tags-plugin/no-unused-tags`). Set the value to `on` or `off` to enable or disable a decorator, or use a [Decorator object](#decorator-object) to configure additional options for a specific decorator.
+- **REQUIRED**. You can add as many decorators as you wish. The keys must be either built-in decorators (for example `info-description-override`), or a decorator from a plugin (for example `tags-plugin/no-unused-tags`). Set the value to `on` or `off` to enable or disable a decorator, or use a [Decorator object](#decorator-object) to configure additional options for a specific decorator.
 
 {% /table %}
 

--- a/docs/configuration/reference/decorators.md
+++ b/docs/configuration/reference/decorators.md
@@ -88,4 +88,3 @@ The example includes adding the plugin, partly to remind you that this is also n
 
 - Learn more about [decorators](../../decorators.md).
 - The [Redocly CLI cookbook](https://github.com/Redocly/redocly-cli-cookbook) is a great resource for learning and sharing decorators and custom plugins.
-

--- a/docs/configuration/reference/decorators.md
+++ b/docs/configuration/reference/decorators.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 The `decorators` configuration section defines the transformation steps that are applied to your API description when it is bundled.
-Both the [built-in decorators](../../decorators.md) and [decorators from custom plugins](../../custom-plugins/custom-decorators.md) are configured this way.
+Both the [built-in decorators](../../decorators.md) and [decorators from custom plugins](../../custom-plugins/custom-decorators.md) are configured in this section.
 The `decorators` block can be used at the root of a configuration file, or inside an [API-specific section](./apis.md).
 
 ## Options

--- a/docs/configuration/reference/decorators.md
+++ b/docs/configuration/reference/decorators.md
@@ -53,7 +53,7 @@ This section covers some examples and common use cases.
 Pick and mix the built-in decorators in your `redocly.yaml` file as you need to.
 The following example enables the `remove-unused-components` decorator, and uses `info-override` to update the title:
 
-```yaml 
+```yaml
 decorators:
   remove-unused-components: on
   info-override:

--- a/docs/configuration/reference/extends.md
+++ b/docs/configuration/reference/extends.md
@@ -13,7 +13,7 @@ Extends is useful if you use a common ruleset across multiple projects.
 Define a ruleset in one location, and each project can `extend` it, with or without modification.
 
 {% admonition type="info" name="Default ruleset: recommended" %}
-If `extends` isn't set, the [recommended ruleset](../../rules/recommended.md) is used by default.
+If there is no `redocly.yaml` configuration file, the [recommended ruleset](../../rules/recommended.md) is used by default.
 {% /admonition %}
 
 ## Options

--- a/docs/configuration/reference/extends.md
+++ b/docs/configuration/reference/extends.md
@@ -1,0 +1,41 @@
+# `extends`
+
+## Introduction
+
+The `extends` configuration entry allows your project configuration to extend an existing configuration set.
+Multiple values are supported, and can include:
+
+- the name of a [built-in ruleset](../../rules.md#rulesets)
+- configuration defined in a [custom plugin](../../custom-plugins/index.md)
+- a path or URL to another `redocly.yaml` file
+
+Extends is useful if you use a common ruleset across multiple projects.
+Define a ruleset in one location, and each project can `extend` it, with or without modification.
+
+{% admonition type="info" name="Default ruleset: recommended" %}
+If `extends` isn't set, the [recommended ruleset](../../rules/recommended.md) is used by default.
+{% /admonition %}
+
+## Options
+
+The `extends` configuration is an array of strings.
+
+The array is parsed in the order it is defined, so the later entries in the array overwrite the earlier ones.
+
+## Examples
+
+To get started, try the following example to configure your project to be based on the [minimal ruleset](../../rules/minimal.md):
+
+```yaml
+extends:
+ - minimal
+```
+
+## Related options
+
+- [apis](./apis.md) configuration options allow setting per-API configuration in `redocly.yaml`.
+- [rules](./rules.md) settings define the linting rules that are used.
+
+## Resources
+
+- Detailed documentation and examples on [extending configuration](../extends.md)

--- a/docs/configuration/reference/extends.md
+++ b/docs/configuration/reference/extends.md
@@ -38,4 +38,4 @@ extends:
 
 ## Resources
 
-- Detailed documentation and examples on [extending configuration](../extends.md)
+- Detailed documentation and examples on [extending configuration](../extends.md).

--- a/docs/configuration/reference/plugins.md
+++ b/docs/configuration/reference/plugins.md
@@ -1,0 +1,34 @@
+# `plugins`
+
+## Introduction
+
+Redocly supports [custom plugins](../../custom-plugins/index.md) for extending lint and decorator behavior.
+Use plugins when you need to add rules beyond the [built-in](../../rules/built-in-rules.md) and [configurable](../../rules/configurable-rules.md), or decorators beyond the [built-in decorators](../../decorators.md).
+
+## Options
+
+The `plugins` configuration is an array of paths to plugin files, relative to the config file.
+You can include as many plugins as you need.
+
+## Examples
+
+A basic example of including two plugins from a directory named `plugins/` is shown in the example below:
+
+```yaml
+plugins:
+  - plugins/my-best-plugin.js
+  - plugins/another-plugin.js
+```
+
+Remember that you need to include plugins in the `plugins` section before you can use the contest of the plugin elsewhere in the configuration file.
+
+## Related options
+
+- [apis](./apis.md) configuration options allow setting per-API configuration in `redocly.yaml`.
+- [rules](./rules.md) settings define the linting rules that are used.
+- [decorators](./decorators.md) offer some transformations for your OpenAPI documents.
+
+## Resources
+
+- The [Redocly CLI cookbook](https://redocly.com/blog/redocly-cli-cookbook/) has many examples of plugins.
+- Read more [configuration examples](../index.md).

--- a/docs/configuration/reference/plugins.md
+++ b/docs/configuration/reference/plugins.md
@@ -20,7 +20,7 @@ plugins:
   - plugins/another-plugin.js
 ```
 
-Remember that you need to include plugins in the `plugins` section before you can use the contest of the plugin elsewhere in the configuration file.
+Remember that you need to include plugins in the `plugins` section before you can use the content of the plugin elsewhere in the configuration file.
 
 ## Related options
 

--- a/docs/configuration/reference/preprocessors.md
+++ b/docs/configuration/reference/preprocessors.md
@@ -1,0 +1,16 @@
+# `preprocessors`
+
+## Introduction
+
+Preprocessors are similar to decorators, but they run before linting rather than after.
+
+Refer to the [`decorator` configuration options](./decorators.md) documentation for details; the options available are the same in both the `decorators` and `preprocessor` sections of the configuration file.
+
+## Related options
+
+- [decorators](./decorators.md) offer some transformations for your OpenAPI documents.
+- [plugins](./plugins.md) allow code extensions to extend the existing functionality.
+
+## Resources
+
+- [Custom plugins](../../custom-plugins/index.md) offer a way to extend the functionality of Redocly.

--- a/docs/configuration/reference/resolve.md
+++ b/docs/configuration/reference/resolve.md
@@ -62,7 +62,7 @@ One HTTP header is supported for each URL resolved.
 
 - envVariable
 - string
-- The name of the environment variable that contains the value to send for the header. Only one of `value` or `envVariable` can be used; `envVariable` is recommended for any secrets. 
+- The name of the environment variable that contains the value to send for the header. Only one of `value` or `envVariable` can be used; `envVariable` is recommended for any secrets.
 
 {% /table %}
 
@@ -84,7 +84,6 @@ resolve:
 ```
 
 When the OpenAPI description references a URL that matches these patterns, it is resolved using the additional header specified.
-
 
 ## Resources
 

--- a/docs/configuration/reference/resolve.md
+++ b/docs/configuration/reference/resolve.md
@@ -43,13 +43,13 @@ One HTTP header is supported for each URL resolved.
 
 - matches
 - string
-- Required. The URL pattern to match, for example `https://api.example.com/v2/**` or `https://example.com/*/test.yaml`.
+- **REQUIRED**. The URL pattern to match, for example `https://api.example.com/v2/**` or `https://example.com/*/test.yaml`.
 
 ---
 
 - name
 - string
-- Required. The header name, for example `Authorization`.
+- **REQUIRED**. The header name, for example `Authorization`.
 
 ---
 

--- a/docs/configuration/reference/resolve.md
+++ b/docs/configuration/reference/resolve.md
@@ -1,0 +1,92 @@
+# `resolve`
+
+## Introduction
+
+The `resolve` configuration provides options for how URLs in API descriptions are handled.
+If a URL is not publicly accessible, use these configuration settings to add the needed details to gain access.
+
+{% admonition type="info" %}
+One HTTP header is supported for each URL resolved.
+{% /admonition %}
+
+
+## Options
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- doNotResolveExamples
+- boolean
+- When running `lint`, set this option to `true` to avoid resolving `$ref` fields in examples. Resolving `$ref`s in other parts of the API is unaffected.
+
+---
+
+- http
+- [HTTP object](#http-object)
+- Describe URL patterns and the corresponding headers to use when resolving references that point to them.
+
+{% /table %}
+
+### HTTP object
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- matches
+- string
+- Required. The URL pattern to match, for example `https://api.example.com/v2/**` or `https://example.com/*/test.yaml`.
+
+---
+
+- name
+- string
+- Required. The header name, for example `Authorization`.
+
+---
+
+- value
+- string
+- The value to send for the header. Only one of `value` or `envVariable` can be used; `envVariable` is recommended for any secrets.
+
+---
+
+- envVariable
+- string
+- The name of the environment variable that contains the value to send for the header. Only one of `value` or `envVariable` can be used; `envVariable` is recommended for any secrets. 
+
+{% /table %}
+
+## Examples
+
+If you have multiple examples to resolve, you can describe multiple entries with patterns to match and headers to include.
+The following example shows two patterns, with the names of environment variables that contain the values to use.
+
+```text
+resolve:
+  http:
+    headers:
+      - matches: https://api.example.com/v2/**
+        name: X-API-KEY
+        envVariable: SECRET_KEY
+      - matches: https://example.com/*/test.yaml
+        name: Authorization
+        envVariable: SECRET_AUTH
+```
+
+When the OpenAPI description references a URL that matches these patterns, it is resolved using the additional header specified.
+
+
+## Resources
+
+- [Configuration for Redocly CLI](../index.md).
+- [How to use `$ref` in OpenAPI](https://redocly.com/docs/resources/ref-guide/).

--- a/docs/configuration/reference/resolve.md
+++ b/docs/configuration/reference/resolve.md
@@ -9,7 +9,6 @@ If a URL is not publicly accessible, use these configuration settings to add the
 One HTTP header is supported for each URL resolved.
 {% /admonition %}
 
-
 ## Options
 
 {% table %}

--- a/docs/configuration/reference/rules.md
+++ b/docs/configuration/reference/rules.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 The `rules` configuration blocks configure linting rules and their severity.
-Configure [built-in rules](../../rules/built-in-rules.md) included by default, [configurable rules](../../rules/configurable-rules.md) you add yourself, and [rules from plugins](../../custom-plugins/rules.md).
+Configure [built-in rules](../../rules/built-in-rules.md) included by default, [configurable rules](../../rules/configurable-rules.md) you add yourself, and [rules from plugins](../../custom-plugins/custom-rules.md).
 The `rules` block can be used at the root of a configuration file, or inside an [API-specific section](./apis.md).
 
 ## Options

--- a/docs/configuration/reference/rules.md
+++ b/docs/configuration/reference/rules.md
@@ -18,7 +18,7 @@ The `rules` block can be used at the root of a configuration file, or inside an 
 
 - {rule name}
 - [Rule object](#rule-object)
-- Required. Add as many rule entries as you like. These keys must be built-in rules (for example `security-defined`), configurable rules that you declare here (for example `rule/my-custom-rule`), or a rule from a plugin (for example `my-plugin/add-awesome`).
+- **REQUIRED**. Add as many rule entries as you like. These keys must be built-in rules (for example `security-defined`), configurable rules that you declare here (for example `rule/my-custom-rule`), or a rule from a plugin (for example `my-plugin/add-awesome`).
 
 {% /table %}
 

--- a/docs/configuration/reference/rules.md
+++ b/docs/configuration/reference/rules.md
@@ -1,0 +1,129 @@
+# `rules` 
+
+## Introduction
+
+The `rules` configuration blocks configure linting rules and their severity.
+Configure [built-in rules](../rules/built-in-rules.md) included by default, [configurable rules](../rules/configurable-rules.md) you add yourself, and [rules from plugins](../custom-plugins/rules.md).
+The `rules` block can be used at the root of a configuration file, or inside an [API-specific section](./apis.md).
+
+## Options
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- {rule name}
+- [Rule object](#rule-object)
+- Required. Add as many rule entries as you like. These keys must be built-in rules (for example `security-defined`), configurable rules that you declare here (for example `rule/my-custom-rule`), or a rule from a plugin (for example `my-plugin/add-awesome`).
+
+{% /table %}
+
+### Rule object
+
+
+{% table %}
+
+- Option
+- Type
+- Description
+
+---
+
+- severity
+- string
+- Severity level of this rule. Must be one of `error`, `warn`, or `off`.
+
+---
+
+- {additional properties}
+- any
+- Some rules allow additional configuration, check the details of each rule to find out the values that can be supplied here. For example the [`boolean-parameter-prefixes` rule](../../rules/boolean-parameter-prefixes.md) supports an additional option of `prefixes` that accepts an array of strings.
+
+{% /table %}
+
+## Examples
+
+This section covers some examples and common use cases.
+
+### Use shorthand format
+
+When the only configuration needed for a rule is the severity, you can set this as the value for the rule.
+The example below sets the `tag-description` rule to `error`:
+
+```yaml
+rules:
+  tag-description: error
+```
+
+This shorter syntax can help to keep your configuration file more readable.
+
+### Configure built-in rules
+
+It's rare for our default rulesets to perfectly fit your project.
+Adjust the severity level of the rules to suit your needs, so that you can have certainty about the quality of your APIs.
+The following example shows some rules configuration:
+
+```yaml
+rules:
+  info-license: error
+  no-ambiguous-paths: error
+  boolean-parameter-prefixes:
+    severity: error
+    prefixes:
+      - is
+      - can
+```
+
+All the rules are configured to produce errors if their criteria are not met, the first two use the shorthand syntax to configure the severity of the rule since no other options are needed for those rules.
+The `boolean-parameter-prefixes` rule also accepts a list of allowed prefixes, and those are also configured in the example.
+
+### Configure your own rules
+
+Redocly supports [configurable rules](../../rules/configurable-rules.md), and those are configured in the config file.
+A rule to check that all `operationId` fields are in camel case is shown in the following example:
+
+```yaml
+rules:
+  rule/operationId-casing:
+    subject:
+      type: Operation
+      property: operationId
+    assertions:
+      casing: camelCase
+
+```
+
+The configurable rules have user-defined names that all start with `rule/` and then a meaningful name.
+Read the [configurable rules documentation](../../rules/configurable-rules.md) for all the details on what configurable rules can do and how to to use them.
+
+### Configure rules from custom plugins
+
+Redocly also supports [custom plugins](../../custom-plugins/custom-rules.md) for advanced users.
+Those are also configured in the `rules` section of the configuration file, using the plugin's module name as a prefix.
+
+The following example shows how to enable a rule named `validate` from a plugin called `openapi-markdown`:
+
+```yaml
+plugins:
+  - './openapi-markdown.js'
+
+rules:
+  openapi-markdown/validate: warn
+```
+
+The example includes an example of including the plugin in your configuration.
+
+## Related options
+
+- [apis](./apis.md) configuration options allow setting per-API configuration in `redocly.yaml`.
+- [decorators](./decorators.md) offer some transformations for your OpenAPI documents.
+
+## Resources
+
+- The [Redocly CLI cookbook](https://github.com/Redocly/redocly-cli-cookbook) is a great resource for configurable rules, plugins, and other examples.
+- Learn more about [rules](../../rules.md) overall.
+- Read the [documentation for configurable rules](../../rules/configurable-rules.md).

--- a/docs/configuration/reference/rules.md
+++ b/docs/configuration/reference/rules.md
@@ -1,9 +1,9 @@
-# `rules` 
+# `rules`
 
 ## Introduction
 
 The `rules` configuration blocks configure linting rules and their severity.
-Configure [built-in rules](../rules/built-in-rules.md) included by default, [configurable rules](../rules/configurable-rules.md) you add yourself, and [rules from plugins](../custom-plugins/rules.md).
+Configure [built-in rules](../../rules/built-in-rules.md) included by default, [configurable rules](../../rules/configurable-rules.md) you add yourself, and [rules from plugins](../../custom-plugins/rules.md).
 The `rules` block can be used at the root of a configuration file, or inside an [API-specific section](./apis.md).
 
 ## Options

--- a/docs/configuration/reference/rules.md
+++ b/docs/configuration/reference/rules.md
@@ -24,7 +24,6 @@ The `rules` block can be used at the root of a configuration file, or inside an 
 
 ### Rule object
 
-
 {% table %}
 
 - Option

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -140,6 +140,10 @@
         - page: configuration/extends.md
         - page: configuration/rules.md
         - page: configuration/apis.md
+        - group: Reference
+          items:
+            - page: configuration/reference/apis.md
+            - page: configuration/reference/resolve.md
     - group: Custom plugins
       page: custom-plugins/index.md
       items:

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -144,6 +144,7 @@
           items:
             - page: configuration/reference/apis.md
             - page: configuration/reference/resolve.md
+            - page: configuration/reference/rules.md
     - group: Custom plugins
       page: custom-plugins/index.md
       items:

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -144,6 +144,8 @@
           items:
             - page: configuration/reference/apis.md
             - page: configuration/reference/decorators.md
+            - page: configuration/reference/extends.md
+            - page: configuration/reference/plugins.md
             - page: configuration/reference/resolve.md
             - page: configuration/reference/rules.md
     - group: Custom plugins

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -146,6 +146,7 @@
             - page: configuration/reference/decorators.md
             - page: configuration/reference/extends.md
             - page: configuration/reference/plugins.md
+            - page: configuration/reference/preprocessors.md
             - page: configuration/reference/resolve.md
             - page: configuration/reference/rules.md
     - group: Custom plugins

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -143,6 +143,7 @@
         - group: Reference
           items:
             - page: configuration/reference/apis.md
+            - page: configuration/reference/decorators.md
             - page: configuration/reference/resolve.md
             - page: configuration/reference/rules.md
     - group: Custom plugins


### PR DESCRIPTION
## What/Why/How?

We have some config options that are in use in the CLI, but the rest of the config docs are still private for the new products. Create matching-format pages for the options that belong here so we can link to them.

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [x] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
