### PR TITLE
Removes two links to the yaml spec as the site is down

### DIFF
--- a/docs/rules/configurable-rules.md
+++ b/docs/rules/configurable-rules.md
@@ -495,7 +495,7 @@ rules:
 
 Take care using `notPattern` with multiline Markdown values such as `description` fields.
 These may end with a newline or a space rather than the character you expect.
-Use the [double-quoted style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
+Use the double-quoted style or take account of this in your pattern.
 
 ### `pattern` example
 
@@ -513,7 +513,7 @@ rules:
 
 Take care using `pattern` with multiline Markdown values such as `description` fields.
 These may end with a newline or a space rather than the character you expect.
-Use the [double-quoted style](https://yaml.org/spec/1.2.2/#731-double-quoted-style) or take account of this in your pattern.
+Use the double-quoted style or take account of this in your pattern.
 
 ### `ref` example
 


### PR DESCRIPTION
## What/Why/How?

I don't know how long the site has been down or when it might be back up, but for now it is breaking our preview builds on the Marketing site so I am removing these links.

## Testing

I ran mlc locally and it has fixed the errors.

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
