### PR TITLE
feat: adds useSchemaTitleAsRef in the bundler

### DIFF
--- a/.changeset/five-snails-divide.md
+++ b/.changeset/five-snails-divide.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": minor
+---
+
+adds useSchemaTitleAsRef in the bundler which uses the schema title as ref instead of the file name

--- a/packages/core/src/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/bundle.test.ts.snap
@@ -233,6 +233,36 @@ components:
 
 `;
 
+exports[`bundle should bundle external refs and use schema title if useSchemaTitleAsRef is true 1`] = `
+openapi: 3.1.0
+paths:
+  /football/match:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FootballMatch'
+  /basketball/match:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasketballMatch'
+components:
+  schemas:
+    FootballMatch:
+      title: FootballMatch
+      type: object
+    BasketballMatch:
+      title: BasketballMatch
+      type: object
+
+`;
+
 exports[`bundle should bundle external refs and warn for conflicting names 1`] = `
 openapi: 3.0.0
 paths:

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -74,6 +74,16 @@ describe('bundle', () => {
     expect(res.parsed).toMatchSnapshot();
   });
 
+  it('should bundle external refs and use schema title if useSchemaTitleAsRef is true', async () => {
+    const { bundle: res, problems } = await bundle({
+      config: new Config({} as ResolvedConfig),
+      ref: path.join(__dirname, 'fixtures/refs/openapi-with-external-refs-using-title-as-ref.yaml'),
+      useSchemaTitleAsRef: true,
+    });
+    expect(problems).toHaveLength(0);
+    expect(res.parsed).toMatchSnapshot();
+  });
+
   it('should dereferenced correctly when used with dereference', async () => {
     const { bundle: res, problems } = await bundleDocument({
       externalRefResolver: new BaseResolver(),

--- a/packages/core/src/__tests__/fixtures/refs/basketball/match.yaml
+++ b/packages/core/src/__tests__/fixtures/refs/basketball/match.yaml
@@ -1,0 +1,2 @@
+title: BasketballMatch
+type: object

--- a/packages/core/src/__tests__/fixtures/refs/football/match.yaml
+++ b/packages/core/src/__tests__/fixtures/refs/football/match.yaml
@@ -1,0 +1,2 @@
+title: FootballMatch
+type: object

--- a/packages/core/src/__tests__/fixtures/refs/openapi-with-external-refs-using-title-as-ref.yaml
+++ b/packages/core/src/__tests__/fixtures/refs/openapi-with-external-refs-using-title-as-ref.yaml
@@ -1,0 +1,18 @@
+openapi: 3.1.0
+paths:
+  /football/match:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: ./football/match.yaml
+  /basketball/match:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: ./basketball/match.yaml


### PR DESCRIPTION
## What/Why/How?

First of all, thank you for creating redoc/redocly. We already have quite a big codebase with schemas used in AsyncAPI specs, and now we want to use the redoc documentation and redocly bundler for some of our OpenAPI specs. This seems to be the only blocker for us.

## Reference

Please see #661. We're not able to use the bundler because it uses the file names instead of the schema titles as references.

## Testing

Added a test in `packages/core/src/__tests__/bundle.test.ts`

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
