### PR TITLE
feat: Add path-aware prefixes instead of numeric suffixes when same-named schemas are found during bundling

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -464,6 +464,24 @@ function makeBundleVisitor(
     }
 
     const prevName = name;
+    const fileParts = fileRef.split('/'); // slice(2) removes "#/"
+
+    // throw away the last segment, we're using that already
+    fileParts.pop()
+    // add path segments until we have a name we can use (max depth = 4)
+    let depth = 0
+    while (fileParts.length > 0) {
+      name = fileParts.pop() + `-${name}`;
+      if (!componentsGroup[name] || isEqualOrEqualRef(componentsGroup[name], target, ctx)) {
+        return name;
+      }
+
+      depth++;
+      if(depth > 3) {
+        break;
+      }
+    }
+
     let serialId = 2;
     while (componentsGroup[name] && !isEqualOrEqualRef(componentsGroup[name], target, ctx)) {
       name = `${prevName}-${serialId}`;


### PR DESCRIPTION
## What/Why/How?

Related to #661 , a possible improvement to avoiding name clashes in schema naming.

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [x] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
