### PR TITLE
docs: adds gsod 2024 folder and proposal page

### DIFF
--- a/.github/ISSUE_TEMPLATE/gsod-project-ideas.md
+++ b/.github/ISSUE_TEMPLATE/gsod-project-ideas.md
@@ -1,0 +1,23 @@
+---
+name: GSOD project ideas
+about: Discuss or contribute to GSOD project ideas
+title: 'GSOD project ideas'
+labels: 'gsod'
+assignees: 'https://github.com/HCloward'
+---
+
+**Which project would you like to contribute to or discuss?**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the changes or enhancements you would add**
+
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/gsod-project-ideas.md
+++ b/.github/ISSUE_TEMPLATE/gsod-project-ideas.md
@@ -3,7 +3,7 @@ name: GSOD project ideas
 about: Discuss or contribute to GSOD project ideas
 title: 'GSOD project ideas'
 labels: 'gsod'
-assignees: 'https://github.com/HCloward'
+assignees: '@HCloward'
 ---
 
 **Which project would you like to contribute to or discuss?**

--- a/docs/gsod/2024/proposal.md
+++ b/docs/gsod/2024/proposal.md
@@ -31,7 +31,7 @@ Be sure to review the skills needed for each project and include references to y
 You also need to be able to meet remotely within the following timezones:
 
 - Eastern Standard Time (EST) - UTC-05:00
-- Greenwich Mean time (GMT) - UTC+01:00
+- Greenwich Mean time (GMT) - UTC+00:00
 
 ## Volunteers/mentors
 

--- a/docs/gsod/2024/proposal.md
+++ b/docs/gsod/2024/proposal.md
@@ -28,7 +28,7 @@ Please send your [statement of interest](https://developers.google.com/season-of
 
 Be sure to review the skills needed for each project and include references to your abilities in these areas in particular.
 
-You will also need to be able to meet remotely within the following timezones:
+You also need to be able to meet remotely within the following timezones:
 
 - Eastern Standard Time (EST) - UTC-05:00
 - Greenwich Mean time (GMT) - UTC+01:00
@@ -49,7 +49,7 @@ The following are the open source projects we would like some help with:
 - [Redocly CLI](https://github.com/Redocly/redocly-cli): Redocly CLI is an open source command-line tool for working with OpenAPI descriptions, developer portals, and other API lifecycle operations including API linting, enhancement, and bundling.
 - [OpenAPI starter](https://github.com/Redocly/openapi-starter): OpenAPI starter is a template repository that you can use to start your own OpenAPI project.
 
-To contribute to or discuss the project ideas, create a [GSOD project ideas](https://github.com/Redocly/redocly-cli/blob/main/.github/ISSUE_TEMPLATE/gsod-project-ideas.md) issue on the [redocly-cli repo](https://github.com/Redocly/redocly-cli/tree/main) in GitHub.
+To contribute to or discuss the project ideas, create a GSOD project ideas issue on the [redocly-cli repo](https://github.com/Redocly/redocly-cli/tree/main) in GitHub.
 
 ### Redocly CLI guides
 
@@ -69,7 +69,6 @@ The following skills are needed:
 - Strong understanding of OpenAPI.
 - Comfortable working in the command-line.
 - Familiarity with Markdown for documentation formatting.
-
 
 ### OpenAPI starter examples
 
@@ -92,7 +91,7 @@ The following skills are needed:
 
 ## Success metrics
 
-We will use the following metrics to determine the success of the projects:
+The following are the success metrics for our projects:
 
 - Increase in page views after updates.
 - Increase in positive reviews using our feedback mechanism.
@@ -101,37 +100,55 @@ We will use the following metrics to determine the success of the projects:
 ## Timeline
 
 {% table %}
-* Time frame
-* Expected activities
+
+- Time frame
+- Expected activities
+
 ---
-* April 10 - 28
-* Review technical writer statements of interest
+
+- April 10 - 28
+- Review technical writer statements of interest
+
 ---
-* May 1 - 10
-* Hire technical writers
+
+- May 1 - 10
+- Hire technical writers
+
 ---
-* May 20 - November 20
-* Documentation work is completed
+
+- May 20 - November 20
+- Documentation work is completed
+
 ---
-* November 23 - December 10
-* Final project evaluation
+
+- November 23 - December 10
+- Final project evaluation
+
 ---
-* December 13
-* Google posts program results
-{% /table %}
+
+- December 13
+- Google posts program results
+  {% /table %}
 
 ## Budget
 
 {% table %}
-* Budget item
-* Total amount
+
+- Budget item
+- Total amount
+
 ---
-* Technical writer stipend
-* $5,000
+
+- Technical writer stipend
+- $5,000
+
 ---
-* Technical writer stipend
-* $5,000
+
+- Technical writer stipend
+- $5,000
+
 ---
-* **Budget Total**
-* **$10,000**
-{% /table %}
+
+- **Budget Total**
+- **$10,000**
+  {% /table %}

--- a/docs/gsod/2024/proposal.md
+++ b/docs/gsod/2024/proposal.md
@@ -24,20 +24,17 @@ Our suite of products makes our customers’ APIs more accessible and loved by t
 ## How to apply
 
 We are glad you are interested in contributing to Redocly's open source project documentation.
-Please send your [statement of interest](https://developers.google.com/season-of-docs/docs/tech-writer-statement) to [gsod@redocly.com](mailto:docs@redocly.com) by April 26th.
+Please send your [statement of interest](https://developers.google.com/season-of-docs/docs/tech-writer-statement) to [gsod@redocly.com](mailto:gsod@redocly.com) by April 26th.
 
 Be sure to review the skills needed for each project and include references to your abilities in these areas in particular.
 
-You also need to be able to meet remotely within the following timezones:
-
-- Eastern Standard Time (EST) - UTC-05:00
-- Greenwich Mean time (GMT) - UTC+00:00
+You also need to be able to meet remotely within the US East Coast and EU time zones.
 
 ## Volunteers/mentors
 
 Heather Cloward - [heather.cloward@redocly.com](mailto:heather.cloward@redocly.com)
 
-Lorna Jane Mitchell - [lorna.mitchell@redocly.com](mailto:loran.mitchell@redocly.com)
+Lorna Jane Mitchell - [lorna.mitchell@redocly.com](mailto:lorna.mitchell@redocly.com)
 
 ## Project ideas
 

--- a/docs/gsod/2024/proposal.md
+++ b/docs/gsod/2024/proposal.md
@@ -1,0 +1,137 @@
+---
+seo:
+  title: Redocly proposal - Google Season of Docs 2024
+slug: /gsod-2024-proposal
+theme:
+  feedback:
+    hide: true
+---
+
+# Google Season of Docs 2024 - Redocly proposal
+
+[Google Season of Docs](https://developers.google.com/season-of-docs) provides support for open-source projects to improve their documentation and gives professional technical writers an opportunity to gain experience in open source.
+Together we raise awareness of open source, of docs, and of technical writing.
+
+Redocly is applying to participate in Google Season of Docs 2024.
+
+## About Redocly
+
+[Redocly](https://redocly.com/) was founded in 2017 with the mission to get more consumers using APIs with less hands-on support.
+We were born out of [Redoc](https://redocly.com/docs/redoc/), the popular open-source OpenAPI documentation software project used by thousands of companies worldwide.
+We make API design and documentation software with the goal to accelerate API ubiquity.
+Our suite of products makes our customers’ APIs more accessible and loved by their end users and consumers.
+
+## How to apply
+
+We are glad you are interested in contributing to Redocly's open source project documentation.
+Please send your [statement of interest](https://developers.google.com/season-of-docs/docs/tech-writer-statement) to [gsod@redocly.com](mailto:docs@redocly.com) by April 26th.
+
+Be sure to review the skills needed for each project and include references to your abilities in these areas in particular.
+
+You will also need to be able to meet remotely within the following timezones:
+
+- Eastern Standard Time (EST) - UTC-05:00
+- Greenwich Mean time (GMT) - UTC+01:00
+
+## Volunteers/mentors
+
+Heather Cloward - [heather.cloward@redocly.com](mailto:heather.cloward@redocly.com)
+
+Lorna Jane Mitchell - [lorna.mitchell@redocly.com](mailto:loran.mitchell@redocly.com)
+
+## Project ideas
+
+Our open-source tools allow developer teams to create clean, accessible documentation to complement their APIs.
+By making sure that the project documentation is complete, accurate, and up-to-date, community contributors can add immense value to our open-source projects.
+
+The following are the open source projects we would like some help with:
+
+- [Redocly CLI](https://github.com/Redocly/redocly-cli): Redocly CLI is an open source command-line tool for working with OpenAPI descriptions, developer portals, and other API lifecycle operations including API linting, enhancement, and bundling.
+- [OpenAPI starter](https://github.com/Redocly/openapi-starter): OpenAPI starter is a template repository that you can use to start your own OpenAPI project.
+
+To contribute to or discuss the project ideas, create a [GSOD project ideas](https://github.com/Redocly/redocly-cli/blob/main/.github/ISSUE_TEMPLATE/gsod-project-ideas.md) issue on the [redocly-cli repo](https://github.com/Redocly/redocly-cli/tree/main) in GitHub.
+
+### Redocly CLI guides
+
+We would like to enhance the [guide section](https://redocly.com/docs/cli/guides/) of the [Redocly CLI documentation](https://redocly.com/docs/cli/) by having a technical writer complete the following tasks:
+
+- Read and attempt to complete the steps in each guide.
+- Edit guides for accuracy and usability.
+- Add depth and examples where needed.
+- Devise an information architecture to organize the guides in the sidenav and landing page.
+
+#### Skills needed
+
+The following skills are needed:
+
+- Full Professional Proficiency in US English.
+- Docs-as-code experience and skills.
+- Strong understanding of OpenAPI.
+- Comfortable working in the command-line.
+- Familiarity with Markdown for documentation formatting.
+
+
+### OpenAPI starter examples
+
+We would like to enhance the OpenAPI starter project by having a technical writer complete the following tasks:
+
+- Add more examples for complex use cases and scenarios.
+- Add clear explanations for when and why you would use each option.
+- Review and edit the README files with further explanations and examples where needed.
+- Review and update the [How to use openapi-starter guide](https://redocly.com/docs/cli/openapi-starter/).
+
+#### Skills needed
+
+The following skills are needed:
+
+- Full Professional Proficiency in US English.
+- Docs-as-code experience and skills.
+- Strong understanding of OpenAPI.
+- Comfortable working in the command-line.
+- Familiarity with Markdown for documentation formatting.
+
+## Success metrics
+
+We will use the following metrics to determine the success of the projects:
+
+- Increase in page views after updates.
+- Increase in positive reviews using our feedback mechanism.
+- Reduction in negative reviews using our feedback mechanism.
+
+## Timeline
+
+{% table %}
+* Time frame
+* Expected activities
+---
+* April 10 - 28
+* Review technical writer statements of interest
+---
+* May 1 - 10
+* Hire technical writers
+---
+* May 20 - November 20
+* Documentation work is completed
+---
+* November 23 - December 10
+* Final project evaluation
+---
+* December 13
+* Google posts program results
+{% /table %}
+
+## Budget
+
+{% table %}
+* Budget item
+* Total amount
+---
+* Technical writer stipend
+* $5,000
+---
+* Technical writer stipend
+* $5,000
+---
+* **Budget Total**
+* **$10,000**
+{% /table %}


### PR DESCRIPTION
## What/Why/How?

We want to participate in Google Season of Docs 2024 and to do so we need a public proposal page that can be commented on and discussed within the community. Since this repo is public it is the ideal location, particularly since one of the projects will be to enhance the guides doc within this project.

This PR also includes a new issue template specific to gsod discussion so that it won't get easily mixed up with the bug or feature requests for the project itself.

## Reference

Closes [this issue](https://github.com/Redocly/marketing-site-portal/issues/1212)

## Testing

I built it locally in the marketing site, so the formatting should work once it is pulled into the marketing site.

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
