### PR TITLE
fix: add type tree for metadata-schema rule

### DIFF
--- a/.changeset/metal-countries-complain.md
+++ b/.changeset/metal-countries-complain.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Added a type tree for the `metadata-schema` rule.

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -353,6 +353,12 @@ const ObjectRule: NodeType = {
   required: ['severity'],
 };
 
+// TODO: add better type tree for this
+const Schema: NodeType = {
+  properties: {},
+  additionalProperties: {},
+};
+
 const AssertionDefinitionSubject: NodeType = {
   properties: {
     type: {
@@ -1120,6 +1126,7 @@ const CoreConfigTypes: Record<string, NodeType> = {
   ButtonOverrides,
   Overrides,
   ObjectRule,
+  Schema,
   RightPanel,
   Rules,
   Shape,


### PR DESCRIPTION
## What/Why/How?

Fixes failures on the `metadata-schema` rule. 

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
