### PR TITLE
docs: fixes spacing issue that cut budget table out of gsod proposal doc

### DIFF
--- a/docs/gsod/2024/proposal.md
+++ b/docs/gsod/2024/proposal.md
@@ -148,4 +148,5 @@ The following are the success metrics for our projects:
 
 - **Budget Total**
 - **$10,000**
-  {% /table %}
+
+{% /table %}

--- a/docs/gsod/2024/proposal.md
+++ b/docs/gsod/2024/proposal.md
@@ -125,7 +125,8 @@ The following are the success metrics for our projects:
 
 - December 13
 - Google posts program results
-  {% /table %}
+
+{% /table %}
 
 ## Budget
 


### PR DESCRIPTION
## What/Why/How?

There was a space addd to the closing Markdoc bracket that kept the final budget table from showing up on the gsod proposal page. This PR is to fix that spacing issue.

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
