### PR TITLE
Ignore validating example with externalValue against schema

### DIFF
--- a/.changeset/funny-hornets-agree.md
+++ b/.changeset/funny-hornets-agree.md
@@ -1,0 +1,6 @@
+---
+"@redocly/cli": patch
+"@redocly/openapi-core": patch
+---
+
+Fixed [`no-invalid-media-type-examples`](https://redocly.com/docs/cli/rules/no-invalid-media-type-examples/) rule `externalValue` example validation.

--- a/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
@@ -250,8 +250,6 @@ describe('no-invalid-media-type-examples', () => {
                           value:
                             a: test
                             b: 35
-                        test3:
-                          externalValue: "https://example.com/example.json"
                       schema:
                         type: object
                         properties:
@@ -460,8 +458,6 @@ describe('no-invalid-media-type-examples', () => {
                       examples:
                         first:
                           value: {}
-                        second:
-                          externalValue: "https://example.com/example.json"
       `,
       'foobar.yaml'
     );

--- a/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
@@ -250,6 +250,8 @@ describe('no-invalid-media-type-examples', () => {
                           value:
                             a: test
                             b: 35
+                        test3:
+                          externalValue: "https://example.com/example.json"
                       schema:
                         type: object
                         properties:
@@ -458,6 +460,8 @@ describe('no-invalid-media-type-examples', () => {
                       examples:
                         first:
                           value: {}
+                        second:
+                          externalValue: "https://example.com/example.json"
       `,
       'foobar.yaml'
     );

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -36,7 +36,7 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
             example = resolved.node;
           }
           if (isMultiple && typeof example.value === 'undefined') {
-            return
+            return;
           }
           validateExample(
             isMultiple ? example.value : example,

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -35,7 +35,7 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
             location = isMultiple ? resolved.location.child('value') : resolved.location;
             example = resolved.node;
           }
-          if (Object.prototype.hasOwnProperty.call(example, 'externalValue')) {
+          if (isMultiple && typeof example.value === 'undefined') {
             return
           }
           validateExample(

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -35,6 +35,9 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
             location = isMultiple ? resolved.location.child('value') : resolved.location;
             example = resolved.node;
           }
+          if (Object.prototype.hasOwnProperty.call(example, 'externalValue')) {
+            return
+          }
           validateExample(
             isMultiple ? example.value : example,
             mediaType.schema!,


### PR DESCRIPTION
## What/Why/How?

Currently, when an example object has `externalValue` property [`no-invalid-media-type-examples`](https://redocly.com/docs/cli/rules/no-invalid-media-type-examples/) lint rule fails as it is validating the _example_ object (the parent object) against the schema definition.

I could assume there are couple of ways to handle this case. However, as there is already another lint rule ([`no-example-value-and-externalValue`](https://redocly.com/docs/cli/rules/no-example-value-and-externalValue/)), which is kind of related to this one, and its default severity level causes either one of `value`, or `externalValue` properties to exist for a specific example object, I decided to go with the simple exclusion condition, which basically deactivates the validation for example objects that has `externalValue` set. I also intentionally didn't implement the logic to verify the specified URL set for `externalValue` to check whether the target resource actually matches the schema definition or not (by issuing HTTP request for example) as it's both complex to implement properly due to various cases including relative URLs, and for external resources being unpredictable by nature, e.g., the server might be unavailable at the time of linting, or returing a temporary failure due to network issues.

## Reference

I faced the issue while I was trying to add file examples for request, and response bodies of an API according to the official documentation ([here](https://swagger.io/docs/specification/adding-examples/#external)).

## Testing

Relevant tests are updated to cover this scenario.

## Screenshots (optional)

It can be tested by disabling the condition I added to the lint rule.

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
