### PR TITLE
fix: not assert extended types when linting configuration

### DIFF
--- a/.changeset/mean-ants-draw.md
+++ b/.changeset/mean-ants-draw.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Skip configuration linting of custom extended types.

--- a/bughunting/plugins/type-extention.js
+++ b/bughunting/plugins/type-extention.js
@@ -1,0 +1,27 @@
+const XMetaData = {
+  properties: {
+    lifecycle: { type: 'string', enum: ['development', 'staging', 'production'] },
+    'owner-team': { type: 'string' },
+  },
+  required: ['lifecycle'],
+};
+
+module.exports = {
+  id: 'type-extension',
+  typeExtension: {
+    oas3(types) {
+      newTypes = {
+        ...types,
+        XMetaData: XMetaData,
+        Info: {
+          ...types.Info,
+          properties: {
+            ...types.Info.properties,
+            'x-metadata': 'XMetaData',
+          },
+        },
+      };
+      return newTypes;
+    },
+  },
+};

--- a/bughunting/redocly.yaml
+++ b/bughunting/redocly.yaml
@@ -1,0 +1,13 @@
+extends: []
+
+plugins:
+  - plugins/type-extention.js
+
+rules:
+  spec: warn
+  rule/metadata-lifecycle:
+    subject:
+      type: XMetaData
+      property: 'lifecycle'
+    assertions:
+      enum: ['alpha', 'beta', 'production', 'deprecated']

--- a/bughunting/test.yaml
+++ b/bughunting/test.yaml
@@ -1,0 +1,32 @@
+openapi: 3.1.0
+info:
+  title: Food Empire API
+  version: 0.5.1
+  x-metadata:
+    lifecycle: production
+    owner-team: Engineering/Integrations
+paths:
+  /test-api:
+    get:
+      operationId: testApi
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $defs:
+                  main_data:
+                    $anchor: main_data
+                    type: object
+                    properties:
+                      foo:
+                        type: string
+                type: object
+                oneOf:
+                  - properties:
+                      wrapper:
+                        $ref: '#main_data'
+                  - $ref: '#main_data'
+              example:
+                foo: TEST

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -361,8 +361,8 @@ const Schema: NodeType = {
 
 const AssertionDefinitionSubject: NodeType = {
   properties: {
-    type: {
-      enum: [
+    type: (value: unknown) => {
+      const definitionTypes = [
         ...new Set([
           'any',
           ...oas2NodeTypesList,
@@ -371,7 +371,16 @@ const AssertionDefinitionSubject: NodeType = {
           ...asyncNodeTypesList,
           'SpecExtension',
         ]),
-      ],
+      ];
+
+      // Do not validate if it's a custom type starting with 'X'
+      if (typeof value === 'string' && value.startsWith('X') && !definitionTypes.includes(value)) {
+        return { type: 'string' };
+      }
+
+      return {
+        enum: definitionTypes,
+      }
     },
     property: (value: unknown) => {
       if (Array.isArray(value)) {

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -380,7 +380,7 @@ const AssertionDefinitionSubject: NodeType = {
 
       return {
         enum: definitionTypes,
-      }
+      };
     },
     property: (value: unknown) => {
       if (Array.isArray(value)) {


### PR DESCRIPTION
## What/Why/How?

This PR holds a small changes that will allow to ignore custom extended types during configuration file validation phase.

NOTE: supported files will be removed later


- [x] Ignore extended types
- [x] Test VSCode extention
- [ ] Delete supported content before merge

Alternative solution would include relatively extensive refactoring and influence all commands.
This will include changing lintConfig order and resolving plugins and types earlier, witch might have another complexity with extension located elsewhere. 

## Reference

Closes [#1223](https://github.com/Redocly/redocly-cli/issues/1223)

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
