### PR TITLE
fix: correct contribute documentation preview locally (#1532)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,17 @@ Don't forget to revert the changes to **package.json** files later.
 
 Additions and updates to our documentation are very welcome. You can find the documentation in the `docs/` folder, and this is published to https://redocly.com/docs/cli/ as part of our main website.
 
-To preview your changes locally, run this command from the `docs/` folder:
+To preview your documentation changes locally:
+
+1. Make sure `redocly` is already installed on your local computer. See [installation](https://redocly.com/docs/cli/installation/).
+
+2. Run this command from the `docs/` folder:
 
 ```bash
-https://redocly.com/docs/cli/
+redocly preview
 ```
+
+By default, you can access the docs preview at http://localhost:4000 or http://127.0.0.1:4000.
 
 > Please note that currently the custom markdoc tags used in the main website are not available in the local preview version, and links that point to the wider website do show as errors when using a local platform. The pull request workflows generate a full preview, so rest assured that you are able to check everything is in good shape before we review and merge your changes.
 


### PR DESCRIPTION
## What/Why/How?
fixed the incorrect command to preview local docs changes in contributing.md

## Reference
https://github.com/Redocly/redocly-cli/issues/1532

## Testing
vscode preview of markdown file `contributing.md`
ran `vale \docs`
checked with `markdownlint` vscode extension