### PR TITLE
fix: prevent loadConfig from failing in browser env and do not sent auth requests

### DIFF
--- a/.changeset/young-apes-sell.md
+++ b/.changeset/young-apes-sell.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Improved loading of configuration files in environments different from Node.js.

--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -13,10 +13,9 @@ const path = require('path');
 describe('loadConfig', () => {
   it('should resolve config http header by US region', async () => {
     jest
-      .spyOn(RedoclyClient.prototype, 'getTokens')
-      .mockImplementation(() =>
-        Promise.resolve([{ region: 'us', token: 'accessToken', valid: true }])
-      );
+      .spyOn(RedoclyClient.prototype, 'getAllTokens')
+      .mockImplementation(() => [{ region: 'us', token: 'accessToken' }]);
+    jest.spyOn(RedoclyClient.prototype, 'hasTokens').mockImplementation(() => true);
     const config = await loadConfig();
     expect(config.resolve.http.headers).toStrictEqual([
       {
@@ -36,10 +35,9 @@ describe('loadConfig', () => {
 
   it('should resolve config http header by EU region', async () => {
     jest
-      .spyOn(RedoclyClient.prototype, 'getTokens')
-      .mockImplementation(() =>
-        Promise.resolve([{ region: 'eu', token: 'accessToken', valid: true }])
-      );
+      .spyOn(RedoclyClient.prototype, 'getAllTokens')
+      .mockImplementation(() => [{ region: 'eu', token: 'accessToken' }]);
+    jest.spyOn(RedoclyClient.prototype, 'hasTokens').mockImplementation(() => true);
     const config = await loadConfig();
     expect(config.resolve.http.headers).toStrictEqual([
       {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -206,7 +206,7 @@ export function isCustomRuleId(id: string) {
 export function doesYamlFileExist(filePath: string): boolean {
   return (
     (extname(filePath) === '.yaml' || extname(filePath) === '.yml') &&
-    fs.hasOwnProperty('existsSync') &&
+    fs?.hasOwnProperty?.('existsSync') &&
     fs.existsSync(filePath)
   );
 }


### PR DESCRIPTION

## What/Why/How?

This PR addresses two issues:
- prevents the `loadConfig` function from failing in browser environment
- removes auth requests to the registry api when loading a config file (which cause perf issues)


## Reference

Partially related to: 
- https://github.com/Redocly/redocly/pull/7883
- https://github.com/Redocly/redocly/issues/8381

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
