### PR TITLE
fix: check if the config file exists

### DIFF
--- a/.changeset/hot-vans-smile.md
+++ b/.changeset/hot-vans-smile.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Fix the failure when the path to a not existing config file is provided.
+Improved the experience when the config file doesn't exist or isn't found.

--- a/.changeset/hot-vans-smile.md
+++ b/.changeset/hot-vans-smile.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fix the failure when the path to a not existing config file is provided.


### PR DESCRIPTION
## What/Why/How?

Return a default fallbeck if there is no config file for the provided path.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
