### PR TITLE
chore: add checks for browser env

### DIFF
--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -8,6 +8,7 @@ import { ConfigValidationError, transformConfig } from './utils';
 import { resolveConfig, resolveConfigFileAndRefs } from './config-resolvers';
 import { bundleConfig } from '../bundle';
 import { BaseResolver } from '../resolve';
+import { isBrowser } from '../env';
 
 import type { Document } from '../resolve';
 import type { RegionalToken, RegionalTokenWithValidity } from '../redocly/redocly-client-types';
@@ -103,7 +104,7 @@ export async function loadConfig(
   } = options;
   const rawConfig = await getConfig({ configPath, processRawConfig, externalRefResolver });
 
-  const redoclyClient = isEmptyObject(fs) ? undefined : new RedoclyClient();
+  const redoclyClient = isBrowser ? undefined : new RedoclyClient();
   const tokens = redoclyClient && redoclyClient.hasTokens() ? redoclyClient.getAllTokens() : [];
 
   return addConfigMetadata({
@@ -146,13 +147,8 @@ export async function getConfig(
     processRawConfig,
     externalRefResolver = new BaseResolver(),
   } = options;
-  try {
-    if (!configPath || !(await externalRefResolver.resolveDocument(null, configPath))) {
-      return {};
-    }
-  } catch (e) {
-    return {};
-  }
+  if (!configPath) return {};
+
   try {
     const { document, resolvedRefMap } = await resolveConfigFileAndRefs({
       configPath,

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,6 +1,4 @@
 export const isBrowser =
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   typeof window !== 'undefined' ||
   typeof process === 'undefined' ||
   (process?.platform as any) === 'browser'; // main and worker thread

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -6,7 +6,7 @@ const coreVersion = require('../../package.json').version;
 
 import { NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject } from '../walk';
 import { getCodeframe, getLineColLocation } from './codeframes';
-import { env } from '../env';
+import { env, isBrowser } from '../env';
 import { isAbsoluteUrl } from '../ref-utils';
 
 export type Totals = {
@@ -89,7 +89,7 @@ export function formatProblems(
 ) {
   const {
     maxProblems = 100,
-    cwd = process.cwd(),
+    cwd = isBrowser ? '' : process.cwd(),
     format = 'codeframe',
     color = colorOptions.enabled,
     totals = getTotals(problems),

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -6,6 +6,7 @@ import type { YAMLNode, LoadOptions } from 'yaml-ast-parser';
 import { NormalizedNodeType, isNamedType, SpecExtension } from './types';
 import { readFileFromUrl, parseYaml, nextTick } from './utils';
 import { ResolveConfig } from './config/types';
+import { isBrowser } from './env';
 
 export type CollectedRefs = Map<string /* absoluteFilePath */, Document>;
 
@@ -106,7 +107,7 @@ export class BaseResolver {
       return new URL(ref, base).href;
     }
 
-    return path.resolve(base ? path.dirname(base) : process.cwd(), ref);
+    return path.resolve(base ? path.dirname(base) : isBrowser ? '' : process.cwd(), ref);
   }
 
   async loadExternalRef(absoluteRef: string): Promise<Source> {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -6,7 +6,6 @@ import type { YAMLNode, LoadOptions } from 'yaml-ast-parser';
 import { NormalizedNodeType, isNamedType, SpecExtension } from './types';
 import { readFileFromUrl, parseYaml, nextTick } from './utils';
 import { ResolveConfig } from './config/types';
-import { isBrowser } from './env';
 
 export type CollectedRefs = Map<string /* absoluteFilePath */, Document>;
 
@@ -107,7 +106,7 @@ export class BaseResolver {
       return new URL(ref, base).href;
     }
 
-    return path.resolve(base ? path.dirname(base) : isBrowser ? '' : process.cwd(), ref);
+    return path.resolve(base ? path.dirname(base) : process.cwd(), ref);
   }
 
   async loadExternalRef(absoluteRef: string): Promise<Source> {


### PR DESCRIPTION
## What/Why/How?

- Added checks for browser environment when using Node.js features in openapi-core.
- Removed needless [try...catch](https://github.com/Redocly/redocly-cli/pull/1565/files#diff-91233afeb25fea2c651ad22452d823830a0c6e8378deba81a1109b57cdae3fb6L149) block.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
