### PR TITLE
fix: falsy values in no-invalid-media-type-examples, no-invalid-parameter-examples, and no-invalid-schema-examples rules

### DIFF
--- a/.changeset/strong-crews-change.md
+++ b/.changeset/strong-crews-change.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed the `no-invalid-media-type-examples` rule which allowed falsy example values to pass for any schema.
+Fixed `no-invalid-media-type-examples`, `no-invalid-parameter-examples`, and `no-invalid-schema-examples` rules which allowed falsy example values to pass for any schema.

--- a/.changeset/strong-crews-change.md
+++ b/.changeset/strong-crews-change.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed the `no-invalid-media-type-examples` rule which allowed falsy example values to pass for any schema.

--- a/packages/core/src/rules/common/__tests__/no-invalid-parameter-examples.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-invalid-parameter-examples.test.ts
@@ -1,0 +1,53 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, replaceSourceWithRef, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('no-invalid-parameter-examples', () => {
+  it('should report on invalid falsy example', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        paths:
+          /results:
+            get:
+              parameters:
+                - name: username
+                  in: query
+                  schema:
+                    type: string
+                    maxLength: 15
+                  example: false
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'no-invalid-parameter-examples': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "from": {
+            "pointer": "#/paths/~1results/get/parameters/0",
+            "source": "foobar.yaml",
+          },
+          "location": [
+            {
+              "pointer": "#/paths/~1results/get/parameters/0/example",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Example value must conform to the schema: type must be string.",
+          "ruleId": "no-invalid-parameter-examples",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/common/__tests__/no-invalid-schema-examples.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-invalid-schema-examples.test.ts
@@ -1,0 +1,51 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, replaceSourceWithRef, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('no-invalid-schema-examples', () => {
+  it('should report on invalid falsy example', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        components:
+          schemas:
+            Car:
+              type: object
+              properties:
+                color:
+                  type: string
+                  example: 0
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ 'no-invalid-schema-examples': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "from": {
+            "pointer": "#/components/schemas/Car/properties/color",
+            "source": "foobar.yaml",
+          },
+          "location": [
+            {
+              "pointer": "#/components/schemas/Car/properties/color/example",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Example value must conform to the schema: type must be string.",
+          "ruleId": "no-invalid-schema-examples",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/common/no-invalid-parameter-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-parameter-examples.ts
@@ -7,7 +7,7 @@ export const NoInvalidParameterExamples: any = (opts: any) => {
   return {
     Parameter: {
       leave(parameter: Oas3Parameter, ctx: UserContext) {
-        if (parameter.example) {
+        if (parameter.example !== undefined) {
           validateExample(
             parameter.example,
             parameter.schema!,

--- a/packages/core/src/rules/common/no-invalid-schema-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-schema-examples.ts
@@ -18,7 +18,7 @@ export const NoInvalidSchemaExamples: any = (opts: any) => {
             );
           }
         }
-        if (schema.example) {
+        if (schema.example !== undefined) {
           validateExample(schema.example, schema, ctx.location.child('example'), ctx, true);
         }
       },

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -12,9 +12,9 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
       leave(mediaType, ctx: UserContext) {
         const { location, resolve } = ctx;
         if (!mediaType.schema) return;
-        if (mediaType.example) {
+        if (typeof mediaType.example !== 'undefined') {
           resolveAndValidateExample(mediaType.example, location.child('example'));
-        } else if (mediaType.examples) {
+        } else if (typeof mediaType.examples !== 'undefined') {
           for (const exampleName of Object.keys(mediaType.examples)) {
             resolveAndValidateExample(
               mediaType.examples[exampleName],

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -12,9 +12,9 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
       leave(mediaType, ctx: UserContext) {
         const { location, resolve } = ctx;
         if (!mediaType.schema) return;
-        if (typeof mediaType.example !== 'undefined') {
+        if (mediaType.example !== undefined) {
           resolveAndValidateExample(mediaType.example, location.child('example'));
-        } else if (typeof mediaType.examples !== 'undefined') {
+        } else if (mediaType.examples) {
           for (const exampleName of Object.keys(mediaType.examples)) {
             resolveAndValidateExample(
               mediaType.examples[exampleName],


### PR DESCRIPTION
## What/Why/How?

Fixed a small issue in `no-invalid-media-type-examples`, `no-invalid-parameter-examples`, and `no-invalid-schema-examples` rules which allowed to pass falsy examples for any schema.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
