### PR TITLE
chore: replace ➡️ with 🔀 to align the words

### DIFF
--- a/.changeset/shy-cherries-tie.md
+++ b/.changeset/shy-cherries-tie.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Replace path items emoji with 🔀 so the width is consistent.

--- a/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
+++ b/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
@@ -91,7 +91,7 @@ Document: openapi.yaml stats:
 📈 Schemas: 1 
 👉 Parameters: 0 
 🔗 Links: 0 
-➡️  Path Items: 2 
+➡️ Path Items: 2 
 👷 Operations: 2 
 🔖 Tags: 0 
 

--- a/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
+++ b/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
@@ -91,7 +91,7 @@ Document: openapi.yaml stats:
 📈 Schemas: 1 
 👉 Parameters: 0 
 🔗 Links: 0 
-➡️ Path Items: 2 
+🔀 Path Items: 2 
 👷 Operations: 2 
 🔖 Tags: 0 
 

--- a/__tests__/stats/stats-json/snapshot.js
+++ b/__tests__/stats/stats-json/snapshot.js
@@ -23,7 +23,7 @@ exports[`E2E stats stats should produce correct JSON output 1`] = `
     "total": 0
   },
   "pathItems": {
-    "metric": "➡️  Path Items",
+    "metric": "➡️ Path Items",
     "total": 5
   },
   "operations": {

--- a/__tests__/stats/stats-json/snapshot.js
+++ b/__tests__/stats/stats-json/snapshot.js
@@ -23,7 +23,7 @@ exports[`E2E stats stats should produce correct JSON output 1`] = `
     "total": 0
   },
   "pathItems": {
-    "metric": "➡️ Path Items",
+    "metric": "🔀 Path Items",
     "total": 5
   },
   "operations": {

--- a/__tests__/stats/stats-markdown/snapshot.js
+++ b/__tests__/stats/stats-markdown/snapshot.js
@@ -8,7 +8,7 @@ exports[`E2E stats stats should produce correct Markdown format 1`] = `
 | 📈 Schemas | 22 |
 | 👉 Parameters | 6 |
 | 🔗 Links | 0 |
-| ➡️ Path Items | 5 |
+| 🔀 Path Items | 5 |
 | 👷 Operations | 8 |
 | 🔖 Tags | 3 |
 

--- a/__tests__/stats/stats-markdown/snapshot.js
+++ b/__tests__/stats/stats-markdown/snapshot.js
@@ -8,7 +8,7 @@ exports[`E2E stats stats should produce correct Markdown format 1`] = `
 | 📈 Schemas | 22 |
 | 👉 Parameters | 6 |
 | 🔗 Links | 0 |
-| ➡️  Path Items | 5 |
+| ➡️ Path Items | 5 |
 | 👷 Operations | 8 |
 | 🔖 Tags | 3 |
 

--- a/__tests__/stats/stats-stylish/snapshot.js
+++ b/__tests__/stats/stats-stylish/snapshot.js
@@ -9,7 +9,7 @@ Document: museum.yaml stats:
 📈 Schemas: 22 
 👉 Parameters: 6 
 🔗 Links: 0 
-➡️  Path Items: 5 
+➡️ Path Items: 5 
 👷 Operations: 8 
 🔖 Tags: 3 
 

--- a/__tests__/stats/stats-stylish/snapshot.js
+++ b/__tests__/stats/stats-stylish/snapshot.js
@@ -9,7 +9,7 @@ Document: museum.yaml stats:
 📈 Schemas: 22 
 👉 Parameters: 6 
 🔗 Links: 0 
-➡️ Path Items: 5 
+🔀 Path Items: 5 
 👷 Operations: 8 
 🔖 Tags: 3 
 

--- a/docs/commands/stats.md
+++ b/docs/commands/stats.md
@@ -93,7 +93,7 @@ Document: museum.yaml stats:
 📈 Schemas: 23
 👉 Parameters: 6
 🔗 Links: 0
-➡️ Path Items: 5
+🔀 Path Items: 5
 👷 Operations: 8
 🔖 Tags: 3
 
@@ -131,7 +131,7 @@ An example of the format is shown in the following example:
     "total": 0
   },
   "pathItems": {
-    "metric": "➡️ Path Items",
+    "metric": "🔀 Path Items",
     "total": 5
   },
   "operations": {
@@ -160,7 +160,7 @@ It uses a table format; there are examples of the source and the formatted outpu
 | 📈 Schemas | 23 |
 | 👉 Parameters | 6 |
 | 🔗 Links | 0 |
-| ➡️ Path Items | 5 |
+| 🔀 Path Items | 5 |
 | 👷 Operations | 8 |
 | 🔖 Tags | 3 |
 ```
@@ -172,7 +172,7 @@ It uses a table format; there are examples of the source and the formatted outpu
 | 📈 Schemas            | 23    |
 | 👉 Parameters         | 6     |
 | 🔗 Links              | 0     |
-| ➡️ Path Items         | 5     |
+| 🔀 Path Items         | 5     |
 | 👷 Operations         | 8     |
 | 🔖 Tags               | 3     |
 

--- a/docs/commands/stats.md
+++ b/docs/commands/stats.md
@@ -93,7 +93,7 @@ Document: museum.yaml stats:
 📈 Schemas: 23
 👉 Parameters: 6
 🔗 Links: 0
-➡️  Path Items: 5
+➡️ Path Items: 5
 👷 Operations: 8
 🔖 Tags: 3
 
@@ -131,7 +131,7 @@ An example of the format is shown in the following example:
     "total": 0
   },
   "pathItems": {
-    "metric": "➡️  Path Items",
+    "metric": "➡️ Path Items",
     "total": 5
   },
   "operations": {
@@ -160,7 +160,7 @@ It uses a table format; there are examples of the source and the formatted outpu
 | 📈 Schemas | 23 |
 | 👉 Parameters | 6 |
 | 🔗 Links | 0 |
-| ➡️  Path Items | 5 |
+| ➡️ Path Items | 5 |
 | 👷 Operations | 8 |
 | 🔖 Tags | 3 |
 ```

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -23,7 +23,7 @@ const statsAccumulator: StatsAccumulator = {
   schemas: { metric: '📈 Schemas', total: 0, color: 'white' },
   parameters: { metric: '👉 Parameters', total: 0, color: 'yellow', items: new Set() },
   links: { metric: '🔗 Links', total: 0, color: 'cyan', items: new Set() },
-  pathItems: { metric: '➡️ Path Items', total: 0, color: 'green' },
+  pathItems: { metric: '🔀 Path Items', total: 0, color: 'green' },
   operations: { metric: '👷 Operations', total: 0, color: 'yellow' },
   tags: { metric: '🔖 Tags', total: 0, color: 'white', items: new Set() },
 };

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -23,7 +23,7 @@ const statsAccumulator: StatsAccumulator = {
   schemas: { metric: '📈 Schemas', total: 0, color: 'white' },
   parameters: { metric: '👉 Parameters', total: 0, color: 'yellow', items: new Set() },
   links: { metric: '🔗 Links', total: 0, color: 'cyan', items: new Set() },
-  pathItems: { metric: '➡️  Path Items', total: 0, color: 'green' },
+  pathItems: { metric: '➡️ Path Items', total: 0, color: 'green' },
   operations: { metric: '👷 Operations', total: 0, color: 'yellow' },
   tags: { metric: '🔖 Tags', total: 0, color: 'white', items: new Set() },
 };


### PR DESCRIPTION
## What/Why/How?

The ➡️ should be the same width as other emojis normally though it shows differently in GitHub's code viewer (`➡️`). Currently, the additional space makes the `stats` subcommand print such outputs, which is weird

<img width="321" alt="image" src="https://github.com/Redocly/redocly-cli/assets/8898435/75019efa-ddef-4914-b54d-e98d9be8d366">

The PR fixes it by removing the space.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
