### PR TITLE
chore: fix the historical benchmark pipeline

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Benchmark
         run: |
           cd benchmark/
-          npm run unit
+          npm test # This command is generated and injected into package.json in the previous step.
           cat benchmark_check.md
         env:
           CI: true


### PR DESCRIPTION
## What/Why/How?

Reverting changes in the historical benchmark pipeline introduced by a mistake [here](https://github.com/Redocly/redocly-cli/pull/1593/files#diff-6430b1987c0968143b0c52c4307f47c660827da3bc20f60862f40423b96267fdR67), which cause [this failure](https://github.com/Redocly/redocly-cli/actions/runs/9745432780/job/26893357203?pr=1596). 
It's a separate benchmark test command, not the root level one.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
