### PR TITLE
docs: try to make it clearer that preview is for next-gen products

### DIFF
--- a/docs/commands/preview.md
+++ b/docs/commands/preview.md
@@ -4,7 +4,7 @@
 
 The `preview` command starts a local preview server for a Redocly project. Use the preview to develop your project locally before deployment.
 
-{% admonition type="info" name="Pre-release" %}
+{% admonition type="warning" name="Pre-release" %}
 This command is for our pre-release products, currently open for early access to a small number of users. Announcements regarding the release are made through our [mailing list](https://redocly.com/product-updates/).
 {% /admonition %}
 


### PR DESCRIPTION
## What/Why/How?

We received some feedback that it isn't clear enough that the preview command is only for early access users. This pull request upgrades the admonition level in an attempt to make it more likely it will be seen/read.

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [x] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
