### PR TITLE
Remove unsupported keyword OAS 3.0.x typing - `additionalItems`

### DIFF
--- a/.changeset/hungry-files-scream.md
+++ b/.changeset/hungry-files-scream.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Removed `additionalItems` from OAS 3.0.x typings. This keyword is not supported by the specification
+Removed `additionalItems` from OAS 3.0.x typings. This keyword is not supported by the specification.

--- a/.changeset/hungry-files-scream.md
+++ b/.changeset/hungry-files-scream.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Removed `additionalItems` from OAS 3.0.x typings. This keyword is not supported by the specification

--- a/packages/core/src/types/oas3.ts
+++ b/packages/core/src/types/oas3.ts
@@ -346,13 +346,6 @@ const Schema: NodeType = {
         return 'Schema';
       }
     },
-    additionalItems: (value: any) => {
-      if (typeof value === 'boolean') {
-        return { type: 'boolean' };
-      } else {
-        return 'Schema';
-      }
-    },
     additionalProperties: (value: any) => {
       if (typeof value === 'boolean') {
         return { type: 'boolean' };


### PR DESCRIPTION
related #707


## What/Why/How?

This is a JSON Schema keyword but **IS NOT** supported by OpenAPI 3.0.x.  This type was incorrectly added to the Schema object typings. 

## Reference
related https://github.com/OAI/OpenAPI-Specification/pull/741#issuecomment-235959201

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
