### PR TITLE
chore: change link checker config to internal links only

### DIFF
--- a/.mlc.toml
+++ b/.mlc.toml
@@ -5,3 +5,5 @@ ignore-links=["../../*", "/docs/*",
 ]
 # Path to the root folder used to resolve all relative paths
 root-dir="./docs"
+offline = true
+


### PR DESCRIPTION
## What/Why/How?

We have a link checker, but if a 3rd party site is down then we see a build failure when in fact it's not a fault on our side. This pull request adjusts the link checking to be local-only in the CI pipeline that is used on every pull request.

This change brings the checks in line with the other docs sites.

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
