### PR TITLE
fix: arazzo parameter schema update

### DIFF
--- a/packages/core/src/types/arazzo.ts
+++ b/packages/core/src/types/arazzo.ts
@@ -87,7 +87,7 @@ const parameter = {
     {
       type: 'object',
       properties: {
-        in: { type: 'string', enum: ['header', 'query', 'path', 'cookie'] },
+        in: { type: 'string', enum: ['header', 'query', 'path', 'cookie', 'body'] },
         name: { type: 'string' },
         value: {
           oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }],


### PR DESCRIPTION
## What/Why/How?

Arazzo parameter schema update: added `body` to the allowed parameter `in` value.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
