### PR TITLE
fix: add correct typing for patternProperties

### DIFF
--- a/.changeset/forty-planes-dream.md
+++ b/.changeset/forty-planes-dream.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fix bundling `$refs` inside `patternProperties`.
+Fixed bundling of `$refs` inside `patternProperties`.

--- a/.changeset/forty-planes-dream.md
+++ b/.changeset/forty-planes-dream.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fix bundling `$refs` inside `patternProperties`.

--- a/__tests__/bundle/oas3_1-pattern-porperties/object.yaml
+++ b/__tests__/bundle/oas3_1-pattern-porperties/object.yaml
@@ -1,0 +1,1 @@
+type: object

--- a/__tests__/bundle/oas3_1-pattern-porperties/redocly.yaml
+++ b/__tests__/bundle/oas3_1-pattern-porperties/redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./test.yaml

--- a/__tests__/bundle/oas3_1-pattern-porperties/snapshot.js
+++ b/__tests__/bundle/oas3_1-pattern-porperties/snapshot.js
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle oas3_1-pattern-porperties 1`] = `
+openapi: 3.1.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /asset/{assetId}:
+    get:
+      operationId: assetGetAsset
+      summary: Fetch an asset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              patternProperties:
+                .*:
+                  $ref: '#/components/schemas/object'
+components:
+  schemas:
+    object:
+      type: object
+
+bundling ./test.yaml...
+📦 Created a bundle for ./test.yaml at stdout <test>ms.
+
+`;

--- a/__tests__/bundle/oas3_1-pattern-porperties/test.yaml
+++ b/__tests__/bundle/oas3_1-pattern-porperties/test.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /asset/{assetId}:
+    get:
+      operationId: assetGetAsset
+      summary: Fetch an asset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              patternProperties:
+                .*:
+                  $ref: object.yaml

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -139,7 +139,7 @@ const Schema: NodeType = {
     contains: 'Schema',
     minContains: { type: 'integer', minimum: 0 },
     maxContains: { type: 'integer', minimum: 0 },
-    patternProperties: { type: 'object' },
+    patternProperties: 'SchemaProperties',
     propertyNames: 'Schema',
     unevaluatedItems: (value: unknown) => {
       if (typeof value === 'boolean') {


### PR DESCRIPTION
## What/Why/How?

Added correct typing for JSON Schema `patternProperties`.

## Reference

Fixes #792 

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
