### PR TITLE
Treat `dependentSchemas` as a map not array.

### DIFF
--- a/.changeset/five-cougars-arrive.md
+++ b/.changeset/five-cougars-arrive.md
@@ -1,6 +1,6 @@
 ---
-"@redocly/openapi-core": minor
-"@redocly/cli": minor
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
 ---
 
-Spec rule properly parses dependentSchemas as map, not array.
+Spec rule properly parses `dependentSchemas` as map, not array.

--- a/.changeset/five-cougars-arrive.md
+++ b/.changeset/five-cougars-arrive.md
@@ -4,4 +4,4 @@
 ---
 
 Fixed an issue in the OpenAPI `spec` rule where `dependentSchemas` was parsed as an array.
-`dependentSchemas` is now correctly parsed as a map.
+It is now correctly parsed as a map. 

--- a/.changeset/five-cougars-arrive.md
+++ b/.changeset/five-cougars-arrive.md
@@ -3,4 +3,5 @@
 "@redocly/cli": patch
 ---
 
-Spec rule properly parses `dependentSchemas` as map, not array.
+Fixed an issue in the OpenAPI `spec` rule where `dependentSchemas` was parsed as an array.
+`dependentSchemas` is now correctly parsed as a map.

--- a/.changeset/five-cougars-arrive.md
+++ b/.changeset/five-cougars-arrive.md
@@ -4,4 +4,4 @@
 ---
 
 Fixed an issue in the OpenAPI `spec` rule where `dependentSchemas` was parsed as an array.
-It is now correctly parsed as a map. 
+It is now correctly parsed as a map.

--- a/.changeset/five-cougars-arrive.md
+++ b/.changeset/five-cougars-arrive.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": minor
+"@redocly/cli": minor
+---
+
+Spec rule properly parses dependentSchemas as map, not array.

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -607,4 +607,51 @@ describe('Oas3.1 spec', () => {
       ]
     `);
   });
+
+  it('should flag invalid dependentSchemas', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      openapi: 3.1.0
+      info:
+        version: 1.0.0
+        title: Example.com
+        description: info,
+        license:
+          name: Apache 2.0
+          url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+      components:
+        schemas:
+          withInvalidDependentSchemas:
+            dependentSchemas:
+              - invalid1
+              - invalid2
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ spec: 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "from": undefined,
+          "location": [
+            {
+              "pointer": "#/components/schemas/withInvalidDependentSchemas/dependentSchemas",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Expected type \`SchemaMap\` (object) but got \`array\`",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/src/types/oas3_1.ts
+++ b/packages/core/src/types/oas3_1.ts
@@ -133,7 +133,7 @@ const Schema: NodeType = {
     if: 'Schema',
     then: 'Schema',
     else: 'Schema',
-    dependentSchemas: listOf('Schema'),
+    dependentSchemas: mapOf('Schema'),
     dependentRequired: 'DependentRequired',
     prefixItems: listOf('Schema'),
     contains: 'Schema',


### PR DESCRIPTION
## What/Why/How?

When validating an OpenAPI 3.1 spec that utilizes `dependentSchemas`, `redocly-cli` emits an error:

```json
    {
      "ruleId": "spec",
      "severity": "error",
      "message": "Expected type `SchemaList` (array) but got `object`",
      "suggest": [],
      "location": [
        {
          "source": {
            "ref": "https://raw.githubusercontent.com/json-api/json-api/a2034598b22daf77322b9123c707165ef3ead3ea/schemas/1.0/schema.json"
          },
          "pointer": "#/dependentSchemas",
          "reportOnKey": false
        }
      ]
    }
```

which led me to discover that `dependentSchemas` was configured to be an array, but is in fact [a map](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4).

https://github.com/Redocly/redocly-cli/blob/368c34fc5faa8e9e920a1c003b19350cee47224e/packages/core/src/types/oas3_1.ts#L136

The line in question dates to the initial implementation of 3.1 support so I imagine this was either incorrect from the beginning and didn't have test coverage, or changed in the OpenAPI spec since then.

## Reference

https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4

## Testing

Test coverage includes a failing test for a `dependentSchemas` property that is actually an array.

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
