### PR TITLE
Displaying a real error unrelated to the plugin

### DIFF
--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -130,6 +130,7 @@ export function resolvePlugins(
         if (e instanceof SyntaxError) {
           throw e;
         }
+        console.warn(e);
         throw new Error(`Failed to load plugin "${plugin}". Please provide a valid path`);
       }
     }


### PR DESCRIPTION
## What/Why/How?

If program has any error and redocly.yaml which has plugin - error replaced by text. Real info about error is hiding.

For example add mistake in syntax package.json and rund redocly with any plugin.

After this fix, error should be showed throth console.warn().

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [x] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
