### PR TITLE
fix: add webhooks to stats and fix crash for webhooks tags

### DIFF
--- a/.changeset/short-onions-live.md
+++ b/.changeset/short-onions-live.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Added webhook support for stats and fixed a crash that occurred when tags were included in webhooks.

--- a/.changeset/short-onions-live.md
+++ b/.changeset/short-onions-live.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Added webhook support for stats and fixed a crash that occurred when tags were not included in webhooks.
+Added support for webhooks in stats and fixed a crash that occurred when tags were not included in webhooks.

--- a/.changeset/short-onions-live.md
+++ b/.changeset/short-onions-live.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Added webhook support for stats and fixed a crash that occurred when tags were included in webhooks.
+Added webhook support for stats and fixed a crash that occurred when tags were not included in webhooks.

--- a/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
+++ b/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot.js
@@ -92,6 +92,7 @@ Document: openapi.yaml stats:
 👉 Parameters: 0 
 🔗 Links: 0 
 🔀 Path Items: 2 
+🎣 Webhooks: 0 
 👷 Operations: 2 
 🔖 Tags: 0 
 

--- a/__tests__/stats/stats-json/snapshot.js
+++ b/__tests__/stats/stats-json/snapshot.js
@@ -26,6 +26,10 @@ exports[`E2E stats stats should produce correct JSON output 1`] = `
     "metric": "🔀 Path Items",
     "total": 5
   },
+  "webhooks": {
+    "metric": "🎣 Webhooks",
+    "total": 0
+  },
   "operations": {
     "metric": "👷 Operations",
     "total": 8

--- a/__tests__/stats/stats-markdown/snapshot.js
+++ b/__tests__/stats/stats-markdown/snapshot.js
@@ -9,6 +9,7 @@ exports[`E2E stats stats should produce correct Markdown format 1`] = `
 | 👉 Parameters | 6 |
 | 🔗 Links | 0 |
 | 🔀 Path Items | 5 |
+| 🎣 Webhooks | 0 |
 | 👷 Operations | 8 |
 | 🔖 Tags | 3 |
 

--- a/__tests__/stats/stats-stylish/snapshot.js
+++ b/__tests__/stats/stats-stylish/snapshot.js
@@ -10,6 +10,7 @@ Document: museum.yaml stats:
 👉 Parameters: 6 
 🔗 Links: 0 
 🔀 Path Items: 5 
+🎣 Webhooks: 0 
 👷 Operations: 8 
 🔖 Tags: 3 
 

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -29,6 +29,7 @@ const statsAccumulator: StatsAccumulator = {
   parameters: { metric: '👉 Parameters', total: 0, color: 'yellow', items: new Set() },
   links: { metric: '🔗 Links', total: 0, color: 'cyan', items: new Set() },
   pathItems: { metric: '🔀 Path Items', total: 0, color: 'green' },
+  webhooks: { metric: '🎣 Webhooks', total: 0, color: 'green' },
   operations: { metric: '👷 Operations', total: 0, color: 'yellow' },
   tags: { metric: '🔖 Tags', total: 0, color: 'white', items: new Set() },
 };

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -62,6 +62,7 @@ export function commandWrapper<T extends CommandOptions>(
       }
       code = 0;
     } catch (err) {
+      console.log(err);
       // Do nothing
     } finally {
       if (process.env.REDOCLY_TELEMETRY !== 'off' && telemetry !== 'off') {

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -62,7 +62,6 @@ export function commandWrapper<T extends CommandOptions>(
       }
       code = 0;
     } catch (err) {
-      console.log(err);
       // Do nothing
     } finally {
       if (process.env.REDOCLY_TELEMETRY !== 'off' && telemetry !== 'off') {

--- a/packages/core/src/rules/other/stats.ts
+++ b/packages/core/src/rules/other/stats.ts
@@ -35,9 +35,11 @@ export const Stats = (statsAccumulator: StatsAccumulator) => {
     WebhooksMap: {
       Operation: {
         leave(operation: any) {
-          operation.tags.forEach((tag: string) => {
-            statsAccumulator.tags.items!.add(tag);
-          });
+          statsAccumulator.webhooks.total++;
+          operation.tags &&
+            operation.tags.forEach((tag: string) => {
+              statsAccumulator.tags.items!.add(tag);
+            });
         },
       },
     },

--- a/packages/core/src/typings/common.ts
+++ b/packages/core/src/typings/common.ts
@@ -13,5 +13,6 @@ export type StatsName =
   | 'pathItems'
   | 'links'
   | 'schemas'
+  | 'webhooks'
   | 'parameters';
 export type StatsAccumulator = Record<StatsName, StatsRow>;


### PR DESCRIPTION
## What/Why/How?

stats command was crashing for GitHub API (tags was undefined).

Also added support for webhooks in stats.

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
