### PR TITLE
docs: Link to the cookbook from the custom decorators page

### DIFF
--- a/docs/custom-plugins/custom-decorators.md
+++ b/docs/custom-plugins/custom-decorators.md
@@ -147,6 +147,7 @@ With this configuration, an `operationId` called `GetAllItems` would be rewritte
 
 See some more examples of decorators:
 
+- There's a [Redocly CLI cookbook](https://github.com/Redocly/redocly-cli-cookbook) containing many more examples and ready-to-use scripts from our community.
 - Follow our [replace-servers-url tutorial](../guides/replace-servers-url.md).
 - Change your [OAuth2 token URL](../guides/change-token-url.md).
 


### PR DESCRIPTION
## What/Why/How?

We have lots of custom decorators in the cookbook now, so add a link to the cookbook from the decorators page.

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
