### PR TITLE
feat: report endpoint sunset

### DIFF
--- a/.changeset/tiny-boats-check.md
+++ b/.changeset/tiny-boats-check.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Added a warning message to "push" and "push-status" commands that will notify user about upcoming or ongoing resource deprecation.

--- a/.changeset/tiny-boats-check.md
+++ b/.changeset/tiny-boats-check.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Added a warning message to "push" and "push-status" commands that notifies user about upcoming or ongoing resource deprecation.
+Added a warning message to the `push` and `push-status` commands to notify users about upcoming or ongoing resource deprecation.

--- a/.changeset/tiny-boats-check.md
+++ b/.changeset/tiny-boats-check.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Added a warning message to "push" and "push-status" commands that will notify user about upcoming or ongoing resource deprecation.
+Added a warning message to "push" and "push-status" commands that notifies user about upcoming or ongoing resource deprecation.

--- a/packages/cli/src/cms/api/__tests__/api.client.test.ts
+++ b/packages/cli/src/cms/api/__tests__/api.client.test.ts
@@ -95,14 +95,18 @@ describe('ApiClient', () => {
           branchName: 'test-branch',
         }),
         headers: new Headers({
-          'Sunset': sunsetDate.toISOString(),
-        })
+          Sunset: sunsetDate.toISOString(),
+        }),
       });
 
       await apiClient.remotes.getDefaultBranch(testOrg, testProject);
       apiClient.reportSunsetWarnings();
-      
-      expect(process.stdout.write).toHaveBeenCalledWith(red(`Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
+
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        red(
+          `Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`
+        )
+      );
     });
   });
 
@@ -201,14 +205,18 @@ describe('ApiClient', () => {
         ok: true,
         json: jest.fn().mockResolvedValue(responseMock),
         headers: new Headers({
-          'Sunset': sunsetDate.toISOString(),
-        })
+          Sunset: sunsetDate.toISOString(),
+        }),
       });
 
       await apiClient.remotes.upsert(testOrg, testProject, remotePayload);
       apiClient.reportSunsetWarnings();
-      
-      expect(process.stdout.write).toHaveBeenCalledWith(red(`Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
+
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        red(
+          `Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`
+        )
+      );
     });
   });
 
@@ -332,14 +340,18 @@ describe('ApiClient', () => {
         ok: true,
         json: jest.fn().mockResolvedValue(responseMock),
         headers: new Headers({
-          'Sunset': sunsetDate.toISOString(),
-        })
+          Sunset: sunsetDate.toISOString(),
+        }),
       });
 
       await apiClient.remotes.push(testOrg, testProject, pushPayload, filesMock);
       apiClient.reportSunsetWarnings();
-      
-      expect(process.stdout.write).toHaveBeenCalledWith(red(`Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
+
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        red(
+          `Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`
+        )
+      );
     });
   });
 });

--- a/packages/cli/src/cms/api/__tests__/api.client.test.ts
+++ b/packages/cli/src/cms/api/__tests__/api.client.test.ts
@@ -1,8 +1,8 @@
 import fetch, { Response } from 'node-fetch';
 import * as FormData from 'form-data';
+import { red } from 'colorette';
 
 import { ReuniteApi, PushPayload, ReuniteApiError } from '../api-client';
-import { red } from 'colorette';
 
 jest.mock('node-fetch', () => ({
   default: jest.fn(),
@@ -102,7 +102,7 @@ describe('ApiClient', () => {
       await apiClient.remotes.getDefaultBranch(testOrg, testProject);
       apiClient.reportSunsetWarnings();
       
-      expect(process.stdout.write).toHaveBeenCalledWith(red(`Endpoint required for proper work of "push" command is DEPRECATED on ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
+      expect(process.stdout.write).toHaveBeenCalledWith(red(`Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
     });
   });
 
@@ -208,7 +208,7 @@ describe('ApiClient', () => {
       await apiClient.remotes.upsert(testOrg, testProject, remotePayload);
       apiClient.reportSunsetWarnings();
       
-      expect(process.stdout.write).toHaveBeenCalledWith(red(`Endpoint required for proper work of "push" command is DEPRECATED on ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
+      expect(process.stdout.write).toHaveBeenCalledWith(red(`Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
     });
   });
 
@@ -339,7 +339,7 @@ describe('ApiClient', () => {
       await apiClient.remotes.push(testOrg, testProject, pushPayload, filesMock);
       apiClient.reportSunsetWarnings();
       
-      expect(process.stdout.write).toHaveBeenCalledWith(red(`Endpoint required for proper work of "push" command is DEPRECATED on ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
+      expect(process.stdout.write).toHaveBeenCalledWith(red(`Support for "push" command is deprecated after ${sunsetDate.toLocaleString()}. Please update the version of Redocly CLI.\n\n`))
     });
   });
 });

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -335,16 +335,15 @@ export class ReuniteApi {
     if (sunsetWarnings.length) {
       const [{ isSunsetExpired, sunsetDate }] = sunsetWarnings.sort(
         (a: SunsetWarning, b: SunsetWarning) => {
-        // First, prioritize by expiration status
-        if (a.isSunsetExpired !== b.isSunsetExpired) {
-          return a.isSunsetExpired ? -1 : 1;
+          // First, prioritize by expiration status
+          if (a.isSunsetExpired !== b.isSunsetExpired) {
+            return a.isSunsetExpired ? -1 : 1;
+          }
+
+          // If both are either expired or not, sort by sunset date
+          return a.sunsetDate > b.sunsetDate ? 1 : -1;
         }
-
-        // If both are either expired or not, sort by sunset date
-        return a.sunsetDate > b.sunsetDate ? 1 : -1;
-      }
-    );
-
+      );
 
       const updateVersionMessage = `Update to the latest version by running "npm install @redocly/cli@latest".`;
 

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -51,29 +51,26 @@ class ReuniteApiClient implements BaseApiClient {
   private collectSunsetWarning(response: Response) {
     const sunsetTime = this.getSunsetDate(response);
 
-    if (sunsetTime) {
-      const sunsetDate = new Date(sunsetTime);
-      let sunsetWarning: SunsetWarning;
-
-      if (sunsetTime > Date.now()) {
-        sunsetWarning = {
+    if (!sunsetTime) return
+    
+    const sunsetDate = new Date(sunsetTime);
+    if (sunsetTime > Date.now()) {
+        this.sunsetWarnings.push({
           sunsetDate,
           isSunsetExpired: false,
           warning: `Endpoint ${
             response.url
           } is marked for removal after ${sunsetDate.toISOString()}`,
-        };
+        });
       } else {
-        sunsetWarning = {
+        this.sunsetWarnings.push({
           sunsetDate,
           isSunsetExpired: true,
           warning: `Endpoint ${
             response.url
           } support expired on ${sunsetDate.toISOString()} and will be removed.`,
         };
-      }
-
-      this.sunsetWarnings.push(sunsetWarning);
+      })
     }
   }
 

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -84,19 +84,8 @@ class ReuniteApiClient implements BaseApiClient {
       return;
     }
 
-    let sunsetDate = headers.get('sunset');
-
-    if (sunsetDate) {
-      return Date.parse(sunsetDate);
-    }
-
-    sunsetDate = headers.get('Sunset');
-
-    if (sunsetDate) {
-      return Date.parse(sunsetDate);
-    }
-
-    return;
+    const sunsetDate = headers.get('sunset') || headers.get('Sunset');
+    return sunsetDate && Date.parse(sunsetDate)
   }
 }
 

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -61,7 +61,7 @@ class ReuniteApiClient implements BaseApiClient {
             isSunsetExpired: false,
             warning: `Endpoint ${
               response.url
-            } is deprecated for removal on ${sunsetDate.toISOString()}`,
+            } is marked for removal after ${sunsetDate.toISOString()}`,
           };
         } else {
           sunsetWarning = {
@@ -69,7 +69,7 @@ class ReuniteApiClient implements BaseApiClient {
             isSunsetExpired: true,
             warning: `Endpoint ${
               response.url
-            } was deprecated for removal on ${sunsetDate.toISOString()} and could be removed AT ANY TIME`,
+            } support expired on ${sunsetDate.toISOString()} and will be removed.`,
           };
         }
 
@@ -361,16 +361,15 @@ export class ReuniteApi {
         }
       });
 
-      const sunsetMessagePrevix = `Endpoint required for proper work of "${this.command}" command is`;
       const updateVersionMessage = `Please update the version of Redocly CLI.`;
 
       if (isSunsetExpired) {
         process.stdout.write(
-          red(`${sunsetMessagePrevix} DEPRECATED on ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`)
+          red(`Support for "${this.command}" command is deprecated after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`)
         );
       } else {
         process.stdout.write(
-          yellow(`${sunsetMessagePrevix} going to deprecate on ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`)
+          yellow(`Support for "${this.command}" command is marked for deprecation after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`)
         );
       }
     }

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -363,22 +363,20 @@ export class ReuniteApi {
         }
       );
 
-      const updateVersionMessage = `Please update the version of Redocly CLI.`;
+      const updateVersionMessage = `Update to the latest version by running "npm install @redocly/cli@latest".`;
 
       if (isSunsetExpired) {
         process.stdout.write(
           red(
-            `Support for "${
-              this.command
-            }" command is deprecated after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`
+            `The "${this.command}" command is not compatible with your version of Redocly CLI. ${updateVersionMessage}\n\n`
           )
         );
       } else {
         process.stdout.write(
           yellow(
-            `Support for "${
+            `The "${
               this.command
-            }" command is marked for deprecation after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`
+            }" command will be incompatible with your version of Redocly CLI after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`
           )
         );
       }

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -335,33 +335,16 @@ export class ReuniteApi {
     if (sunsetWarnings.length) {
       const [{ isSunsetExpired, sunsetDate }] = sunsetWarnings.sort(
         (a: SunsetWarning, b: SunsetWarning) => {
-          if (a.isSunsetExpired && b.isSunsetExpired) {
-            if (a.sunsetDate > b.sunsetDate) {
-              // b will shutdown earlier
-              return 1;
-            } else {
-              return -1;
-            }
-          }
-
-          if (a.isSunsetExpired) {
-            // a should come before b because it is already expired
-            return -1;
-          }
-
-          if (b.isSunsetExpired) {
-            // b should come before a because it is already expired
-            return 1;
-          }
-
-          if (a.sunsetDate > b.sunsetDate) {
-            // b will shutdown earlier
-            return 1;
-          } else {
-            return -1;
-          }
+        // First, prioritize by expiration status
+        if (a.isSunsetExpired !== b.isSunsetExpired) {
+          return a.isSunsetExpired ? -1 : 1;
         }
-      );
+
+        // If both are either expired or not, sort by sunset date
+        return a.sunsetDate > b.sunsetDate ? 1 : -1;
+      }
+    );
+
 
       const updateVersionMessage = `Update to the latest version by running "npm install @redocly/cli@latest".`;
 

--- a/packages/cli/src/cms/api/api-client.ts
+++ b/packages/cli/src/cms/api/api-client.ts
@@ -18,7 +18,7 @@ interface BaseApiClient {
   request(url: string, options: FetchWithTimeoutOptions): Promise<Response>;
 }
 type CommandOption = 'push' | 'push-status';
-export type SunsetWarning = { sunsetDate: Date; isSunsetExpired: boolean; warning: string };
+export type SunsetWarning = { sunsetDate: Date; isSunsetExpired: boolean };
 export type SunsetWarningsBuffer = SunsetWarning[];
 
 export class ReuniteApiError extends Error {
@@ -51,26 +51,20 @@ class ReuniteApiClient implements BaseApiClient {
   private collectSunsetWarning(response: Response) {
     const sunsetTime = this.getSunsetDate(response);
 
-    if (!sunsetTime) return
-    
+    if (!sunsetTime) return;
+
     const sunsetDate = new Date(sunsetTime);
+
     if (sunsetTime > Date.now()) {
-        this.sunsetWarnings.push({
-          sunsetDate,
-          isSunsetExpired: false,
-          warning: `Endpoint ${
-            response.url
-          } is marked for removal after ${sunsetDate.toISOString()}`,
-        });
-      } else {
-        this.sunsetWarnings.push({
-          sunsetDate,
-          isSunsetExpired: true,
-          warning: `Endpoint ${
-            response.url
-          } support expired on ${sunsetDate.toISOString()} and will be removed.`,
-        };
-      })
+      this.sunsetWarnings.push({
+        sunsetDate,
+        isSunsetExpired: false,
+      });
+    } else {
+      this.sunsetWarnings.push({
+        sunsetDate,
+        isSunsetExpired: true,
+      });
     }
   }
 
@@ -82,7 +76,12 @@ class ReuniteApiClient implements BaseApiClient {
     }
 
     const sunsetDate = headers.get('sunset') || headers.get('Sunset');
-    return sunsetDate && Date.parse(sunsetDate)
+
+    if (!sunsetDate) {
+      return;
+    }
+
+    return Date.parse(sunsetDate);
   }
 }
 

--- a/packages/cli/src/cms/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/cms/commands/__tests__/push-status.test.ts
@@ -17,8 +17,9 @@ jest.mock('colorette', () => ({
 
 jest.mock('../../api', () => ({
   ...jest.requireActual('../../api'),
-  ReuniteApiClient: jest.fn().mockImplementation(function (this: any, ...args) {
+  ReuniteApi: jest.fn().mockImplementation(function (this: any, ...args) {
     this.remotes = remotes;
+    this.reportSunsetWarnings = jest.fn();
   }),
 }));
 

--- a/packages/cli/src/cms/commands/__tests__/push.test.ts
+++ b/packages/cli/src/cms/commands/__tests__/push.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { handlePush } from '../push';
-import { ReuniteApiClient, ReuniteApiError } from '../../api';
+import { ReuniteApi, ReuniteApiError } from '../../api';
 
 const remotes = {
   push: jest.fn(),
@@ -15,8 +15,9 @@ jest.mock('@redocly/openapi-core', () => ({
 
 jest.mock('../../api', () => ({
   ...jest.requireActual('../../api'),
-  ReuniteApiClient: jest.fn().mockImplementation(function (this: any, ...args) {
+  ReuniteApi: jest.fn().mockImplementation(function (this: any, ...args) {
     this.remotes = remotes;
+    this.reportSunsetWarnings = jest.fn();
   }),
 }));
 
@@ -332,7 +333,7 @@ describe('handlePush()', () => {
       version: 'cli-version',
     });
 
-    expect(ReuniteApiClient).toBeCalledWith({
+    expect(ReuniteApi).toBeCalledWith({
       domain: 'test-domain-from-env',
       apiKey: 'test-api-key',
       version: 'cli-version',

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -168,7 +168,7 @@ export async function handlePushStatus({
       printScorecard(pushResponse.status.production.scorecard);
     }
     printPushStatusInfo({ orgId, projectId, pushId, startedAt });
-    
+
     client.reportSunsetWarnings();
 
     const summary: PushStatusSummary = {

--- a/packages/cli/src/cms/commands/push-status.ts
+++ b/packages/cli/src/cms/commands/push-status.ts
@@ -2,7 +2,7 @@ import * as colors from 'colorette';
 import { exitWithError, printExecutionTime } from '../../utils/miscellaneous';
 import { Spinner } from '../../utils/spinner';
 import { DeploymentError } from '../utils';
-import { ReuniteApiClient, getApiKeys, getDomain } from '../api';
+import { ReuniteApi, getApiKeys, getDomain } from '../api';
 import { capitalize } from '../../utils/js-utils';
 import { handleReuniteError, retryUntilConditionMet } from './utils';
 
@@ -68,7 +68,7 @@ export async function handlePushStatus({
 
   try {
     const apiKey = getApiKeys(domain);
-    const client = new ReuniteApiClient({ domain, apiKey, version, command: 'push-status' });
+    const client = new ReuniteApi({ domain, apiKey, version, command: 'push-status' });
 
     let pushResponse: PushResponse;
 
@@ -168,6 +168,8 @@ export async function handlePushStatus({
       printScorecard(pushResponse.status.production.scorecard);
     }
     printPushStatusInfo({ orgId, projectId, pushId, startedAt });
+    
+    client.reportSunsetWarnings();
 
     const summary: PushStatusSummary = {
       preview: pushResponse.status.preview,

--- a/packages/cli/src/cms/commands/push.ts
+++ b/packages/cli/src/cms/commands/push.ts
@@ -156,7 +156,7 @@ export async function handlePush({
         )} uploaded to organization ${orgId}, project ${projectId}. Push ID: ${id}.`
       );
 
-      client.reportSunsetWarnings();
+    client.reportSunsetWarnings();
 
     return {
       pushId: id,


### PR DESCRIPTION
## What/Why/How?
Warn user about planned endpoint sunset.

Currently there is no way to let user know about breaking changes in the endpoints or endpoint deprecation used for specific command.

Lookup for `Sunset` header in responses received from Reunite to notify users if there are resources that is going to deprecate or is already deprecated (but is still functioning).   

## Reference

## Testing

## Screenshots (optional)

*Endpoint is about to be deprecated*

<img width="903" alt="365737829-3ab90010-0739-4d3b-8ce2-c0a0505b3be9" src="https://github.com/user-attachments/assets/2a0e5417-f0f8-4b9a-96ed-73123857b20c">

*Endpoint is already deprecated*

<img width="881" alt="image" src="https://github.com/user-attachments/assets/24b052f5-251f-46ad-a522-65b120ee3177">



## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
