### PR TITLE
fix: fix validation of redocly.yaml for product folder

### DIFF
--- a/.changeset/few-hotels-promise.md
+++ b/.changeset/few-hotels-promise.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed validation of `redocly.yaml` for product folders.

--- a/packages/core/src/types/__tests__/redocly-yaml.test.ts
+++ b/packages/core/src/types/__tests__/redocly-yaml.test.ts
@@ -1,0 +1,37 @@
+import { createConfigTypes } from '../redocly-yaml';
+
+describe('createConfigTypes', () => {
+  test('should create types for config root and include expected properties', () => {
+    const result = createConfigTypes({
+      properties: {
+        apis: {
+          additionalProperties: {
+            properties: {
+              foo: {
+                type: 'string',
+              },
+              bar: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toHaveProperty('ConfigRoot');
+    expect(result.ConfigRoot).toHaveProperty('properties');
+
+    const apisPropertiesName = result.ConfigRoot.properties?.apis;
+    expect(apisPropertiesName).toBeDefined();
+    const additionalPropertiesName = result[apisPropertiesName as any].additionalProperties;
+    expect(additionalPropertiesName).toBeDefined();
+    const apisProperties = result[additionalPropertiesName].properties;
+    expect(apisProperties).toBeDefined();
+    const propNames = Object.keys(apisProperties);
+    expect(propNames).toContain('root');
+    expect(propNames).toContain('output');
+    expect(propNames).toContain('foo');
+    expect(propNames).toContain('bar');
+  });
+});

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -7,6 +7,7 @@ import { SpecVersion, getTypes } from '../oas-types';
 import type { JSONSchema } from 'json-schema-to-ts';
 import type { NodeType } from '.';
 import type { Config } from '../config';
+import { output } from '../output';
 
 const builtInCommonOASRules = [
   'spec',
@@ -313,6 +314,8 @@ const createConfigApisProperties = (nodeTypes: Record<string, NodeType>): NodeTy
   ...nodeTypes['rootRedoclyConfigSchema.apis_additionalProperties'],
   properties: {
     ...nodeTypes['rootRedoclyConfigSchema.apis_additionalProperties']?.properties,
+    root: { type: 'string' },
+    output: { type: 'string' },
     labels: {
       type: 'array',
       items: {


### PR DESCRIPTION
## What/Why/How?

The product config was missing root and output types so validation failed.

## Reference
Fixes https://github.com/Redocly/redocly/issues/10504

## Testing
I have added unit tests.

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
