### PR TITLE
fix: resolve config in browser throws an error

### DIFF
--- a/.changeset/curvy-rivers-itch.md
+++ b/.changeset/curvy-rivers-itch.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed an issue where resolving config in the browser always threw an error.

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -111,13 +111,17 @@ export async function resolveConfig({
 }
 
 function getDefaultPluginPath(configPath: string): string | undefined {
+  if (isBrowser) {
+    return;
+  }
+
   for (const pluginPath of DEFAULT_PROJECT_PLUGIN_PATHS) {
     const absolutePluginPath = path.resolve(path.dirname(configPath), pluginPath);
     if (existsSync(absolutePluginPath)) {
       return pluginPath;
     }
   }
-  return undefined;
+  return;
 }
 
 export async function resolvePlugins(


### PR DESCRIPTION
## What/Why/How?

The `resolveConfig` function tried to use the `existsSync` function from the `fs` module in a browser which resulted in an error being thrown.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
