### PR TITLE
docs: add translate command page

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -9,6 +9,7 @@ Documentation commands:
 - [`preview-docs`](preview-docs.md) Preview API reference docs for the specified API description.
 - [`build-docs`](build-docs.md) Build API description into an HTML file.
 - [`preview`](preview.md) Start a local preview of a Redocly project with one of the product NPM packages.
+- [`translate`](translate.md) Generate translation keys for a Redocly Realm, Reef, or Revel project.
 
 API management commands:
 

--- a/docs/commands/translate.md
+++ b/docs/commands/translate.md
@@ -1,0 +1,87 @@
+# `translate`
+
+The `translate` command helps manage multiple translations in your Redocly project.
+It creates or updates `translations.yaml` files, populating them with "translation keys" that map to elements in your documentation's UI.
+
+This command serves two purposes:
+
+- On first run, `translate` creates (or populates) a file with built-in translation keys for common UI elements.
+- On future runs, `translate` adds custom, user-defined translation keys from your `redocly.yaml` or `sidebars.yaml` files.
+
+## Usage
+
+```bash
+redocly translate <locale>
+redocly translate all
+redocly translate <locale> [--project-dir=<path>]
+redocly translate --help
+redocly translate --version
+```
+
+## Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `locale` | string | **REQUIRED**. Name of a locale folder, inside your project's `l10n` directory, to generate translations for. Use `all` for all locales. |
+| `--project-dir`, `-d` | string | Specifies the destination of translated files. |
+| `--lint-config` | string | Severity level for config file linting. Possible values: `warn`, `error`, `off`. Defaults to `warn`. |
+| `--help` | boolean | Show help. |
+| `--version` | boolean | Show version number. |
+
+## Examples
+
+### Populate translation keys for specific locale
+
+The following command generates or updates translations for the Dutch locale:
+
+```bash {% title="Translate specific locale" %}
+redocly translate nl-NL
+```
+
+This example updates the file `@l10n/nl-NL/translations.yaml`.
+If the file (or folder) doesn't exist, they're created and populated with translation keys.
+
+### Populate translation keys for all locales
+
+Use the `all` keyword to generate translations for all locale folders inside the `@l10n` directory:
+
+```bash {% title="Translate all locales" %}
+redocly translate all
+```
+
+This command updates the `translation.yaml` files for every locale with a folder in `@l10n`, as shown in the following example:
+
+```treeview {% title="Project with multiple locales" %}
+your-awesome-project
+├── @l10n/
+│   ├── es-ES/
+│   │   ├── transcriptions.yaml
+│   │   └── ...
+│   ├── fr/
+│   │   ├── transcriptions.yaml
+│   │   └── ...
+│   └── nl-NL/
+│       ├── transcriptions.yaml
+│       └── ...
+├── index.md
+├── sidebars.md
+├── redocly.yaml
+└── ...
+```
+
+## Tips for using `translate`
+
+- The command is additive; it doesn't overwrite existing translation keys.
+
+- Custom translation keys used in React components **must be manually added** to the `translation.yaml` file.
+They are not populated by the command.
+
+- After using the command, review a translation file to ensure new translation keys are present.
+
+- Automating this command can help keep translation keys updated across multiple locales.
+
+## Resources
+
+- See how to [configure localization](https://redocly.com/docs/realm/author/how-to/config-l10n) in your Redocly project.
+
+- Configure which languages users can select using the [localization option](https://redocly.com/docs/realm/config/l10n) (`l10n`) in `redocly.yaml`.

--- a/docs/commands/translate.md
+++ b/docs/commands/translate.md
@@ -21,7 +21,7 @@ redocly translate --version
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `locale` | string | **REQUIRED**. Name of a locale folder, inside your project's `l10n` directory, to generate translations for. Use `all` for all locales. |
+| `locale` | string | **REQUIRED** Name of a locale folder, inside your project's `l10n` directory, to generate translations for. Use `all` for all locales. |
 | `--lint-config` | string | Severity level for config file linting. Possible values: `warn`, `error`, `off`. Defaults to `warn`. |
 | `--help` | boolean | Show help. |
 | `--version` | boolean | Show version number. |

--- a/docs/commands/translate.md
+++ b/docs/commands/translate.md
@@ -1,6 +1,6 @@
 # `translate`
 
-The `translate` command helps manage multiple translations in your Redocly project.
+The `translate` command helps you to manage multiple translations in your Redocly project (Reef, Revel, or Realm only).
 It creates or updates `translations.yaml` files, populating them with "translation keys" that map to elements in your documentation's UI.
 
 This command serves two purposes:
@@ -28,6 +28,8 @@ redocly translate --version
 
 ## Examples
 
+The following sections show some common use cases for the `translate` command.
+
 ### Populate translation keys for specific locale
 
 The following command generates or updates translations for the Dutch locale:
@@ -36,12 +38,12 @@ The following command generates or updates translations for the Dutch locale:
 redocly translate nl-NL
 ```
 
-This example updates the file `@l10n/nl-NL/translations.yaml`.
+The translations are placed in the file `@l10n/nl-NL/translations.yaml`.
 If the file (or folder) doesn't exist, they're created and populated with translation keys.
 
 ### Populate translation keys for all locales
 
-Use the `all` keyword to generate translations for all locale folders inside the `@l10n` directory:
+Use the `all` keyword to generate translations for all the locale folders inside the `@l10n` directory:
 
 ```bash {% title="Translate all locales" %}
 redocly translate all
@@ -72,7 +74,7 @@ your-awesome-project
 - The command is additive; it doesn't overwrite existing translation keys.
 
 - Custom translation keys used in React components **must be manually added** to the `translation.yaml` file.
-They are not populated by the command.
+  They are not populated by the command.
 
 - After using the command, review a translation file to ensure new translation keys are present.
 

--- a/docs/commands/translate.md
+++ b/docs/commands/translate.md
@@ -19,12 +19,12 @@ redocly translate --version
 
 ## Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `locale` | string | **REQUIRED** Name of a locale folder, inside your project's `l10n` directory, to generate translations for. Use `all` for all locales. |
-| `--lint-config` | string | Severity level for config file linting. Possible values: `warn`, `error`, `off`. Defaults to `warn`. |
-| `--help` | boolean | Show help. |
-| `--version` | boolean | Show version number. |
+| Option          | Type    | Description                                                                                                                            |
+| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `locale`        | string  | **REQUIRED** Name of a locale folder, inside your project's `l10n` directory, to generate translations for. Use `all` for all locales. |
+| `--lint-config` | string  | Severity level for config file linting. Possible values: `warn`, `error`, `off`. Defaults to `warn`.                                   |
+| `--help`        | boolean | Show help.                                                                                                                             |
+| `--version`     | boolean | Show version number.                                                                                                                   |
 
 ## Examples
 

--- a/docs/commands/translate.md
+++ b/docs/commands/translate.md
@@ -13,7 +13,6 @@ This command serves two purposes:
 ```bash
 redocly translate <locale>
 redocly translate all
-redocly translate <locale> [--project-dir=<path>]
 redocly translate --help
 redocly translate --version
 ```
@@ -23,7 +22,6 @@ redocly translate --version
 | Option | Type | Description |
 |--------|------|-------------|
 | `locale` | string | **REQUIRED**. Name of a locale folder, inside your project's `l10n` directory, to generate translations for. Use `all` for all locales. |
-| `--project-dir`, `-d` | string | Specifies the destination of translated files. |
 | `--lint-config` | string | Severity level for config file linting. Possible values: `warn`, `error`, `off`. Defaults to `warn`. |
 | `--help` | boolean | Show help. |
 | `--version` | boolean | Show version number. |

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -12,6 +12,8 @@
           page: commands/build-docs.md
         - label: bundle
           page: commands/bundle.md
+        - label: check-config
+          page: commands/check-config.md
         - label: join
           page: commands/join.md
         - label: lint
@@ -32,8 +34,8 @@
           page: commands/split.md
         - label: stats
           page: commands/stats.md
-        - label: check-config
-          page: commands/check-config.md
+        - label: translate
+          page: commands/translate.md
     - group: Guides
       page: guides/index.md
       items:


### PR DESCRIPTION
## What/Why/How?

- Adds page for `translate` command
- Sidebar entry in commands group

Note: `--project-dir` option not working as expected -- temporarily removed.

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
