### PR TITLE
fix: eject command with no component specified

### DIFF
--- a/.changeset/wicked-birds-jam.md
+++ b/.changeset/wicked-birds-jam.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Allowed to run the `eject` command without specifying components which show a selectable list of all awailable components.
+Added the ability to run the `eject` command without specifying components, which displays a selectable list of all available components.

--- a/.changeset/wicked-birds-jam.md
+++ b/.changeset/wicked-birds-jam.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Allowed to run the `eject` command without specifying components which show a selectable list of all awailable components.

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -5,7 +5,7 @@ import type { VerifyConfigOptions } from '../types';
 
 export type EjectOptions = {
   type: 'component';
-  path: string;
+  path?: string;
   'project-dir'?: string;
   force: boolean;
 } & VerifyConfigOptions;
@@ -20,7 +20,7 @@ export const handleEject = async ({ argv }: CommandArgs<EjectOptions>) => {
       '@redocly/realm',
       'eject',
       `${argv.type}`,
-      `${argv.path}`,
+      `${argv.path ?? ''}`,
       `-d=${argv['project-dir']}`,
       argv.force ? `--force=${argv.force}` : '',
     ],

--- a/packages/cli/src/commands/preview-project/index.ts
+++ b/packages/cli/src/commands/preview-project/index.ts
@@ -26,7 +26,7 @@ export const previewProject = async ({ argv }: CommandArgs<PreviewProjectOptions
 
   spawn(
     npxExecutableName,
-    ['-y', packageName, 'develop', `--plan=${plan}`, `--port=${port || 4000}`],
+    ['-y', packageName, 'preview', `--plan=${plan}`, `--port=${port || 4000}`],
     {
       stdio: 'inherit',
       cwd: projectDir,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -817,7 +817,7 @@ yargs
     }
   )
   .command(
-    'eject <type> <path>',
+    'eject <type> [path]',
     'Helper function to eject project elements for customization.',
     (yargs) =>
       yargs
@@ -830,7 +830,6 @@ yargs
         .positional('path', {
           description: 'Filepath to a component or filepath with glob pattern.',
           type: 'string',
-          demandOption: true,
         })
         .options({
           'project-dir': {


### PR DESCRIPTION
## What/Why/How?

Added the ability to run the `eject` command without specifying components, which displays a selectable list of all available components.

## Reference

Resolves https://github.com/Redocly/redocly/issues/9612#issuecomment-2324936729

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
