### PR TITLE
docs: remove outdated yarn install instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,54 +2,41 @@
 
 Choose the most appropriate installation method for your needs:
 
-- [Install locally, using `npm` or `yarn`](#install-globally) to make the `redocly` command available on your system.
-- [Use `npx` to get the tool at runtime](#use-npx-at-runtime) rather than installing it.
+- [Install locally, using `npm`](#install-globally) to make the `redocly` command available on your system.
+- [Use `npx` to get the tool at runtime](#use-the-command-at-runtime) rather than installing it.
 - The command is also [available via Docker](#docker) if you'd prefer to use it that way.
 
 ## Install globally
 
 {% admonition type="success" name="Tip" %}
-Make sure you have the newest version of `npm`/`yarn` before you begin.
+Make sure you have the newest version of `npm` before you begin.
 {% /admonition %}
 
-{% tabs %}
-{% tab label="npm" %}
+Install the tool with the following command:
 
 ```shell
 npm i -g @redocly/cli@latest
 ```
 
-{% /tab  %}
-{% tab label="yarn" %}
-
-```shell
-yarn global add @redocly/cli
-```
-
-{% /tab  %}
-{% /tabs  %}
-
 Running `redocly --version` confirms that the installation was successful, and the currently-installed version of the tool.
 
-## Use `npx` at runtime
+## Use the command at runtime
 
 [npx](https://docs.npmjs.com/cli/v9/commands/npx/) is npm's package runner. It installs and runs a command without installing it globally. You might use this where you can't install a new command, or in a CI context where the command is only used a handful of times.
-{% tabs %}
-{% tab label="Command" %}
+
+To run Redocly CLI with `npx`, the command looks like the following example:
 
 ```shell
 npx @redocly/cli <command> [options]
 ```
 
-{% /tab  %}
-{% tab label="Example with lint command" %}
+For example, to run `redocly lint` on a file named `openapi.yaml`, use the following command:
 
 ```shell
 npx @redocly/cli@latest lint openapi.yaml
 ```
 
-{% /tab  %}
-{% /tabs  %}
+Replace `redocly` with `npx @redocly/cli@latest` to prepend to other commands you see in documentation.
 
 ## <a id="docker"></a>Run commands inside Docker
 


### PR DESCRIPTION
## What/Why/How?

We received user feedback that the `yarn global` command is not supported in newer versions of yarn, so drop these instructions.

## Reference

(internal feedback link) https://app.cloud.redocly.com/org/redocly/project/marketing-site/feedback/fb_01j5wyxcs83a19tebkxdn8gd1q

Affected page: https://redocly.com/docs/cli/installation

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [x] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
