### PR TITLE
docs: Fix an outdated admonition format

### DIFF
--- a/docs/guides/lint-asyncapi.md
+++ b/docs/guides/lint-asyncapi.md
@@ -99,13 +99,12 @@ opportunities to make sure that your AsyncAPI spec conforms with expectations
 (we'd also love to see what you're building, it helps us know how things are
 going!).
 
-:::info Custom plugins
-
+{% admonition type="info" name="Custom plugins" %}
 For those users with advanced requirements and JavaScript skills, the [custom
 plugins](../custom-plugins/index.md) feature offers some extension points if you need
 them.
 
-:::
+{% /admonition %}
 
 ## Supported protocols
 

--- a/docs/guides/migrate-from-swagger-cli.md
+++ b/docs/guides/migrate-from-swagger-cli.md
@@ -46,13 +46,7 @@ redocly lint openapi.yml
 
 You can add more [built-in rules](../rules/built-in-rules.md) by adding them in the configuration file, and adjust the level of the messages by using `warn` rather than `error`.
 
-<!-- :::info Redocly configuration -->
-
-<!-- :::info Redocly configuration -->
-
 Learn more about [configuring Redocly CLI](../configuration/index.md) in the documentation.
-
-<!-- ::: -->
 
 ## Bundle OpenAPI/Swagger into a single file
 


### PR DESCRIPTION
## What/Why/How?

Spotted a stray `::: info` in one of our guides, so I updated to the new admonition format. Grep also found another one that was in comments, removed that one.

## Reference

https://redocly.com/docs/cli/guides/lint-asyncapi#configurable-rule-example

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
