### PR TITLE
fix: camelCase assertion for single letter

### DIFF
--- a/.changeset/fresh-cheetahs-love.md
+++ b/.changeset/fresh-cheetahs-love.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed camelCase assertion for single letter.
+Fixed `camelCase` assertion for single-letter values.

--- a/.changeset/fresh-cheetahs-love.md
+++ b/.changeset/fresh-cheetahs-love.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed camelCase assertion for single letter.

--- a/packages/core/src/rules/common/assertions/__tests__/asserts.test.ts
+++ b/packages/core/src/rules/common/assertions/__tests__/asserts.test.ts
@@ -317,6 +317,14 @@ describe('oas3 assertions', () => {
         expect(asserts.casing(['testExample', 'fooBar'], 'camelCase', assertionProperties)).toEqual(
           []
         );
+        expect(asserts.casing(['f'], 'camelCase', assertionProperties)).toEqual([]);
+        expect(asserts.casing(['Q'], 'camelCase', assertionProperties)).toEqual([
+          {
+            message: '"Q" should use camelCase',
+            location: baseLocation.child('Q').key(),
+          },
+        ]);
+        expect(asserts.casing(['fQ'], 'camelCase', assertionProperties)).toEqual([]);
         expect(asserts.casing(['testExample', 'FooBar'], 'camelCase', assertionProperties)).toEqual(
           [
             {

--- a/packages/core/src/rules/common/assertions/asserts.ts
+++ b/packages/core/src/rules/common/assertions/asserts.ts
@@ -243,7 +243,7 @@ export const asserts: Asserts = {
     if (typeof value === 'undefined' || isPlainObject(value)) return []; // property doesn't exist or is an object, no need to lint it with this assert
     const values = Array.isArray(value) ? value : [value];
     const casingRegexes: Record<string, RegExp> = {
-      camelCase: /^[a-z]([a-zA-Z0-9]+)?$/g,
+      camelCase: /^[a-z][a-zA-Z0-9]*$/g,
       'kebab-case': /^([a-z][a-z0-9]*)(-[a-z0-9]+)*$/g,
       snake_case: /^([a-z][a-z0-9]*)(_[a-z0-9]+)*$/g,
       PascalCase: /^[A-Z][a-zA-Z0-9]+$/g,

--- a/packages/core/src/rules/common/assertions/asserts.ts
+++ b/packages/core/src/rules/common/assertions/asserts.ts
@@ -243,7 +243,7 @@ export const asserts: Asserts = {
     if (typeof value === 'undefined' || isPlainObject(value)) return []; // property doesn't exist or is an object, no need to lint it with this assert
     const values = Array.isArray(value) ? value : [value];
     const casingRegexes: Record<string, RegExp> = {
-      camelCase: /^[a-z][a-zA-Z0-9]+$/g,
+      camelCase: /^[a-z]([a-zA-Z0-9]+)?$/g,
       'kebab-case': /^([a-z][a-z0-9]*)(-[a-z0-9]+)*$/g,
       snake_case: /^([a-z][a-z0-9]*)(_[a-z0-9]+)*$/g,
       PascalCase: /^[A-Z][a-zA-Z0-9]+$/g,


### PR DESCRIPTION
## What/Why/How?

Fixing reported issue with camelCase assertion:
```
Small issue in camelCase assertion: single-character lower-case string (e.g. f ) is reported as not camelcase
```

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
