### PR TITLE
chore: delay _importDynamic initialization

### DIFF
--- a/.changeset/early-ducks-deliver.md
+++ b/.changeset/early-ducks-deliver.md
@@ -1,5 +1,0 @@
----
-"@redocly/openapi-core": patch
----
-
-Delayed helper function initialization for dynamic plugins import.

--- a/.changeset/early-ducks-deliver.md
+++ b/.changeset/early-ducks-deliver.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Delayed helper function initialization for dynamic plugins import.

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -40,9 +40,6 @@ import type { Document, ResolvedRefMap } from '../resolve';
 
 const DEFAULT_PROJECT_PLUGIN_PATHS = ['@theme/plugin.js', '@theme/plugin.cjs', '@theme/plugin.mjs'];
 
-// Workaround for dynamic imports being transpiled to require by Typescript: https://github.com/microsoft/TypeScript/issues/43329#issuecomment-811606238
-const _importDynamic = new Function('modulePath', 'return import(modulePath)');
-
 // Cache instantiated plugins during a single execution
 const pluginsCache: Map<string, Plugin> = new Map();
 
@@ -151,6 +148,8 @@ export async function resolvePlugins(
             // @ts-ignore
             requiredPlugin = __non_webpack_require__(absolutePluginPath);
           } else {
+            // Workaround for dynamic imports being transpiled to require by Typescript: https://github.com/microsoft/TypeScript/issues/43329#issuecomment-811606238
+            const _importDynamic = new Function('modulePath', 'return import(modulePath)');
             // you can import both cjs and mjs
             const mod = await _importDynamic(pathToFileURL(absolutePluginPath).href);
             requiredPlugin = mod.default || mod;


### PR DESCRIPTION
## What/Why/How?
We use some of `@redocly/openapi-core` util functions in Reunite.
`_importDynamic` is an eval function that is initialized in the root of `config-resolvers` module which violates content security policies in Reunite.
This PR delays `_importDynamic ` init to a later time - avoiding it's initialization in Reunite completely.

## Reference
https://github.com/Redocly/redocly/issues/11257

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
