### PR TITLE
fix: expand glob before checking API count in join

### DIFF
--- a/.changeset/long-donkeys-bathe.md
+++ b/.changeset/long-donkeys-bathe.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue where join threw an error when glob was provided.
+Fixed an issue where `join` would throw an error when a glob pattern was provided.

--- a/.changeset/long-donkeys-bathe.md
+++ b/.changeset/long-donkeys-bathe.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue where join threw an error when glob was provided.

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -64,18 +64,12 @@ export async function handleJoin({
 }: CommandArgs<JoinOptions>) {
   const startedAt = performance.now();
 
-  if (argv.apis.length < 2) {
-    return exitWithError(`At least 2 apis should be provided.`);
-  }
-
-  const fileExtension = getAndValidateFileExtension(argv.output || argv.apis[0]);
-
   const {
     'prefix-components-with-info-prop': prefixComponentsWithInfoProp,
     'prefix-tags-with-filename': prefixTagsWithFilename,
     'prefix-tags-with-info-prop': prefixTagsWithInfoProp,
     'without-x-tag-groups': withoutXTagGroups,
-    output: specFilename = `openapi.${fileExtension}`,
+    output,
   } = argv;
 
   const usedTagsOptions = [
@@ -91,6 +85,13 @@ export async function handleJoin({
   }
 
   const apis = await getFallbackApisOrExit(argv.apis, config);
+  if (apis.length < 2) {
+    return exitWithError(`At least 2 APIs should be provided.`);
+  }
+
+  const fileExtension = getAndValidateFileExtension(output || apis[0].path);
+  const specFilename = output || `openapi.${fileExtension}`;
+
   const externalRefResolver = new BaseResolver(config.resolve);
   const documents = await Promise.all(
     apis.map(


### PR DESCRIPTION
## What/Why/How?

Fixes https://github.com/Redocly/redocly-cli/issues/1196.

## Reference

## Testing

Tested locally in `/bin/sh` env and works where it was previously failing.

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
