### PR TITLE
feat: remove support of x-assert extension for spot

### DIFF
--- a/.changeset/happy-avocados-rule.md
+++ b/.changeset/happy-avocados-rule.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Removed support of `x-assert` extension for Arazzo.
+Removed support of the `x-assert` extension for Arazzo.

--- a/.changeset/happy-avocados-rule.md
+++ b/.changeset/happy-avocados-rule.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Removed support of `x-assert` extension for Arazzo.

--- a/packages/core/src/types/arazzo.ts
+++ b/packages/core/src/types/arazzo.ts
@@ -145,7 +145,6 @@ const Step: NodeType = {
     outputs: 'Outputs',
     'x-inherit': { enum: ['auto', 'none'] },
     'x-expect': 'ExpectSchema',
-    'x-assert': { type: 'string' },
     'x-operation': 'ExtendedOperation',
     requestBody: 'RequestBody',
   },

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -115,7 +115,6 @@ export interface Step {
   };
   'x-inherit'?: 'auto' | 'none';
   'x-expect'?: ExpectSchema;
-  'x-assert'?: string;
   'x-operation'?: ExtendedOperation;
   requestBody?: RequestBody;
 }


### PR DESCRIPTION
## What/Why/How?

Remove support of x-assert extension for spot.

## Reference

Closes: https://github.com/Redocly/redocly/issues/11345

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
