### PR TITLE
fix: component-name-unique rule should report location

### DIFF
--- a/.changeset/real-chicken-cheat.md
+++ b/.changeset/real-chicken-cheat.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": minor
 ---
 
-Fixed `component-name-unique` problems to include correct location
+Fixed `component-name-unique` problems to include correct location.

--- a/.changeset/real-chicken-cheat.md
+++ b/.changeset/real-chicken-cheat.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": minor
+---
+
+Fixed `component-name-unique` problems to include correct location

--- a/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
@@ -49,9 +49,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
-        - /foobar.yaml#/components/schemas/SomeSchema
+            "message": "Component 'schemas/SomeSchema' is not unique. It is also defined at:
         - /test.yaml#/components/schemas/SomeSchema",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/schemas/SomeSchema",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'schemas/SomeSchema' is not unique. It is also defined at:
+        - /foobar.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -104,9 +117,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
-        - /foobar.yaml#/components/schemas/SomeSchema
+            "message": "Component 'schemas/SomeSchema' is not unique. It is also defined at:
         - /SomeSchema.yaml",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/",
+                "reportOnKey": false,
+                "source": "/SomeSchema.yaml",
+              },
+            ],
+            "message": "Component 'schemas/SomeSchema' is not unique. It is also defined at:
+        - /foobar.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -207,9 +233,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at:
-        - /foobar.yaml#/components/parameters/ParameterOne
+            "message": "Component 'parameters/ParameterOne' is not unique. It is also defined at:
         - /test.yaml#/components/parameters/ParameterOne",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/parameters/ParameterOne",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'parameters/ParameterOne' is not unique. It is also defined at:
+        - /foobar.yaml#/components/parameters/ParameterOne",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -266,9 +305,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at:
-        - /foobar.yaml#/components/parameters/ParameterOne
+            "message": "Component 'parameters/ParameterOne' is not unique. It is also defined at:
         - /ParameterOne.yaml",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/",
+                "reportOnKey": false,
+                "source": "/ParameterOne.yaml",
+              },
+            ],
+            "message": "Component 'parameters/ParameterOne' is not unique. It is also defined at:
+        - /foobar.yaml#/components/parameters/ParameterOne",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -383,9 +435,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at:
-        - /foobar.yaml#/components/responses/SuccessResponse
+            "message": "Component 'responses/SuccessResponse' is not unique. It is also defined at:
         - /test.yaml#/components/responses/SuccessResponse",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/responses/SuccessResponse",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'responses/SuccessResponse' is not unique. It is also defined at:
+        - /foobar.yaml#/components/responses/SuccessResponse",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -449,9 +514,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at:
-        - /foobar.yaml#/components/responses/SuccessResponse
+            "message": "Component 'responses/SuccessResponse' is not unique. It is also defined at:
         - /SuccessResponse.yaml",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/",
+                "reportOnKey": false,
+                "source": "/SuccessResponse.yaml",
+              },
+            ],
+            "message": "Component 'responses/SuccessResponse' is not unique. It is also defined at:
+        - /foobar.yaml#/components/responses/SuccessResponse",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -570,9 +648,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
         - /test.yaml#/components/requestBodies/MyRequestBody",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/requestBodies/MyRequestBody",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -637,9 +728,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
         - /MyRequestBody.yaml",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/",
+                "reportOnKey": false,
+                "source": "/MyRequestBody.yaml",
+              },
+            ],
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -766,9 +870,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
         - /test.yaml#/components/requestBodies/MyRequestBody",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/requestBodies/MyRequestBody",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -781,9 +898,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
-        - /foobar.yaml#/components/schemas/SomeSchema
+            "message": "Component 'schemas/SomeSchema' is not unique. It is also defined at:
         - /test.yaml#/components/schemas/SomeSchema",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/schemas/SomeSchema",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'schemas/SomeSchema' is not unique. It is also defined at:
+        - /foobar.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -809,9 +939,22 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
         - /test.yaml#/components/requestBodies/MyRequestBody",
+            "ruleId": "component-name-unique",
+            "severity": "error",
+            "suggest": [],
+          },
+          {
+            "location": [
+              {
+                "pointer": "#/components/requestBodies/MyRequestBody",
+                "reportOnKey": false,
+                "source": "/test.yaml",
+              },
+            ],
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is also defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],

--- a/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
@@ -44,7 +44,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/schemas/SomeSchema",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -99,7 +99,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/schemas/SomeSchema",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -202,7 +202,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/parameters/ParameterOne",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -261,7 +261,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/parameters/ParameterOne",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -378,7 +378,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/responses/SuccessResponse",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -444,7 +444,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/responses/SuccessResponse",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -565,7 +565,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/requestBodies/MyRequestBody",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -632,7 +632,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/requestBodies/MyRequestBody",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -761,7 +761,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/requestBodies/MyRequestBody",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -776,7 +776,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/schemas/SomeSchema",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },
@@ -804,7 +804,7 @@ describe('Oas3 component-name-unique', () => {
           {
             "location": [
               {
-                "pointer": "#/",
+                "pointer": "#/components/requestBodies/MyRequestBody",
                 "reportOnKey": false,
                 "source": "/foobar.yaml",
               },

--- a/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
@@ -49,9 +49,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
-        - /foobar.yaml#/components/schemas/SomeSchema
-        - /test.yaml#/components/schemas/SomeSchema",
+            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at: /foobar.yaml#/components/schemas/SomeSchema, /test.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -104,9 +102,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
-        - /foobar.yaml#/components/schemas/SomeSchema
-        - /SomeSchema.yaml",
+            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at: /foobar.yaml#/components/schemas/SomeSchema, /SomeSchema.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -207,9 +203,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at:
-        - /foobar.yaml#/components/parameters/ParameterOne
-        - /test.yaml#/components/parameters/ParameterOne",
+            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at: /foobar.yaml#/components/parameters/ParameterOne, /test.yaml#/components/parameters/ParameterOne",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -266,9 +260,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at:
-        - /foobar.yaml#/components/parameters/ParameterOne
-        - /ParameterOne.yaml",
+            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at: /foobar.yaml#/components/parameters/ParameterOne, /ParameterOne.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -383,9 +375,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at:
-        - /foobar.yaml#/components/responses/SuccessResponse
-        - /test.yaml#/components/responses/SuccessResponse",
+            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at: /foobar.yaml#/components/responses/SuccessResponse, /test.yaml#/components/responses/SuccessResponse",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -449,9 +439,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at:
-        - /foobar.yaml#/components/responses/SuccessResponse
-        - /SuccessResponse.yaml",
+            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at: /foobar.yaml#/components/responses/SuccessResponse, /SuccessResponse.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -570,9 +558,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
-        - /test.yaml#/components/requestBodies/MyRequestBody",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /test.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -637,9 +623,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
-        - /MyRequestBody.yaml",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /MyRequestBody.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -766,9 +750,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
-        - /test.yaml#/components/requestBodies/MyRequestBody",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /test.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -781,9 +763,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
-        - /foobar.yaml#/components/schemas/SomeSchema
-        - /test.yaml#/components/schemas/SomeSchema",
+            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at: /foobar.yaml#/components/schemas/SomeSchema, /test.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -809,9 +789,7 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
-        - /foobar.yaml#/components/requestBodies/MyRequestBody
-        - /test.yaml#/components/requestBodies/MyRequestBody",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /test.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],

--- a/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/component-name-unique.test.ts
@@ -49,7 +49,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at: /foobar.yaml#/components/schemas/SomeSchema, /test.yaml#/components/schemas/SomeSchema",
+            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
+        - /foobar.yaml#/components/schemas/SomeSchema
+        - /test.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -102,7 +104,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at: /foobar.yaml#/components/schemas/SomeSchema, /SomeSchema.yaml",
+            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
+        - /foobar.yaml#/components/schemas/SomeSchema
+        - /SomeSchema.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -203,7 +207,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at: /foobar.yaml#/components/parameters/ParameterOne, /test.yaml#/components/parameters/ParameterOne",
+            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at:
+        - /foobar.yaml#/components/parameters/ParameterOne
+        - /test.yaml#/components/parameters/ParameterOne",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -260,7 +266,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at: /foobar.yaml#/components/parameters/ParameterOne, /ParameterOne.yaml",
+            "message": "Component 'parameters/ParameterOne' is not unique. It is defined at:
+        - /foobar.yaml#/components/parameters/ParameterOne
+        - /ParameterOne.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -375,7 +383,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at: /foobar.yaml#/components/responses/SuccessResponse, /test.yaml#/components/responses/SuccessResponse",
+            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at:
+        - /foobar.yaml#/components/responses/SuccessResponse
+        - /test.yaml#/components/responses/SuccessResponse",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -439,7 +449,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at: /foobar.yaml#/components/responses/SuccessResponse, /SuccessResponse.yaml",
+            "message": "Component 'responses/SuccessResponse' is not unique. It is defined at:
+        - /foobar.yaml#/components/responses/SuccessResponse
+        - /SuccessResponse.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -558,7 +570,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /test.yaml#/components/requestBodies/MyRequestBody",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody
+        - /test.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -623,7 +637,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /MyRequestBody.yaml",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody
+        - /MyRequestBody.yaml",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -750,7 +766,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /test.yaml#/components/requestBodies/MyRequestBody",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody
+        - /test.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -763,7 +781,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at: /foobar.yaml#/components/schemas/SomeSchema, /test.yaml#/components/schemas/SomeSchema",
+            "message": "Component 'schemas/SomeSchema' is not unique. It is defined at:
+        - /foobar.yaml#/components/schemas/SomeSchema
+        - /test.yaml#/components/schemas/SomeSchema",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],
@@ -789,7 +809,9 @@ describe('Oas3 component-name-unique', () => {
                 "source": "/foobar.yaml",
               },
             ],
-            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at: /foobar.yaml#/components/requestBodies/MyRequestBody, /test.yaml#/components/requestBodies/MyRequestBody",
+            "message": "Component 'requestBodies/MyRequestBody' is not unique. It is defined at:
+        - /foobar.yaml#/components/requestBodies/MyRequestBody
+        - /test.yaml#/components/requestBodies/MyRequestBody",
             "ruleId": "component-name-unique",
             "severity": "error",
             "suggest": [],

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -59,9 +59,11 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
           if (value.absolutePointers.size > 1) {
             const component = getComponentFromKey(key);
             const optionComponentName = getOptionComponentNameForTypeName(component.typeName);
-            const definitions = Array.from(value.absolutePointers).join(', ');
+            const definitions = Array.from(value.absolutePointers)
+              .map((v) => `- ${v}`)
+              .join('\n');
             const problem: Problem = {
-              message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
+              message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at:\n${definitions}`,
             };
             problem.location = {
               ...value.locations.sort((a, b) =>

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -59,12 +59,10 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
           if (value.absolutePointers.size > 1) {
             const component = getComponentFromKey(key);
             const optionComponentName = getOptionComponentNameForTypeName(component.typeName);
-            const definitions = Array.from(value)
-              .map((v) => `- ${v}`)
-              .join('\n');
+            const definitions = Array.from(value.absolutePointers).join(', ');
 
             const problem: Problem = {
-              message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at:\n${definitions}`,
+              message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
             };
             problem.location = {
             ...value.locations[0],

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -60,7 +60,7 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
             const component = getComponentFromKey(key);
             const optionComponentName = getOptionComponentNameForTypeName(component.typeName);
             const componentSeverity = optionComponentName ? options[optionComponentName] : null;
-            value.locations.forEach((location) => {
+            for (const location of value.locations) {
               const definitions = Array.from(value.absolutePointers)
                 .filter((v) => v !== location.absolutePointer.toString())
                 .map((v) => `- ${v}`)
@@ -73,8 +73,7 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
                 problem.forceSeverity = componentSeverity;
               }
               ctx.report(problem);
-            });
-
+            }
           }
         });
       },

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -133,7 +133,7 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
     const entry: ComponentsMapValue = components.get(key) ?? {
       absolutePointers: new Set(),
       locations: []
-    } satisfies ComponentsMapValue;
+    };
     const absoluteLocation = location.absolutePointer.toString();
     if (!entry.absolutePointers.has(absoluteLocation)) {
       entry.absolutePointers.add(absoluteLocation);

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -1,4 +1,4 @@
-import type { Location } from "../../ref-utils";
+import type { Location } from '../../ref-utils';
 import type { Problem, UserContext } from '../../walk';
 import type { Oas2Rule, Oas3Rule, Oas3Visitor } from '../../visitors';
 import type {
@@ -22,7 +22,7 @@ const TYPE_NAME_TO_OPTION_COMPONENT_NAME: { [key: string]: string } = {
   [TYPE_NAME_REQUEST_BODY]: 'requestBodies',
 };
 
-type ComponentsMapValue = { absolutePointers: Set<string>, locations: Location[] };
+type ComponentsMapValue = { absolutePointers: Set<string>; locations: Location[] };
 
 export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
   const components = new Map<string, ComponentsMapValue>();
@@ -64,7 +64,9 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
               message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
             };
             problem.location = {
-              ...value.locations.sort((a, b) => a.absolutePointer.localeCompare(b.absolutePointer))[0],
+              ...value.locations.sort((a, b) =>
+                a.absolutePointer.localeCompare(b.absolutePointer)
+              )[0],
             };
 
             const componentSeverity = optionComponentName ? options[optionComponentName] : null;
@@ -124,15 +126,11 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
     return componentName;
   }
 
-  function addFoundComponent(
-    typeName: string,
-    componentName: string,
-    location: Location
-  ): void {
+  function addFoundComponent(typeName: string, componentName: string, location: Location): void {
     const key = getKeyForComponent(typeName, componentName);
     const entry: ComponentsMapValue = components.get(key) ?? {
       absolutePointers: new Set(),
-      locations: []
+      locations: [],
     };
     const absoluteLocation = location.absolutePointer.toString();
     if (!entry.absolutePointers.has(absoluteLocation)) {

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -59,23 +59,22 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
           if (value.absolutePointers.size > 1) {
             const component = getComponentFromKey(key);
             const optionComponentName = getOptionComponentNameForTypeName(component.typeName);
-            const definitions = Array.from(value.absolutePointers)
-              .map((v) => `- ${v}`)
-              .join('\n');
-            const problem: Problem = {
-              message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at:\n${definitions}`,
-            };
-            problem.location = {
-              ...value.locations.sort((a, b) =>
-                a.absolutePointer.localeCompare(b.absolutePointer)
-              )[0],
-            };
-
             const componentSeverity = optionComponentName ? options[optionComponentName] : null;
-            if (componentSeverity) {
-              problem.forceSeverity = componentSeverity;
-            }
-            ctx.report(problem);
+            value.locations.forEach((location) => {
+              const definitions = Array.from(value.absolutePointers)
+                .filter((v) => v !== location.absolutePointer.toString())
+                .map((v) => `- ${v}`)
+                .join('\n');
+              const problem: Problem = {
+                message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is also defined at:\n${definitions}`,
+                location: location,
+              };
+              if (componentSeverity) {
+                problem.forceSeverity = componentSeverity;
+              }
+              ctx.report(problem);
+            });
+
           }
         });
       },

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -74,22 +74,6 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
               problem.forceSeverity = componentSeverity;
             }
             ctx.report(problem);
-            // value.locations.forEach((location) => {
-            //   const problem: Problem = {
-            //     message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
-            //   };
-            //   problem.location = {
-            //     ...location,
-            //     //   reportOnKey:
-            //     // error.keyword === 'unevaluatedProperties' || error.keyword === 'additionalProperties',
-            //   };
-            //
-            //   const componentSeverity = optionComponentName ? options[optionComponentName] : null;
-            //   if (componentSeverity) {
-            //     problem.forceSeverity = componentSeverity;
-            //   }
-            //   ctx.report(problem);
-            // });
           }
         });
       },

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -74,6 +74,22 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
               problem.forceSeverity = componentSeverity;
             }
             ctx.report(problem);
+            // value.locations.forEach((location) => {
+            //   const problem: Problem = {
+            //     message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
+            //   };
+            //   problem.location = {
+            //     ...location,
+            //     //   reportOnKey:
+            //     // error.keyword === 'unevaluatedProperties' || error.keyword === 'additionalProperties',
+            //   };
+            //
+            //   const componentSeverity = optionComponentName ? options[optionComponentName] : null;
+            //   if (componentSeverity) {
+            //     problem.forceSeverity = componentSeverity;
+            //   }
+            //   ctx.report(problem);
+            // });
           }
         });
       },

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -60,14 +60,11 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
             const component = getComponentFromKey(key);
             const optionComponentName = getOptionComponentNameForTypeName(component.typeName);
             const definitions = Array.from(value.absolutePointers).join(', ');
-
             const problem: Problem = {
               message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
             };
             problem.location = {
-            ...value.locations[0],
-              //   reportOnKey:
-              // error.keyword === 'unevaluatedProperties' || error.keyword === 'additionalProperties',
+              ...value.locations.sort((a, b)=> a.absolutePointer.localeCompare(b.absolutePointer))[0],
             };
 
             const componentSeverity = optionComponentName ? options[optionComponentName] : null;

--- a/packages/core/src/rules/oas3/component-name-unique.ts
+++ b/packages/core/src/rules/oas3/component-name-unique.ts
@@ -64,7 +64,7 @@ export const ComponentNameUnique: Oas3Rule | Oas2Rule = (options) => {
               message: `Component '${optionComponentName}/${component.componentName}' is not unique. It is defined at: ${definitions}`,
             };
             problem.location = {
-              ...value.locations.sort((a, b)=> a.absolutePointer.localeCompare(b.absolutePointer))[0],
+              ...value.locations.sort((a, b) => a.absolutePointer.localeCompare(b.absolutePointer))[0],
             };
 
             const componentSeverity = optionComponentName ? options[optionComponentName] : null;


### PR DESCRIPTION
## What/Why/How?
What: This sets the location on the reported problem & makes the message one line instead of multiple lines.

Why: The `component-name-unique` didn't report any location. That location is specifically useful when using the ignore file. The message is more aligned with the other reports.

How: By using passing the `location` and reporting it instead of just passing the `absolutePointer`.

## Reference

## Testing
See updated test code.

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
