### PR TITLE
feat: remove x-parameters extension for Spot

### DIFF
--- a/.changeset/stupid-suits-deny.md
+++ b/.changeset/stupid-suits-deny.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Removed support of the `x-parameters` extension for Arazzo.
+Removed the support of the `x-parameters` extension for Arazzo description files.

--- a/.changeset/stupid-suits-deny.md
+++ b/.changeset/stupid-suits-deny.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Removed support of the `x-parameters` extension for Arazzo.

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -305,7 +305,6 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
       }
     case SpecMajorVersion.Arazzo:
       switch (typeName) {
-        case 'Root.x-parameters_items':
         case 'Root.workflows_items.parameters_items':
         case 'Root.workflows_items.steps_items.parameters_items':
           return 'parameters';

--- a/packages/core/src/types/arazzo.ts
+++ b/packages/core/src/types/arazzo.ts
@@ -7,7 +7,6 @@ const Root: NodeType = {
     arazzo: { type: 'string' },
     info: 'Info',
     sourceDescriptions: 'SourceDescriptions',
-    'x-parameters': 'Parameters',
     workflows: 'Workflows',
     components: 'Components',
   },

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -147,7 +147,6 @@ export interface ArazzoDefinition {
   arazzo: '1.0.0';
   info: InfoObject;
   sourceDescriptions: SourceDescription[];
-  'x-parameters'?: Parameter[];
   workflows: Workflow[];
   components?: {
     inputs?: {


### PR DESCRIPTION
## What/Why/How?

Remove x-parameters extension for Spot.

## Reference

https://github.com/Redocly/redocly/issues/11341

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
