### PR TITLE
feat: removed the support of the `x-inherit` extension for Spot

### DIFF
--- a/.changeset/smooth-actors-sneeze.md
+++ b/.changeset/smooth-actors-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Removed the support of the `x-inherit` extension for Arazzo description files.

--- a/packages/core/src/types/arazzo.ts
+++ b/packages/core/src/types/arazzo.ts
@@ -142,7 +142,6 @@ const Step: NodeType = {
     onSuccess: 'OnSuccessActionList',
     onFailure: 'OnFailureActionList',
     outputs: 'Outputs',
-    'x-inherit': { enum: ['auto', 'none'] },
     'x-expect': 'ExpectSchema',
     'x-operation': 'ExtendedOperation',
     requestBody: 'RequestBody',

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -129,7 +129,6 @@ export interface Step {
   outputs?: {
     [key: string]: string | object | any[] | boolean | number;
   };
-  'x-inherit'?: 'auto' | 'none';
   'x-expect'?: ExpectSchema;
   'x-operation'?: ExtendedOperation;
   requestBody?: RequestBody;


### PR DESCRIPTION
## What/Why/How?

 Removed the support of the `x-inherit` extension for Spot

## Reference

https://github.com/Redocly/redocly/issues/11346

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
