### PR TITLE
chore: bump `redoc` to the latest

### DIFF
--- a/.changeset/hip-ducks-hear.md
+++ b/.changeset/hip-ducks-hear.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Updated redoc to v2.2.0
+Updated redoc to v2.2.0.

--- a/.changeset/hip-ducks-hear.md
+++ b/.changeset/hip-ducks-hear.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Updated redoc to v2.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -11144,9 +11144,9 @@
       }
     },
     "node_modules/redoc": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.1.5.tgz",
-      "integrity": "sha512-POSbVg+7WLf+/5/c6GWLxL7+9t2D+1WlZdLN0a6qaCQc+ih3XYzteRBkXEN5kjrYrRNjdspfxTZkDLN5WV3Tzg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.2.0.tgz",
+      "integrity": "sha512-52rz/xJtpUBc3Y/GAkaX03czKhQXTxoU7WnkXNzRLuGwiGb/iEO4OgwcgQqtwHWrYNaZXTyqZ4MAVXpi/e1gAg==",
       "dependencies": {
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@redocly/openapi-core": "^1.4.0",
@@ -13756,7 +13756,7 @@
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0",
         "react-dom": "^17.0.0 || ^18.2.0",
-        "redoc": "~2.1.5",
+        "redoc": "~2.2.0",
         "semver": "^7.5.2",
         "simple-websocket": "^9.0.0",
         "styled-components": "^6.0.7",
@@ -16481,7 +16481,7 @@
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0",
         "react-dom": "^17.0.0 || ^18.2.0",
-        "redoc": "~2.1.5",
+        "redoc": "~2.2.0",
         "semver": "^7.5.2",
         "simple-websocket": "^9.0.0",
         "styled-components": "^6.0.7",
@@ -22243,9 +22243,9 @@
       }
     },
     "redoc": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.1.5.tgz",
-      "integrity": "sha512-POSbVg+7WLf+/5/c6GWLxL7+9t2D+1WlZdLN0a6qaCQc+ih3XYzteRBkXEN5kjrYrRNjdspfxTZkDLN5WV3Tzg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.2.0.tgz",
+      "integrity": "sha512-52rz/xJtpUBc3Y/GAkaX03czKhQXTxoU7WnkXNzRLuGwiGb/iEO4OgwcgQqtwHWrYNaZXTyqZ4MAVXpi/e1gAg==",
       "requires": {
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@redocly/openapi-core": "^1.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "pluralize": "^8.0.0",
     "react": "^17.0.0 || ^18.2.0",
     "react-dom": "^17.0.0 || ^18.2.0",
-    "redoc": "~2.1.5",
+    "redoc": "~2.2.0",
     "semver": "^7.5.2",
     "simple-websocket": "^9.0.0",
     "styled-components": "^6.0.7",


### PR DESCRIPTION
## What/Why/How?
It should fix the next vulnerabilities for the `openapi-starter`:
- https://github.com/Redocly/openapi-starter/security/dependabot/17
- https://github.com/Redocly/openapi-starter/security/dependabot/18

## Reference
https://app.vanta.com/tests/packages-checked-for-vulnerabilities-v2-records-closed-github-dependabot-high?tab=results

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
