### PR TITLE
docs: replace absolute links for a more portable docs set

### DIFF
--- a/docs/rules/no-server-example-com.md
+++ b/docs/rules/no-server-example-com.md
@@ -27,7 +27,7 @@ Although commonly used in different kinds of documentation, `example.com` is not
 Your consumers cannot use it to test your APIs.
 Be helpful - give them something they can use.
 
-If you can't reveal a production server, consider a [Redocly mock server](/docs/api-registry/guides/mock-server-quickstart.md) instead.
+If you can't reveal a production server, consider a [Redocly mock server](https://redocly.com/docs/realm/author/how-to/try-apis-with-mock-server) instead.
 
 ## Configuration
 

--- a/docs/rules/no-unresolved-refs.md
+++ b/docs/rules/no-unresolved-refs.md
@@ -91,4 +91,4 @@ components:
 ## Resources
 
 - [Rule source](https://github.com/Redocly/redocly-cli/blob/main/packages/core/src/rules/no-unresolved-refs.ts)
-- Read our guide on [how to use JSON references ($refs)](/docs/resources/ref-guide.md)
+- Read our guide on [how to use JSON references ($refs)](https://redocly.com/docs/resources/ref-guide)

--- a/docs/rules/required-string-property-missing-min-length.md
+++ b/docs/rules/required-string-property-missing-min-length.md
@@ -19,7 +19,7 @@ The `minLength` keyword constrains string values. When a property of type `strin
 ## Configuration
 
 To configure the rule, add it to the `rules` object in your configuration file.
-Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
+Set the desired [severity](../rules.md#severity-settings) for the rule.
 
 ```yaml
 rules:

--- a/docs/rules/scalar-property-missing-example.md
+++ b/docs/rules/scalar-property-missing-example.md
@@ -22,7 +22,7 @@ Providing examples for properties in your API description not only improves the 
 ## Configuration
 
 To configure the rule, add it to the `rules` object in your configuration file.
-Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
+Set the desired [severity](../rules.md#severity-settings) for the rule.
 
 ```yaml
 rules:

--- a/docs/rules/spec-strict-refs.md
+++ b/docs/rules/spec-strict-refs.md
@@ -36,7 +36,7 @@ The following is a list of elements the `$ref` can be used with according to the
 ## Configuration
 
 To configure the rule, add it to the `rules` object in your configuration file, and
-set the desired [severity](/docs/cli/rules.md#severity-settings).
+set the desired [severity](../rules.md#severity-settings).
 
 | Option   | Type   | Description                                                                              |
 | -------- | ------ | ---------------------------------------------------------------------------------------- |

--- a/docs/rules/tag-description.md
+++ b/docs/rules/tag-description.md
@@ -41,7 +41,7 @@ Remember folks, we use docs-as-code to write the docs, but the docs are the prod
 ## Configuration
 
 To configure the rule, add it to the `rules` object in your configuration file.
-Set the desired [severity](/docs/cli/rules.md#severity-settings) for the rule.
+Set the desired [severity](../rules.md#severity-settings) for the rule.
 
 ```yaml
 rules:


### PR DESCRIPTION
## What/Why/How?

When using the CLI docs by themselves, they report some broken links. Update them to be relative or fully-qualified.

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
