### PR TITLE
docs(all): changes admonition type from 'attention' to 'info'

### DIFF
--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -152,7 +152,7 @@ Apart from uploading your API description file, the `push` command can automatic
 - The `package.json` file (if it exists) from the folder where you're executing the `push` command. Redocly Workflows uses the `@redocly/cli` version specified in `package.json`.
 - The HTML template and the full contents of the folder specified as the `theme.openapi.htmlTemplate` parameter in the Redocly configuration file.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 If a plugin is referenced in the Redocly configuration file, the `push` command recursively scans the folder containing the plugin and uploads all `.js`, `.json`, `.mjs` and `.ts` files.
 
 Make sure that each plugin has all the required files in its folder; otherwise, they are not uploaded.
@@ -260,7 +260,7 @@ Note that the organization ID can differ from the organization name. Owners can 
 
 #### API name and version
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 The name and version of your API should contain only supported characters (`a-z`, `A-Z`, `0-9`, `-`, `.`). Using a restricted character results in an error, and your API doesn't get created.
 {% /admonition %}
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -242,6 +242,6 @@ theme:
     $ref: ./mockserver.yaml
 ```
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 When using the `push` command with a config file that includes `$ref`s, all referenced files are explicitly uploaded using the `--files` option.
 {% /admonition %}

--- a/docs/custom-plugins/visitor.md
+++ b/docs/custom-plugins/visitor.md
@@ -67,7 +67,7 @@ The `Schema` **visitor function** is called by Redocly CLI only if the Schema Ob
 
 As the third argument, `enter()` in a **nested visitor object** accepts the `parents` object with corresponding parent nodes as defined in the **visitor object**.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 It is executed only for the first level of the Schema Object.
 {% /admonition %}
 

--- a/docs/guides/configure-rules.md
+++ b/docs/guides/configure-rules.md
@@ -36,7 +36,7 @@ extends:
 
 The configuration here is _very_ minimal with only the ruleset defined so far. Your config file also holds settings for themes, much more detailed configuration for linting and decorating, and custom plugins.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 You can also define rulesets and other linting details differently for each API if you need to.
 {% /admonition %}
 

--- a/docs/guides/hide-apis.md
+++ b/docs/guides/hide-apis.md
@@ -26,7 +26,7 @@ The following image highlights what is to be removed in this tutorial.
 
 ## Prerequisites
 
-{% admonition type="note" name="We do, You do" %}
+{% admonition type="info" name="We do, You do" %}
 This tutorial is most effective when you follow along and complete the steps.
 {% /admonition %}
 

--- a/docs/guides/hide-specification-extensions.md
+++ b/docs/guides/hide-specification-extensions.md
@@ -19,7 +19,7 @@ For this tutorial, we've prepared a sample containing OpenAPI specification exte
 
 ## Prerequisites
 
-{% admonition type="note" name="We do, You do" %}
+{% admonition type="info" name="We do, You do" %}
 This tutorial is most effective when you follow along and complete the steps.
 {% /admonition %}
 

--- a/docs/guides/hide-specification-extensions.md
+++ b/docs/guides/hide-specification-extensions.md
@@ -54,7 +54,7 @@ In this step, create a custom plugin and define the decorator dependency.
 
 1. Save the file.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 You can name the plugins directory and the file anything you want. Make sure you use the correct name in the Redocly configuration file (Step 3 below).
 {% /admonition %}
 
@@ -88,7 +88,7 @@ You can name the plugins directory and the file anything you want. Make sure you
 
 1. Save the file.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 You can name the decorators directory anything you want. Make sure you use the correct directory name in the line 1 of the `plugin.js` file (Step 1 above).
 {% /admonition %}
 

--- a/docs/guides/replace-servers-url.md
+++ b/docs/guides/replace-servers-url.md
@@ -94,7 +94,7 @@ module.exports = function replaceServersUrlPlugin() {
 
 3. Save the file.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 If you change the names of the plugins directory or the files, make sure to change them also in the Redocly configuration file [when registering your plugins and decorators](#add-a-decorator-and-associate-it-with-an-environment-variable).
 {% /admonition %}
 
@@ -128,7 +128,7 @@ function ReplaceServersURL({serverUrl}) {
 
 3. Save the file.
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 If you change the name of the decorators directory, make sure to also change it in line 1 of the [`plugin.js` file](#create-a-custom-plugin).
 {% /admonition %}
 

--- a/docs/guides/response-contains-property.md
+++ b/docs/guides/response-contains-property.md
@@ -35,13 +35,13 @@ Let's get started!
         └── users_{username}.yaml
 ```
 
-{% admonition type="note" %}
+{% admonition type="info" %}
 Make sure that the @redocly/cli has version `1.0.0-beta.99` or later
 {% /admonition %}
 
 - If you're using VS Code as your favorite code editor, we recommend you install the [Redocly OpenAPI VS Code extension](https://redocly.com/docs/redocly-openapi/).
 
-{% admonition type="note" name="We do, You do" %}
+{% admonition type="info" name="We do, You do" %}
 This guide is most effective when you follow along and complete the steps.
 {% /admonition %}
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ Before you start:
 - Create a new project folder and `cd` into the folder
 - If you have an OpenAPI description to use, copy it into your project (we assume it's called `openapi.yaml`), or [try our example](https://github.com/Redocly/openapi-starter/blob/main/openapi/openapi.yaml)
 
-{% admonition type="attention" %}
+{% admonition type="info" %}
 There's also an [openapi-starter](https://github.com/Redocly/openapi-starter) repository that you can clone and experiment with to get your bearings
 {% /admonition %}
 


### PR DESCRIPTION
## What/Why/How?

- Changes admonition type from "attention" to "info"
- Eliminates downstream validation errors on admonition Markdoc tag

## Reference

## Testing

Manually verify admonition change in branch preview

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
