### PR TITLE
feat: add typings and interfaces for Overlay Specification v1.0.0

### DIFF
--- a/.changeset/stale-starfishes-rule.md
+++ b/.changeset/stale-starfishes-rule.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": minor
+"@redocly/cli": minor
+---
+
+Added typings and interfaces for Overlay Specification v1.0.0.

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -502,6 +502,7 @@ describe('checkIfRulesetExist', () => {
       async2: {},
       async3: {},
       arazzo1: {},
+      overlay1: {},
     };
     expect(() => checkIfRulesetExist(rules)).toThrowError(
       '⚠️ No rules were configured. Learn how to configure rules: https://redocly.com/docs/cli/rules/'

--- a/packages/core/src/types/overlay.ts
+++ b/packages/core/src/types/overlay.ts
@@ -1,0 +1,40 @@
+import { type NodeType, listOf } from '.';
+
+const Root: NodeType = {
+  properties: {
+    overlay: { type: 'string' },
+    info: 'Info',
+    extends: { type: 'string' },
+    actions: 'Actions',
+  },
+  required: ['overlay', 'info', 'actions'],
+  extensionsPrefix: 'x-',
+};
+
+const Info: NodeType = {
+  properties: {
+    title: { type: 'string' },
+    version: { type: 'string' },
+  },
+  required: ['title', 'version'],
+  extensionsPrefix: 'x-',
+};
+
+const Actions: NodeType = listOf('Action');
+const Action: NodeType = {
+  properties: {
+    target: { type: 'string' },
+    description: { type: 'string' },
+    update: {}, // any
+    remove: { type: 'boolean' },
+  },
+  required: ['target'],
+  extensionsPrefix: 'x-',
+};
+
+export const Overlay1Types: Record<string, NodeType> = {
+  Root,
+  Info,
+  Actions,
+  Action,
+};

--- a/packages/core/src/typings/overlay.ts
+++ b/packages/core/src/typings/overlay.ts
@@ -1,0 +1,19 @@
+export interface InfoObject {
+  title: string;
+  version: string;
+}
+
+export interface ActionObject {
+  target: string;
+  description?: string;
+  update?: unknown;
+  remove?: boolean;
+}
+export interface Overlay1Definition {
+  overlay: '1.0.0';
+  info: InfoObject;
+  extends?: string;
+  actions: ActionObject[];
+}
+
+export const VERSION_PATTERN = /^1\.0\.\d+(-.+)?$/;


### PR DESCRIPTION
related #1246

## What/Why/How?

Provides typings and interfaces for a structured Overlay description per the https://github.com/OAI/Overlay-Specification

Hopefully this is the first step to providing support for this new specification!

Can't wait to see what you build! 

## Reference
https://github.com/OAI/Overlay-Specification/releases/tag/1.0.0

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines
