### PR TITLE
fix: do not try resolving exteranlValues used as property names

### DIFF
--- a/.changeset/tricky-balloons-kick.md
+++ b/.changeset/tricky-balloons-kick.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed the problem where using `externalValue` as a property name was causing an API description processing failure.

--- a/.changeset/tricky-balloons-kick.md
+++ b/.changeset/tricky-balloons-kick.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed the problem where using `externalValue` as a property name was causing an API description processing failure.
+Fixed an issue where using `externalValue` as a property name was causing the API description validation process to fail.

--- a/packages/core/src/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/bundle.test.ts.snap
@@ -262,6 +262,30 @@ components:
 
 `;
 
+exports[`bundle should bundle schemas with properties named $ref and externalValues correctly 1`] = `
+openapi: 3.1.0
+info: {}
+paths:
+  /example:
+    get:
+      summary: Get Example
+      description: This endpoint returns an example response.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  externalValue:
+                    type: string
+                  $ref:
+                    type: string
+components: {}
+
+`;
+
 exports[`bundle should dereferenced correctly when used with dereference 1`] = `
 openapi: 3.0.0
 paths:

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -256,6 +256,15 @@ describe('bundle', () => {
     expect(problems).toHaveLength(0);
     expect(parsed).toEqual(origCopy);
   });
+
+  it('should bundle schemas with properties named $ref and externalValues correctly', async () => {
+    const { bundle: res, problems } = await bundle({
+      config: new Config({} as ResolvedConfig),
+      ref: path.join(__dirname, 'fixtures/refs/openapi-with-special-names-in-props.yaml'),
+    });
+    expect(problems).toHaveLength(0);
+    expect(res.parsed).toMatchSnapshot();
+  });
 });
 
 describe('bundleFromString', () => {

--- a/packages/core/src/__tests__/fixtures/refs/openapi-with-special-names-in-props.yaml
+++ b/packages/core/src/__tests__/fixtures/refs/openapi-with-special-names-in-props.yaml
@@ -1,0 +1,19 @@
+openapi: 3.1.0
+info: {}
+paths:
+  /example:
+    get:
+      summary: Get Example
+      description: This endpoint returns an example response.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  externalValue:
+                    type: string
+                  $ref:
+                    type: string

--- a/packages/core/src/ref-utils.ts
+++ b/packages/core/src/ref-utils.ts
@@ -1,4 +1,4 @@
-import { isTruthy } from './utils';
+import { isPlainObject, isTruthy } from './utils';
 
 import type { Source } from './resolve';
 import type { OasRef } from './typings/openapi';
@@ -8,8 +8,12 @@ export function joinPointer(base: string, key: string | number) {
   return base[base.length - 1] === '/' ? base + key : base + '/' + key;
 }
 
-export function isRef(node: any): node is OasRef {
-  return node && typeof node.$ref === 'string';
+export function isRef(node: unknown): node is OasRef {
+  return isPlainObject(node) && typeof node.$ref === 'string';
+}
+
+export function isExternalValue(node: unknown) {
+  return isPlainObject(node) && typeof node.isExternalValue === 'string';
 }
 
 export class Location {

--- a/packages/core/src/ref-utils.ts
+++ b/packages/core/src/ref-utils.ts
@@ -13,7 +13,7 @@ export function isRef(node: unknown): node is OasRef {
 }
 
 export function isExternalValue(node: unknown) {
-  return isPlainObject(node) && typeof node.isExternalValue === 'string';
+  return isPlainObject(node) && typeof node.externalValue === 'string';
 }
 
 export class Location {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -1,6 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { isRef, joinPointer, escapePointer, parseRef, isAbsoluteUrl, isAnchor } from './ref-utils';
+import {
+  isRef,
+  joinPointer,
+  escapePointer,
+  parseRef,
+  isAbsoluteUrl,
+  isAnchor,
+  isExternalValue,
+} from './ref-utils';
 import { isNamedType, SpecExtension } from './types';
 import { readFileFromUrl, parseYaml, nextTick } from './utils';
 
@@ -337,7 +345,7 @@ export async function resolveDocument(opts: {
       }
 
       // handle example.externalValue as reference
-      if (node.externalValue) {
+      if (isExternalValue(node)) {
         const promise = followRef(
           rootNodeDocument,
           { $ref: node.externalValue },


### PR DESCRIPTION
## What/Why/How?

Fixes https://github.com/Redocly/redocly-cli/issues/1765

The original bug was introduced in https://github.com/Redocly/redocly-cli/pull/1747

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
