### PR TITLE
fix: remove-unused-components to handle circular schemas

### DIFF
--- a/.changeset/mean-fireants-lay.md
+++ b/.changeset/mean-fireants-lay.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": major
+---
+
+Fixed an issue where remove-unused-components was not remove all the circular schemas

--- a/packages/core/src/decorators/oas3/__tests__/circular-ref.yaml
+++ b/packages/core/src/decorators/oas3/__tests__/circular-ref.yaml
@@ -1,0 +1,88 @@
+openapi: 3.1.0
+info:
+  title: 'Test'
+  version: '1.0.0'
+paths:
+  /pet:
+    post:
+      parameters:
+        - in: query
+          name: test
+          schema:
+            $ref: '#/components/schemas/wefewf'
+components:
+  schemas:
+    abc:
+      properties:
+        property:
+          type: string
+      type: object
+    jkl:
+      properties:
+        filters:
+          items:
+            $ref: '#/components/schemas/abc'
+          type: array
+      type: object
+    def:
+      type: object
+    ghi:
+      properties:
+        property:
+          allOf:
+            - $ref: '#/components/schemas/jkl'
+        property1:
+          items:
+            $ref: '#/components/schemas/def'
+          type: array
+        property2:
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/ghi'
+              - $ref: '#/components/schemas/mnor'
+          type: array
+        property3:
+          items:
+            $ref: '#/components/schemas/pqr'
+          type: array
+        property4:
+          allOf:
+            - $ref: '#/components/schemas/stu'
+      type: object
+    pqr:
+      properties:
+        property:
+          items:
+            $ref: '#/components/schemas/def'
+          type: array
+      type: object
+    mnor:
+      properties:
+        property:
+          items:
+            $ref: '#/components/schemas/def'
+          type: array
+        property1:
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/ghi'
+              - $ref: '#/components/schemas/mnor'
+          type: array
+        property2:
+          items:
+            $ref: '#/components/schemas/pqr'
+          type: array
+      type: object
+    stu:
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/vwx'
+          default: absolute
+      type: object
+    vwx:
+      description: An enumeration.
+    wefewf:
+      properties:
+        property:
+          type: string

--- a/packages/core/src/decorators/oas3/__tests__/remove-unused-components.test.ts
+++ b/packages/core/src/decorators/oas3/__tests__/remove-unused-components.test.ts
@@ -2,6 +2,8 @@ import { outdent } from 'outdent';
 import { parseYamlToDocument, makeConfig } from '../../../../__tests__/utils';
 import { bundleDocument } from '../../../bundle';
 import { BaseResolver } from '../../../resolve';
+const fs = require('fs');
+const path = require('path');
 
 describe('oas3 remove-unused-components', () => {
   it('should remove unused components', async () => {
@@ -305,6 +307,150 @@ describe('oas3 remove-unused-components', () => {
           },
           Used: {
             type: 'integer',
+          },
+        },
+      },
+    });
+  });
+
+  it('should remove simple unused recusive components', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        paths:
+          /pets:
+            get:
+              summary: List all pets
+              operationId: listPets
+              responses:
+                '200': 
+                  content:
+                    application/json:
+                      schema: 
+                        $ref: '#/components/schemas/Used'
+        components:
+          schemas:
+            Used:
+              type: object
+              properties:
+                link:
+                  $ref: '#/components/schemas/InnerUsed'
+            InnerUsed:
+              type: object
+              properties:
+                link:
+                  type: string
+            iwillbedrop:
+              properties:
+                name:
+                  title: Name
+                  type: string
+              type: object
+            iwontbdedrop:
+              properties:
+                Myprop:
+                  items:
+                    anyOf:
+                      - $ref: '#/components/schemas/iwontbdedrop'
+                  type: array
+              type: object
+              x-fgff: dd
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await bundleDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ rules: {} }),
+      removeUnusedComponents: true,
+    });
+
+    expect(results.bundle.parsed).toEqual({
+      openapi: '3.1.0',
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'List all pets',
+            operationId: 'listPets',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Used',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          InnerUsed: {
+            type: 'object',
+            properties: {
+              link: {
+                type: 'string',
+              },
+            },
+          },
+          Used: {
+            type: 'object',
+            properties: {
+              link: {
+                $ref: '#/components/schemas/InnerUsed',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should remove complex unused recusive components', async () => {
+    const filePath = path.resolve(__dirname, 'circular-ref.yaml');
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const document = parseYamlToDocument(fileContents);
+
+    const results = await bundleDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await makeConfig({ rules: {} }),
+      removeUnusedComponents: true,
+    });
+
+    expect(results.bundle.parsed).toEqual({
+      openapi: '3.1.0',
+      info: {
+        title: 'Test',
+        version: '1.0.0',
+      },
+      paths: {
+        '/pet': {
+          post: {
+            parameters: [
+              {
+                in: 'query',
+                name: 'test',
+                schema: {
+                  $ref: '#/components/schemas/wefewf',
+                },
+              },
+            ],
+          },
+        },
+      },
+      components: {
+        schemas: {
+          wefewf: {
+            properties: {
+              property: {
+                type: 'string',
+              },
+            },
           },
         },
       },

--- a/packages/core/src/decorators/oas3/remove-unused-components.ts
+++ b/packages/core/src/decorators/oas3/remove-unused-components.ts
@@ -119,10 +119,7 @@ export const RemoveUnusedComponents: Oas3Decorator = () => {
           const resolvedRef = resolve(ref);
           if (!resolvedRef.location) return;
 
-          const [fileLocation, localPointer] = resolvedRef.location.absolutePointer.split('#', 2);
-          const componentLevelLocalPointer = localPointer.split('/').slice(0, 4).join('/');
-          const pointer = `${fileLocation}#${componentLevelLocalPointer}`;
-
+          const pointer = getBasePath(resolvedRef.location.absolutePointer);
           const registered = components.get(pointer);
           const basePath = getBasePath(location.absolutePointer);
 

--- a/packages/core/src/decorators/oas3/remove-unused-components.ts
+++ b/packages/core/src/decorators/oas3/remove-unused-components.ts
@@ -63,7 +63,7 @@ export const RemoveUnusedComponents: Oas3Decorator = () => {
       if (!visited.has(path)) {
         stack.clear();
         visited.clear();
-        detectCircularDependencies(path)
+        detectCircularDependencies(path);
       }
     }
 


### PR DESCRIPTION
## What/Why/How?

Remove-unused-components was not handle circular dependencies as describe in the [issue](https://github.com/Redocly/redocly-cli/issues/1783). This was leading to left over schemas within the specification.

This PR is to handle both self referenced schemas as well as circular schemas

## Reference

## Testing

`npm run unit:watch -- packages/core/src/decorators/oas3`

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
