### PR TITLE
fix: do not fail when bundling a description containing null in examples

### DIFF
--- a/.changeset/slimy-humans-nail.md
+++ b/.changeset/slimy-humans-nail.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed API descriptions bundling. Previously, schemas containing nulls in examples were causing failures.

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -265,6 +265,57 @@ describe('bundle', () => {
     expect(problems).toHaveLength(0);
     expect(res.parsed).toMatchSnapshot();
   });
+
+  it('should not fail when bundling openapi with nulls', async () => {
+    const testDocument = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        paths: 
+          /:
+            get: 
+              responses: 
+                200:
+                  content: 
+                    application/json: 
+                      schema: 
+                        type: object
+                        properties: 
+                      examples: 
+                        Foo:           
+      `,
+      ''
+    );
+
+    const config = await makeConfig({ rules: {} });
+
+    const {
+      bundle: { parsed },
+      problems,
+    } = await bundleDocument({
+      document: testDocument,
+      config: config,
+      externalRefResolver: new BaseResolver(),
+    });
+
+    expect(problems).toHaveLength(0);
+    expect(parsed).toMatchInlineSnapshot(`
+      openapi: 3.1.0
+      paths:
+        /:
+          get:
+            responses:
+              '200':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties: null
+                    examples:
+                      Foo: null
+      components: {}
+
+    `);
+  });
 });
 
 describe('bundleFromString', () => {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -9,7 +9,7 @@ import {
   SpecMajorVersion,
   SpecVersion,
 } from './oas-types';
-import { isAbsoluteUrl, isRef, refBaseName } from './ref-utils';
+import { isAbsoluteUrl, isExternalValue, isRef, refBaseName } from './ref-utils';
 import { initRules } from './config/rules';
 import { reportUnresolvedRef } from './rules/no-unresolved-refs';
 import { dequal, isPlainObject, isTruthy } from './utils';
@@ -380,7 +380,7 @@ function makeBundleVisitor(
     },
     Example: {
       leave(node: any, ctx: UserContext) {
-        if (node.externalValue && node.value === undefined) {
+        if (isExternalValue(node) && node.value === undefined) {
           const resolved = ctx.resolve({ $ref: node.externalValue });
 
           if (!resolved.location || resolved.node === undefined) {


### PR DESCRIPTION
## What/Why/How?

Fixed API descriptions bundling. Previously, schemas containing nulls in examples were causing failures.

## Reference

The original bug was introduced [here](https://github.com/Redocly/redocly-cli/pull/1747).

## Testing

Discovered the bug while testing the OpenAPI VSCode extension:

```yaml
        openapi: 3.1.0
        paths: 
          /:
            get: 
              responses: 
                200:
                  content: 
                    application/json: 
                      examples: 
                        Foo:   # <-- if fails when trying to resolve externalValues here
```

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
