### PR TITLE
chore: fix the remove-x-internal decorator for Node.js v17-

### DIFF
--- a/.changeset/dull-kiwis-agree.md
+++ b/.changeset/dull-kiwis-agree.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue with the `remove-x-internal` decorator where bundling API descirptions containing discriminators could fail when using **Node.js** v17 or earlier.

--- a/packages/core/src/decorators/common/remove-x-internal.ts
+++ b/packages/core/src/decorators/common/remove-x-internal.ts
@@ -65,7 +65,7 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({
   return {
     DiscriminatorMapping: {
       enter: (mapping: Record<string, string>) => {
-        originalMapping = structuredClone(mapping);
+        originalMapping = JSON.parse(JSON.stringify(mapping));
       },
     },
     any: {


### PR DESCRIPTION
## What/Why/How?

Fixed an issue with the `remove-x-internal` decorator where bundling API descirptions containing discriminators could fail when using **Node.js** v17 or earlier.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
