### PR TITLE
fix: make isAuthorizedWithRedocly recognize valid Redocly tokens

### DIFF
--- a/.changeset/nervous-bikes-wait.md
+++ b/.changeset/nervous-bikes-wait.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue when valid Redocly tokens were not recognized.
+Fixed an issue where valid Redocly tokens were not recognized.

--- a/.changeset/nervous-bikes-wait.md
+++ b/.changeset/nervous-bikes-wait.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue when valid Redocly tokens were not recognized.

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { homedir } from 'os';
 import { RegistryApi } from './registry-api';
 import { env } from '../env';
-import { isNotEmptyObject } from '../utils';
+import { isNotEmptyArray, isNotEmptyObject } from '../utils';
 import { colorize } from '../logger';
 import {
   AVAILABLE_REGIONS,
@@ -135,7 +135,7 @@ export class RedoclyClient {
   }
 
   async isAuthorizedWithRedocly(): Promise<boolean> {
-    return this.hasTokens() && isNotEmptyObject(await this.getValidTokens());
+    return this.hasTokens() && isNotEmptyArray(await this.getValidTokens());
   }
 
   readCredentialsFile(credentialsPath: string) {


### PR DESCRIPTION
## What/Why/How?

The check inside `isAuthorizedWithRedocly` was incorrect. We were checking for objects, but the argument is actually an array.

## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/1805

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
