### PR TITLE
fix: use stdout instead of stderr for simple logs in build-docs

### DIFF
--- a/.changeset/wild-scissors-rest.md
+++ b/.changeset/wild-scissors-rest.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-fix: cli build-docs / use stdout instead of stderr for simple logs
+Updated the Redocly CLI command `redocly build-docs` to use `stdout` instead of `stderr` for simple logs.

--- a/.changeset/wild-scissors-rest.md
+++ b/.changeset/wild-scissors-rest.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+fix: cli build-docs / use stdout instead of stderr for simple logs

--- a/__tests__/build-docs/build-docs-with-config-option/snapshot.js
+++ b/__tests__/build-docs/build-docs-with-config-option/snapshot.js
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`E2E build-docs build docs with config option 1`] = `
+Found nested/redocly.yaml and using theme.openapi options
+Prerendering docs
 
 🎉 bundled successfully in: nested/redoc-static.html (33 KiB) [⏱ <test>ms].
 
-Found nested/redocly.yaml and using theme.openapi options
-Prerendering docs
 
 `;

--- a/__tests__/build-docs/simple-build-docs/snapshot.js
+++ b/__tests__/build-docs/simple-build-docs/snapshot.js
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`E2E build-docs simple build-docs 1`] = `
+Found undefined and using theme.openapi options
+Prerendering docs
 
 🎉 bundled successfully in: redoc-static.html (324 KiB) [⏱ <test>ms].
 
-Found undefined and using theme.openapi options
-Prerendering docs
 
 `;

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -37,7 +37,7 @@ export function getObjectOrJSON(
       break;
     default: {
       if (config) {
-        process.stderr.write(`Found ${config.configFile} and using theme.openapi options\n`);
+        process.stdout.write(`Found ${config.configFile} and using theme.openapi options\n`);
 
         return config.theme.openapi ? config.theme.openapi : {};
       }
@@ -60,7 +60,7 @@ export async function getPageHTML(
   }: BuildDocsOptions,
   configPath?: string
 ) {
-  process.stderr.write('Prerendering docs\n');
+  process.stdout.write('Prerendering docs\n');
 
   const apiUrl = redocOptions.specUrl || (isAbsoluteUrl(pathToApi) ? pathToApi : undefined);
   const store = await createStore(api, apiUrl, redocOptions);


### PR DESCRIPTION
Hey there,

Using CLI `redocly build-docs`
This always prints the following into `stderr`.

```
Found /Users/(...)/redocly.yaml and using theme.openapi options
Prerendering docs
```

I have many other stuff happening in my project, and generating multiple docs, so this just adds noise & annoyance, whereas it's just (verbose) logs and not errors anyway.