### PR TITLE
chore: test check-pr-title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,5 +12,13 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo TEST
-          echo "$PR_TITLE"
+          if ! echo "$PR_TITLE" | grep -E "^(fix|feat|chore|docs)(\([a-z-]+\))?: (🔖 )?[a-z].+[^.]$"; then
+            echo "❌ PR title '$PR_TITLE' does not match the required format"
+            echo "Required format: type(scope): subject"
+            echo "Examples:"
+            echo "  feat: add new feature"
+            echo "  fix(core): fix bug"
+            echo "  docs: update README"
+            exit 1
+          fi
+          echo "✅ PR title format is valid"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,16 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo TEST
+          echo "$PR_TITLE"


### PR DESCRIPTION
## What/Why/How?

This PR adds a GitHub Action to check PR titles.
They should follow this pattern: `<type>[(scope)]: <subject>`.

The goal is to ensure all commit messages follow the same style (see the [contribution guide](https://github.com/Redocly/redocly-cli/blob/125d240465d70a65475ad444032e3762dd13092c/CONTRIBUTING.md?plain=1#L35)).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
