### PR TITLE
feat: add redocBundleURL option

### DIFF
--- a/.changeset/heavy-gifts-beg.md
+++ b/.changeset/heavy-gifts-beg.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": minor
+---
+
+add redocBundleURL option

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -75,6 +75,11 @@ export async function getPageHTML(
     : redocOptions?.htmlTemplate
     ? resolve(configPath ? dirname(configPath) : '', redocOptions.htmlTemplate)
     : join(__dirname, './template.hbs');
+
+  const redocBundleURL =
+    redocOptions.redocBundleURL ||
+    'https://cdn.redocly.com/redoc/v${redocCurrentVersion}/bundles/redoc.standalone.js';
+
   const template = compile(readFileSync(templateFileName).toString());
   return template({
     redocHTML: `
@@ -86,9 +91,7 @@ export async function getPageHTML(
       Redoc.${'hydrate(__redoc_state, container)'};
 
       </script>`,
-    redocHead:
-      `<script src="https://cdn.redocly.com/redoc/v${redocCurrentVersion}/bundles/redoc.standalone.js"></script>` +
-      css,
+    redocHead: `<script src="${redocBundleURL}"></script>` + css,
     title: title || api.info.title || 'ReDoc documentation',
     disableGoogleFont,
     templateOptions,

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -10,7 +10,9 @@ import type { IncomingMessage } from 'http';
 
 function getPageHTML(
   htmlTemplate: string,
-  redocOptions: object = {},
+  redocOptions: {
+    redocBundleURL?: string;
+  } = {},
   useRedocPro: boolean,
   wsPort: number,
   host: string
@@ -24,6 +26,12 @@ function getPageHTML(
 
   const template = compile(templateSrc);
 
+  const redocBundleURL =
+    redocOptions.redocBundleURL ||
+    (useRedocPro
+      ? 'https://cdn.redocly.com/reference-docs/latest/redocly-reference-docs.min.js'
+      : 'https://cdn.redocly.com/redoc/latest/bundles/redoc.standalone.js');
+
   return template({
     redocHead: `
   <script>
@@ -33,11 +41,7 @@ function getPageHTML(
   </script>
   <script src="/simplewebsocket.min.js"></script>
   <script src="/hot.js"></script>
-  <script src="${
-    useRedocPro
-      ? 'https://cdn.redocly.com/reference-docs/latest/redocly-reference-docs.min.js'
-      : 'https://cdn.redocly.com/redoc/latest/bundles/redoc.standalone.js'
-  }"></script>
+<script src="${redocBundleURL}"></script>
 `,
     redocHTML: `
   <div id="redoc"></div>


### PR DESCRIPTION
## What/Why/How?

It is helpful to be able render documentation with a non-standard redoc bundle, e.g., for testing.  In theory, one could use a custom HTML template for this purpose but in practice that's not straight-forward because the template would have to be different depending on whether or not `preview-docs` or `build-docs` is run. The template would also have to include all the CSS code.

## Testing

unit tests and e2e tests all passed.
