### PR TITLE
fix: consider the cli install directory when resolving plugins

### DIFF
--- a/.changeset/tender-forks-argue.md
+++ b/.changeset/tender-forks-argue.md
@@ -3,4 +3,5 @@
 "@redocly/cli": patch
 ---
 
-Fixed a bug where running a preview command when Realm is not in the `node_modules` of the project failed because one of it's dependencies could not be resolved.
+Fixed an issue where running the `preview` command failed because one of its dependencies could not be resolved.
+The issue occurred when Realm was not installed in the `node_modules` of the project.

--- a/.changeset/tender-forks-argue.md
+++ b/.changeset/tender-forks-argue.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed a bug where running a preview command when Realm is not in the `node_modules` of the project failed because one of it's dependencies could not be resolved.

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -136,7 +136,14 @@ export async function resolvePlugins(
         const absolutePluginPath = existsSync(maybeAbsolutePluginPath)
           ? maybeAbsolutePluginPath
           : // For plugins imported from packages specifically
-            require.resolve(plugin, { paths: [configDir, __dirname] });
+            require.resolve(plugin, {
+              paths: [
+                // Plugins imported from the node_modules in the project directory
+                configDir,
+                // Plugins imported from the node_modules in package install directory (for example, npx cache directory)
+                __dirname,
+              ],
+            });
 
         if (!pluginsCache.has(absolutePluginPath)) {
           let requiredPlugin: ImportedPlugin | undefined;

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -140,7 +140,7 @@ export async function resolvePlugins(
               paths: [
                 // Plugins imported from the node_modules in the project directory
                 configDir,
-                // Plugins imported from the node_modules in package install directory (for example, npx cache directory)
+                // Plugins imported from the node_modules in the package install directory (for example, npx cache directory)
                 __dirname,
               ],
             });

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -136,7 +136,7 @@ export async function resolvePlugins(
         const absolutePluginPath = existsSync(maybeAbsolutePluginPath)
           ? maybeAbsolutePluginPath
           : // For plugins imported from packages specifically
-            require.resolve(plugin, { paths: [configDir] });
+            require.resolve(plugin, { paths: [configDir, __dirname] });
 
         if (!pluginsCache.has(absolutePluginPath)) {
           let requiredPlugin: ImportedPlugin | undefined;


### PR DESCRIPTION
## What/Why/How?

There is an issue when running the `npx @redocly/cli preview` command when the `@redocly/realm` package is not installed in the project's `node_modules`: it's dependent package cannot be resolved.

This happens because the npx installs both the `@redocly/realm` and it's dependency `@redocly/openapi-core` into a cache directory (`~/.npm/_npx` for mac and linux) but when resolving plugins, only the project directory is considered.

This PR adds the package location to the list of directories to resolve the Realm plugins from.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
