### PR TITLE
feat: migrate from node-fetch to native fetch

### DIFF
--- a/.changeset/warm-tips-sit.md
+++ b/.changeset/warm-tips-sit.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": minor
+"@redocly/cli": minor
+---
+
+Switched to using native `fetch` API instead of `node-fetch` dependency, improving performance and reducing bundle size.

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -104,58 +104,6 @@ jobs:
           node-version: 18
       - run: bash ./__tests__/smoke/run-smoke.sh "npm i redoc redocly-cli.tgz" "npm run"
 
-  run-smoke--npm--node-16:
-    needs: prepare-smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: __tests__/smoke/
-          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redocly-cli.tgz" "npm run"
-
-  run-smoke--npm--node-16--redoc:
-    needs: prepare-smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: __tests__/smoke/
-          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redoc redocly-cli.tgz" "npm run"
-
-  run-smoke--npm--node-14:
-    needs: prepare-smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: __tests__/smoke/
-          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redocly-cli.tgz" "npm run"
-
-  run-smoke--npm--node-14--redoc:
-    needs: prepare-smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: __tests__/smoke/
-          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redoc redocly-cli.tgz" "npm run"
-
   run-smoke--yarn--node-22:
     needs: prepare-smoke
     runs-on: ubuntu-latest
@@ -234,7 +182,7 @@ jobs:
           node-version: 18
       - run: bash ./__tests__/smoke/run-smoke.sh "yarn add redoc ./redocly-cli.tgz" "yarn"
 
-  run-smoke--webpack--node-14:
+  run-smoke--webpack--node-22:
     needs: prepare-smoke
     runs-on: ubuntu-latest
     steps:
@@ -244,12 +192,68 @@ jobs:
           key: cache-${{ github.run_id }}-${{ github.run_attempt }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 22
       - run: |
           cd __tests__/smoke/
           node bundle.js --version
           node bundle.js lint openapi.yaml --extends minimal
           node bundle.js bundle openapi.yaml
+
+  run-smoke--npm--node-22--windows:
+    needs: prepare-smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: __tests__/smoke/
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+          enableCrossOsArchive: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22
+      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redocly-cli.tgz" "npm run"
+
+  run-smoke--yarn--node-22--windows:
+    needs: prepare-smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: __tests__/smoke/
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+          enableCrossOsArchive: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22
+      - run: bash ./__tests__/smoke/run-smoke.sh "yarn add ./redocly-cli.tgz" "yarn"
+
+  run-smoke--npm--node-20--windows:
+    needs: prepare-smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: __tests__/smoke/
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+          enableCrossOsArchive: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: bash ./__tests__/smoke/run-smoke.sh "npm i redocly-cli.tgz" "npm run"
+
+  run-smoke--yarn--node-20--windows:
+    needs: prepare-smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: __tests__/smoke/
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+          enableCrossOsArchive: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: bash ./__tests__/smoke/run-smoke.sh "yarn add ./redocly-cli.tgz" "yarn"
 
   run-smoke--npm--node-18--windows:
     needs: prepare-smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Before submitting a pull request, please make sure the following is done:
 
 ## Development setup
 
-[Node.js](http://nodejs.org) at v14.19.0+ and NPM v7.0.0+ are required.
+[Node.js](http://nodejs.org) at v18.17.0+ and NPM v10.8.2+ are required.
 
 After forking the repo, run:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then you can use it as `redocly [command] [options]`, for example:
 redocly lint path-to-root-file.yaml
 ```
 
-The minimum required versions of Node.js and NPM are 14.19.0 and 7.0.0 respectively.
+The minimum required versions of Node.js and NPM are 18.17.0 and 10.8.2 respectively.
 
 ### Docker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,8 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "node": ">=15.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=18.17.0",
+        "npm": ">=10.8.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3457,16 +3457,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "node_modules/@types/pluralize": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
@@ -6366,20 +6356,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
-    },
-    "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",
@@ -12588,7 +12564,6 @@
         "glob": "^7.1.6",
         "handlebars": "^4.7.6",
         "mobx": "^6.0.4",
-        "node-fetch": "^2.6.1",
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0",
         "react-dom": "^17.0.0 || ^18.2.0",
@@ -12613,8 +12588,8 @@
         "typescript": "5.5.3"
       },
       "engines": {
-        "node": ">=14.19.0",
-        "npm": ">=7.0.0"
+        "node": ">=18.17.0",
+        "npm": ">=10.8.2"
       }
     },
     "packages/cli/node_modules/form-data": {
@@ -12638,11 +12613,10 @@
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.20.1",
         "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "minimatch": "^5.0.1",
-        "node-fetch": "^2.6.1",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
@@ -12650,34 +12624,31 @@
         "@types/js-levenshtein": "^1.1.0",
         "@types/js-yaml": "^4.0.3",
         "@types/minimatch": "^3.0.5",
-        "@types/node": "^20.11.5",
-        "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "json-schema-to-ts": "^3.1.0",
         "typescript": "5.5.3"
       },
       "engines": {
-        "node": ">=14.19.0",
-        "npm": ">=7.0.0"
+        "node": ">=18.17.0",
+        "npm": ">=10.8.2"
       }
     },
     "packages/core/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "packages/core/node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -15064,7 +15035,6 @@
         "glob": "^7.1.6",
         "handlebars": "^4.7.6",
         "mobx": "^6.0.4",
-        "node-fetch": "^2.6.1",
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0",
         "react-dom": "^17.0.0 || ^18.2.0",
@@ -15101,35 +15071,29 @@
         "@types/js-levenshtein": "^1.1.0",
         "@types/js-yaml": "^4.0.3",
         "@types/minimatch": "^3.0.5",
-        "@types/node": "^20.11.5",
-        "@types/node-fetch": "^2.5.7",
         "@types/pluralize": "^0.0.29",
         "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "json-schema-to-ts": "^3.1.0",
         "minimatch": "^5.0.1",
-        "node-fetch": "^2.6.1",
         "pluralize": "^8.0.0",
         "typescript": "5.5.3",
         "yaml-ast-parser": "0.0.43"
       },
       "dependencies": {
         "agent-base": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-          "requires": {
-            "debug": "^4.3.4"
-          }
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
         },
         "https-proxy-agent": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-          "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
           "requires": {
-            "agent-base": "^7.0.2",
+            "agent-base": "^7.1.2",
             "debug": "4"
           }
         }
@@ -15359,16 +15323,6 @@
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
       }
     },
     "@types/pluralize": {
@@ -17558,17 +17512,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
-    },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
     },
     "fs-extra": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=15.0.0",
-    "npm": ">=7.0.0"
+    "node": ">=18.17.0",
+    "npm": ">=10.8.2"
   },
   "engineStrict": true,
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,8 +8,8 @@
     "redocly": "bin/cli.js"
   },
   "engines": {
-    "node": ">=14.19.0",
-    "npm": ">=7.0.0"
+    "node": ">=18.17.0",
+    "npm": ">=10.8.2"
   },
   "engineStrict": true,
   "scripts": {
@@ -46,7 +46,6 @@
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",
     "mobx": "^6.0.4",
-    "node-fetch": "^2.6.1",
     "pluralize": "^8.0.0",
     "react": "^17.0.0 || ^18.2.0",
     "react-dom": "^17.0.0 || ^18.2.0",

--- a/packages/cli/src/__tests__/commands/push-region.test.ts
+++ b/packages/cli/src/__tests__/commands/push-region.test.ts
@@ -2,19 +2,29 @@ import { getMergedConfig } from '@redocly/openapi-core';
 import { handlePush } from '../../commands/push';
 import { promptClientToken } from '../../commands/login';
 import { ConfigFixture } from '../fixtures/config';
+import { Readable } from 'node:stream';
 
-jest.mock('fs');
-jest.mock('node-fetch', () => ({
-  default: jest.fn(() => ({
-    ok: true,
-    json: jest.fn().mockResolvedValue({}),
-  })),
+// Mock fs operations
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  createReadStream: () => {
+    const readable = new Readable();
+    readable.push('test data');
+    readable.push(null);
+    return readable;
+  },
+  statSync: () => ({ size: 9 }),
+  readFileSync: () => Buffer.from('test data'),
+  existsSync: () => false,
+  readdirSync: () => [],
 }));
+
+(getMergedConfig as jest.Mock).mockImplementation((config) => config);
+
+// Mock OpenAPI core
 jest.mock('@redocly/openapi-core');
 jest.mock('../../commands/login');
 jest.mock('../../utils/miscellaneous');
-
-(getMergedConfig as jest.Mock).mockImplementation((config) => config);
 
 const mockPromptClientToken = promptClientToken as jest.MockedFunction<typeof promptClientToken>;
 
@@ -22,12 +32,41 @@ describe('push-with-region', () => {
   const redoclyClient = require('@redocly/openapi-core').__redoclyClient;
   redoclyClient.isAuthorizedWithRedoclyByRegion = jest.fn().mockResolvedValue(false);
 
+  const originalFetch = fetch;
+
   beforeAll(() => {
+    // Mock global fetch
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+        headers: new Headers(),
+        statusText: 'OK',
+        redirected: false,
+        type: 'default',
+        url: '',
+        clone: () => ({} as Response),
+        body: new ReadableStream(),
+        bodyUsed: false,
+        arrayBuffer: async () => new ArrayBuffer(0),
+        blob: async () => new Blob(),
+        formData: async () => new FormData(),
+        text: async () => '',
+      } as Response)
+    );
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
     jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
   });
 
   it('should call login with default domain when region is US', async () => {
-    redoclyClient.domain = 'redoc.ly';
+    redoclyClient.domain = 'redocly.com';
     await handlePush({
       argv: {
         upsert: true,
@@ -38,12 +77,16 @@ describe('push-with-region', () => {
       config: ConfigFixture as any,
       version: 'cli-version',
     });
+
     expect(mockPromptClientToken).toBeCalledTimes(1);
     expect(mockPromptClientToken).toHaveBeenCalledWith(redoclyClient.domain);
   });
 
   it('should call login with EU domain when region is EU', async () => {
     redoclyClient.domain = 'eu.redocly.com';
+    // Update config for EU region
+    const euConfig = { ...ConfigFixture, region: 'eu' };
+
     await handlePush({
       argv: {
         upsert: true,
@@ -51,9 +94,10 @@ describe('push-with-region', () => {
         destination: '@org/my-api@1.0.0',
         branchName: 'test',
       },
-      config: ConfigFixture as any,
+      config: euConfig as any,
       version: 'cli-version',
     });
+
     expect(mockPromptClientToken).toBeCalledTimes(1);
     expect(mockPromptClientToken).toHaveBeenCalledWith(redoclyClient.domain);
   });

--- a/packages/cli/src/__tests__/fetch-with-timeout.test.ts
+++ b/packages/cli/src/__tests__/fetch-with-timeout.test.ts
@@ -1,11 +1,36 @@
 import AbortController from 'abort-controller';
 import fetchWithTimeout from '../utils/fetch-with-timeout';
-import nodeFetch from 'node-fetch';
 import { getProxyAgent } from '@redocly/openapi-core';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
-jest.mock('node-fetch');
 jest.mock('@redocly/openapi-core');
+
+const signalInstance = new AbortController().signal;
+
+const mockFetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({}),
+    headers: new Headers(),
+    statusText: 'OK',
+    redirected: false,
+    type: 'default',
+    url: '',
+    clone: () => ({} as Response),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: async () => new ArrayBuffer(0),
+    blob: async () => new Blob(),
+    formData: async () => new FormData(),
+    text: async () => '',
+    signal: signalInstance,
+    dispatcher: undefined,
+  } as Response)
+);
+
+const originalFetch = global.fetch;
+global.fetch = mockFetch;
 
 describe('fetchWithTimeout', () => {
   beforeAll(() => {
@@ -18,36 +43,39 @@ describe('fetchWithTimeout', () => {
     (getProxyAgent as jest.Mock).mockReturnValueOnce(undefined);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
-  it('should call node-fetch with signal', async () => {
+  it('should call fetch with signal', async () => {
     await fetchWithTimeout('url', { timeout: 1000 });
 
     expect(global.setTimeout).toHaveBeenCalledTimes(1);
-    expect(nodeFetch).toHaveBeenCalledWith('url', {
-      signal: new AbortController().signal,
-      agent: undefined,
-    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'url',
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        dispatcher: undefined,
+      })
+    );
     expect(global.clearTimeout).toHaveBeenCalledTimes(1);
   });
 
-  it('should call node-fetch with proxy agent', async () => {
+  it('should call fetch with proxy agent', async () => {
     (getProxyAgent as jest.Mock).mockRestore();
     const proxyAgent = new HttpsProxyAgent('http://localhost');
     (getProxyAgent as jest.Mock).mockReturnValueOnce(proxyAgent);
 
     await fetchWithTimeout('url');
 
-    expect(nodeFetch).toHaveBeenCalledWith('url', { agent: proxyAgent });
+    expect(global.fetch).toHaveBeenCalledWith('url', { dispatcher: proxyAgent });
   });
 
-  it('should call node-fetch without signal when timeout is not passed', async () => {
+  it('should call fetch without signal when timeout is not passed', async () => {
     await fetchWithTimeout('url');
 
     expect(global.setTimeout).not.toHaveBeenCalled();
-    expect(nodeFetch).toHaveBeenCalledWith('url', { agent: undefined });
+    expect(global.fetch).toHaveBeenCalledWith('url', { agent: undefined });
     expect(global.clearTimeout).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -6,11 +6,23 @@ import { Arguments } from 'yargs';
 import { handlePush, PushOptions } from '../commands/push';
 import { detectSpec } from '@redocly/openapi-core';
 
-jest.mock('node-fetch');
+const mockFetch = jest.fn();
+const originalFetch = global.fetch;
+
 jest.mock('../utils/miscellaneous', () => ({
   sendTelemetry: jest.fn(),
   loadConfigAndHandleErrors: jest.fn(),
 }));
+
+beforeAll(() => {
+  global.fetch = mockFetch;
+});
+
+afterAll(() => {
+  jest.resetAllMocks();
+  global.fetch = originalFetch;
+});
+
 jest.mock('../commands/lint', () => ({
   handleLint: jest.fn().mockImplementation(({ collectSpecData }) => {
     collectSpecData({ openapi: '3.1.0' });

--- a/packages/cli/src/utils/fetch-with-timeout.ts
+++ b/packages/cli/src/utils/fetch-with-timeout.ts
@@ -1,5 +1,3 @@
-import nodeFetch, { type RequestInit } from 'node-fetch';
-import AbortController from 'abort-controller';
 import { getProxyAgent } from '@redocly/openapi-core';
 
 export const DEFAULT_FETCH_TIMEOUT = 3000;
@@ -10,24 +8,23 @@ export type FetchWithTimeoutOptions = RequestInit & {
 
 export default async (url: string, { timeout, ...options }: FetchWithTimeoutOptions = {}) => {
   if (!timeout) {
-    return nodeFetch(url, {
+    return fetch(url, {
       ...options,
-      agent: getProxyAgent(),
-    });
+      dispatcher: getProxyAgent(),
+    } as RequestInit);
   }
 
-  const controller = new AbortController();
+  const controller = new globalThis.AbortController();
   const timeoutId = setTimeout(() => {
     controller.abort();
   }, timeout);
 
-  const res = await nodeFetch(url, {
+  const res = await fetch(url, {
     signal: controller.signal,
     ...options,
-    agent: getProxyAgent(),
-  });
+    dispatcher: getProxyAgent(),
+  } as RequestInit);
 
   clearTimeout(timeoutId);
-
   return res;
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=14.19.0",
-    "npm": ">=7.0.0"
+    "node": ">=18.17.0",
+    "npm": ">=10.8.2"
   },
   "engineStrict": true,
   "license": "MIT",
@@ -17,7 +17,6 @@
     "fs": false,
     "path": "path-browserify",
     "os": false,
-    "node-fetch": false,
     "colorette": false,
     "https-proxy-agent": false
   },
@@ -38,11 +37,10 @@
     "@redocly/ajv": "^8.11.2",
     "@redocly/config": "^0.20.1",
     "colorette": "^1.2.0",
-    "https-proxy-agent": "^7.0.4",
+    "https-proxy-agent": "^7.0.5",
     "js-levenshtein": "^1.1.6",
     "js-yaml": "^4.1.0",
     "minimatch": "^5.0.1",
-    "node-fetch": "^2.6.1",
     "pluralize": "^8.0.0",
     "yaml-ast-parser": "0.0.43"
   },
@@ -50,8 +48,6 @@
     "@types/js-levenshtein": "^1.1.0",
     "@types/js-yaml": "^4.0.3",
     "@types/minimatch": "^3.0.5",
-    "@types/node": "^20.11.5",
-    "@types/node-fetch": "^2.5.7",
     "@types/pluralize": "^0.0.29",
     "json-schema-to-ts": "^3.1.0",
     "typescript": "5.5.3"

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -1,12 +1,7 @@
 import { setRedoclyDomain } from '../domains';
 import { RedoclyClient } from '../index';
 
-jest.mock('node-fetch', () => ({
-  default: jest.fn(() => ({
-    ok: true,
-    json: jest.fn().mockResolvedValue({}),
-  })),
-}));
+const originalFetch = global.fetch;
 
 describe('RedoclyClient', () => {
   const REDOCLY_DOMAIN_US = 'redocly.com';
@@ -14,6 +9,19 @@ describe('RedoclyClient', () => {
   const REDOCLY_AUTHORIZATION_TOKEN = 'redocly-auth-token';
   const testRedoclyDomain = 'redoclyDomain.com';
   const testToken = 'test-token';
+
+  beforeAll(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+      } as any)
+    );
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
 
   afterEach(() => {
     delete process.env.REDOCLY_DOMAIN;

--- a/packages/core/src/redocly/registry-api.ts
+++ b/packages/core/src/redocly/registry-api.ts
@@ -1,8 +1,6 @@
-import fetch from 'node-fetch';
 import { getProxyAgent, isNotEmptyObject } from '../utils';
 import { getRedoclyDomain } from './domains';
 
-import type { RequestInit, HeadersInit } from 'node-fetch';
 import type {
   NotFoundProblemResponse,
   PrepareFileuploadOKResponse,
@@ -43,10 +41,13 @@ export class RegistryApi {
       throw new Error('Unauthorized');
     }
 
-    const response = await fetch(
-      `${this.getBaseUrl()}${path}`,
-      Object.assign({}, options, { headers, agent: getProxyAgent() })
-    );
+    const requestOptions = {
+      ...options,
+      headers,
+      agent: getProxyAgent(),
+    };
+
+    const response = await fetch(`${this.getBaseUrl()}${path}`, requestOptions);
 
     if (response.status === 401) {
       throw new Error('Unauthorized');

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import { extname } from 'path';
 import * as minimatch from 'minimatch';
-import fetch from 'node-fetch';
 import { parseYaml } from './js-yaml';
 import { env } from './env';
 import { logger, colorize } from './logger';


### PR DESCRIPTION
## What/Why/How?

- bump required node version
- migrate from node-fetch to fetch
- fix punycode Deprecation warning message in Spot but not in CLI itself due to its inner dependencies

## Reference

## Testing

- Monorepo run => https://github.com/Redocly/redocly/pull/12932
- push to workflows
- push to github

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
