### PR TITLE
feat: remove support in-body parameter in arazzo

### DIFF
--- a/.changeset/blue-coats-rescue.md
+++ b/.changeset/blue-coats-rescue.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Removed support for `in: body` parameters due to Arazzo specification updates.

--- a/packages/core/src/types/arazzo.ts
+++ b/packages/core/src/types/arazzo.ts
@@ -84,7 +84,7 @@ const ReusableObject: NodeType = {
 };
 const Parameter: NodeType = {
   properties: {
-    in: { type: 'string', enum: ['header', 'query', 'path', 'cookie', 'body'] },
+    in: { type: 'string', enum: ['header', 'query', 'path', 'cookie'] },
     name: { type: 'string' },
     value: {}, // any
   },

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -21,7 +21,7 @@ export interface ArazzoSourceDescription {
 export type SourceDescription = OpenAPISourceDescription | ArazzoSourceDescription;
 
 export interface Parameter {
-  in?: 'header' | 'query' | 'path' | 'cookie' | 'body';
+  in?: 'header' | 'query' | 'path' | 'cookie';
   name: string;
   value: string | number | boolean;
   reference?: string;


### PR DESCRIPTION
## What/Why/How?

Removed support for in: body parameters due to [Arazzo specification updates](https://spec.openapis.org/arazzo/latest.html#parameter-object).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
