### PR TITLE
chore(dockerfile): optimize image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,26 +8,22 @@ COPY packages/cli/package.json /build/packages/cli/
 COPY packages/core/package.json   /build/packages/core/
 COPY packages/cli/bin/ /build/packages/cli/bin/
 
-RUN npm ci --no-optional --ignore-scripts
-
 # Copy rest of the files
 COPY . /build/
-RUN npm run prepare
 
-# Install redocly-cli globally, similar to npm install --global @redocly/cli
-# but the local package is used here
-RUN apk update && apk add jq && \
-    apk add git && \
+RUN npm ci --no-optional --ignore-scripts && \
+    npm run prepare && \
+    # Install redocly-cli globally, similar to npm install --global @redocly/cli
+    # but the local package is used here
+    apk add --no-cache jq git && \
     npm run pack:prepare && \
-    npm install --global redocly-cli.tgz
-
-# npm pack in the previous RUN command does not include these assets
-RUN cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/default.hbs && \
+    npm install --global redocly-cli.tgz && \
+    # npm pack in the previous RUN command does not include these assets
+    cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/default.hbs && \
     cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/cli/lib/commands/preview-docs/preview-server/hot.js && \
-    cp packages/cli/src/commands/build-docs/template.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/build-docs/template.hbs
-
-# Clean up to reduce image size
-RUN npm cache clean --force && rm -rf /build
+    cp packages/cli/src/commands/build-docs/template.hbs /usr/local/lib/node_modules/@redocly/cli/lib/commands/build-docs/template.hbs && \
+    # Clean up to reduce image size
+    npm cache clean --force && rm -rf /build
 
 WORKDIR /spec
 


### PR DESCRIPTION
## What/Why/How?

The current structure of the Dockerfile results in a bloated image, because files get cleaned up not in the same layers where they were created (=> they do not disappear from the end image, just get "hidden" by OverlayFS).
By slightly rearranging and merging RUN instructions + removing apk cache, we can reduce the image size from ~523MB to ~248MB.