### PR TITLE
docs(all): adds info for finding org and project slugs to push-status command doc and removes broken links

### DIFF
--- a/docs/commands/push-status.md
+++ b/docs/commands/push-status.md
@@ -30,11 +30,20 @@ REDOCLY_AUTHORIZATION=<api-key> redocly push-status <pushId> --organization <org
 | Option               | Type    | Description                                                                                                                     |
 | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | pushId               | string  | **REQUIRED.** Identifier of the push you are tracking. Returned as result of the [`push`](./push.md) command.                   |
-| --organization, -o   | string  | **REQUIRED.** [Organization slug](https://redocly.com/docs/realm/setup/how-to/git-providers/gitlab-self-managed#find-org-slug). |
-| --project, -p        | string  | **REQUIRED.** [Project slug](https://redocly.com/docs/realm/setup/how-to/git-providers/gitlab-self-managed#find-org-slug).      |
+| --organization, -o   | string  | **REQUIRED.** [Organization slug](#find-org-slug). |
+| --project, -p        | string  | **REQUIRED.** [Project slug](#find-org-slug).      |
 | --domain, -d         | string  | The domain that the `push` command pushed to. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com).  |
 | --wait               | boolean | Waits until the build is completed if it is in progress. Default value is `false`.                                              |
 | --max-execution-time | number  | Maximum wait time for build completion in seconds (used in conjunction with the `--wait` option). Default value is `600`.       |
+
+<details>
+<summary>How to find and copy the Reunite organization or project slugs<a id="find-org-slug"></a></summary>
+
+  1. Log in to Reunite.
+  2. Select your organization and project.
+  3. Copy the value of the `{ORGANIZATION_SLUG}` or `{PROJECT_SLUG}` from the page URL in your browser, based on the following structure, `https://{REDOCLY_HOST}/org/{ORGANIZATION_SLUG}/project/{PROJECT_SLUG}`.
+
+</details>
 
 ## Examples
 

--- a/docs/commands/push-status.md
+++ b/docs/commands/push-status.md
@@ -27,21 +27,21 @@ REDOCLY_AUTHORIZATION=<api-key> redocly push-status <pushId> --organization <org
 
 ## Options
 
-| Option               | Type    | Description                                                                                                                     |
-| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| pushId               | string  | **REQUIRED.** Identifier of the push you are tracking. Returned as result of the [`push`](./push.md) command.                   |
-| --organization, -o   | string  | **REQUIRED.** [Organization slug](#find-org-slug). |
-| --project, -p        | string  | **REQUIRED.** [Project slug](#find-org-slug).      |
-| --domain, -d         | string  | The domain that the `push` command pushed to. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com).  |
-| --wait               | boolean | Waits until the build is completed if it is in progress. Default value is `false`.                                              |
-| --max-execution-time | number  | Maximum wait time for build completion in seconds (used in conjunction with the `--wait` option). Default value is `600`.       |
+| Option               | Type    | Description                                                                                                                    |
+| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| pushId               | string  | **REQUIRED.** Identifier of the push you are tracking. Returned as result of the [`push`](./push.md) command.                  |
+| --organization, -o   | string  | **REQUIRED.** [Organization slug](#find-org-slug).                                                                             |
+| --project, -p        | string  | **REQUIRED.** [Project slug](#find-org-slug).                                                                                  |
+| --domain, -d         | string  | The domain that the `push` command pushed to. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com). |
+| --wait               | boolean | Waits until the build is completed if it is in progress. Default value is `false`.                                             |
+| --max-execution-time | number  | Maximum wait time for build completion in seconds (used in conjunction with the `--wait` option). Default value is `600`.      |
 
 <details>
 <summary>How to find and copy the Reunite organization or project slugs<a id="find-org-slug"></a></summary>
 
-  1. Log in to Reunite.
-  2. Select your organization and project.
-  3. Copy the value of the `{ORGANIZATION_SLUG}` or `{PROJECT_SLUG}` from the page URL in your browser, based on the following structure, `https://{REDOCLY_HOST}/org/{ORGANIZATION_SLUG}/project/{PROJECT_SLUG}`.
+1. Log in to Reunite.
+2. Select your organization and project.
+3. Copy the value of the `{ORGANIZATION_SLUG}` or `{PROJECT_SLUG}` from the page URL in your browser, based on the following structure, `https://{REDOCLY_HOST}/org/{ORGANIZATION_SLUG}/project/{PROJECT_SLUG}`.
 
 </details>
 


### PR DESCRIPTION
## What/Why/How?

Users who were trying to use the push-status command were getting frustrated because the links on the page describing the org and project slugs currently are broken. The content was removed from our docs site and these links were not updated, so I copied the content into the command doc and removed the broken links.

## Reference

[#13071 on the docs content board](https://github.com/orgs/Redocly/projects/57?pane=issue&itemId=95114380&issue=Redocly%7Credocly%7C13071#:~:text=to%20404%20error-,%2313071,-Edit)

## Testing

I ran the content in my local version of the marketing repo to be sure the formatting and links work.

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
