### PR TITLE
fix: validate configurable rules severity overrides correctly in config

### DIFF
--- a/.changeset/dry-candles-lie.md
+++ b/.changeset/dry-candles-lie.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Resolved an issue where overrides for the severity of configurable rules raised warnings when validating the config.

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -392,10 +392,18 @@ const Rules: NodeType = {
   properties: {},
   additionalProperties: (value: unknown, key: string) => {
     if (key.startsWith('rule/')) {
-      return 'Assert';
+      if (typeof value === 'string') {
+        return { enum: ['error', 'warn', 'off'] };
+      } else {
+        return 'Assert';
+      }
     } else if (key.startsWith('assert/')) {
       // keep the old assert/ prefix as an alias
-      return 'Assert';
+      if (typeof value === 'string') {
+        return { enum: ['error', 'warn', 'off'] };
+      } else {
+        return 'Assert';
+      }
     } else if (builtInRules.includes(key as BuiltInRuleId) || isCustomRuleId(key)) {
       if (typeof value === 'string') {
         return { enum: ['error', 'warn', 'off'] };


### PR DESCRIPTION
## What/Why/How?


Resolved an issue where overrides for the severity of configurable rules raised warnings when validating the config.

## Reference

Closes https://github.com/Redocly/redocly-cli/issues/1865

It's a follow-up to https://github.com/Redocly/redocly-cli/pull/1811

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
