### PR TITLE
feat: added 1.0.1 arazzo version to spot supported versions rule

### DIFF
--- a/.changeset/big-kings-sort.md
+++ b/.changeset/big-kings-sort.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Added support for Arazzo version 1.0.1 in Spot validation rules.

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -167,4 +167,4 @@ export interface ArazzoDefinition {
 
 export const VERSION_PATTERN = /^1\.0\.\d+(-.+)?$/;
 
-export const ARAZZO_VERSIONS_SUPPORTED_BY_SPOT = ['1.0.0'];
+export const ARAZZO_VERSIONS_SUPPORTED_BY_SPOT = ['1.0.0', '1.0.1'];


### PR DESCRIPTION
## What/Why/How?

Added support for Arazzo version 1.0.1 in Spot validation rules.
Adding it as a enum as it takes some time to adapt tooling and despite on patch Arazzo spec version update - some changes can cause not valid file due to some supported syntax was removed or changed (request-in-body, $message from runtime expression, changes on how we can access outputs from the body response).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
