### PR TITLE
chore: reduce recommended npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       },
       "engines": {
         "node": ">=18.17.0",
-        "npm": ">=10.8.2"
+        "npm": ">=9.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12589,7 +12589,7 @@
       },
       "engines": {
         "node": ">=18.17.0",
-        "npm": ">=10.8.2"
+        "npm": ">=9.5.0"
       }
     },
     "packages/cli/node_modules/form-data": {
@@ -12630,7 +12630,7 @@
       },
       "engines": {
         "node": ">=18.17.0",
-        "npm": ">=10.8.2"
+        "npm": ">=9.5.0"
       }
     },
     "packages/core/node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "engines": {
     "node": ">=18.17.0",
-    "npm": ">=10.8.2"
+    "npm": ">=9.5.0"
   },
   "engineStrict": true,
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "npm": ">=10.8.2"
+    "npm": ">=9.5.0"
   },
   "engineStrict": true,
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "engines": {
     "node": ">=18.17.0",
-    "npm": ">=10.8.2"
+    "npm": ">=9.5.0"
   },
   "engineStrict": true,
   "license": "MIT",


### PR DESCRIPTION
## What/Why/How?

Reduce recommended npm version to 9.5 as it has a number of security fixes and compatible with recommended node js version.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
