### PR TITLE
chore: update contributing guide and mark technical package.jsons private

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ It only checks links within the local docs (it can't check links to other docs s
 ## Built-in rules changes
 
 After adding a new rule, make sure it is added to the `minimal`, `recommended`, `recommended-strict` (the same as the previous but with warnings turned into error) and `all` rulesets with appropriate severity levels. The defaults are `off` for `minimal` and `recommended` and `error` for `all`.
-Also add the rule to the `builtInRulesList` in [the config types tree](../packages/core/src/types/redocly-yaml.ts).
+Also add the rule to the built-in rules list in [the config types tree](./packages/core/src/types/redocly-yaml.ts).
 
 Separately, open a merge request with the corresponding documentation changes.
 

--- a/__tests__/smoke-plugins/package.json
+++ b/__tests__/smoke-plugins/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-project-smoke-plugins",
+  "private": true,
   "scripts": {
     "redocly-version": "redocly --version",
     "redocly-lint": "redocly lint openapi.yaml"

--- a/__tests__/smoke/package.json
+++ b/__tests__/smoke/package.json
@@ -2,6 +2,7 @@
   "name": "test-project",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "index.js",
   "scripts": {
     "redocly-version": "redocly --version",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -2,6 +2,7 @@
   "name": "benchmark",
   "version": "1.0.0",
   "description": "Test benchmark for Redocly CLI",
+  "private": true,
   "scripts": {
     "chart": "node chart.mjs > benchmark_chart.md",
     "make-test": "bash make-test-command.sh"


### PR DESCRIPTION


## What/Why/How?

- Fixed the CONTRIBUTING guide
- Marked technical package.jsons as private for clarity

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
