### PR TITLE
fix: calculate redoc version correctly in build-docs command

### DIFF
--- a/.changeset/weak-bears-perform.md
+++ b/.changeset/weak-bears-perform.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue where the `build-docs` command produced incorrect output.

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -667,7 +667,7 @@ describe('E2E', () => {
       (<any>expect(cleanupOutput(result))).toMatchSpecificSnapshot(join(testPath, 'snapshot.js'));
 
       expect(fs.existsSync(join(testPath, 'nested/redoc-static.html'))).toEqual(true);
-      expect(fs.statSync(join(testPath, 'nested/redoc-static.html')).size).toEqual(36237);
+      expect(fs.statSync(join(testPath, 'nested/redoc-static.html')).size).toEqual(36238);
     });
   });
 

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -29,7 +29,7 @@ export const handlerBuildCommand = async ({
     redocOptions: getObjectOrJSON(argv.theme?.openapi, config),
   };
 
-  const redocCurrentVersion = require('../../../package.json').dependencies.redoc.substring(1); // remove ~
+  const redocCurrentVersion = require('../../../package.json').dependencies.redoc;
 
   try {
     const elapsed = getExecutionTime(startedAt);


### PR DESCRIPTION
## What/Why/How?

Fixed an issue where the `build-docs` command produced incorrect output.

## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/1895#issuecomment-2643680046

This fixes an issue introduced in https://github.com/Redocly/redocly-cli/pull/1892

## Testing

Tested locally, updated the snapshot size.

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
