### PR TITLE
fix: $file decorator resolves wrong path to the file

### DIFF
--- a/packages/respect-core/src/modules/__tests__/config-parcer/parse-request-body.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parcer/parse-request-body.test.ts
@@ -1,24 +1,33 @@
 import * as fs from 'node:fs';
 import { Buffer } from 'node:buffer';
 
-import type { RequestBody } from '../../../types';
+import type { RequestBody, TestContext } from '../../../types';
 
 import { parseRequestBody, stripFileDecorator } from '../../config-parser';
 
 jest.mock('node:fs');
 
 describe('parseRequestBody', () => {
+  const ctx = {
+    options: {
+      workflowPath: 'test.yaml',
+    },
+  } as unknown as TestContext;
+
   it('should return empty object if no body', async () => {
-    expect(await parseRequestBody(undefined)).toEqual({});
+    expect(await parseRequestBody(undefined, ctx)).toEqual({});
   });
 
   it('should return body with no ctx provided', async () => {
     expect(
-      await parseRequestBody({
-        payload: {
-          test: 'test',
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+          },
         },
-      })
+        ctx
+      )
     ).toEqual({
       payload: { test: 'test' },
       contentType: undefined,
@@ -28,16 +37,19 @@ describe('parseRequestBody', () => {
 
   it('should return body with ctx provided', async () => {
     expect(
-      await parseRequestBody({
-        payload: 'clientId={$input.clientID}&grant_type=12',
-        contentType: 'application/x-www-form-urlencoded',
-        replacements: [
-          {
-            target: '/clientId',
-            value: '123',
-          },
-        ],
-      })
+      await parseRequestBody(
+        {
+          payload: 'clientId={$input.clientID}&grant_type=12',
+          contentType: 'application/x-www-form-urlencoded',
+          replacements: [
+            {
+              target: '/clientId',
+              value: '123',
+            },
+          ],
+        },
+        ctx
+      )
     ).toEqual({
       payload: {
         clientId: '123',
@@ -50,13 +62,16 @@ describe('parseRequestBody', () => {
 
   it('should return body with string replacement applied', async () => {
     expect(
-      await parseRequestBody({
-        payload: {
-          test: 'test',
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+          },
+          contentType: 'application/json',
+          encoding: 'utf-8',
         },
-        contentType: 'application/json',
-        encoding: 'utf-8',
-      })
+        ctx
+      )
     ).toEqual({
       payload: { test: 'test' },
       contentType: 'application/json',
@@ -66,13 +81,16 @@ describe('parseRequestBody', () => {
 
   it('should handle multipart/form-data', async () => {
     expect(
-      await parseRequestBody({
-        payload: {
-          test: 'test',
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+          },
+          contentType: 'multipart/form-data',
+          encoding: 'utf-8',
         },
-        contentType: 'multipart/form-data',
-        encoding: 'utf-8',
-      })
+        ctx
+      )
     ).toEqual({
       payload: expect.any(Object),
       contentType: expect.stringMatching(
@@ -89,14 +107,17 @@ describe('parseRequestBody', () => {
       callback();
     });
     expect(
-      await parseRequestBody({
-        payload: {
-          test: 'test',
-          file: "$file('file1.txt')",
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+            file: "$file('file1.txt')",
+          },
+          contentType: 'multipart/form-data',
+          encoding: 'utf-8',
         },
-        contentType: 'multipart/form-data',
-        encoding: 'utf-8',
-      })
+        ctx
+      )
     ).toEqual({
       payload: expect.any(Object),
       contentType: expect.stringMatching(
@@ -109,16 +130,19 @@ describe('parseRequestBody', () => {
   });
 
   it('should handle multipart/form-data with nested object', async () => {
-    const { payload, contentType, encoding } = await parseRequestBody({
-      payload: {
-        commit: {
-          message: 'test',
-          author: 'John Doe',
+    const { payload, contentType, encoding } = await parseRequestBody(
+      {
+        payload: {
+          commit: {
+            message: 'test',
+            author: 'John Doe',
+          },
         },
+        contentType: 'multipart/form-data',
+        encoding: 'utf-8',
       },
-      contentType: 'multipart/form-data',
-      encoding: 'utf-8',
-    });
+      ctx
+    );
     expect(contentType).toMatch('multipart/form-data; boundary=--------------------------');
     expect(encoding).toBe('utf-8');
     expect(typeof payload).toBe('object');
@@ -131,14 +155,17 @@ describe('parseRequestBody', () => {
 
   it('should handle multipart/form-data with array', async () => {
     expect(
-      await parseRequestBody({
-        payload: {
-          test: 'test',
-          array: ['test', 'test2'],
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+            array: ['test', 'test2'],
+          },
+          contentType: 'multipart/form-data',
+          encoding: 'utf-8',
         },
-        contentType: 'multipart/form-data',
-        encoding: 'utf-8',
-      })
+        ctx
+      )
     ).toEqual({
       payload: expect.any(Object),
       contentType: expect.stringMatching(
@@ -155,14 +182,17 @@ describe('parseRequestBody', () => {
       callback();
     });
     expect(
-      await parseRequestBody({
-        payload: {
-          test: 'test',
-          array: ['test', "$file('file2.txt')"],
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+            array: ['test', "$file('file2.txt')"],
+          },
+          contentType: 'multipart/form-data',
+          encoding: 'utf-8',
         },
-        contentType: 'multipart/form-data',
-        encoding: 'utf-8',
-      })
+        ctx
+      )
     ).toEqual({
       payload: expect.any(Object),
       contentType: expect.stringMatching(
@@ -180,14 +210,17 @@ describe('parseRequestBody', () => {
       callback(new Error('error'));
     });
     try {
-      await parseRequestBody({
-        payload: {
-          test: 'test',
-          array: ['test', "$file('file2.txt')"],
+      await parseRequestBody(
+        {
+          payload: {
+            test: 'test',
+            array: ['test', "$file('file2.txt')"],
+          },
+          contentType: 'multipart/form-data',
+          encoding: 'utf-8',
         },
-        contentType: 'multipart/form-data',
-        encoding: 'utf-8',
-      });
+        ctx
+      );
     } catch (error) {
       expect(error.message).toContain("file2.txt doesn't exist or isn't readable.");
     }
@@ -200,11 +233,14 @@ describe('parseRequestBody', () => {
       callback();
     });
     expect(
-      await parseRequestBody({
-        payload: "$file('file3.txt')",
-        contentType: 'application/octet-stream',
-        encoding: 'utf-8',
-      })
+      await parseRequestBody(
+        {
+          payload: "$file('file3.txt')",
+          contentType: 'application/octet-stream',
+          encoding: 'utf-8',
+        },
+        ctx
+      )
     ).toEqual({
       payload: 'readStream',
       contentType: 'application/octet-stream',
@@ -215,11 +251,14 @@ describe('parseRequestBody', () => {
 
   it('should handle application/octet-stream with string payload', async () => {
     expect(
-      await parseRequestBody({
-        payload: new Buffer('test') as unknown as RequestBody['payload'],
-        contentType: 'application/octet-stream',
-        encoding: 'utf-8',
-      })
+      await parseRequestBody(
+        {
+          payload: new Buffer('test') as unknown as RequestBody['payload'],
+          contentType: 'application/octet-stream',
+          encoding: 'utf-8',
+        },
+        ctx
+      )
     ).toEqual({
       payload: new Buffer('test'),
       contentType: 'application/octet-stream',
@@ -234,11 +273,14 @@ describe('parseRequestBody', () => {
       callback(new Error('error'));
     });
     await expect(
-      parseRequestBody({
-        payload: "$file('file3.txt')",
-        contentType: 'application/octet-stream',
-        encoding: 'utf-8',
-      })
+      parseRequestBody(
+        {
+          payload: "$file('file3.txt')",
+          contentType: 'application/octet-stream',
+          encoding: 'utf-8',
+        },
+        ctx
+      )
     ).rejects.toThrow("file3.txt doesn't exist or isn't readable.");
   });
 });

--- a/packages/respect-core/src/modules/flow-runner/prepare-request.ts
+++ b/packages/respect-core/src/modules/flow-runner/prepare-request.ts
@@ -80,7 +80,7 @@ export async function prepareRequest(
     payload: stepRequestBodyPayload,
     // encoding: stepRequestBodyEncoding,
     contentType: stepRequestBodyContentType,
-  } = await parseRequestBody(step['requestBody']);
+  } = await parseRequestBody(step['requestBody'], ctx);
 
   const requestBody = stepRequestBodyPayload || requestDataFromOpenAPI?.requestBody;
   const contentType = stepRequestBodyContentType || requestDataFromOpenAPI?.contentType;


### PR DESCRIPTION
## What/Why/How?

File path resolving was broken:

```
      - stepId: pushFilesToRemote
        operationId: push
        requestBody:
          contentType: multipart/form-data
          payload:
            remoteId: $steps.upsertRemote.outputs.remoteId
            replace: true
            commit:
              message: 'Push files to remote'
              author:
                name: John Doe
                email: integration-test-owner1@redocly.com
              branchName: dev
            'petstore.yaml': $file('petstore.yaml')
```

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
