### PR TITLE
feat: removed extended option from generate-arazzo command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -954,11 +954,6 @@ yargs
             describe: 'Output File name',
             type: 'string',
           },
-          extended: {
-            describe:
-              'Generate config with populated values from description using success criteria',
-            type: 'boolean',
-          },
         });
     },
     async (argv) => {

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -9,7 +9,6 @@ import { type CommandArgs } from '../types';
 export type GenerateArazzoFileOptions = {
   descriptionPath: string;
   'output-file'?: string;
-  extended?: boolean;
 };
 
 const logger = DefaultLogger.getInstance();

--- a/packages/respect-core/src/modules/__tests__/test-config-generator/generate-test-config.test.ts
+++ b/packages/respect-core/src/modules/__tests__/test-config-generator/generate-test-config.test.ts
@@ -42,56 +42,12 @@ const BUNDLED_DESCRIPTION_MOCK = {
 };
 
 describe('generateTestConfig', () => {
-  it('should generate test config', async () => {
-    (bundleOpenApi as jest.Mock).mockReturnValue(BUNDLED_DESCRIPTION_MOCK);
-    expect(
-      await generateTestConfig({
-        descriptionPath: 'description.yaml',
-        extended: false,
-      })
-    ).toEqual({
-      arazzo: '1.0.1',
-      info: {
-        title: 'Swagger Petstore',
-        version: '1.0.0',
-      },
-      sourceDescriptions: [
-        {
-          name: 'description',
-          type: 'openapi',
-          url: 'description.yaml',
-        },
-      ],
-      workflows: [
-        {
-          workflowId: 'get-pet-workflow',
-          steps: [
-            {
-              operationId: '$sourceDescriptions.description.getPet',
-              stepId: 'get-pet-step',
-            },
-          ],
-        },
-        {
-          workflowId: 'get-fact-workflow',
-          steps: [
-            {
-              operationId: '$sourceDescriptions.description.getFact',
-              stepId: 'get-fact-step',
-            },
-          ],
-        },
-      ],
-    });
-  });
-
   it('should generate test config when output file is provided', async () => {
     (bundleOpenApi as jest.Mock).mockReturnValue(BUNDLED_DESCRIPTION_MOCK);
     expect(
       await generateTestConfig({
         descriptionPath: 'description.yaml',
         'output-file': './final-test-location/output.yaml',
-        extended: false,
       })
     ).toEqual({
       arazzo: '1.0.1',
@@ -113,6 +69,7 @@ describe('generateTestConfig', () => {
             {
               operationId: '$sourceDescriptions.description.getPet',
               stepId: 'get-pet-step',
+              successCriteria: [{ condition: '$statusCode == 200' }],
             },
           ],
         },
@@ -129,7 +86,7 @@ describe('generateTestConfig', () => {
     });
   });
 
-  it('should generate test config with extended', async () => {
+  it('should generate test config with', async () => {
     (bundleOpenApi as jest.Mock).mockReturnValue(BUNDLED_DESCRIPTION_MOCK);
     (getOperationFromDescription as jest.Mock).mockReturnValue({
       responses: {
@@ -154,7 +111,6 @@ describe('generateTestConfig', () => {
     expect(
       await generateTestConfig({
         descriptionPath: 'description.yaml',
-        extended: true,
       })
     ).toEqual({
       arazzo: '1.0.1',
@@ -193,12 +149,11 @@ describe('generateTestConfig', () => {
     });
   });
 
-  it('should generate extended test config with not existing description', async () => {
+  it('should generate test config with not existing description', async () => {
     (bundleOpenApi as jest.Mock).mockReturnValue(undefined);
     expect(
       await generateTestConfig({
         descriptionPath: 'description.yaml',
-        extended: false,
       })
     ).toEqual({
       arazzo: '1.0.1',

--- a/packages/respect-core/src/modules/test-config-generator/generate-test-config.ts
+++ b/packages/respect-core/src/modules/test-config-generator/generate-test-config.ts
@@ -8,9 +8,6 @@ import type { GenerateArazzoFileOptions } from '../../handlers/generate';
 type WorkflowsFromDescriptionInput = {
   descriptionPaths: any;
   sourceDescriptionName: string;
-  options: {
-    extended?: boolean;
-  };
 };
 
 function generateParametersWithSuccessCriteria(
@@ -32,10 +29,8 @@ function generateOperationId(path: string, method: OperationMethod) {
 
 function generateWorkflowsFromDescription({
   descriptionPaths,
-  options,
   sourceDescriptionName,
 }: WorkflowsFromDescriptionInput): Workflow[] {
-  const { extended } = options;
   const workflows = [] as Workflow[];
 
   for (const pathItemKey in descriptionPaths) {
@@ -72,10 +67,9 @@ function generateWorkflowsFromDescription({
             {
               stepId: pathKey ? `${method}-${pathKey}-step` : `${method}-step`,
               operationId: `$sourceDescriptions.${sourceDescriptionName}.${resolvedOperationId}`,
-              ...(extended &&
-                generateParametersWithSuccessCriteria(
-                  descriptionPaths[pathItemKey][method].responses
-                )),
+              ...generateParametersWithSuccessCriteria(
+                descriptionPaths[pathItemKey][method].responses
+              ),
             } as unknown as Step,
           ],
         });
@@ -98,7 +92,6 @@ function resolveDescriptionNameFromPath(descriptionPath: string): string {
 export async function generateTestConfig({
   descriptionPath,
   'output-file': outputFile,
-  extended,
 }: GenerateArazzoFileOptions) {
   const { paths: pathsObject, info } = (await bundleOpenApi(descriptionPath, '')) || {};
   const sourceDescriptionName = resolveDescriptionNameFromPath(descriptionPath);
@@ -121,7 +114,6 @@ export async function generateTestConfig({
     ],
     workflows: generateWorkflowsFromDescription({
       descriptionPaths: pathsObject,
-      options: { extended },
       sourceDescriptionName,
     }),
   };


### PR DESCRIPTION
## What/Why/How?

Remove `extended` option from `generate-arazzo` command.
This will be the default behavior.

e.g. of generated file =>

```yaml
arazzo: 1.0.1
info:
  title: Redocly Museum API
  version: 1.1.1
sourceDescriptions:
  - name: museum
    type: openapi
    url: resources/museum.yaml
workflows:
  - workflowId: get-museum-hours-workflow
    steps:
      - stepId: get-museum-hours-step
        operationId: $sourceDescriptions.museum.getMuseumHours
        successCriteria:
          - condition: $statusCode == 200
```

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
