### PR TITLE
feat: resolve server url

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
       lines: 64,
     },
     'packages/respect-core/': {
-      statements: 84,
+      statements: 83,
       branches: 74,
       functions: 84,
       lines: 84,

--- a/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
@@ -285,4 +285,58 @@ describe('getServerUrl', () => {
     const result = getServerUrl({ ctx, descriptionName });
     expect(result).toEqual({ url: 'https://cli.com' });
   });
+
+  it('should return server url from openapi server with variables', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          paths: {
+            '/test': {
+              get: {
+                servers: [
+                  {
+                    url: 'https://{region}@{task}.{region}.openapi-server-with-vars.com/v1',
+                    variables: {
+                      region: {
+                        default: 'us',
+                        enum: ['us', 'eu', 'asia'],
+                      },
+                      task: {
+                        default: 'ping',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    } as unknown as TestContext;
+    const openapiOperation = {
+      servers: [
+        {
+          url: 'https://{region}@{task}.{region}.openapi-server-with-vars.{domain}/v1?param={task}#fragment,param={task}',
+          variables: {
+            domain: {
+              default: 'com',
+              enum: ['com', 'net'],
+            },
+            region: {
+              default: 'us',
+              enum: ['us', 'eu', 'asia'],
+            },
+            task: {
+              default: 'ping',
+            },
+          },
+        },
+      ],
+    } as unknown as OperationDetails;
+    const descriptionName = 'test';
+    const result = getServerUrl({ ctx, descriptionName, openapiOperation });
+    expect(result).toEqual({
+      url: 'https://us@ping.us.openapi-server-with-vars.com/v1?param=ping#fragment,param=ping',
+    });
+  });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
@@ -12,7 +12,7 @@ describe('getServerUrl', () => {
     } as unknown as TestContext;
     const descriptionName = 'test';
     const result = getServerUrl({ ctx, descriptionName });
-    expect(result).toEqual({ url: 'https://example.com' });
+    expect(result).toEqual({ url: 'https://example.com', parameters: [] });
   });
 
   it('should return undefined when path does not include url and no servers provided', () => {
@@ -38,7 +38,7 @@ describe('getServerUrl', () => {
     } as unknown as TestContext;
     const descriptionName = 'test';
     const result = getServerUrl({ ctx, descriptionName });
-    expect(result).toEqual({ url: 'https://example.com' });
+    expect(result).toEqual({ url: 'https://example.com', parameters: [] });
   });
 
   it('should return server url from sourceDescription x-serverUrl resolved from context', () => {
@@ -56,7 +56,7 @@ describe('getServerUrl', () => {
     } as unknown as TestContext;
     const descriptionName = 'test';
     const result = getServerUrl({ ctx, descriptionName });
-    expect(result).toEqual({ url: 'https://example.com' });
+    expect(result).toEqual({ url: 'https://example.com', parameters: [] });
   });
 
   it('should return overwritten server url from sourceDescription x-serverUrl resolved from context', () => {
@@ -97,7 +97,7 @@ describe('getServerUrl', () => {
     } as unknown as OperationDetails & { servers: { url: string }[] };
     const descriptionName = 'test';
     const result = getServerUrl({ ctx, descriptionName, openapiOperation });
-    expect(result).toEqual({ url: 'https://example1.com' });
+    expect(result).toEqual({ url: 'https://example1.com', parameters: [] });
   });
 
   it('should return "x-operation" url as server url when descriptionName is not provided', () => {
@@ -156,7 +156,7 @@ describe('getServerUrl', () => {
     } as unknown as TestContext;
 
     const result = getServerUrl({ ctx, descriptionName: '' });
-    expect(result).toEqual({ url: 'https://api.example.com' });
+    expect(result).toEqual({ url: 'https://api.example.com', parameters: [] });
   });
 
   it('should return undefined when neither x-serverUrl nor $sourceDescriptions server is available when descriptionName is not provided and there is only one sourceDescription', () => {
@@ -211,7 +211,7 @@ describe('getServerUrl', () => {
       openapiOperation: mockDescriptionOperation,
     } as unknown as GetServerUrlInput);
 
-    expect(result).toEqual({ url: 'https://server1.com' });
+    expect(result).toEqual({ url: 'https://server1.com', parameters: [] });
   });
 
   it('should return undefined when descriptionOperation.servers is empty', () => {
@@ -340,7 +340,12 @@ describe('getServerUrl', () => {
     const descriptionName = 'test';
     const result = getServerUrl({ ctx, descriptionName, openapiOperation });
     expect(result).toEqual({
-      url: 'https://us@ping.us.openapi-server-with-vars.com/v1?param=ping#fragment,param=ping',
+      url: 'https://{region}@{task}.{region}.openapi-server-with-vars.{domain}/v1?param={task}#fragment,param={task}',
+      parameters: [
+        { name: 'domain', value: 'com', in: 'path' },
+        { name: 'region', value: 'us', in: 'path' },
+        { name: 'task', value: 'ping', in: 'path' },
+      ],
     });
   });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
@@ -295,8 +295,12 @@ describe('getServerUrl', () => {
               get: {
                 servers: [
                   {
-                    url: 'https://{region}@{task}.{region}.openapi-server-with-vars.com/v1',
+                    url: 'https://{region}@{task}.{region}.openapi-server-with-vars.{domain}/v1?param={task}#fragment,param={task}',
                     variables: {
+                      domain: {
+                        default: 'com',
+                        enum: ['com', 'net'],
+                      },
                       region: {
                         default: 'us',
                         enum: ['us', 'eu', 'asia'],

--- a/packages/respect-core/src/modules/__tests__/flow-runner/prepare-request.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/prepare-request.test.ts
@@ -428,7 +428,7 @@ describe('prepareRequest', () => {
       summary: 'Get a list of breeds',
       tags: ['Breeds'],
     });
-    expect(serverUrl).toEqual({ url: 'https://catfact.ninja/' });
+    expect(serverUrl).toEqual({ url: 'https://catfact.ninja/', parameters: [] });
     expect(requestBody).toEqual(undefined);
   });
 

--- a/packages/respect-core/src/modules/description-parser/get-request-data-from-openapi.ts
+++ b/packages/respect-core/src/modules/description-parser/get-request-data-from-openapi.ts
@@ -14,6 +14,7 @@ export interface OpenApiRequestData {
   requestBody?: Record<string, unknown>;
   contentType?: string;
   parameters: ParameterWithIn[];
+  contentTypeParameters: ParameterWithIn[];
 }
 
 export function getRequestDataFromOpenApi(
@@ -30,13 +31,15 @@ export function getRequestDataFromOpenApi(
   const accept = getAcceptHeader(operation);
   const parameters = getUniqueParameters([
     ...transformParameters(operation.pathParameters),
-    { name: 'content-type', in: 'header' as const, value: contentType },
-    ...(accept ? [{ name: 'accept', in: 'header' as const, value: accept }] : []),
     ...transformParameters(operation.parameters),
   ]).filter(({ value }) => value);
 
   return {
     parameters,
+    contentTypeParameters: [
+      ...(contentType ? [{ name: 'content-type', in: 'header' as const, value: contentType }] : []),
+      ...(accept ? [{ name: 'accept', in: 'header' as const, value: accept }] : []),
+    ],
     requestBody,
     contentType,
   };

--- a/packages/respect-core/src/modules/flow-runner/get-server-url.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-server-url.ts
@@ -55,9 +55,9 @@ export function getServerUrl({
       };
     }
 
-    return {
-      url: getValueFromContext('$' + `sourceDescriptions.${descriptionName}.servers.0.url`, ctx),
-    };
+    return resolveOpenApiServerUrlWithVariables(
+      getValueFromContext('$' + `sourceDescriptions.${descriptionName}.servers.0`, ctx)
+    );
   }
 
   if (openapiOperation?.servers?.[0]) {
@@ -86,14 +86,15 @@ export function getServerUrl({
   if (!descriptionName && ctx?.sourceDescriptions && ctx.sourceDescriptions.length === 1) {
     const sourceDescription = ctx.sourceDescriptions[0];
 
-    let serverUrl = '';
     if ('x-serverUrl' in sourceDescription && sourceDescription['x-serverUrl']) {
-      serverUrl = sourceDescription['x-serverUrl'];
+      return { url: sourceDescription['x-serverUrl'] };
     } else {
-      serverUrl = ctx.$sourceDescriptions[sourceDescription.name]?.servers[0]?.url || undefined;
+      return (
+        resolveOpenApiServerUrlWithVariables(
+          ctx.$sourceDescriptions[sourceDescription.name]?.servers[0]
+        ) || undefined
+      );
     }
-
-    return serverUrl ? { url: serverUrl } : undefined;
   }
 
   if (
@@ -106,25 +107,38 @@ export function getServerUrl({
   }
 
   // Get first available server url from the description
-  return ctx.$sourceDescriptions[descriptionName].servers[0];
+  return resolveOpenApiServerUrlWithVariables(ctx.$sourceDescriptions[descriptionName].servers?.[0]);
 }
 
-function resolveOpenApiServerUrlWithVariables(server: ServerObject) {
-  if (!server.url) {
+function resolveOpenApiServerUrlWithVariables(server?: ServerObject) {
+  if (!server) {
     return undefined;
   }
+  return {
+    url: server.url,
+    parameters: Object.entries(server.variables || {})
+      .map(([key, value]) => ({
+        in: 'path',
+        name: key,
+        value: value.default,
+      }))
+      .filter(({ value }) => !!value),
+  };
+  // if (!server.url) {
+  //   return undefined;
+  // }
 
-  // If no variables in URL or no variables defined, return URL as is
-  if (!server.url.includes('{') || !server.variables) {
-    return { url: server.url };
-  }
+  // // If no variables in URL or no variables defined, return URL as is
+  // if (!server.url.includes('{') || !server.variables) {
+  //   return { url: server.url };
+  // }
 
-  // Replace all variables with their default values
-  let resolvedUrl = server.url;
-  for (const [varName, varConfig] of Object.entries(server.variables)) {
-    const variablePattern = new RegExp(`{${varName}}`, 'g');
-    resolvedUrl = resolvedUrl.replace(variablePattern, varConfig.default);
-  }
+  // // Replace all variables with their default values
+  // let resolvedUrl = server.url;
+  // for (const [varName, varConfig] of Object.entries(server.variables)) {
+  //   const variablePattern = new RegExp(`{${varName}}`, 'g');
+  //   resolvedUrl = resolvedUrl.replace(variablePattern, varConfig.default);
+  // }
 
-  return { url: resolvedUrl };
+  // return { url: resolvedUrl };
 }

--- a/packages/respect-core/src/modules/flow-runner/get-server-url.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-server-url.ts
@@ -126,21 +126,4 @@ function resolveOpenApiServerUrlWithVariables(server?: ServerObject) {
       }))
       .filter(({ value }) => !!value),
   };
-  // if (!server.url) {
-  //   return undefined;
-  // }
-
-  // // If no variables in URL or no variables defined, return URL as is
-  // if (!server.url.includes('{') || !server.variables) {
-  //   return { url: server.url };
-  // }
-
-  // // Replace all variables with their default values
-  // let resolvedUrl = server.url;
-  // for (const [varName, varConfig] of Object.entries(server.variables)) {
-  //   const variablePattern = new RegExp(`{${varName}}`, 'g');
-  //   resolvedUrl = resolvedUrl.replace(variablePattern, varConfig.default);
-  // }
-
-  // return { url: resolvedUrl };
 }

--- a/packages/respect-core/src/modules/flow-runner/get-server-url.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-server-url.ts
@@ -107,7 +107,9 @@ export function getServerUrl({
   }
 
   // Get first available server url from the description
-  return resolveOpenApiServerUrlWithVariables(ctx.$sourceDescriptions[descriptionName].servers?.[0]);
+  return resolveOpenApiServerUrlWithVariables(
+    ctx.$sourceDescriptions[descriptionName].servers?.[0]
+  );
 }
 
 function resolveOpenApiServerUrlWithVariables(server?: ServerObject) {

--- a/packages/respect-core/src/modules/flow-runner/prepare-request.ts
+++ b/packages/respect-core/src/modules/flow-runner/prepare-request.ts
@@ -50,7 +50,8 @@ export async function prepareRequest(
 
   let path = '';
   let method;
-  const serverUrl: { url: string; descriptionName?: string } | undefined = getServerUrl({
+
+  const serverUrl: { url: string; parameters?: ParameterWithIn[] } | undefined = getServerUrl({
     ctx,
     descriptionName: openapiOperation?.descriptionName,
     openapiOperation,
@@ -89,7 +90,10 @@ export async function prepareRequest(
     typeof requestBody === 'object'
       ? [{ in: 'header', name: 'content-type', value: 'application/json' }]
       : [],
-    requestDataFromOpenAPI?.parameters || [],
+    serverUrl?.parameters || [],
+    requestDataFromOpenAPI?.contentTypeParameters || [],
+    // if step.parameters is defined, we do not auto-populate parameters from the openapi operation
+    step.parameters ? [] : requestDataFromOpenAPI?.parameters || [],
     resolveParameters(workflowLevelParameters, ctx),
     stepRequestBodyContentType
       ? [{ in: 'header', name: 'content-type', value: stepRequestBodyContentType }]


### PR DESCRIPTION
## What/Why/How?

As `openapiOperation.servers[0]` already have servers resolved with priority of `Operation--Path--Root` (from higher to lower) we extend it to also resolve complex server url description with variables, `default` value will be selected and resolved in the final server url.
```
  - url: https://{region}-server-with-vars.com/v1
    description: Regional server
    variables:
      region:
        default: us
        enum:
          - us
          - eu
          - asia
```         

## Reference

Closes: https://github.com/Redocly/redocly/issues/11205

## Testing

```openAPI.yaml
openapi: 3.1.0
info:
  title: Minimal API
  version: 1.0.0
security: []
servers:
  - url: https://{region}.{task}-server-with-vars.{domain}/v1
    description: Regional server
    variables:
      region:
        default: us
        enum:
          - us
          - eu
          - asia
      task:
        default: ping
      domain:
        default: com
  - url: https://top-level-server.com
    description: Production server
  - url: https://top-level-server-2.com
    description: Staging server
paths:
  /ping:
    servers:
      - url: https://path-level-server.com
        description: Ping-specific server
    get:
      operationId: ping
      summary: Ping the server
      servers:
        - url: https://{region}@{task}.{region}.operation-level.com/v1
          description: Regional server
          variables:
            region:
              default: us
              enum:
                - us
                - eu
                - asia
            task:
              default: ping
      responses:
        '200':
          description: Successful response
```

```Arazzo.yaml
arazzo: 1.0.1
info:
  title: servers
  description: servers
  version: 1.0.0

sourceDescriptions:
  - name: servers
    type: openapi
    url: api-servers.yaml

workflows:
  - workflowId: get-servers
    description: get servers
    steps:
      - stepId: ping
        operationId: ping
```

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
