### PR TITLE
fix: server selection by index

### DIFF
--- a/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
@@ -46,17 +46,34 @@ describe('getServerUrl', () => {
       sourceDescriptions: [
         {
           name: 'test',
-          'x-serverUrl': '$servers.0.url',
+          'x-serverUrl': '$servers.2.url',
           type: 'openapi',
         },
       ],
       $sourceDescriptions: {
-        test: { servers: [{ url: 'https://example.com' }] },
+        test: {
+          servers: [
+            { url: 'https://example.com' },
+            { url: 'https://example2.com' },
+            {
+              url: 'https://example3.{domain}',
+              variables: {
+                domain: {
+                  default: 'com',
+                  enum: ['com', 'net'],
+                },
+              },
+            },
+          ],
+        },
       },
     } as unknown as TestContext;
     const descriptionName = 'test';
     const result = getServerUrl({ ctx, descriptionName });
-    expect(result).toEqual({ url: 'https://example.com', parameters: [] });
+    expect(result).toEqual({
+      url: 'https://example3.{domain}',
+      parameters: [{ name: 'domain', value: 'com', in: 'path' }],
+    });
   });
 
   it('should return overwritten server url from sourceDescription x-serverUrl resolved from context', () => {

--- a/packages/respect-core/src/modules/flow-runner/get-server-url.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-server-url.ts
@@ -64,7 +64,7 @@ export function getServerUrl({
     }
 
     const serverObject = getValueFromContext(
-      '$' + `sourceDescriptions.${descriptionName}.servers.${serverIndexInDescription}`,
+      `$sourceDescriptions.${descriptionName}.servers.${serverIndexInDescription}`,
       ctx
     );
 

--- a/packages/respect-core/src/modules/flow-runner/get-server-url.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-server-url.ts
@@ -55,9 +55,20 @@ export function getServerUrl({
       };
     }
 
-    return resolveOpenApiServerUrlWithVariables(
-      getValueFromContext('$' + `sourceDescriptions.${descriptionName}.servers.0`, ctx)
+    const serverIndexInDescription = sourceDescription['x-serverUrl'].startsWith('$servers.')
+      ? sourceDescription['x-serverUrl'].split('.')[1]
+      : undefined;
+
+    if (!serverIndexInDescription) {
+      return undefined;
+    }
+
+    const serverObject = getValueFromContext(
+      '$' + `sourceDescriptions.${descriptionName}.servers.${serverIndexInDescription}`,
+      ctx
     );
+
+    return resolveOpenApiServerUrlWithVariables(serverObject);
   }
 
   if (openapiOperation?.servers?.[0]) {


### PR DESCRIPTION
## What/Why/How?

Fixed resolving serverUrl with `x-serverUrl': '$servers.2.url'` syntax.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
