### PR TITLE
chore: add @redocly/config to @redocly/cli dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14184,6 +14184,7 @@
         "@opentelemetry/resources": "1.26.0",
         "@opentelemetry/sdk-trace-node": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
+        "@redocly/config": "^0.21.0",
         "@redocly/openapi-core": "1.31.2",
         "@redocly/respect-core": "1.31.2",
         "abort-controller": "^3.0.0",
@@ -14223,6 +14224,12 @@
         "node": ">=18.17.0",
         "npm": ">=9.5.0"
       }
+    },
+    "packages/cli/node_modules/@redocly/config": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.21.0.tgz",
+      "integrity": "sha512-JBtrrjBIURTnzb7KUIWOF46vSgpfC3rO6Mm8LjtRjtTNCLTyB+mOuU7HrTkVcvUCEBuSuzkivlTHMWT4JETz9A==",
+      "license": "MIT"
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
@@ -16981,6 +16988,7 @@
         "@opentelemetry/resources": "1.26.0",
         "@opentelemetry/sdk-trace-node": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
+        "@redocly/config": "^0.21.0",
         "@redocly/openapi-core": "1.31.2",
         "@redocly/respect-core": "1.31.2",
         "@types/configstore": "^5.0.1",
@@ -17009,6 +17017,13 @@
         "styled-components": "^6.0.7",
         "typescript": "5.5.3",
         "yargs": "17.0.1"
+      },
+      "dependencies": {
+        "@redocly/config": {
+          "version": "0.21.0",
+          "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.21.0.tgz",
+          "integrity": "sha512-JBtrrjBIURTnzb7KUIWOF46vSgpfC3rO6Mm8LjtRjtTNCLTyB+mOuU7HrTkVcvUCEBuSuzkivlTHMWT4JETz9A=="
+        }
       }
     },
     "@redocly/config": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "Roman Hotsiy <roman@redocly.com> (https://redocly.com/)"
   ],
   "dependencies": {
+    "@redocly/config": "^0.21.0",
     "@redocly/openapi-core": "1.31.2",
     "@redocly/respect-core": "1.31.2",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
## What/Why/How?

`@redocly/cli` was missing a dependency on `@redocly/config`. This adds that dependency so that installing and using `@redocly/cli` using tools like `pnpm` won't fail. Specifically, this is when hoisting is not enabled: https://pnpm.io/npmrc#hoist

## Reference

https://github.com/Redocly/redocly-cli/blob/b11ded51062c3b9d296e9c81663144a0410a409b/packages/cli/src/utils/miscellaneous.ts#L28

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
