### PR TITLE
feat: improve generate-arazzo command output

### DIFF
--- a/.changeset/green-hairs-suffer.md
+++ b/.changeset/green-hairs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed OAS3SecurityScheme type.

--- a/.changeset/green-hairs-suffer.md
+++ b/.changeset/green-hairs-suffer.md
@@ -1,6 +1,0 @@
----
-"@redocly/openapi-core": patch
----
-
-Fixed the `OAS3SecurityScheme` type to be compliant with OpenAPI Specification v3.1.1.
-Added support for `mutualTLS` and made the `bearerFormat` optional.

--- a/.changeset/green-hairs-suffer.md
+++ b/.changeset/green-hairs-suffer.md
@@ -2,4 +2,5 @@
 "@redocly/openapi-core": patch
 ---
 
-Fixed the `OAS3SecurityScheme` type to be compliant with OpenAPI Specification v3.1.1. Added support for `mutualTLS` and made the `bearerFormat` optional.
+Fixed the `OAS3SecurityScheme` type to be compliant with OpenAPI Specification v3.1.1.
+Added support for `mutualTLS` and made the `bearerFormat` optional.

--- a/.changeset/green-hairs-suffer.md
+++ b/.changeset/green-hairs-suffer.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Fixed OAS3SecurityScheme type.
+Fixed the `OAS3SecurityScheme` type to be compliant with OpenAPI Specification v3.1.1. Added support for `mutualTLS` and made the `bearerFormat` optional.

--- a/.changeset/silver-crews-eat.md
+++ b/.changeset/silver-crews-eat.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Add support for basic, bearer, and apiKey security schemes in workflow generation with `generate-arazzo` command.
+Added support for `basic`, `bearer`, and `apiKey` security schemes in workflow generation with `generate-arazzo` command.

--- a/.changeset/silver-crews-eat.md
+++ b/.changeset/silver-crews-eat.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Add support for basic, bearer, and apiKey security schemes in workflow generation with `generate-arazzo` command.

--- a/packages/core/src/typings/openapi.ts
+++ b/packages/core/src/typings/openapi.ts
@@ -292,12 +292,12 @@ export interface Oas3SecurityRequirement {
 }
 
 export interface Oas3SecurityScheme {
-  type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect';
+  type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect' | 'mutualTLS';
   description?: string;
   name?: string;
   in?: 'query' | 'header' | 'cookie';
   scheme?: string;
-  bearerFormat: string;
+  bearerFormat?: string;
   flows: {
     implicit?: {
       refreshUrl?: string;

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-inputs-arazzo-components.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-inputs-arazzo-components.test.ts
@@ -21,14 +21,61 @@ describe('generateSecurityInputsArazzoComponents', () => {
         basicAuth: {
           type: 'object',
           properties: {
-            username: { type: 'string', description: 'Username for basic authentication' },
-            password: {
+            basicAuth: {
               type: 'string',
+              description: 'Basic authentication',
               format: 'password',
-              description: 'Password for basic authentication',
             },
           },
-          required: ['username', 'password'],
+        },
+      },
+    });
+  });
+
+  it('should generate the correct inputs for the Bearer auth security scheme', () => {
+    const securitySchemes = {
+      bearerAuth: {
+        type: 'http' as const,
+        scheme: 'bearer',
+      } as Oas3SecurityScheme,
+    };
+    const result = generateSecurityInputsArazzoComponents(securitySchemes);
+    expect(result).toEqual({
+      inputs: {
+        bearerAuth: {
+          type: 'object',
+          properties: {
+            bearerAuth: {
+              type: 'string',
+              description: 'JWT Authentication token for ${name}',
+              format: 'password',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should generate the correct inputs for the ApiKey auth security scheme', () => {
+    const securitySchemes = {
+      apiKey: {
+        type: 'apiKey' as const,
+        name: 'X-API-Key',
+        in: 'header',
+      } as Oas3SecurityScheme,
+    };
+    const result = generateSecurityInputsArazzoComponents(securitySchemes);
+    expect(result).toEqual({
+      inputs: {
+        apiKey: {
+          type: 'object',
+          properties: {
+            apiKey: {
+              type: 'string',
+              description: 'Authentication token for apiKey',
+              format: 'password',
+            },
+          },
         },
       },
     });

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-inputs-arazzo-components.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-inputs-arazzo-components.test.ts
@@ -1,0 +1,36 @@
+import { Oas3SecurityScheme } from 'core/src/typings/openapi';
+import { generateSecurityInputsArazzoComponents } from '../../arazzo-description-generator';
+
+describe('generateSecurityInputsArazzoComponents', () => {
+  it('should generate empty inputs for the security schemes if there are no security schemes', () => {
+    const securitySchemes = {};
+    const result = generateSecurityInputsArazzoComponents(securitySchemes);
+    expect(result).toEqual({ inputs: {} });
+  });
+
+  it('should generate the correct inputs for the Basic auth security scheme', () => {
+    const securitySchemes = {
+      basicAuth: {
+        type: 'http' as const,
+        scheme: 'basic',
+      } as Oas3SecurityScheme,
+    };
+    const result = generateSecurityInputsArazzoComponents(securitySchemes);
+    expect(result).toEqual({
+      inputs: {
+        basicAuth: {
+          type: 'object',
+          properties: {
+            username: { type: 'string', description: 'Username for basic authentication' },
+            password: {
+              type: 'string',
+              format: 'password',
+              description: 'Password for basic authentication',
+            },
+          },
+          required: ['username', 'password'],
+        },
+      },
+    });
+  });
+});

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-workflow-security-inputs.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-workflow-security-inputs.test.ts
@@ -1,0 +1,44 @@
+import { generateWorkflowSecurityInputs } from '../../arazzo-description-generator';
+
+describe('generateWorkflowSecurityInputs', () => {
+  it('should return undefined if there are no security requirements', () => {
+    const inputsComponents = {};
+    const security = [] as any[];
+    const result = generateWorkflowSecurityInputs(inputsComponents, security);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the correct workflow security inputs reference', () => {
+    const inputsComponents = {
+      inputs: {
+        basicAuth: {
+          type: 'object',
+        },
+        bearerAuth: {
+          type: 'string',
+        },
+      },
+    };
+    const security = [{ basicAuth: [] }];
+    const result = generateWorkflowSecurityInputs(inputsComponents, security);
+    expect(result).toEqual({
+      $ref: '#/components/inputs/basicAuth',
+    });
+  });
+
+  it('should return undefined if the security requirement is not found in the inputs components', () => {
+    const inputsComponents = {
+      inputs: {
+        basicAuth: {
+          type: 'object',
+        },
+        bearerAuth: {
+          type: 'string',
+        },
+      },
+    };
+    const security = [{ apiKey: [] }];
+    const result = generateWorkflowSecurityInputs(inputsComponents, security);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-workflow-security-parameters.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-workflow-security-parameters.test.ts
@@ -1,0 +1,105 @@
+import { generateWorkflowSecurityParameters } from '../../arazzo-description-generator';
+
+describe('generateWorkflowSecurityParameters', () => {
+  it('should return the correct workflow security parameters for Basic authentication', () => {
+    const inputsComponents = {
+      inputs: {
+        basicAuth: {
+          type: 'object',
+          properties: {
+            username: {
+              type: 'string',
+              description: 'Username for basic authentication',
+            },
+            password: {
+              type: 'string',
+              description: 'Password for basic authentication',
+              format: 'password',
+            },
+          },
+        },
+      },
+    };
+
+    const security = [{ basicAuth: [] }];
+
+    const securitySchemes = {
+      basicAuth: {
+        type: 'http',
+        scheme: 'basic',
+      },
+    } as any;
+
+    const result = generateWorkflowSecurityParameters(inputsComponents, security, securitySchemes);
+
+    expect(result).toEqual([
+      {
+        name: 'Authorization',
+        value: `Basic ....`,
+        in: 'header',
+      },
+    ]);
+  });
+
+  it('should return the correct workflow security parameters for Bearer authentication', () => {
+    const inputsComponents = {
+      inputs: {
+        bearerAuth: {
+          type: 'string',
+          description: 'Bearer token',
+          format: 'password',
+        },
+      },
+    };
+
+    const security = [{ bearerAuth: [] }];
+
+    const securitySchemes = {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+      },
+    } as any;
+
+    const result = generateWorkflowSecurityParameters(inputsComponents, security, securitySchemes);
+
+    expect(result).toEqual([
+      {
+        name: 'Authorization',
+        value: `Bearer {$inputs.bearerAuth}`,
+        in: 'header',
+      },
+    ]);
+  });
+
+  it('should return an empty array if there are no security parameters', () => {
+    const inputsComponents = {};
+    const security = [] as any;
+    const securitySchemes = {};
+
+    const result = generateWorkflowSecurityParameters(inputsComponents, security, securitySchemes);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array if the security scheme is not supported', () => {
+    const inputsComponents = {
+      inputs: {
+        oauth2Auth: {
+          type: 'string',
+          description: 'OAuth2 token',
+        },
+      },
+    };
+    const security = [{ oauth2Auth: [] }] as any;
+    const securitySchemes = {
+      oauth2Auth: {
+        type: 'oauth2',
+      },
+    } as any;
+
+    const result = generateWorkflowSecurityParameters(inputsComponents, security, securitySchemes);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-workflow-security-parameters.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-workflow-security-parameters.test.ts
@@ -7,13 +7,9 @@ describe('generateWorkflowSecurityParameters', () => {
         basicAuth: {
           type: 'object',
           properties: {
-            username: {
+            basicAuth: {
               type: 'string',
-              description: 'Username for basic authentication',
-            },
-            password: {
-              type: 'string',
-              description: 'Password for basic authentication',
+              description: 'Basic authentication',
               format: 'password',
             },
           },
@@ -35,7 +31,7 @@ describe('generateWorkflowSecurityParameters', () => {
     expect(result).toEqual([
       {
         name: 'Authorization',
-        value: `Basic ....`,
+        value: `Basic {$inputs.basicAuth}`,
         in: 'header',
       },
     ]);
@@ -67,6 +63,38 @@ describe('generateWorkflowSecurityParameters', () => {
       {
         name: 'Authorization',
         value: `Bearer {$inputs.bearerAuth}`,
+        in: 'header',
+      },
+    ]);
+  });
+
+  it('should return the correct workflow security parameters for ApiKey authentication', () => {
+    const inputsComponents = {
+      inputs: {
+        apiKey: {
+          type: 'string',
+          description: 'ApiKey token',
+          format: 'password',
+        },
+      },
+    };
+
+    const security = [{ apiKey: [] }];
+
+    const securitySchemes = {
+      apiKey: {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+      },
+    } as any;
+
+    const result = generateWorkflowSecurityParameters(inputsComponents, security, securitySchemes);
+
+    expect(result).toEqual([
+      {
+        name: 'X-API-Key',
+        value: `$inputs.apiKey`,
         in: 'header',
       },
     ]);

--- a/packages/respect-core/src/modules/__tests__/flow-runner/context/__snapshots__/create-runtime-expression-ctx.test.ts.snap
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/context/__snapshots__/create-runtime-expression-ctx.test.ts.snap
@@ -37,6 +37,66 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
   "$response": undefined,
   "$sourceDescriptions": {
     "cats": {
+      "components": {
+        "schemas": {
+          "Breed": {
+            "description": "Breed",
+            "properties": {
+              "breed": {
+                "description": "Breed",
+                "format": "string",
+                "title": "Breed",
+                "type": "string",
+              },
+              "coat": {
+                "description": "Coat",
+                "format": "string",
+                "title": "Coat",
+                "type": "string",
+              },
+              "country": {
+                "description": "Country",
+                "format": "string",
+                "title": "Country",
+                "type": "string",
+              },
+              "origin": {
+                "description": "Origin",
+                "format": "string",
+                "title": "Origin",
+                "type": "string",
+              },
+              "pattern": {
+                "description": "Pattern",
+                "format": "string",
+                "title": "Pattern",
+                "type": "string",
+              },
+            },
+            "title": "Breed model",
+            "type": "object",
+          },
+          "CatFact": {
+            "description": "CatFact",
+            "properties": {
+              "fact": {
+                "description": "Fact",
+                "format": "string",
+                "title": "Fact",
+                "type": "string",
+              },
+              "length": {
+                "description": "Length",
+                "format": "int32",
+                "title": "Length",
+                "type": "integer",
+              },
+            },
+            "title": "CatFact model",
+            "type": "object",
+          },
+        },
+      },
       "info": {
         "title": "Cat Facts API",
         "version": "1.0",
@@ -230,6 +290,7 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
           },
         },
       },
+      "security": undefined,
       "servers": [
         {
           "url": "https://catfact.ninja/",
@@ -237,6 +298,66 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
       ],
     },
     "catsTwo": {
+      "components": {
+        "schemas": {
+          "Breed": {
+            "description": "Breed",
+            "properties": {
+              "breed": {
+                "description": "Breed",
+                "format": "string",
+                "title": "Breed",
+                "type": "string",
+              },
+              "coat": {
+                "description": "Coat",
+                "format": "string",
+                "title": "Coat",
+                "type": "string",
+              },
+              "country": {
+                "description": "Country",
+                "format": "string",
+                "title": "Country",
+                "type": "string",
+              },
+              "origin": {
+                "description": "Origin",
+                "format": "string",
+                "title": "Origin",
+                "type": "string",
+              },
+              "pattern": {
+                "description": "Pattern",
+                "format": "string",
+                "title": "Pattern",
+                "type": "string",
+              },
+            },
+            "title": "Breed model",
+            "type": "object",
+          },
+          "CatFact": {
+            "description": "CatFact",
+            "properties": {
+              "fact": {
+                "description": "Fact",
+                "format": "string",
+                "title": "Fact",
+                "type": "string",
+              },
+              "length": {
+                "description": "Length",
+                "format": "int32",
+                "title": "Length",
+                "type": "integer",
+              },
+            },
+            "title": "CatFact model",
+            "type": "object",
+          },
+        },
+      },
       "info": {
         "title": "Cat Facts API",
         "version": "1.0",
@@ -430,6 +551,7 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
           },
         },
       },
+      "security": undefined,
       "servers": [
         {
           "url": "https://catfact.ninja/",
@@ -547,6 +669,66 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
   },
   "$sourceDescriptions": {
     "cats": {
+      "components": {
+        "schemas": {
+          "Breed": {
+            "description": "Breed",
+            "properties": {
+              "breed": {
+                "description": "Breed",
+                "format": "string",
+                "title": "Breed",
+                "type": "string",
+              },
+              "coat": {
+                "description": "Coat",
+                "format": "string",
+                "title": "Coat",
+                "type": "string",
+              },
+              "country": {
+                "description": "Country",
+                "format": "string",
+                "title": "Country",
+                "type": "string",
+              },
+              "origin": {
+                "description": "Origin",
+                "format": "string",
+                "title": "Origin",
+                "type": "string",
+              },
+              "pattern": {
+                "description": "Pattern",
+                "format": "string",
+                "title": "Pattern",
+                "type": "string",
+              },
+            },
+            "title": "Breed model",
+            "type": "object",
+          },
+          "CatFact": {
+            "description": "CatFact",
+            "properties": {
+              "fact": {
+                "description": "Fact",
+                "format": "string",
+                "title": "Fact",
+                "type": "string",
+              },
+              "length": {
+                "description": "Length",
+                "format": "int32",
+                "title": "Length",
+                "type": "integer",
+              },
+            },
+            "title": "CatFact model",
+            "type": "object",
+          },
+        },
+      },
       "info": {
         "title": "Cat Facts API",
         "version": "1.0",
@@ -740,6 +922,7 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
           },
         },
       },
+      "security": undefined,
       "servers": [
         {
           "url": "https://catfact.ninja/",
@@ -747,6 +930,66 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
       ],
     },
     "catsTwo": {
+      "components": {
+        "schemas": {
+          "Breed": {
+            "description": "Breed",
+            "properties": {
+              "breed": {
+                "description": "Breed",
+                "format": "string",
+                "title": "Breed",
+                "type": "string",
+              },
+              "coat": {
+                "description": "Coat",
+                "format": "string",
+                "title": "Coat",
+                "type": "string",
+              },
+              "country": {
+                "description": "Country",
+                "format": "string",
+                "title": "Country",
+                "type": "string",
+              },
+              "origin": {
+                "description": "Origin",
+                "format": "string",
+                "title": "Origin",
+                "type": "string",
+              },
+              "pattern": {
+                "description": "Pattern",
+                "format": "string",
+                "title": "Pattern",
+                "type": "string",
+              },
+            },
+            "title": "Breed model",
+            "type": "object",
+          },
+          "CatFact": {
+            "description": "CatFact",
+            "properties": {
+              "fact": {
+                "description": "Fact",
+                "format": "string",
+                "title": "Fact",
+                "type": "string",
+              },
+              "length": {
+                "description": "Length",
+                "format": "int32",
+                "title": "Length",
+                "type": "integer",
+              },
+            },
+            "title": "CatFact model",
+            "type": "object",
+          },
+        },
+      },
       "info": {
         "title": "Cat Facts API",
         "version": "1.0",
@@ -940,6 +1183,7 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
           },
         },
       },
+      "security": undefined,
       "servers": [
         {
           "url": "https://catfact.ninja/",
@@ -1047,6 +1291,66 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
   "$response": undefined,
   "$sourceDescriptions": {
     "cats": {
+      "components": {
+        "schemas": {
+          "Breed": {
+            "description": "Breed",
+            "properties": {
+              "breed": {
+                "description": "Breed",
+                "format": "string",
+                "title": "Breed",
+                "type": "string",
+              },
+              "coat": {
+                "description": "Coat",
+                "format": "string",
+                "title": "Coat",
+                "type": "string",
+              },
+              "country": {
+                "description": "Country",
+                "format": "string",
+                "title": "Country",
+                "type": "string",
+              },
+              "origin": {
+                "description": "Origin",
+                "format": "string",
+                "title": "Origin",
+                "type": "string",
+              },
+              "pattern": {
+                "description": "Pattern",
+                "format": "string",
+                "title": "Pattern",
+                "type": "string",
+              },
+            },
+            "title": "Breed model",
+            "type": "object",
+          },
+          "CatFact": {
+            "description": "CatFact",
+            "properties": {
+              "fact": {
+                "description": "Fact",
+                "format": "string",
+                "title": "Fact",
+                "type": "string",
+              },
+              "length": {
+                "description": "Length",
+                "format": "int32",
+                "title": "Length",
+                "type": "integer",
+              },
+            },
+            "title": "CatFact model",
+            "type": "object",
+          },
+        },
+      },
       "info": {
         "title": "Cat Facts API",
         "version": "1.0",
@@ -1240,6 +1544,7 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
           },
         },
       },
+      "security": undefined,
       "servers": [
         {
           "url": "https://catfact.ninja/",
@@ -1247,6 +1552,66 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
       ],
     },
     "catsTwo": {
+      "components": {
+        "schemas": {
+          "Breed": {
+            "description": "Breed",
+            "properties": {
+              "breed": {
+                "description": "Breed",
+                "format": "string",
+                "title": "Breed",
+                "type": "string",
+              },
+              "coat": {
+                "description": "Coat",
+                "format": "string",
+                "title": "Coat",
+                "type": "string",
+              },
+              "country": {
+                "description": "Country",
+                "format": "string",
+                "title": "Country",
+                "type": "string",
+              },
+              "origin": {
+                "description": "Origin",
+                "format": "string",
+                "title": "Origin",
+                "type": "string",
+              },
+              "pattern": {
+                "description": "Pattern",
+                "format": "string",
+                "title": "Pattern",
+                "type": "string",
+              },
+            },
+            "title": "Breed model",
+            "type": "object",
+          },
+          "CatFact": {
+            "description": "CatFact",
+            "properties": {
+              "fact": {
+                "description": "Fact",
+                "format": "string",
+                "title": "Fact",
+                "type": "string",
+              },
+              "length": {
+                "description": "Length",
+                "format": "int32",
+                "title": "Length",
+                "type": "integer",
+              },
+            },
+            "title": "CatFact model",
+            "type": "object",
+          },
+        },
+      },
       "info": {
         "title": "Cat Facts API",
         "version": "1.0",
@@ -1440,6 +1805,7 @@ exports[`createRuntimeExpressionCtx should create limited runtime expression con
           },
         },
       },
+      "security": undefined,
       "servers": [
         {
           "url": "https://catfact.ninja/",

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
@@ -1,84 +1,10 @@
 import * as path from 'path';
-import { sortMethods } from '../../utils/sort';
 import { bundleOpenApi } from '../description-parser';
+import { generateWorkflowsFromDescription } from './generate-workflows-from-description';
+import { generateSecurityInputsArazzoComponents } from './generate-inputs-arazzo-components';
 
-import type { OperationMethod, TestDescription, Workflow, Step } from '../../types';
+import type { TestDescription } from '../../types';
 import type { GenerateArazzoFileOptions } from '../../handlers/generate';
-
-type WorkflowsFromDescriptionInput = {
-  descriptionPaths: any;
-  sourceDescriptionName: string;
-};
-
-function generateParametersWithSuccessCriteria(
-  responses: any
-): [] | { successCriteria: { condition: string }[] } {
-  const responseCodesFromDescription = Object.keys(responses || {});
-
-  if (!responseCodesFromDescription.length) {
-    return [];
-  }
-
-  const firstResponseCode = responseCodesFromDescription?.[0];
-  return { successCriteria: [{ condition: `$statusCode == ${firstResponseCode}` }] };
-}
-
-function generateOperationId(path: string, method: OperationMethod) {
-  return `${method}@${path}`;
-}
-
-function generateWorkflowsFromDescription({
-  descriptionPaths,
-  sourceDescriptionName,
-}: WorkflowsFromDescriptionInput): Workflow[] {
-  const workflows = [] as Workflow[];
-
-  for (const pathItemKey in descriptionPaths) {
-    for (const pathItemObjectKey of Object.keys(descriptionPaths[pathItemKey]).sort(sortMethods)) {
-      const keyToCheck = pathItemObjectKey.toLocaleLowerCase();
-
-      if (
-        [
-          'get',
-          'post',
-          'put',
-          'delete',
-          'patch',
-          'head',
-          'options',
-          'trace',
-          'connect',
-          'query',
-        ].includes(keyToCheck.toLocaleLowerCase())
-      ) {
-        const method = keyToCheck as OperationMethod;
-        const pathKey = pathItemKey
-          .replace(/^\/|\/$/g, '')
-          .split('/')
-          .join('-');
-
-        const resolvedOperationId =
-          descriptionPaths[pathItemKey][method]?.operationId ||
-          generateOperationId(pathItemKey, method);
-
-        workflows.push({
-          workflowId: pathKey ? `${method}-${pathKey}-workflow` : `${method}-workflow`,
-          steps: [
-            {
-              stepId: pathKey ? `${method}-${pathKey}-step` : `${method}-step`,
-              operationId: `$sourceDescriptions.${sourceDescriptionName}.${resolvedOperationId}`,
-              ...generateParametersWithSuccessCriteria(
-                descriptionPaths[pathItemKey][method].responses
-              ),
-            } as unknown as Step,
-          ],
-        });
-      }
-    }
-  }
-
-  return workflows;
-}
 
 export const infoSubstitute = {
   title: '[REPLACE WITH API title]',
@@ -96,11 +22,20 @@ export async function generateArazzoDescription({
   descriptionPath,
   'output-file': outputFile,
 }: GenerateArazzoFileOptions) {
-  const { paths: pathsObject, info } = (await bundleOpenApi(descriptionPath, '')) || {};
+  const {
+    paths: pathsObject,
+    info,
+    security: rootSecurity,
+    components,
+  } = (await bundleOpenApi(descriptionPath, '')) || {};
+
   const sourceDescriptionName = resolveDescriptionNameFromPath(descriptionPath);
   const resolvedDescriptionPath = outputFile
     ? path.relative(path.dirname(outputFile), path.resolve(descriptionPath))
     : descriptionPath;
+  const inputsComponents = components?.securitySchemes
+    ? generateSecurityInputsArazzoComponents(components?.securitySchemes)
+    : undefined;
 
   const testDescription: TestDescription = {
     arazzo: '1.0.1',
@@ -118,6 +53,14 @@ export async function generateArazzoDescription({
     workflows: generateWorkflowsFromDescription({
       descriptionPaths: pathsObject,
       sourceDescriptionName,
+      rootSecurity,
+      inputsComponents,
+      securitySchemes: components?.securitySchemes,
+    }),
+    ...(inputsComponents && {
+      components: {
+        ...inputsComponents,
+      },
     }),
   };
 

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
@@ -54,13 +54,11 @@ export async function generateArazzoDescription({
       descriptionPaths: pathsObject,
       sourceDescriptionName,
       rootSecurity,
-      inputsComponents,
+      inputsComponents: inputsComponents || {},
       securitySchemes: components?.securitySchemes,
     }),
     ...(inputsComponents && {
-      components: {
-        ...inputsComponents,
-      },
+      components: inputsComponents,
     }),
   };
 

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-inputs-arazzo-components.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-inputs-arazzo-components.ts
@@ -11,37 +11,41 @@ export function generateSecurityInputsArazzoComponents(
 
   for (const [name, securityScheme] of Object.entries(securitySchemes)) {
     if (securityScheme.type !== 'http' && securityScheme.type !== 'apiKey') {
-      return;
+      continue;
     }
 
     if (securityScheme?.scheme?.toLowerCase() === 'basic') {
       inputs[name] = {
         type: 'object',
         properties: {
-          username: {
+          [name]: {
             type: 'string',
-            description: 'Username for basic authentication',
-          },
-          password: {
-            type: 'string',
-            description: 'Password for basic authentication',
+            description: 'Basic authentication',
             format: 'password',
           },
         },
-        required: ['username', 'password'],
       };
     } else if (securityScheme?.scheme?.toLowerCase() === 'bearer') {
       inputs[name] = {
-        type: 'string',
-        description: securityScheme?.description || `JWT Authentication token for ${name}`,
-        format: 'password',
+        type: 'object',
+        properties: {
+          [name]: {
+            type: 'string',
+            description: 'JWT Authentication token for ${name}',
+            format: 'password',
+          },
+        },
       };
     } else {
-      // TODO: clarify this
       inputs[name] = {
-        type: 'string',
-        description: securityScheme?.description || `Authentication token for ${name}`,
-        format: 'password',
+        type: 'object',
+        properties: {
+          [name]: {
+            type: 'string',
+            description: securityScheme?.description || `Authentication token for ${name}`,
+            format: 'password',
+          },
+        },
       };
     }
   }

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-inputs-arazzo-components.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-inputs-arazzo-components.ts
@@ -1,0 +1,50 @@
+import { type Oas3SecurityScheme } from 'core/src/typings/openapi';
+
+export function generateSecurityInputsArazzoComponents(
+  securitySchemes: Record<string, Oas3SecurityScheme>
+) {
+  const inputs: {
+    [key: string]: {
+      [key: string]: any;
+    };
+  } = {};
+
+  for (const [name, securityScheme] of Object.entries(securitySchemes)) {
+    if (securityScheme.type !== 'http' && securityScheme.type !== 'apiKey') {
+      return;
+    }
+
+    if (securityScheme?.scheme?.toLowerCase() === 'basic') {
+      inputs[name] = {
+        type: 'object',
+        properties: {
+          username: {
+            type: 'string',
+            description: 'Username for basic authentication',
+          },
+          password: {
+            type: 'string',
+            description: 'Password for basic authentication',
+            format: 'password',
+          },
+        },
+        required: ['username', 'password'],
+      };
+    } else if (securityScheme?.scheme?.toLowerCase() === 'bearer') {
+      inputs[name] = {
+        type: 'string',
+        description: securityScheme?.description || `JWT Authentication token for ${name}`,
+        format: 'password',
+      };
+    } else {
+      // TODO: clarify this
+      inputs[name] = {
+        type: 'string',
+        description: securityScheme?.description || `Authentication token for ${name}`,
+        format: 'password',
+      };
+    }
+  }
+
+  return { inputs };
+}

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-inputs-arazzo-components.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-inputs-arazzo-components.ts
@@ -1,13 +1,10 @@
+import { type ArazzoDefinition } from 'core/src/typings/arazzo';
 import { type Oas3SecurityScheme } from 'core/src/typings/openapi';
 
 export function generateSecurityInputsArazzoComponents(
   securitySchemes: Record<string, Oas3SecurityScheme>
 ) {
-  const inputs: {
-    [key: string]: {
-      [key: string]: any;
-    };
-  } = {};
+  const inputs: NonNullable<ArazzoDefinition['components']>['inputs'] = {};
 
   for (const [name, securityScheme] of Object.entries(securitySchemes)) {
     if (securityScheme.type !== 'http' && securityScheme.type !== 'apiKey') {

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-inputs.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-inputs.ts
@@ -1,12 +1,14 @@
 export function generateWorkflowSecurityInputs(inputsComponents: any, security: any[]) {
-  if (security?.length > 0) {
-    for (const securityRequirement of security) {
-      for (const securityName of Object.keys(securityRequirement)) {
-        if (inputsComponents?.inputs?.[securityName]) {
-          return {
-            $ref: `#/components/inputs/${securityName}`,
-          };
-        }
+  if (!security?.length) {
+    return undefined;
+  }
+
+  for (const securityRequirement of security) {
+    for (const securityName of Object.keys(securityRequirement)) {
+      if (inputsComponents?.inputs?.[securityName]) {
+        return {
+          $ref: `#/components/inputs/${securityName}`,
+        };
       }
     }
   }

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-inputs.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-inputs.ts
@@ -1,0 +1,15 @@
+export function generateWorkflowSecurityInputs(inputsComponents: any, security: any[]) {
+  if (security?.length > 0) {
+    for (const securityRequirement of security) {
+      for (const securityName of Object.keys(securityRequirement)) {
+        if (inputsComponents?.inputs?.[securityName]) {
+          return {
+            $ref: `#/components/inputs/${securityName}`,
+          };
+        }
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
@@ -30,21 +30,19 @@ export function generateWorkflowSecurityParameters(
         parameters.push({
           name: securityScheme?.name,
           value: `$inputs.${securityName}`,
-          in: inputsComponents?.inputs?.[securityName]?.in || 'header',
+          in: securityScheme?.in || 'header',
         });
-      }
-
-      if (securityScheme?.scheme === 'bearer') {
+      } else if (securityScheme?.scheme === 'bearer') {
         parameters.push({
           name: 'Authorization',
           value: `Bearer {$inputs.${securityName}}`,
-          in: inputsComponents?.inputs?.[securityName]?.in || 'header',
+          in: securityScheme?.in || 'header',
         });
       } else if (securityScheme?.scheme === 'basic') {
         parameters.push({
           name: 'Authorization',
           value: `Basic {$inputs.${securityName}}`,
-          in: inputsComponents?.inputs?.[securityName]?.in || 'header',
+          in: securityScheme?.in || 'header',
         });
       }
     }

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
@@ -1,0 +1,50 @@
+import { type Oas3SecurityRequirement, type Oas3SecurityScheme } from 'core/src/typings/openapi';
+
+export function generateWorkflowSecurityParameters(
+  inputsComponents: any,
+  security: Oas3SecurityRequirement[],
+  securitySchemes: Record<string, Oas3SecurityScheme>
+) {
+  if (!security?.length) {
+    return [];
+  }
+
+  const parameters = [];
+
+  for (const securityRequirement of security) {
+    for (const securityName of Object.keys(securityRequirement)) {
+      if (!inputsComponents?.inputs?.[securityName]) {
+        continue;
+      }
+
+      const securityScheme = securitySchemes[securityName];
+
+      if (
+        securityScheme?.type &&
+        !['apikey', 'http'].includes(securityScheme?.type?.toLowerCase())
+      ) {
+        continue;
+      }
+
+      if (securityScheme?.scheme === 'bearer') {
+        parameters.push({
+          // TODO: clarify parameter name
+          name: 'Authorization',
+          value: `Bearer {$inputs.${securityName}}`,
+          in: inputsComponents?.inputs?.[securityName]?.in || 'header',
+        });
+      } else if (securityScheme?.scheme === 'basic') {
+        parameters.push({
+          // TODO: clarify parameter name
+          name: 'Authorization',
+          value: `Basic ....`,
+          in: inputsComponents?.inputs?.[securityName]?.in || 'header',
+        });
+      } else {
+        continue;
+      }
+    }
+  }
+
+  return parameters;
+}

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
@@ -26,18 +26,24 @@ export function generateWorkflowSecurityParameters(
         continue;
       }
 
+      if (securityScheme?.type === 'apiKey') {
+        parameters.push({
+          name: securityScheme?.name,
+          value: `$inputs.${securityName}`,
+          in: inputsComponents?.inputs?.[securityName]?.in || 'header',
+        });
+      }
+
       if (securityScheme?.scheme === 'bearer') {
         parameters.push({
-          // TODO: clarify parameter name
           name: 'Authorization',
           value: `Bearer {$inputs.${securityName}}`,
           in: inputsComponents?.inputs?.[securityName]?.in || 'header',
         });
       } else if (securityScheme?.scheme === 'basic') {
         parameters.push({
-          // TODO: clarify parameter name
           name: 'Authorization',
-          value: `Basic ....`,
+          value: `Basic {$inputs.${securityName}}`,
           in: inputsComponents?.inputs?.[securityName]?.in || 'header',
         });
       } else {

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflow-security-parameters.ts
@@ -46,8 +46,6 @@ export function generateWorkflowSecurityParameters(
           value: `Basic {$inputs.${securityName}}`,
           in: inputsComponents?.inputs?.[securityName]?.in || 'header',
         });
-      } else {
-        continue;
       }
     }
   }

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflows-from-description.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflows-from-description.ts
@@ -1,0 +1,98 @@
+import { sortMethods } from '../../utils/sort';
+import { generateWorkflowSecurityInputs } from './generate-workflow-security-inputs';
+import { type OperationMethod, type Workflow, type Step } from '../../types';
+import { generateWorkflowSecurityParameters } from './generate-workflow-security-parameters';
+
+export type WorkflowsFromDescriptionInput = {
+  descriptionPaths: any;
+  sourceDescriptionName: string;
+  rootSecurity: any;
+  inputsComponents: any;
+  securitySchemes: any;
+};
+
+export function generateWorkflowsFromDescription({
+  descriptionPaths,
+  sourceDescriptionName,
+  rootSecurity,
+  inputsComponents,
+  securitySchemes,
+}: WorkflowsFromDescriptionInput): Workflow[] {
+  const workflows = [] as Workflow[];
+
+  for (const pathItemKey in descriptionPaths) {
+    for (const pathItemObjectKey of Object.keys(descriptionPaths[pathItemKey]).sort(sortMethods)) {
+      const methodToCheck = pathItemObjectKey.toLocaleLowerCase();
+
+      if (
+        [
+          'get',
+          'post',
+          'put',
+          'delete',
+          'patch',
+          'head',
+          'options',
+          'trace',
+          'connect',
+          'query',
+        ].includes(methodToCheck.toLocaleLowerCase())
+      ) {
+        const method = methodToCheck as OperationMethod;
+        const pathKey = pathItemKey
+          .replace(/^\/|\/$/g, '')
+          .split('/')
+          .join('-');
+
+        const operation = descriptionPaths[pathItemKey][method];
+        const operationSecurity = operation?.security || undefined;
+        const operationId = operation?.operationId || generateOperationId(pathItemKey, method);
+        const workflowSecurityInputs = generateWorkflowSecurityInputs(
+          inputsComponents,
+          operationSecurity || rootSecurity || []
+        );
+        const workflowSecurityParameters = generateWorkflowSecurityParameters(
+          inputsComponents,
+          operationSecurity || rootSecurity || [],
+          securitySchemes
+        );
+
+        workflows.push({
+          workflowId: pathKey ? `${method}-${pathKey}-workflow` : `${method}-workflow`,
+          ...(workflowSecurityInputs && { inputs: workflowSecurityInputs }),
+          ...(workflowSecurityParameters.length && {
+            parameters: workflowSecurityParameters,
+          }),
+          steps: [
+            {
+              stepId: pathKey ? `${method}-${pathKey}-step` : `${method}-step`,
+              operationId: `$sourceDescriptions.${sourceDescriptionName}.${operationId}`,
+              ...generateParametersWithSuccessCriteria(
+                descriptionPaths[pathItemKey][method].responses
+              ),
+            } as unknown as Step,
+          ],
+        } as unknown as Workflow);
+      }
+    }
+  }
+
+  return workflows;
+}
+
+function generateParametersWithSuccessCriteria(
+  responses: any
+): [] | { successCriteria: { condition: string }[] } {
+  const responseCodesFromDescription = Object.keys(responses || {});
+
+  if (!responseCodesFromDescription.length) {
+    return [];
+  }
+
+  const firstResponseCode = responseCodesFromDescription?.[0];
+  return { successCriteria: [{ condition: `$statusCode == ${firstResponseCode}` }] };
+}
+
+function generateOperationId(path: string, method: OperationMethod) {
+  return `${method}@${path}`;
+}

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-workflows-from-description.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-workflows-from-description.ts
@@ -88,9 +88,9 @@ export function generateWorkflowsFromDescription({
               ...generateParametersWithSuccessCriteria(
                 descriptionPaths[pathItemKey][methodToCheck.toLowerCase() as HttpMethod]?.responses
               ),
-            } as unknown as Step,
+            } as Step,
           ],
-        } as unknown as Workflow);
+        } as Workflow);
       }
     }
   }

--- a/packages/respect-core/src/modules/arazzo-description-generator/index.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/index.ts
@@ -2,3 +2,7 @@ export * from './generate-arazzo-description';
 export * from './cleanup-test-description';
 export * from './generate-test-data-from-json-schema';
 export * from './generate-example-value';
+export * from './generate-workflows-from-description';
+export * from './generate-inputs-arazzo-components';
+export * from './generate-workflow-security-inputs';
+export * from './generate-workflow-security-parameters';

--- a/packages/respect-core/src/modules/description-parser/bundle-openapi.ts
+++ b/packages/respect-core/src/modules/description-parser/bundle-openapi.ts
@@ -41,9 +41,9 @@ export async function bundleOpenApi(path: string = '', workflowPath: string): Pr
 
   const {
     bundle: {
-      parsed: { paths, servers, info },
+      parsed: { paths, servers, info, security, components },
     },
   } = bundleDocument;
 
-  return { paths, servers, info };
+  return { paths, servers, info, security, components };
 }


### PR DESCRIPTION
## What/Why/How?

Expend Arazzo genration to handle simple cases of securitySchemes (basic, apiKey, bearer) and create `inputs` on `components` level, `parameters` and `inputs` per Workflow.
Autogeneration is still not perfect, but can give more insides about Step security requirements. 

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/1961

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
