### PR TITLE
fix: add node types to tsconfig in respect-core

### DIFF
--- a/packages/respect-core/tsconfig.json
+++ b/packages/respect-core/tsconfig.json
@@ -14,6 +14,7 @@
     "strict": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
+    "types": ["node"],
     "skipLibCheck": true,
     "allowJs": true
   },


### PR DESCRIPTION
## What/Why/How?

Fixed types exporting from respect-core.



## Testing

No testing needed



## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
