### PR TITLE
fix: change arazzo supported version validation

### DIFF
--- a/.changeset/hip-apricots-juggle.md
+++ b/.changeset/hip-apricots-juggle.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Added validation to ensure Arazzo files use supported versions (1.0.0 or 1.0.1).
+Changed validation to ensure both (1.0.0 or 1.0.1) Arazzo version works with Respect.

--- a/.changeset/hip-apricots-juggle.md
+++ b/.changeset/hip-apricots-juggle.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Added validation to ensure Arazzo files use supported versions (1.0.0 or 1.0.1).

--- a/packages/core/src/rules/arazzo/__tests__/respect-supported-versions.test.ts
+++ b/packages/core/src/rules/arazzo/__tests__/respect-supported-versions.test.ts
@@ -81,7 +81,7 @@ describe('Arazzo respect-supported-versions', () => {
               "source": "arazzo.yaml",
             },
           ],
-          "message": "Only 1.0.0, 1.0.1 Arazzo versions are supported by Respect.",
+          "message": "Only 1.0.1 Arazzo version is fully supported by Respect.",
           "ruleId": "respect-supported-versions",
           "severity": "error",
           "suggest": [],

--- a/packages/core/src/rules/arazzo/__tests__/respect-supported-versions.test.ts
+++ b/packages/core/src/rules/arazzo/__tests__/respect-supported-versions.test.ts
@@ -81,7 +81,7 @@ describe('Arazzo respect-supported-versions', () => {
               "source": "arazzo.yaml",
             },
           ],
-          "message": "Only 1.0.1 Arazzo version is supported by Respect.",
+          "message": "Only 1.0.0, 1.0.1 Arazzo versions are supported by Respect.",
           "ruleId": "respect-supported-versions",
           "severity": "error",
           "suggest": [],

--- a/packages/core/src/rules/respect/respect-supported-versions.ts
+++ b/packages/core/src/rules/respect/respect-supported-versions.ts
@@ -14,7 +14,7 @@ export const RespectSupportedVersions: Arazzo1Rule = () => {
             message: `Only ${supportedVersions} Arazzo ${pluralize(
               'version is',
               ARAZZO_VERSIONS_SUPPORTED_BY_RESPECT.length
-            )} supported by Respect.`,
+            )} fully supported by Respect.`,
             location: location.child('arazzo'),
           });
         }

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -169,4 +169,4 @@ export interface ArazzoDefinition {
 
 export const VERSION_PATTERN = /^1\.0\.\d+(-.+)?$/;
 
-export const ARAZZO_VERSIONS_SUPPORTED_BY_RESPECT = ['1.0.0', '1.0.1'];
+export const ARAZZO_VERSIONS_SUPPORTED_BY_RESPECT = ['1.0.1'];

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -169,4 +169,4 @@ export interface ArazzoDefinition {
 
 export const VERSION_PATTERN = /^1\.0\.\d+(-.+)?$/;
 
-export const ARAZZO_VERSIONS_SUPPORTED_BY_RESPECT = ['1.0.1'];
+export const ARAZZO_VERSIONS_SUPPORTED_BY_RESPECT = ['1.0.0', '1.0.1'];

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/__snapshots__/run-test-file.test.ts.snap
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/__snapshots__/run-test-file.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`runTestFile should throw Invalid file configuration error when contains lint errors 1`] = `[Error: [31mInvalid file configuration[39m [1mtest.yaml[22m]`;
+exports[`runTestFile should throw Found errors in Arazzo description error when contains lint errors 1`] = `[Error: [31mFound errors in Arazzo description[39m [1mtest.yaml[22m]`;

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
@@ -94,7 +94,7 @@ describe('runTestFile', () => {
     );
   });
 
-  it('should throw Invalid file configuration error when contains lint errors', async () => {
+  it('should throw Found errors in Arazzo description error when contains lint errors', async () => {
     const testDescription = {
       workflows: [],
     };

--- a/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
@@ -55,7 +55,7 @@ export async function bundleArazzo(filePath: string) {
 
     const errorLintProblems = lintProblems.filter((problem) => problem.severity === 'error');
     if (errorLintProblems.length) {
-      throw new Error(`${red('Invalid file configuration')} ${bold(fileName)}`);
+      throw new Error(`${red('Found errors in Arazzo description')} ${bold(fileName)}`);
     }
   }
 

--- a/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
@@ -34,7 +34,7 @@ export async function bundleArazzo(filePath: string) {
     extends: ['recommended-strict'],
     arazzo1Rules: {
       'no-criteria-xpath': 'error',
-      'respect-supported-versions': 'error',
+      'respect-supported-versions': 'warn',
     },
   });
 
@@ -53,7 +53,10 @@ export async function bundleArazzo(filePath: string) {
 
     printConfigLintTotals(fileTotals);
 
-    throw new Error(`${red('Invalid file configuration')} ${bold(fileName)}`);
+    const errorLintProblems = lintProblems.filter((problem) => problem.severity === 'error');
+    if (errorLintProblems.length) {
+      throw new Error(`${red('Invalid file configuration')} ${bold(fileName)}`);
+    }
   }
 
   const bundledDocument = await bundle({

--- a/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
@@ -1,5 +1,6 @@
 import { bold, red } from 'colorette';
 import { getTotals, formatProblems, lint, bundle, createConfig } from '@redocly/openapi-core';
+import { type CollectFn } from '@redocly/openapi-core/src/utils';
 import * as path from 'node:path';
 import { existsSync } from 'node:fs';
 import { type TestDescription } from '../../types';
@@ -8,7 +9,7 @@ import { version } from '../../../package.json';
 import { isTestFile } from '../../utils/file';
 import { readYaml } from '../../utils/yaml';
 
-export async function bundleArazzo(filePath: string) {
+export async function bundleArazzo(filePath: string, collectSpecData?: CollectFn) {
   const fileName = path.basename(filePath);
 
   if (!fileName) {
@@ -52,11 +53,6 @@ export async function bundleArazzo(filePath: string) {
     });
 
     printConfigLintTotals(fileTotals);
-
-    const errorLintProblems = lintProblems.filter((problem) => problem.severity === 'error');
-    if (errorLintProblems.length) {
-      throw new Error(`${red('Found errors in Arazzo description')} ${bold(fileName)}`);
-    }
   }
 
   const bundledDocument = await bundle({
@@ -64,6 +60,13 @@ export async function bundleArazzo(filePath: string) {
     config,
     dereference: true,
   });
+
+  collectSpecData?.(bundledDocument.bundle.parsed);
+
+  const errorLintProblems = lintProblems.filter((problem) => problem.severity === 'error');
+  if (errorLintProblems.length) {
+    throw new Error(`${red('Found errors in Arazzo description')} ${bold(fileName)}`);
+  }
 
   return (bundledDocument.bundle.parsed || {}) as TestDescription;
 }

--- a/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
@@ -61,7 +61,7 @@ export async function bundleArazzo(filePath: string, collectSpecData?: CollectFn
     dereference: true,
   });
 
-  collectSpecData?.(bundledDocument.bundle.parsed);
+  collectSpecData?.(bundledDocument.bundle.parsed || {});
 
   const errorLintProblems = lintProblems.filter((problem) => problem.severity === 'error');
   if (errorLintProblems.length) {

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -66,8 +66,7 @@ export async function runTestFile(
     },
   };
 
-  const bundledTestDescription = await bundleArazzo(filePath);
-  collectSpecData?.(bundledTestDescription);
+  const bundledTestDescription = await bundleArazzo(filePath, collectSpecData);
 
   const result = await runWorkflows(bundledTestDescription, options);
 


### PR DESCRIPTION
## What/Why/How?

Change arazzo supported version validation by adding 1.0.0 version warning but not prevent execution.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
