### PR TITLE
fix(types): oas schema type definition

### DIFF
--- a/.changeset/light-lizards-play.md
+++ b/.changeset/light-lizards-play.md
@@ -1,0 +1,7 @@
+---
+"@redocly/respect-core": patch
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Updated OAS3 Schema type definition to correct `type` keyword enum, removed `null`.

--- a/.changeset/light-lizards-play.md
+++ b/.changeset/light-lizards-play.md
@@ -1,5 +1,4 @@
 ---
-"@redocly/respect-core": patch
 "@redocly/openapi-core": patch
 "@redocly/cli": patch
 ---

--- a/packages/core/src/types/oas3.ts
+++ b/packages/core/src/types/oas3.ts
@@ -332,7 +332,7 @@ const Schema: NodeType = {
     required: { type: 'array', items: { type: 'string' } },
     enum: { type: 'array' },
     type: {
-      enum: ['object', 'array', 'string', 'number', 'integer', 'boolean', 'null'],
+      enum: ['object', 'array', 'string', 'number', 'integer', 'boolean'],
     },
     allOf: listOf('Schema'),
     anyOf: listOf('Schema'),


### PR DESCRIPTION
## What/Why/How?

the `type` keyword should not include the `null` value.

OAS3 uses the `nullable` keyword.

closes #https://github.com/Redocly/redocly-vs-code/issues/48

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
