### PR TITLE
chore: update S3 sandbox deploymet pipeline

### DIFF
--- a/.github/workflows/deploy-s3-sandbox.yaml
+++ b/.github/workflows/deploy-s3-sandbox.yaml
@@ -9,16 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: node --version
-      - run: npm --version
-      - name: cache node modules
-        uses: actions/cache@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            npm-${{ hashFiles('package-lock.json') }}
-            npm-
+          node-version: 20
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## What/Why/How?

Updated S3 sandbox deploymet pipeline (replaced an old caching action).

## Reference

The failing job: https://github.com/Redocly/redocly-cli/actions/runs/13627145806/job/38086720934?pr=1971

## Testing

Tested in this PR: https://github.com/Redocly/redocly-cli/actions/runs/13627383886/job/38087432615?pr=1973

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
