### PR TITLE
fix: nested external workflow in json logs

### DIFF
--- a/.changeset/short-mayflies-lay.md
+++ b/.changeset/short-mayflies-lay.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Fixed: JSON logs now properly capture data from nested external workflows.

--- a/.changeset/short-mayflies-lay.md
+++ b/.changeset/short-mayflies-lay.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed: JSON logs now properly capture data from nested external workflows.
+Fixed an issue where JSON logs did not properly capture data from nested external workflows.

--- a/packages/respect-core/src/modules/cli-output/json-logs.ts
+++ b/packages/respect-core/src/modules/cli-output/json-logs.ts
@@ -29,9 +29,7 @@ export function composeJsonLogsFiles(
     files[fileResult.file] = maskSecrets(
       {
         totalRequests: fileResult.totalRequests,
-        executedWorkflows: executedWorkflows.map((workflow) =>
-          mapJsonWorkflow(workflow, fileResult.ctx)
-        ),
+        executedWorkflows: executedWorkflows.map((workflow) => mapJsonWorkflow(workflow)),
         totalTimeMs: fileResult.totalTimeMs,
       },
       secretFields || new Set()
@@ -41,16 +39,14 @@ export function composeJsonLogsFiles(
   return files;
 }
 
-function mapJsonWorkflow(
-  workflow: WorkflowExecutionResult,
-  ctx: TestContext
-): WorkflowExecutionResultJson {
+function mapJsonWorkflow(workflow: WorkflowExecutionResult): WorkflowExecutionResultJson {
+  const { ctx, ...rest } = workflow;
   const steps = workflow.executedSteps.map((step) => mapJsonStep(step, workflow.workflowId, ctx));
 
   const totals = calculateTotals([workflow]);
 
   const result: WorkflowExecutionResultJson = {
-    ...workflow,
+    ...rest,
     executedSteps: steps,
     status: totals.steps.failed > 0 ? 'error' : totals.steps.warnings > 0 ? 'warn' : 'success',
     totalRequests: totals.totalRequests,
@@ -66,7 +62,7 @@ function mapJsonStep(
   ctx: TestContext
 ): StepExecutionResult | WorkflowExecutionResultJson {
   if ('executedSteps' in step) {
-    return mapJsonWorkflow(step as WorkflowExecutionResult, ctx);
+    return mapJsonWorkflow(step as WorkflowExecutionResult);
   }
 
   const publicStep = ctx.$workflows[workflowId].steps[step.stepId];

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -67,7 +67,6 @@ export async function runTestFile(
   };
 
   const bundledTestDescription = await bundleArazzo(filePath, collectSpecData);
-
   const result = await runWorkflows(bundledTestDescription, options);
 
   if (output?.harFile && Object.keys(result.harLogs).length) {
@@ -226,6 +225,7 @@ export async function runWorkflow({
     endTime,
     totalTimeMs: Math.ceil(endTime - workflowStartTime),
     executedSteps: ctx.executedSteps,
+    ctx,
   };
 }
 

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -236,9 +236,10 @@ export interface WorkflowExecutionResult {
 
   executedSteps: (Step | WorkflowExecutionResult)[];
   invocationContext?: string;
+  ctx: TestContext;
 }
 
-export type WorkflowExecutionResultJson = Omit<WorkflowExecutionResult, 'executedSteps'> & {
+export type WorkflowExecutionResultJson = Omit<WorkflowExecutionResult, 'executedSteps' | 'ctx'> & {
   executedSteps: (StepExecutionResult | WorkflowExecutionResultJson)[];
   status: ExecutionStatus;
   totalRequests: number;


### PR DESCRIPTION
## What/Why/How?

Nested external workflow in json logs were not included and crashed.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
