### PR TITLE
chore: fix x-example node type in oas2

### DIFF
--- a/.changeset/red-birds-give.md
+++ b/.changeset/red-birds-give.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed the `x-example` property in Swagger 2.0 to accept any data type, rather than requiring it to be an object.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 * @Redocly/dark-side
-.changeset/ @Redocly/technical-writers @Redocly/dark-side
-README.md @Redocly/technical-writers @Redocly/dark-side
+.changeset/ @Redocly/dark-side
+.changeset/ @Redocly/technical-writers
+README.md @Redocly/dark-side
+README.md @Redocly/technical-writers
 docs/ @Redocly/technical-writers

--- a/packages/core/src/types/oas2.ts
+++ b/packages/core/src/types/oas2.ts
@@ -166,7 +166,7 @@ const Parameter: NodeType = {
     uniqueItems: { type: 'boolean' },
     enum: { type: 'array' },
     multipleOf: { type: 'number' },
-    'x-example': 'Example',
+    'x-example': {}, // any
     'x-examples': 'ExamplesMap',
   },
   required(value) {


### PR DESCRIPTION
## What/Why/How?

Made the `x-example` property in `oas2` accept any data. Although it should be a primitive, it looks like Redoc supports also objects, so I decided not to restrict it too much.

Also, updated the CODEOWNERS file to require approval from all owners.

## Reference

Partially resolves https://github.com/Redocly/redocly-vs-code/issues/75

## Testing

Tested manually. 

## Check yourself

- [x] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
