### PR TITLE
docs(oas): add no-schema-type-mismatch to sidebar

### DIFF
--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -98,6 +98,7 @@
             - page: rules/oas/no-invalid-schema-examples.md
             - page: rules/oas/no-path-trailing-slash.md
             - page: rules/oas/no-required-schema-properties-undefined.md
+            - page: rules/oas/no-schema-type-mismatch.md
             - page: rules/oas/no-server-example-com.md
             - page: rules/oas/no-server-trailing-slash.md
             - page: rules/oas/no-server-variables-empty-enum.md


### PR DESCRIPTION
## What/Why/How?

Add no-schema-type-mismatch to sidebar.

When adding this rule back then, I thought the sidebar is auto. After self-learning more about redocly, I discovered this rule is not yet included in the sidebar.

## Reference

#1890

## Testing

no need

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
