### PR TITLE
fix(respect-core): consider severity in the next step execution when onFailure is omitted

### DIFF
--- a/.changeset/fast-islands-sell.md
+++ b/.changeset/fast-islands-sell.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Fixed step execution to respect severity levels when handling step failures. Previously, steps would always break workflow execution on failure when onFailure is ommited, but now they properly consider the configured severity level (e.g., `warn` | `off` severity allows subsequent steps to execute).

--- a/.changeset/fast-islands-sell.md
+++ b/.changeset/fast-islands-sell.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed step execution to respect severity levels when handling step failures. Previously, steps would always break workflow execution on failure when onFailure is ommited, but now they properly consider the configured severity level (e.g., `warn` | `off` severity allows subsequent steps to execute).
+Fixed step execution to respect severity levels when handling step failures. Previously, steps would always break workflow execution on failure when onFailure is omitted, but now they properly consider the configured severity level (e.g., `warn` | `off` severity allows subsequent steps to execute).

--- a/__tests__/respect/consider-severity-in-next-step-execution/__snapshots__/consider-severity-in-next-step-execution.test.ts.snap
+++ b/__tests__/respect/consider-severity-in-next-step-execution/__snapshots__/consider-severity-in-next-step-execution.test.ts.snap
@@ -1,0 +1,313 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not follow the default behavior to break and return if onFailure omitted with warn severity and continue execution of the next step 1`] = `
+"────────────────────────────────────────────────────────────────────────────────
+
+  Running workflow consider-severity-in-next-step-execution.arazzo.yaml / first-workflow
+
+  ✓ GET /museum-hours - step first-step
+
+    Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
+    Request Headers:
+      accept: application/json, application/problem+json
+      authorization: Basic Og==
+
+
+    Response status code: 200
+    Response time: <test> ms
+    Response Body:
+      [
+        {
+          "date": "2023-09-11",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-12",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-13",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-14",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-15",
+          "timeOpen": "10:00",
+          "timeClose": "16:00"
+        },
+        {
+          "date": "2023-09-18",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-19",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-20",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-21",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-22",
+          "timeOpen": "10:00",
+          "timeClose": "16:00"
+        }
+      ]
+
+    ✓ success criteria check - $statusCode == 200
+    ✓ status code check - $statusCode in [200, 400, 404]
+    ✓ content-type check
+    ✓ schema check
+
+────────────────────────────────────────────────────────────────────────────────
+
+  Running workflow consider-severity-in-next-step-execution.arazzo.yaml / second-workflow
+
+  ✗ GET /special-events - step list-events
+
+    Request URL: https://redocly.com/_mock/demo/openapi/museum-api/special-events
+    Request Headers:
+      accept: application/json, application/problem+json
+      authorization: Basic Og==
+
+
+    Response status code: 200
+    Response time: <test> ms
+    Response Body:
+      [
+        {
+          "eventId": "f3e0e76e-e4a8-466e-ab9c-ae36c15b8e97",
+          "name": "Sasquatch Ballet",
+          "location": "Seattle... probably",
+          "eventDescription": "They're big, they're hairy, but they're also graceful. Come learn how the biggest feet can have the lightest touch.",
+          "dates": [
+            "2023-12-15",
+            "2023-12-22"
+          ],
+          "price": 40
+        },
+        {
+          "eventId": "2f14374a-9c65-4ee5-94b7-fba66d893483",
+          "name": "Solar Telescope Demonstration",
+          "location": "Far from the sun.",
+          "eventDescription": "Look at the sun without going blind!",
+          "dates": [
+            "2023-09-07",
+            "2023-09-14"
+          ],
+          "price": 50
+        },
+        {
+          "eventId": "6aaa61ba-b2aa-4868-b803-603dbbf7bfdb",
+          "name": "Cook like a Caveman",
+          "location": "Fire Pit on East side",
+          "eventDescription": "Learn to cook on an open flame.",
+          "dates": [
+            "2023-11-10",
+            "2023-11-17",
+            "2023-11-24"
+          ],
+          "price": 5
+        },
+        {
+          "eventId": "602b75e1-5696-4ab8-8c7a-f9e13580f910",
+          "name": "Underwater Basket Weaving",
+          "location": "Rec Center Pool next door.",
+          "eventDescription": "Learn to weave baskets underwater.",
+          "dates": [
+            "2023-09-12",
+            "2023-09-15"
+          ],
+          "price": 15
+        },
+        {
+          "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",
+          "name": "Mermaid Treasure Identification and Analysis",
+          "location": "Room Sea-12",
+          "eventDescription": "Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits — kindly donated by Ariel.",
+          "dates": [
+            "2023-09-05",
+            "2023-09-08"
+          ],
+          "price": 30
+        },
+        {
+          "eventId": "6744a0da-4121-49cd-8479-f8cc20526495",
+          "name": "Time Traveler Tea Party",
+          "location": "Temporal Tearoom",
+          "eventDescription": "Sip tea with important historical figures.",
+          "dates": [
+            "2023-11-18",
+            "2023-11-25",
+            "2023-12-02"
+          ],
+          "price": 60
+        },
+        {
+          "eventId": "3be6453c-03eb-4357-ae5a-984a0e574a54",
+          "name": "Pirate Coding Workshop",
+          "location": "Computer Room",
+          "eventDescription": "Captain Blackbeard shares his love of the C...language. And possibly Arrrrr (R lang).",
+          "dates": [
+            "2023-10-29",
+            "2023-10-30",
+            "2023-10-31"
+          ],
+          "price": 45
+        },
+        {
+          "eventId": "9d90d29a-2af5-4206-97d9-9ea9ceadcb78",
+          "name": "Llama Street Art Through the Ages",
+          "location": "Auditorium",
+          "eventDescription": "Llama street art?! Alpaca my bags -- let's go!",
+          "dates": [
+            "2023-10-29",
+            "2023-10-30",
+            "2023-10-31"
+          ],
+          "price": 45
+        },
+        {
+          "eventId": "a3c7b2c4-b5fb-4ef7-9322-00a919864957",
+          "name": "The Great Parrot Debate",
+          "location": "Outdoor Amphitheatre",
+          "eventDescription": "See leading parrot minds discuss important geopolitical issues.",
+          "dates": [
+            "2023-11-03",
+            "2023-11-10"
+          ],
+          "price": 35
+        },
+        {
+          "eventId": "b92d46b7-4c5d-422b-87a5-287767e26f29",
+          "name": "Eat a Bunch of Corn",
+          "location": "Cafeteria",
+          "eventDescription": "We accidentally bought too much corn. Please come eat it.",
+          "dates": [
+            "2023-11-10",
+            "2023-11-17",
+            "2023-11-24"
+          ],
+          "price": 5
+        }
+      ]
+
+    ⚠ success criteria check - $statusCode == 201
+    ✓ status code check - $statusCode in [200, 400, 404]
+    ✓ content-type check
+    ✓ schema check
+
+  Running child workflow for the step call-first-workflow
+  Running workflow consider-severity-in-next-step-execution.arazzo.yaml / first-workflow
+
+  ✓ GET /museum-hours - step first-step
+
+    Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
+    Request Headers:
+      accept: application/json, application/problem+json
+      authorization: Basic Og==
+
+
+    Response status code: 200
+    Response time: <test> ms
+    Response Body:
+      [
+        {
+          "date": "2023-09-11",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-12",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-13",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-14",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-15",
+          "timeOpen": "10:00",
+          "timeClose": "16:00"
+        },
+        {
+          "date": "2023-09-18",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-19",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-20",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-21",
+          "timeOpen": "09:00",
+          "timeClose": "18:00"
+        },
+        {
+          "date": "2023-09-22",
+          "timeOpen": "10:00",
+          "timeClose": "16:00"
+        }
+      ]
+
+    ✓ success criteria check - $statusCode == 200
+    ✓ status code check - $statusCode in [200, 400, 404]
+    ✓ content-type check
+    ✓ schema check
+
+
+
+  Failed tests info:
+
+  Workflow name: second-workflow
+
+    stepId - list-events
+    ⚠ success criteria check
+      Checking simple criteria: {"condition":"$statusCode == 201"}
+      
+  Summary for consider-severity-in-next-step-execution.arazzo.yaml
+  
+  Workflows: 2 passed, 2 total
+  Steps: 3 passed, 1 warnings, 3 total
+  Checks: 12 passed, 1 warnings, 12 total
+  Time: <test>ms
+
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────┬─────────┬──────────┐
+│ Filename                                                                                     │ Workflows  │ Passed  │ Failed  │ Warnings │
+├──────────────────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────┼─────────┼──────────┤
+│ ✓ consider-severity-in-next-step-execution.arazzo.yaml                                       │ 2          │ 2       │ -       │ 1        │
+└──────────────────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────┴─────────┴──────────┘
+
+
+"
+`;

--- a/__tests__/respect/consider-severity-in-next-step-execution/consider-severity-in-next-step-execution.arazzo.yaml
+++ b/__tests__/respect/consider-severity-in-next-step-execution/consider-severity-in-next-step-execution.arazzo.yaml
@@ -1,0 +1,37 @@
+arazzo: 1.0.1
+info:
+  title: Redocly Museum API
+  version: 1.0.0
+
+sourceDescriptions:
+  - name: museum-api
+    type: openapi
+    url: ../museum-api.yaml
+
+workflows:
+  - workflowId: first-workflow
+    parameters:
+      - in: header
+        name: Authorization
+        value: Basic Og==
+    steps:
+      - stepId: first-step
+        operationId: museum-api.getMuseumHours
+        successCriteria:
+          - condition: $statusCode == 200
+  - workflowId: second-workflow
+    description: >-
+      This workflow demonstrates how to list, create, update, and delete special events at the museum.
+    parameters:
+      - in: header
+        name: Authorization
+        value: Basic Og==
+    steps:
+      - stepId: list-events
+        operationPath: '{$sourceDescriptions.museum-api.url}#/paths/~1special-events/get'
+        successCriteria:
+          #  Make this check fail
+          - condition: $statusCode == 201
+        # should not follow the default behavior to break and return if onFailure omitted with warn severity and continue execution of the next step
+      - stepId: call-first-workflow
+        workflowId: first-workflow

--- a/__tests__/respect/consider-severity-in-next-step-execution/consider-severity-in-next-step-execution.test.ts
+++ b/__tests__/respect/consider-severity-in-next-step-execution/consider-severity-in-next-step-execution.test.ts
@@ -1,0 +1,23 @@
+import { getParams, getCommandOutput } from '../utils';
+import { join } from 'path';
+
+test('should not follow the default behavior to break and return if onFailure omitted with warn severity and continue execution of the next step', () => {
+  const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
+  const fixturesPath = join(__dirname, 'consider-severity-in-next-step-execution.arazzo.yaml');
+  const args = getParams(indexEntryPoint, [
+    'respect',
+    fixturesPath,
+    '--verbose',
+    '--severity',
+    'STATUS_CODE_CHECK=off',
+    '--severity',
+    'SCHEMA_CHECK=warn',
+    '--severity',
+    'SUCCESS_CRITERIA_CHECK=warn',
+    '--severity',
+    'CONTENT_TYPE_CHECK=off',
+  ]);
+
+  const result = getCommandOutput(args);
+  expect(result).toMatchSnapshot();
+});

--- a/packages/respect-core/src/modules/__tests__/flow-runner/call-api-and-analyze-results.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/call-api-and-analyze-results.test.ts
@@ -371,7 +371,7 @@ describe('callAPIAndAnalyzeResults', () => {
       },
     });
     expect(result).toEqual({
-      expectCheck: true,
+      schemaCheck: true,
       networkCheck: true,
       successCriteriaCheck: true,
     });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -645,7 +645,7 @@ describe('runStep', () => {
         },
       ];
 
-      return { successCriteriaCheck: true, expectCheck: true };
+      return { successCriteriaCheck: true, schemaCheck: true };
     });
 
     await runStep({
@@ -698,7 +698,7 @@ describe('runStep', () => {
     callAPIAndAnalyzeResults.mockImplementationOnce(async ({ step }: { step: Step }) => {
       step.checks = [];
 
-      return { successCriteriaCheck: true, expectCheck: true };
+      return { successCriteriaCheck: true, schemaCheck: true };
     });
     await runStep({
       step,
@@ -765,7 +765,7 @@ describe('runStep', () => {
         },
       ];
 
-      return { successCriteriaCheck: true, expectCheck: true };
+      return { successCriteriaCheck: true, schemaCheck: true };
     });
 
     // @ts-ignore
@@ -874,7 +874,7 @@ describe('runStep', () => {
         },
       ];
 
-      return { successCriteriaCheck: true, expectCheck: true };
+      return { successCriteriaCheck: true, schemaCheck: true };
     });
 
     // @ts-ignore
@@ -1002,7 +1002,7 @@ describe('runStep', () => {
           },
         ];
 
-        return { successCriteriaCheck: true, expectCheck: true };
+        return { successCriteriaCheck: true, schemaCheck: true };
       }
     );
 
@@ -1123,7 +1123,7 @@ describe('runStep', () => {
           },
         ];
 
-        return { successCriteriaCheck: true, expectCheck: true };
+        return { successCriteriaCheck: true, schemaCheck: true };
       }
     );
 
@@ -1242,7 +1242,7 @@ describe('runStep', () => {
           },
         ];
 
-        return { successCriteriaCheck: false, expectCheck: true };
+        return { successCriteriaCheck: false, schemaCheck: true };
       }
     );
 
@@ -1351,7 +1351,7 @@ describe('runStep', () => {
           },
         ];
 
-        return { successCriteriaCheck: false, expectCheck: true };
+        return { successCriteriaCheck: false, schemaCheck: true };
       }
     );
 
@@ -1481,7 +1481,7 @@ describe('runStep', () => {
         },
       ];
 
-      return { successCriteriaCheck: false, expectCheck: true };
+      return { successCriteriaCheck: false, schemaCheck: true };
     });
 
     (checkCriteria as jest.Mock).mockImplementation(() => [
@@ -1598,7 +1598,7 @@ describe('runStep', () => {
         },
       ];
 
-      return { successCriteriaCheck: false, expectCheck: true };
+      return { successCriteriaCheck: false, schemaCheck: true };
     });
 
     // @ts-ignore
@@ -1723,7 +1723,7 @@ describe('runStep', () => {
         } as unknown as ResponseContext;
       }
 
-      return { successCriteriaCheck: false, expectCheck: true };
+      return { successCriteriaCheck: false, schemaCheck: true };
     });
 
     // @ts-ignore
@@ -1847,7 +1847,7 @@ describe('runStep', () => {
           } as unknown as ResponseContext;
         }
 
-        return { successCriteriaCheck: false, expectCheck: true };
+        return { successCriteriaCheck: false, schemaCheck: true };
       }
     );
 
@@ -1862,7 +1862,7 @@ describe('runStep', () => {
           },
         ];
 
-        return { successCriteriaCheck: true, expectCheck: true };
+        return { successCriteriaCheck: true, schemaCheck: true };
       }
     );
 
@@ -1889,7 +1889,7 @@ describe('runStep', () => {
           } as unknown as ResponseContext;
         }
 
-        return { successCriteriaCheck: true, expectCheck: true };
+        return { successCriteriaCheck: true, schemaCheck: true };
       }
     );
 
@@ -2007,7 +2007,7 @@ describe('runStep', () => {
         } as unknown as ResponseContext;
       }
 
-      return { successCriteriaCheck: false, expectCheck: true };
+      return { successCriteriaCheck: false, schemaCheck: true };
     });
 
     (checkCriteria as jest.Mock).mockImplementation(() => [

--- a/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
+++ b/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
@@ -59,7 +59,7 @@ export async function callAPIAndAnalyzeResults({
     });
 
     checksResult.successCriteriaCheck = successCriteriaChecks.every(
-      (check) => check.passed || (['off', 'warn'].includes(check.severity) && !check.passed)
+      (check) => check.passed || ['off', 'warn'].includes(check.severity)
     );
     step.checks.push(...successCriteriaChecks);
   }
@@ -76,7 +76,7 @@ export async function callAPIAndAnalyzeResults({
 
   if (schemaChecks.length) {
     checksResult.schemaCheck = schemaChecks.every(
-      (check) => check.passed || (['off', 'warn'].includes(check.severity) && !check.passed)
+      (check) => check.passed || ['off', 'warn'].includes(check.severity)
     );
     step.checks.push(...schemaChecks);
   }

--- a/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
+++ b/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
@@ -24,7 +24,7 @@ export async function callAPIAndAnalyzeResults({
 
   const checksResult = {
     successCriteriaCheck: true,
-    expectCheck: true,
+    schemaCheck: true,
     networkCheck: true,
   };
 
@@ -58,7 +58,9 @@ export async function callAPIAndAnalyzeResults({
       },
     });
 
-    checksResult.successCriteriaCheck = successCriteriaChecks.every((check) => check.passed);
+    checksResult.successCriteriaCheck = successCriteriaChecks.every(
+      (check) => check.passed || (['off', 'warn'].includes(check.severity) && !check.passed)
+    );
     step.checks.push(...successCriteriaChecks);
   }
 
@@ -73,7 +75,9 @@ export async function callAPIAndAnalyzeResults({
   });
 
   if (schemaChecks.length) {
-    checksResult.expectCheck = schemaChecks.every((check) => check.passed);
+    checksResult.schemaCheck = schemaChecks.every(
+      (check) => check.passed || (['off', 'warn'].includes(check.severity) && !check.passed)
+    );
     step.checks.push(...schemaChecks);
   }
 


### PR DESCRIPTION
## What/Why/How?

Consider severity in the next step execution when onFailure is omitted.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
