### PR TITLE
fix(respect): generate-arazzo with provided folder path

### DIFF
--- a/.changeset/happy-impalas-matter.md
+++ b/.changeset/happy-impalas-matter.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Fixed `generate-arazzo` command to properly handle directory paths when creating output files. Now correctly creates the output file in the specified directory and automatically appends the default filename when a directory path is provided.

--- a/.changeset/happy-impalas-matter.md
+++ b/.changeset/happy-impalas-matter.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed `generate-arazzo` command to properly handle directory paths when creating output files. Now correctly creates the output file in the specified directory and automatically appends the default filename when a directory path is provided.
+Fixed `generate-arazzo` command to properly handle output file paths. The `output-file` parameter must have a value when provided.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -954,6 +954,7 @@ yargs
             alias: 'o',
             describe: 'Output File name.',
             type: 'string',
+            requiresArg: true,
           },
         });
     },

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -26,13 +26,13 @@ export async function handleGenerate({ argv }: CommandArgs<GenerateArazzoFileOpt
     const fileName = argv['output-file'] || 'auto-generated.arazzo.yaml';
     writeFileSync(fileName, content);
 
-
-
-    
     logger.log(
       '\n' + blue(`Arazzo description ${yellow(fileName)} successfully generated.`) + '\n'
     );
   } catch (_err) {
-    exitWithError('\n' + '❌  Arazzo description generation failed. Please check the provided output file path or the OpenAPI file content.');
+    exitWithError(
+      '\n' +
+        '❌  Arazzo description generation failed. Please check the provided output file path or the OpenAPI file content.'
+    );
   }
 }

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -5,8 +5,6 @@ import { generateArazzoDescription } from '../modules/arazzo-description-generat
 import { DefaultLogger } from '../utils/logger/logger';
 import { exitWithError } from '../utils/exit-with-error';
 import { type CommandArgs } from '../types';
-import * as path from 'path';
-import * as fs from 'fs';
 
 export type GenerateArazzoFileOptions = {
   descriptionPath: string;

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -5,6 +5,8 @@ import { generateArazzoDescription } from '../modules/arazzo-description-generat
 import { DefaultLogger } from '../utils/logger/logger';
 import { exitWithError } from '../utils/exit-with-error';
 import { type CommandArgs } from '../types';
+import * as path from 'path';
+import * as fs from 'fs';
 
 export type GenerateArazzoFileOptions = {
   descriptionPath: string;
@@ -21,11 +23,19 @@ export async function handleGenerate({ argv }: CommandArgs<GenerateArazzoFileOpt
     const generatedConfig = await generateArazzoDescription(argv);
     const content = stringifyYaml(generatedConfig);
 
-    const fileName = argv['output-file'] || 'auto-generated.arazzo.yaml';
-    writeFileSync(fileName, content);
+    let outputPath = argv['output-file'] || 'auto-generated.arazzo.yaml';
+
+    if (fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()) {
+      outputPath = path.join(outputPath, 'auto-generated.arazzo.yaml');
+    } else if (!path.extname(outputPath)) {
+      fs.mkdirSync(outputPath, { recursive: true });
+      outputPath = path.join(outputPath, 'auto-generated.arazzo.yaml');
+    }
+
+    writeFileSync(outputPath, content);
 
     logger.log(
-      '\n' + blue(`Arazzo description ${yellow(fileName)} successfully generated.`) + '\n'
+      '\n' + blue(`Arazzo description ${yellow(outputPath)} successfully generated.`) + '\n'
     );
   } catch (_err) {
     exitWithError('\n' + '❌  Arazzo description generation failed.');

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -30,7 +30,7 @@ export async function handleGenerate({ argv }: CommandArgs<GenerateArazzoFileOpt
   } catch (_err) {
     exitWithError(
       '\n' +
-        '❌  Failed to generate Arazzo description. Check the output file path you provided or the OpenAPI file content.'
+        '❌  Failed to generate Arazzo description. Check the output file path you provided, or the OpenAPI file content.'
     );
   }
 }

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -30,7 +30,7 @@ export async function handleGenerate({ argv }: CommandArgs<GenerateArazzoFileOpt
   } catch (_err) {
     exitWithError(
       '\n' +
-        '❌  Arazzo description generation failed. Please check the provided output file path or the OpenAPI file content.'
+        '❌  Failed to generate Arazzo description. Check the provided output file path or the OpenAPI file content.'
     );
   }
 }

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -23,21 +23,16 @@ export async function handleGenerate({ argv }: CommandArgs<GenerateArazzoFileOpt
     const generatedConfig = await generateArazzoDescription(argv);
     const content = stringifyYaml(generatedConfig);
 
-    let outputPath = argv['output-file'] || 'auto-generated.arazzo.yaml';
+    const fileName = argv['output-file'] || 'auto-generated.arazzo.yaml';
+    writeFileSync(fileName, content);
 
-    if (fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()) {
-      outputPath = path.join(outputPath, 'auto-generated.arazzo.yaml');
-    } else if (!path.extname(outputPath)) {
-      fs.mkdirSync(outputPath, { recursive: true });
-      outputPath = path.join(outputPath, 'auto-generated.arazzo.yaml');
-    }
 
-    writeFileSync(outputPath, content);
 
+    
     logger.log(
-      '\n' + blue(`Arazzo description ${yellow(outputPath)} successfully generated.`) + '\n'
+      '\n' + blue(`Arazzo description ${yellow(fileName)} successfully generated.`) + '\n'
     );
   } catch (_err) {
-    exitWithError('\n' + '❌  Arazzo description generation failed.');
+    exitWithError('\n' + '❌  Arazzo description generation failed. Please check the provided output file path or the OpenAPI file content.');
   }
 }

--- a/packages/respect-core/src/handlers/generate.ts
+++ b/packages/respect-core/src/handlers/generate.ts
@@ -30,7 +30,7 @@ export async function handleGenerate({ argv }: CommandArgs<GenerateArazzoFileOpt
   } catch (_err) {
     exitWithError(
       '\n' +
-        '❌  Failed to generate Arazzo description. Check the provided output file path or the OpenAPI file content.'
+        '❌  Failed to generate Arazzo description. Check the output file path you provided or the OpenAPI file content.'
     );
   }
 }


### PR DESCRIPTION
## What/Why/How?

- `output-file` is not mandatory, but can't be empty when provided.
- error will be returned if not valid `output-file` provided (e.g. existing directory instead of file).

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/1990

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
