### PR TITLE
feat(respect): alternative timer implementation using performance

### DIFF
--- a/.changeset/silent-suits-kiss.md
+++ b/.changeset/silent-suits-kiss.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": minor
+"@redocly/cli": minor
+---
+
+Add global execution timeout timer to `respect` command execution in order to prevent infinite test runs. The timer can be configured using the `RESPECT_TIMEOUT` environment variable (defaults to 1 hour).

--- a/__tests__/respect/max-steps/__snapshots__/max-steps.test.ts.snap
+++ b/__tests__/respect/max-steps/__snapshots__/max-steps.test.ts.snap
@@ -142,8 +142,9 @@ exports[`should quit an infinite loop on RESPECT_MAX_STEPS 1`] = `
       fetch failed
       
     stepId - ping
-    ✗ unexpected error
-    Reason: Max steps (10) reached
+    ✗ maximum steps reached
+      Max steps (10) reached
+      
   Summary for arazzo.yaml
   
   Workflows: 1 failed, 1 total

--- a/__tests__/respect/max-steps/__snapshots__/max-steps.test.ts.snap
+++ b/__tests__/respect/max-steps/__snapshots__/max-steps.test.ts.snap
@@ -143,8 +143,7 @@ exports[`should quit an infinite loop on RESPECT_MAX_STEPS 1`] = `
       
     stepId - ping
     ✗ maximum steps reached
-      Max steps (10) reached
-      
+    Reason: Max steps (10) reached
   Summary for arazzo.yaml
   
   Workflows: 1 failed, 1 total

--- a/packages/respect-core/src/consts.ts
+++ b/packages/respect-core/src/consts.ts
@@ -1,2 +1,3 @@
-export const RESPECT_TIMEOUT = parseInt(process.env.RESPECT_TIMEOUT || '60 * 60 * 1000', 10); // 1 hour in milliseconds
+export const RESPECT_TIMEOUT = parseInt(process.env.RESPECT_TIMEOUT || '3600000', 10); // 1 hour in milliseconds
 export const MAX_STEPS = parseInt(process.env.RESPECT_MAX_STEPS || '2000', 10);
+export const MAX_FETCH_TIMEOUT = 20000; // 20 seconds in milliseconds

--- a/packages/respect-core/src/consts.ts
+++ b/packages/respect-core/src/consts.ts
@@ -1,3 +1,2 @@
-export const RESPECT_TIMEOUT = parseInt(process.env.RESPECT_TIMEOUT || '3600000', 10); // 1 hour in milliseconds
-export const MAX_STEPS = parseInt(process.env.RESPECT_MAX_STEPS || '2000', 10);
+export const RESPECT_TIMEOUT = 3600000; // 1 hour in milliseconds
 export const MAX_FETCH_TIMEOUT = 20000; // 20 seconds in milliseconds

--- a/packages/respect-core/src/consts.ts
+++ b/packages/respect-core/src/consts.ts
@@ -1,0 +1,2 @@
+export const RESPECT_TIMEOUT = parseInt(process.env.RESPECT_TIMEOUT || '60 * 60 * 1000', 10); // 1 hour in milliseconds
+export const MAX_STEPS = parseInt(process.env.RESPECT_MAX_STEPS || '2000', 10);

--- a/packages/respect-core/src/handlers/run.ts
+++ b/packages/respect-core/src/handlers/run.ts
@@ -12,8 +12,8 @@ import { DefaultLogger } from '../utils/logger/logger';
 import { exitWithError } from '../utils/exit-with-error';
 import { writeFileSync } from 'node:fs';
 import { indent } from '../utils/cli-outputs';
-
-import type { JsonLogs, CommandArgs, RunArgv } from '../types';
+import { Timer } from '../modules/timeout-timer';
+import { type JsonLogs, type CommandArgs, type RunArgv } from '../types';
 
 export type RespectOptions = {
   files: string[];
@@ -53,6 +53,7 @@ export async function handleRun({ argv, collectSpecData }: CommandArgs<RespectOp
   }
 
   try {
+    Timer.getInstance();
     const startedAt = performance.now();
     const testsRunProblemsStatus: boolean[] = [];
     const { files } = argv;
@@ -93,6 +94,7 @@ export async function handleRun({ argv, collectSpecData }: CommandArgs<RespectOp
             files: composeJsonLogsFiles(runAllFilesResult),
             status: hasProblems ? 'error' : hasWarnings ? 'warn' : 'success',
             totalTime: performance.now() - startedAt,
+            globalTimeoutError: Timer.getInstance().isTimedOut(),
           } as JsonLogs,
           null,
           2
@@ -139,5 +141,6 @@ async function runFile(
     ctx,
     totalTimeMs: performance.now() - startedAt,
     totalRequests: totals.totalRequests,
+    globalTimeoutError: Timer.getInstance().isTimedOut(),
   };
 }

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -3545,8 +3545,7 @@ describe('runStep', () => {
           },
         ],
       },
-      localCTX,
-      expect.any(Number)
+      localCTX
     );
     expect(runWorkflow).toHaveBeenCalledTimes(1);
   });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -1,4 +1,4 @@
-import type { Step, TestContext, ResponseContext } from '../../../types';
+import type { Step, TestContext, ResponseContext, Check } from '../../../types';
 
 import {
   runStep,
@@ -3983,5 +3983,41 @@ describe('runStep', () => {
     expect(cleanColors(step?.checks[0]?.message || '')).toEqual(
       'Workflow $sourceDescriptions.wrong-reusable-api.workflows.reusable-external-workflow not found.'
     );
+  });
+
+  it('should report global timeout error and end execution', async () => {
+    // Mock Timer only for this test
+    const mockTimer = {
+      isTimedOut: jest.fn().mockReturnValue(true),
+    };
+    jest.spyOn(require('../../timeout-timer').Timer, 'getInstance').mockReturnValue(mockTimer);
+
+    const checks: Check[] = [];
+    const step = {
+      stepId: 'get-bird',
+      'x-operation': { url: 'http://localhost:3000/bird', method: 'get' },
+      successCriteria: [{ condition: '$statusCode == 200' }],
+      checks,
+    } as unknown as Step;
+    const workflowId = 'get-bird-workflow';
+
+    const result = await runStep({
+      step,
+      ctx: basicCTX,
+      workflowId,
+    });
+
+    expect(result).toEqual({ shouldEnd: true });
+    expect(checks).toEqual([
+      {
+        name: CHECKS.GLOBAL_TIMEOUT_ERROR,
+        passed: false,
+        message: 'Global Respect timer reached',
+        severity: 'error',
+      },
+    ]);
+
+    // Clean up the mock after test
+    jest.restoreAllMocks();
   });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -652,6 +652,7 @@ describe('runStep', () => {
       step,
       ctx: basicCTX,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toMatchSnapshot();
@@ -670,6 +671,7 @@ describe('runStep', () => {
       step,
       ctx: basicCTX,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(step.checks).toEqual([
@@ -704,6 +706,7 @@ describe('runStep', () => {
       step,
       ctx: basicCTX,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     // @ts-ignore
@@ -830,6 +833,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -951,6 +955,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -1070,6 +1075,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -1187,6 +1193,7 @@ describe('runStep', () => {
         step: stepOne,
         ctx: context,
         workflowId,
+        sessionStartTime: performance.now(),
       })
     ).rejects.toThrowError(
       'Cannot use both workflowId: success-action-workflow and stepId: success-action-step in goto action'
@@ -1306,6 +1313,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -1429,6 +1437,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -1544,6 +1553,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -1659,6 +1669,7 @@ describe('runStep', () => {
           step: stepOne,
           ctx: context,
           workflowId,
+          sessionStartTime: performance.now(),
         })
     ).rejects.toThrow(
       'Cannot use both workflowId: failure-action-workflow and stepId: failure-action-step in retry action'
@@ -1787,6 +1798,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -1948,6 +1960,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -2065,6 +2078,7 @@ describe('runStep', () => {
       step: stepOne,
       ctx: context,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(displayChecks).toHaveBeenCalled();
@@ -2126,6 +2140,7 @@ describe('runStep', () => {
         step: stepOne,
         ctx: context,
         workflowId,
+        sessionStartTime: performance.now(),
       })
     ).rejects.toThrow(`Parameter "in" is required for ${stepOne.stepId} step`);
   });
@@ -2579,6 +2594,7 @@ describe('runStep', () => {
       step,
       ctx: localCTX,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(runWorkflow).toHaveBeenCalled();
@@ -3013,6 +3029,7 @@ describe('runStep', () => {
       step,
       ctx: localCTX,
       workflowId: 'test-workflow',
+      sessionStartTime: performance.now(),
     });
 
     // @ts-ignore
@@ -3031,8 +3048,6 @@ describe('runStep', () => {
       ],
       checks: [],
     } as unknown as Step;
-    const parentWorkflowId = undefined;
-    const parentStepId = undefined;
     const localCTX = {
       $request: undefined,
       $response: undefined,
@@ -3488,6 +3503,7 @@ describe('runStep', () => {
       step,
       ctx: localCTX,
       workflowId: 'test-workflow',
+      sessionStartTime: performance.now(),
     });
 
     expect(resolveWorkflowContext).toHaveBeenCalledWith(
@@ -3529,7 +3545,8 @@ describe('runStep', () => {
           },
         ],
       },
-      localCTX
+      localCTX,
+      expect.any(Number)
     );
     expect(runWorkflow).toHaveBeenCalledTimes(1);
   });
@@ -3977,6 +3994,7 @@ describe('runStep', () => {
       step,
       ctx: localCTX,
       workflowId,
+      sessionStartTime: performance.now(),
     });
 
     expect(runWorkflow).not.toHaveBeenCalled();
@@ -3986,11 +4004,9 @@ describe('runStep', () => {
   });
 
   it('should report global timeout error and end execution', async () => {
-    // Mock Timer only for this test
-    const mockTimer = {
-      isTimedOut: jest.fn().mockReturnValue(true),
-    };
-    jest.spyOn(require('../../timeout-timer').Timer, 'getInstance').mockReturnValue(mockTimer);
+    // Mock performance.now() only for this test
+    const mockNow = jest.spyOn(performance, 'now').mockReturnValue(5000000);
+    process.env.RESPECT_TIMEOUT = '1000';
 
     const checks: Check[] = [];
     const step = {
@@ -4005,6 +4021,7 @@ describe('runStep', () => {
       step,
       ctx: basicCTX,
       workflowId,
+      sessionStartTime: 0,
     });
 
     expect(result).toEqual({ shouldEnd: true });
@@ -4017,7 +4034,7 @@ describe('runStep', () => {
       },
     ]);
 
-    // Clean up the mock after test
-    jest.restoreAllMocks();
+    mockNow.mockRestore();
+    delete process.env.RESPECT_TIMEOUT;
   });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/create-workflow-runner.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/create-workflow-runner.test.ts
@@ -95,7 +95,7 @@ describe('runWorkflow', () => {
       },
     } as unknown as TestContext;
 
-    await runWorkflow({ workflowInput: 'test', ctx });
+    await runWorkflow({ workflowInput: 'test', ctx, sessionStartTime: performance.now() });
 
     expect(apiClient.fetchResult).toBeCalled();
   });
@@ -119,7 +119,7 @@ describe('runWorkflow', () => {
       },
     } as unknown as TestContext;
 
-    await runWorkflow({ workflowInput: 'test', ctx });
+    await runWorkflow({ workflowInput: 'test', ctx, sessionStartTime: performance.now() });
 
     expect(apiClient.fetchResult).not.toBeCalled();
   });
@@ -137,7 +137,9 @@ describe('runWorkflow', () => {
         workflowPath: fileName,
       },
     } as unknown as TestContext;
-    await expect(runWorkflow({ workflowInput: 'test', ctx })).rejects.toThrowError();
+    await expect(
+      runWorkflow({ workflowInput: 'test', ctx, sessionStartTime: performance.now() })
+    ).rejects.toThrowError();
     expect(apiClient.fetchResult).not.toBeCalled();
   });
 
@@ -222,7 +224,7 @@ describe('runWorkflow', () => {
       $outputs: {},
     } as unknown as TestContext;
 
-    await runWorkflow({ workflowInput: 'test', ctx });
+    await runWorkflow({ workflowInput: 'test', ctx, sessionStartTime: performance.now() });
 
     expect(ctx.$outputs?.test).toEqual({ test: 'test' });
     expect(ctx.$workflows.test.outputs).toEqual({ test: 'test' });
@@ -293,7 +295,7 @@ describe('runWorkflow', () => {
       $outputs: {},
     } as unknown as TestContext;
 
-    await runWorkflow({ workflowInput: 'test', ctx });
+    await runWorkflow({ workflowInput: 'test', ctx, sessionStartTime: performance.now() });
 
     expect(apiClient.fetchResult).not.toBeCalled();
   });
@@ -349,6 +351,7 @@ describe('runWorkflow', () => {
     await runWorkflow({
       workflowInput: 'test',
       ctx,
+      sessionStartTime: performance.now(),
     });
 
     expect(mockLogger).toMatchSnapshot();
@@ -448,6 +451,7 @@ describe('runWorkflow', () => {
     await runWorkflow({
       workflowInput: workflow,
       ctx,
+      sessionStartTime: performance.now(),
     });
 
     expect(ctx.$outputs?.test).toEqual({ test: 'test' });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
@@ -347,13 +347,13 @@ describe('resolveWorkflowContext', () => {
       executedSteps: [],
     } as any;
 
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx);
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, performance.now());
 
     expect(createTestContext).not.toHaveBeenCalled();
   });
 
   it('should call createTestContext with the correct parameters when sourceDescriptionId is defined for arazzo type', async () => {
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx);
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx, performance.now());
 
     expect(createTestContext).toHaveBeenCalledWith(
       commonCtx.$sourceDescriptions['tickets-from-museum-api'],
@@ -373,7 +373,7 @@ describe('resolveWorkflowContext', () => {
       ...{ sourceDescriptions: [] },
     } as any;
 
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx);
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, performance.now());
 
     expect(createTestContext).toHaveBeenCalledWith(
       ctx.$sourceDescriptions['tickets-from-museum-api'],
@@ -389,7 +389,7 @@ describe('resolveWorkflowContext', () => {
 
   it('should call createTestContext with the correct parameters when sourceDescriptionId is defined for openapi type', async () => {
     const workflowId = '$sourceDescriptions.museum-api';
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx);
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx, performance.now());
 
     expect(createTestContext).toHaveBeenCalledWith(
       commonCtx.$sourceDescriptions['museum-api'],
@@ -528,8 +528,8 @@ describe('resolveWorkflowContext', () => {
     } as any;
     const workflowId = '$sourceDescriptions.wrong-api.workflows.get-museum-tickets';
 
-    await expect(resolveWorkflowContext(workflowId, resolvedWorkflow, ctx)).rejects.toThrowError(
-      'Unknown source description type invalid'
-    );
+    await expect(
+      resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, performance.now())
+    ).rejects.toThrowError('Unknown source description type invalid');
   });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
@@ -528,8 +528,8 @@ describe('resolveWorkflowContext', () => {
     } as any;
     const workflowId = '$sourceDescriptions.wrong-api.workflows.get-museum-tickets';
 
-    await expect(
-      resolveWorkflowContext(workflowId, resolvedWorkflow, ctx)
-    ).rejects.toThrowError('Unknown source description type invalid');
+    await expect(resolveWorkflowContext(workflowId, resolvedWorkflow, ctx)).rejects.toThrowError(
+      'Unknown source description type invalid'
+    );
   });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
@@ -347,13 +347,13 @@ describe('resolveWorkflowContext', () => {
       executedSteps: [],
     } as any;
 
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, performance.now());
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx);
 
     expect(createTestContext).not.toHaveBeenCalled();
   });
 
   it('should call createTestContext with the correct parameters when sourceDescriptionId is defined for arazzo type', async () => {
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx, performance.now());
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx);
 
     expect(createTestContext).toHaveBeenCalledWith(
       commonCtx.$sourceDescriptions['tickets-from-museum-api'],
@@ -373,7 +373,7 @@ describe('resolveWorkflowContext', () => {
       ...{ sourceDescriptions: [] },
     } as any;
 
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, performance.now());
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx);
 
     expect(createTestContext).toHaveBeenCalledWith(
       ctx.$sourceDescriptions['tickets-from-museum-api'],
@@ -389,7 +389,7 @@ describe('resolveWorkflowContext', () => {
 
   it('should call createTestContext with the correct parameters when sourceDescriptionId is defined for openapi type', async () => {
     const workflowId = '$sourceDescriptions.museum-api';
-    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx, performance.now());
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx);
 
     expect(createTestContext).toHaveBeenCalledWith(
       commonCtx.$sourceDescriptions['museum-api'],
@@ -529,7 +529,7 @@ describe('resolveWorkflowContext', () => {
     const workflowId = '$sourceDescriptions.wrong-api.workflows.get-museum-tickets';
 
     await expect(
-      resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, performance.now())
+      resolveWorkflowContext(workflowId, resolvedWorkflow, ctx)
     ).rejects.toThrowError('Unknown source description type invalid');
   });
 });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
@@ -75,7 +75,9 @@ describe('runTestFile', () => {
   });
 
   it(`should trow error if filename is not correct`, async () => {
-    await expect(runTestFile({ file: '' }, {})).rejects.toThrowError('Invalid file name');
+    await expect(runTestFile({ file: '' }, {}, performance.now())).rejects.toThrowError(
+      'Invalid file name'
+    );
   });
 
   it(`should trow error if file is not valid Arazzo test file`, async () => {
@@ -89,7 +91,7 @@ describe('runTestFile', () => {
 
     (readYaml as jest.Mock).mockResolvedValue(mockDocument.parsed);
 
-    await expect(runTestFile({ file: 'test.yaml' }, {})).rejects.toThrowError(
+    await expect(runTestFile({ file: 'test.yaml' }, {}, performance.now())).rejects.toThrowError(
       'No test files found. File test.yaml does not follows naming pattern "*.[yaml | yml | json]" or have not valid "Arazzo" description.'
     );
   });
@@ -140,7 +142,8 @@ describe('runTestFile', () => {
           file: 'test.yaml',
           testDescription,
         },
-        {}
+        {},
+        performance.now()
       )
     ).rejects.toMatchSnapshot();
   });
@@ -210,7 +213,8 @@ describe('runTestFile', () => {
       {
         file: 'test.yaml',
       },
-      {}
+      {},
+      performance.now()
     );
 
     expect(runStep).toHaveBeenCalledTimes(1);
@@ -303,7 +307,8 @@ describe('runTestFile', () => {
       {
         file: 'test.yaml',
       },
-      {}
+      {},
+      performance.now()
     );
 
     // called 3 times, one for each step from each workflow and one from dependsOn
@@ -393,7 +398,7 @@ describe('runTestFile', () => {
       },
     });
 
-    await expect(runTestFile({ file: 'test.yaml' }, {})).rejects.toThrow(
+    await expect(runTestFile({ file: 'test.yaml' }, {}, performance.now())).rejects.toThrow(
       expect.objectContaining({
         // @ts-ignore
         message: expect.stringContaining('Workflow', 'not-existing-workflowId', 'not found'),
@@ -494,7 +499,8 @@ describe('runTestFile', () => {
         {
           file: 'test.yaml',
         },
-        {}
+        {},
+        performance.now()
       )
     ).rejects.toThrowError('Dependent workflows has failed steps');
   }, 8000);
@@ -544,7 +550,7 @@ describe('runTestFile', () => {
         parsed: mockDocument.parsed,
       },
     });
-    await expect(runTestFile({ file: 'test.yaml' }, {})).rejects.toThrowError(
+    await expect(runTestFile({ file: 'test.yaml' }, {}, performance.now())).rejects.toThrowError(
       `Could not find source description file 'api-samples/not-existing.yaml' at path 'test.yaml'`
     );
   });
@@ -599,7 +605,7 @@ describe('runTestFile', () => {
         parsed: mockDocument.parsed,
       },
     });
-    await expect(runTestFile({ file: 'test.yaml' }, {})).rejects.toThrowError(
+    await expect(runTestFile({ file: 'test.yaml' }, {}, performance.now())).rejects.toThrowError(
       `Could not find source description file 'not-existing-arazzo.yaml' at path 'api-samples/not-existing-arazzo.yaml'`
     );
   });

--- a/packages/respect-core/src/modules/__tests__/timeout-timer/timer.test.ts
+++ b/packages/respect-core/src/modules/__tests__/timeout-timer/timer.test.ts
@@ -1,21 +1,15 @@
-import { Timer } from '../../timeout-timer/timer';
+import { isTimedOut } from '../../timeout-timer/timer';
 
 describe('Timer', () => {
-  it('should be a singleton', () => {
-    const timer1 = Timer.getInstance();
-    const timer2 = Timer.getInstance();
-    expect(timer1).toBe(timer2);
-  });
-
   it('should return true if the timer is timed out', () => {
     process.env.RESPECT_TIMEOUT = '0';
-    const timer = Timer.getInstance();
-    expect(timer.isTimedOut()).toBe(true);
+    const startedAt = performance.now();
+    expect(isTimedOut(startedAt)).toBe(true);
     delete process.env.RESPECT_TIMEOUT;
   });
 
   it('should return false if the timer is not timed out', () => {
-    const timer = Timer.getInstance();
-    expect(timer.isTimedOut()).toBe(false);
+    const startedAt = performance.now();
+    expect(isTimedOut(startedAt)).toBe(false);
   });
 });

--- a/packages/respect-core/src/modules/__tests__/timeout-timer/timer.test.ts
+++ b/packages/respect-core/src/modules/__tests__/timeout-timer/timer.test.ts
@@ -1,0 +1,21 @@
+import { Timer } from '../../timeout-timer/timer';
+
+describe('Timer', () => {
+  it('should be a singleton', () => {
+    const timer1 = Timer.getInstance();
+    const timer2 = Timer.getInstance();
+    expect(timer1).toBe(timer2);
+  });
+
+  it('should return true if the timer is timed out', () => {
+    process.env.RESPECT_TIMEOUT = '0';
+    const timer = Timer.getInstance();
+    expect(timer.isTimedOut()).toBe(true);
+    delete process.env.RESPECT_TIMEOUT;
+  });
+
+  it('should return false if the timer is not timed out', () => {
+    const timer = Timer.getInstance();
+    expect(timer.isTimedOut()).toBe(false);
+  });
+});

--- a/packages/respect-core/src/modules/checks/checks.ts
+++ b/packages/respect-core/src/modules/checks/checks.ts
@@ -4,5 +4,6 @@ export const CHECKS = {
   SCHEMA_CHECK: 'schema check',
   CONTENT_TYPE_CHECK: 'content-type check',
   UNEXPECTED_ERROR: 'unexpected error',
+  GLOBAL_TIMEOUT_ERROR: 'global timeout error',
   NETWORK_ERROR: 'failed network request',
 };

--- a/packages/respect-core/src/modules/checks/checks.ts
+++ b/packages/respect-core/src/modules/checks/checks.ts
@@ -6,4 +6,5 @@ export const CHECKS = {
   UNEXPECTED_ERROR: 'unexpected error',
   GLOBAL_TIMEOUT_ERROR: 'global timeout error',
   NETWORK_ERROR: 'failed network request',
+  MAX_STEPS_REACHED_ERROR: 'maximum steps reached',
 };

--- a/packages/respect-core/src/modules/checks/severity.ts
+++ b/packages/respect-core/src/modules/checks/severity.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SEVERITY_CONFIGURATION: {
   CONTENT_TYPE_CHECK: 'error',
   UNEXPECTED_ERROR: 'error',
   NETWORK_ERROR: 'error',
+  GLOBAL_TIMEOUT_ERROR: 'error',
 };
 
 export function resolveSeverityConfiguration(severityArgument: string | string[] | undefined): {

--- a/packages/respect-core/src/modules/checks/severity.ts
+++ b/packages/respect-core/src/modules/checks/severity.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SEVERITY_CONFIGURATION: {
   UNEXPECTED_ERROR: 'error',
   NETWORK_ERROR: 'error',
   GLOBAL_TIMEOUT_ERROR: 'error',
+  MAX_STEPS_REACHED_ERROR: 'error',
 };
 
 export function resolveSeverityConfiguration(severityArgument: string | string[] | undefined): {

--- a/packages/respect-core/src/modules/cli-output/display-errors.ts
+++ b/packages/respect-core/src/modules/cli-output/display-errors.ts
@@ -48,7 +48,11 @@ export function displayErrors(workflows: WorkflowExecutionResult[]) {
 
       for (const failedCheckIndex in failedStepChecks) {
         const { name, message, severity } = failedStepChecks[failedCheckIndex];
-        const showErrorMessage = name !== CHECKS.UNEXPECTED_ERROR;
+        const showErrorMessage = ![
+          CHECKS.UNEXPECTED_ERROR,
+          CHECKS.GLOBAL_TIMEOUT_ERROR,
+          CHECKS.MAX_STEPS_REACHED_ERROR,
+        ].includes(name);
         const messageToDisplay = showErrorMessage
           ? indent(`${removeExtraIndentation(message)}${RESET_ESCAPE_CODE}\n`, 6)
           : indent(`Reason: ${message}`, 4);

--- a/packages/respect-core/src/modules/cli-output/display-files-summary-table.ts
+++ b/packages/respect-core/src/modules/cli-output/display-files-summary-table.ts
@@ -14,6 +14,7 @@ export function displayFilesSummaryTable(
     hasProblems: boolean;
     executedWorkflows: WorkflowExecutionResult[];
     argv?: { workflow?: string[]; skip?: string[] };
+    globalTimeoutError: boolean;
   }[]
 ) {
   const DEFAULT_FILENAME_PADDING = 40;
@@ -41,7 +42,7 @@ export function displayFilesSummaryTable(
   output += `${gray(`├${columns.map((col) => '─'.repeat(col.width + 2)).join('┼')}┤`)}\n`;
 
   // Data rows
-  filesResult.forEach(({ file, executedWorkflows: workflows, argv }) => {
+  filesResult.forEach(({ file, executedWorkflows: workflows, argv, globalTimeoutError }) => {
     const fileName = path.basename(file);
     const workflowArgv = argv?.workflow || [];
     const skippedWorkflowArgv = argv?.skip || [];
@@ -69,9 +70,10 @@ export function displayFilesSummaryTable(
         : gray('-'.padEnd(9));
 
     // First pad the content, then add colors
-    const statusSymbol = testWorkflows.failed > 0 ? 'x' : '✓';
+    const statusSymbol = testWorkflows.failed > 0 || globalTimeoutError ? 'x' : '✓';
     const paddedContent = `${statusSymbol} ${fileName}`.padEnd(maxFilenameLength + 1);
-    const fileNameWithStatus = testWorkflows.failed > 0 ? red(paddedContent) : green(paddedContent);
+    const fileNameWithStatus =
+      testWorkflows.failed > 0 || globalTimeoutError ? red(paddedContent) : green(paddedContent);
 
     output +=
       gray('│') +

--- a/packages/respect-core/src/modules/cli-output/json-logs.ts
+++ b/packages/respect-core/src/modules/cli-output/json-logs.ts
@@ -1,5 +1,6 @@
 import { maskSecrets } from './mask-secrets';
 import { calculateTotals } from './calculate-tests-passed';
+import { Timer } from '../timeout-timer';
 
 import type {
   TestContext,
@@ -18,12 +19,13 @@ export function composeJsonLogsFiles(
     totalTimeMs: number;
     executedWorkflows: WorkflowExecutionResult[];
     ctx: TestContext;
+    globalTimeoutError: boolean;
   }[]
 ): JsonLogs['files'] {
   const files: JsonLogs['files'] = {};
 
   for (const fileResult of filesResult) {
-    const { executedWorkflows } = fileResult;
+    const { executedWorkflows, globalTimeoutError: fileGlobalTimeoutError } = fileResult;
     const { secretFields } = fileResult.ctx;
 
     files[fileResult.file] = maskSecrets(
@@ -31,6 +33,7 @@ export function composeJsonLogsFiles(
         totalRequests: fileResult.totalRequests,
         executedWorkflows: executedWorkflows.map((workflow) => mapJsonWorkflow(workflow)),
         totalTimeMs: fileResult.totalTimeMs,
+        globalTimeoutError: fileGlobalTimeoutError,
       },
       secretFields || new Set()
     );

--- a/packages/respect-core/src/modules/cli-output/json-logs.ts
+++ b/packages/respect-core/src/modules/cli-output/json-logs.ts
@@ -1,6 +1,5 @@
 import { maskSecrets } from './mask-secrets';
 import { calculateTotals } from './calculate-tests-passed';
-import { Timer } from '../timeout-timer';
 
 import type {
   TestContext,

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -18,6 +18,8 @@ import {
 } from '../config-parser';
 import { evaluateRuntimeExpressionPayload } from '../runtime-expressions';
 import { DefaultLogger } from '../../utils/logger/logger';
+import { MAX_STEPS } from '../../consts';
+import { Timer } from '../timeout-timer';
 
 import type {
   Check,
@@ -31,9 +33,8 @@ import type {
 } from '../../types';
 import type { ParameterWithoutIn } from '../config-parser';
 
-const logger = DefaultLogger.getInstance();
 
-const MAX_STEPS = parseInt(process.env.RESPECT_MAX_STEPS || '2000', 10);
+const logger = DefaultLogger.getInstance();
 let stepsRun = 0;
 
 export async function runStep({
@@ -153,6 +154,16 @@ export async function runStep({
       message: `Max steps (${MAX_STEPS}) reached`,
       passed: false,
       severity: ctx.severity['UNEXPECTED_ERROR'],
+    });
+    return { shouldEnd: true };
+  }
+
+  if (Timer.getInstance().isTimedOut()) {
+    step.checks.push({
+      name: CHECKS.GLOBAL_TIMEOUT_ERROR,
+      message: `Global Respect timer reached`,
+      passed: false,
+      severity: ctx.severity['GLOBAL_TIMEOUT_ERROR'],
     });
     return { shouldEnd: true };
   }

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -81,11 +81,7 @@ export async function runStep({
       return;
     }
 
-    const workflowCtx = await resolveWorkflowContext(
-      targetWorkflowRef,
-      targetWorkflow,
-      ctx
-    );
+    const workflowCtx = await resolveWorkflowContext(targetWorkflowRef, targetWorkflow, ctx);
 
     if (resolvedParameters && resolvedParameters.length) {
       // When the step in context specifies a workflowId, then all parameters without `in` maps to workflow inputs.

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -33,7 +33,6 @@ import type {
 } from '../../types';
 import type { ParameterWithoutIn } from '../config-parser';
 
-
 const logger = DefaultLogger.getInstance();
 let stepsRun = 0;
 
@@ -150,10 +149,10 @@ export async function runStep({
   stepsRun++;
   if (stepsRun > MAX_STEPS) {
     step.checks.push({
-      name: CHECKS.UNEXPECTED_ERROR,
+      name: CHECKS.MAX_STEPS_REACHED_ERROR,
       message: `Max steps (${MAX_STEPS}) reached`,
       passed: false,
-      severity: ctx.severity['UNEXPECTED_ERROR'],
+      severity: ctx.severity['MAX_STEPS_REACHED_ERROR'],
     });
     return { shouldEnd: true };
   }

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -18,7 +18,6 @@ import {
 } from '../config-parser';
 import { evaluateRuntimeExpressionPayload } from '../runtime-expressions';
 import { DefaultLogger } from '../../utils/logger/logger';
-import { MAX_STEPS } from '../../consts';
 import { Timer } from '../timeout-timer';
 
 import type {
@@ -34,6 +33,7 @@ import type {
 import type { ParameterWithoutIn } from '../config-parser';
 
 const logger = DefaultLogger.getInstance();
+const MAX_STEPS = parseInt(process.env.RESPECT_MAX_STEPS || '2000', 10);
 let stepsRun = 0;
 
 export async function runStep({

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -84,8 +84,7 @@ export async function runStep({
     const workflowCtx = await resolveWorkflowContext(
       targetWorkflowRef,
       targetWorkflow,
-      ctx,
-      sessionStartTime
+      ctx
     );
 
     if (resolvedParameters && resolvedParameters.length) {
@@ -286,7 +285,7 @@ export async function runStep({
           ? getValueFromContext(action.workflowId, ctx)
           : undefined;
         const targetCtx = action.workflowId
-          ? await resolveWorkflowContext(action.workflowId, targetWorkflow, ctx, sessionStartTime)
+          ? await resolveWorkflowContext(action.workflowId, targetWorkflow, ctx)
           : { ...ctx, executedSteps: [] };
 
         const targetStep = action.stepId ? action.stepId : undefined;

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -28,6 +28,7 @@ import type {
   RunWorkflowInput,
   WorkflowExecutionResult,
 } from '../../types';
+import { Timer } from '../timeout-timer';
 
 const logger = DefaultLogger.getInstance();
 
@@ -102,6 +103,9 @@ async function runWorkflows(testDescription: TestDescription, options: AppOption
       await handleDependsOn({ workflow, ctx });
     }
 
+    if (Timer.getInstance().isTimedOut()) {
+      break;
+    }
     const workflowExecutionResult = await runWorkflow({
       workflowInput: workflow.workflowId,
       ctx,

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -258,8 +258,7 @@ async function handleDependsOn({
       const workflowCtx = await resolveWorkflowContext(
         workflowId,
         resolvedWorkflow,
-        ctx,
-        sessionStartTime
+        ctx
       );
 
       printRequiredWorkflowSeparator(workflow.workflowId);
@@ -284,7 +283,6 @@ export async function resolveWorkflowContext(
   workflowId: string | undefined,
   resolvedWorkflow: Workflow,
   ctx: TestContext,
-  sessionStartTime: number
 ) {
   const sourceDescriptionId =
     workflowId && workflowId.startsWith('$sourceDescriptions.') && workflowId.split('.')[1];

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -255,11 +255,7 @@ async function handleDependsOn({
   const dependenciesWorkflows = await Promise.all(
     workflow.dependsOn.map(async (workflowId) => {
       const resolvedWorkflow = getValueFromContext(workflowId, ctx);
-      const workflowCtx = await resolveWorkflowContext(
-        workflowId,
-        resolvedWorkflow,
-        ctx
-      );
+      const workflowCtx = await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx);
 
       printRequiredWorkflowSeparator(workflow.workflowId);
       return runWorkflow({
@@ -282,7 +278,7 @@ async function handleDependsOn({
 export async function resolveWorkflowContext(
   workflowId: string | undefined,
   resolvedWorkflow: Workflow,
-  ctx: TestContext,
+  ctx: TestContext
 ) {
   const sourceDescriptionId =
     workflowId && workflowId.startsWith('$sourceDescriptions.') && workflowId.split('.')[1];

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -15,6 +15,7 @@ import { evaluateRuntimeExpressionPayload } from '../runtime-expressions';
 import { calculateTotals, maskSecrets } from '../cli-output';
 import { resolveRunningWorkflows } from './resolve-running-workflows';
 import { DefaultLogger } from '../../utils/logger/logger';
+import { Timer } from '../timeout-timer';
 
 import type { CollectFn } from '@redocly/openapi-core/src/utils';
 import type {
@@ -28,7 +29,6 @@ import type {
   RunWorkflowInput,
   WorkflowExecutionResult,
 } from '../../types';
-import { Timer } from '../timeout-timer';
 
 const logger = DefaultLogger.getInstance();
 

--- a/packages/respect-core/src/modules/timeout-timer/index.ts
+++ b/packages/respect-core/src/modules/timeout-timer/index.ts
@@ -1,0 +1,1 @@
+export * from './timer';

--- a/packages/respect-core/src/modules/timeout-timer/timer.ts
+++ b/packages/respect-core/src/modules/timeout-timer/timer.ts
@@ -1,0 +1,26 @@
+import { RESPECT_TIMEOUT } from '../../consts';
+
+export class Timer {
+  private static instance: Timer;
+  private startTime: number;
+
+  private constructor() {
+    this.startTime = Date.now();
+  }
+
+  public static getInstance(): Timer {
+    if (!Timer.instance) {
+      Timer.instance = new Timer();
+    }
+    return Timer.instance;
+  }
+
+  public getRemainingTime(): number {
+    const elapsedTime = Date.now() - this.startTime;
+    return Math.max(0, Number(RESPECT_TIMEOUT) - elapsedTime);
+  }
+
+  public isTimedOut(): boolean {
+    return this.getRemainingTime() <= 0;
+  }
+}

--- a/packages/respect-core/src/modules/timeout-timer/timer.ts
+++ b/packages/respect-core/src/modules/timeout-timer/timer.ts
@@ -1,31 +1,7 @@
 import { RESPECT_TIMEOUT } from '../../consts';
 
-export class Timer {
-  private static instance: Timer;
-  private startTime: number;
-
-  private constructor() {
-    this.startTime = Date.now();
-  }
-
-  public static getInstance(): Timer {
-    if (!Timer.instance) {
-      Timer.instance = new Timer();
-    }
-    return Timer.instance;
-  }
-
-  private getTimeout(): number {
-    return parseInt(process.env.RESPECT_TIMEOUT || RESPECT_TIMEOUT.toString(), 10);
-  }
-
-  public getRemainingTime(): number {
-    const elapsedTime = Date.now() - this.startTime;
-    const timeout = this.getTimeout();
-    return Math.max(0, timeout - elapsedTime);
-  }
-
-  public isTimedOut(): boolean {
-    return this.getRemainingTime() <= 0;
-  }
+export function isTimedOut(startedAt: number) {
+  const elapsedTime = performance.now() - startedAt;
+  const timeout = parseInt(process.env.RESPECT_TIMEOUT || RESPECT_TIMEOUT.toString(), 10);
+  return elapsedTime >= timeout;
 }

--- a/packages/respect-core/src/modules/timeout-timer/timer.ts
+++ b/packages/respect-core/src/modules/timeout-timer/timer.ts
@@ -15,9 +15,14 @@ export class Timer {
     return Timer.instance;
   }
 
+  private getTimeout(): number {
+    return parseInt(process.env.RESPECT_TIMEOUT || RESPECT_TIMEOUT.toString(), 10);
+  }
+
   public getRemainingTime(): number {
     const elapsedTime = Date.now() - this.startTime;
-    return Math.max(0, Number(RESPECT_TIMEOUT) - elapsedTime);
+    const timeout = this.getTimeout();
+    return Math.max(0, timeout - elapsedTime);
   }
 
   public isTimedOut(): boolean {

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -310,6 +310,7 @@ export type JsonLogs = {
   >;
   status: string;
   totalTime: number;
+  globalTimeoutError: boolean;
 };
 
 export type DescriptionChecks = {

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -193,6 +193,7 @@ export type RunWorkflowInput = {
   parentStepId?: string;
   skipLineSeparator?: boolean;
   invocationContext?: string;
+  sessionStartTime: number;
 };
 
 export type ArrazoItemExecutionResult = StepExecutionResult | WorkflowExecutionResult;

--- a/packages/respect-core/src/utils/api-fetcher.ts
+++ b/packages/respect-core/src/utils/api-fetcher.ts
@@ -17,12 +17,11 @@ import { getResponseSchema } from '../modules/description-parser';
 import { collectSecretFields } from '../modules/flow-runner';
 import { createMtlsClient } from './mtls/create-mtls-client';
 import { DefaultLogger } from './logger/logger';
+import { MAX_FETCH_TIMEOUT } from '../consts';
 
 import type { RequestData } from '../modules/flow-runner';
 
 const logger = DefaultLogger.getInstance();
-
-const MAX_FETCH_TIMEOUT = 20000;
 
 interface IFetcher {
   verboseLogs?: VerboseLog;


### PR DESCRIPTION
## What/Why/How?

Alternative timer implementation using performance.now and passing startedAt as parameter through the executed code.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
