### PR TITLE
fix(respect): apply changes to ajv defaultUnevaluatedProperties setting

### DIFF
--- a/.changeset/thin-trees-begin.md
+++ b/.changeset/thin-trees-begin.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Fixed schema validation to properly handle OpenAPI `anyOf` schemas when validating responses using Ajv. This improves validation accuracy for schemas that use `anyOf` to define multiple possible response shapes.

--- a/packages/respect-core/src/modules/flow-runner/schema/schema-checker.ts
+++ b/packages/respect-core/src/modules/flow-runner/schema/schema-checker.ts
@@ -27,7 +27,7 @@ const ajvStrict = new Ajv({
   validateFormats: false,
   logger: false,
   verbose: true,
-  defaultUnevaluatedProperties: false,
+  defaultUnevaluatedProperties: true,
 });
 
 export function checkSchema({


### PR DESCRIPTION
## What/Why/How?

Apply changes to ajv defaultUnevaluatedProperties setting to handle 'anyOff` schema cases.

```
`unevaluatedProperties` works by collecting any properties that are successfully validated when processing the schemas and using those as the allowed list of properties. This allows you to do more complex things like conditionally adding properties. 
```

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
