### PR TITLE
docs: add latest to all npx redocly cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports OpenAPI 3.1, 3.0 and OpenAPI 2.0 (legacy Swagger), AsyncAPI 3.0 and 2.6
 ### Node
 
 ```sh
-npx @redocly/cli lint path-to-root-file.yaml
+npx @redocly/cli@latest lint path-to-root-file.yaml
 ```
 
 Alternatively, install it globally with `npm`:

--- a/docs/commands/generate-arazzo.md
+++ b/docs/commands/generate-arazzo.md
@@ -20,7 +20,7 @@ The first HTTP response is used as the success criteria for each step.
 ## Usage
 
 ```sh
-npx @redocly/cli generate-arazzo <your-OAS-description-file> [-o | --output-file]
+npx @redocly/cli@latest generate-arazzo <your-OAS-description-file> [-o | --output-file]
 ```
 
 ## Options
@@ -41,7 +41,7 @@ npx @redocly/cli generate-arazzo <your-OAS-description-file> [-o | --output-file
 
 ## Examples
 
-Run the command: `npx @redocly/cli generate-arazzo 'https://warp-single-sidebar.redocly.app/_spec/apis/index.yaml'`
+Run the command: `npx @redocly/cli@latest generate-arazzo 'https://warp-single-sidebar.redocly.app/_spec/apis/index.yaml'`
 
 The command generates an `auto-generated.arazzo.yaml` file in the current directory.
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -53,7 +53,7 @@ There are some parameters supported by all commands:
 `--help` display the command help, or the help for the subcommand if you used one. For example:
 
 ```bash
-npx @redocly/cli lint --help
+npx @redocly/cli@latest lint --help
 ```
 
 Try these with any of the other commands.
@@ -69,7 +69,7 @@ If Redocly CLI finds `redocly.yaml` in the root directory, it uses the options s
 You can also specify a config file to most commands using `--config myconfig.yaml` as part of the command. For example:
 
 ```bash
-npx @redocly/cli lint --config redocly-official.yaml openapi.yaml
+npx @redocly/cli@latest lint --config redocly-official.yaml openapi.yaml
 ```
 
 For more information, refer to the [Redocly configuration file](../configuration/index.md) docs.

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -104,7 +104,7 @@ The following command pushes the `docs/museum.yaml` file to the project `push-do
 It uses the variables available in the GitHub actions context to supply information to the destination.
 
 ```bash
-npx @redocly/cli push docs/museum.yaml \
+npx @redocly/cli@latest push docs/museum.yaml \
               --organization "Docs" \
               --project "push-docs" \
               --mount-path "/docs/remotes/cicd" \

--- a/docs/commands/respect.md
+++ b/docs/commands/respect.md
@@ -11,7 +11,7 @@ Use this command to execute API tests described in an Arazzo description.
 ## Usage
 
 ```sh
-npx @redocly/cli respect <your-test-file | multiple files | files bash query> [-w | --workflow] [-s | --skip] [-v | --verbose] [-i | --input] [-S | --server] [-H | --har-output] [-J | --json-output]
+npx @redocly/cli@latest respect <your-test-file | multiple files | files bash query> [-w | --workflow] [-s | --skip] [-v | --verbose] [-i | --input] [-S | --server] [-H | --har-output] [-J | --json-output]
 ```
 
 ## Options
@@ -27,7 +27,7 @@ npx @redocly/cli respect <your-test-file | multiple files | files bash query> [-
 - -w, --workflow
 - [string]
 - Workflow names from the test file to run.
-  For example, the following command runs "first-flow" and "second-flow" workflows from the `test-file.yaml` Arazzo description: `npx @redocly/cli respect test-file.yaml --workflow first-flow second-flow`.
+  For example, the following command runs "first-flow" and "second-flow" workflows from the `test-file.yaml` Arazzo description: `npx @redocly/cli@latest respect test-file.yaml --workflow first-flow second-flow`.
   {% admonition type="warning" %}
   The `--workflow` option can't be used with `--skip`.
   {% /admonition %}
@@ -37,7 +37,7 @@ npx @redocly/cli respect <your-test-file | multiple files | files bash query> [-
 - -s, --skip
 - [string]
 - Workflow names from the test file to skip.
-  For example, the following command skips the "first-flow" workflow from the `test-file.yaml` Arazzo description: `npx @redocly/cli respect test-file.yaml --skip first-flow`.
+  For example, the following command skips the "first-flow" workflow from the `test-file.yaml` Arazzo description: `npx @redocly/cli@latest respect test-file.yaml --skip first-flow`.
   {% admonition type="warning" name="Warning" %}
   The `--skip` option can't be used with `--workflow`.
   {% /admonition %}
@@ -47,38 +47,38 @@ npx @redocly/cli respect <your-test-file | multiple files | files bash query> [-
 - -v, --verbose
 - boolean
 - Runs the command in verbose mode to help with troubleshooting issues.
-  For example, the following command runs all workflows from the `test-file.yaml` Arazzo description in verbose mode: `npx @redocly/cli respect test-file.yaml --verbose`.
+  For example, the following command runs all workflows from the `test-file.yaml` Arazzo description in verbose mode: `npx @redocly/cli@latest respect test-file.yaml --verbose`.
 
 ---
 
 - --har-output
 - string
 - Path for the `har` file for saving logs.
-  For example, the following command runs all workflows from the `test-file.yaml` Arazzo description and saves the logs to the `logs.har` file: `npx @redocly/cli respect test-file.yaml --har-output='logs.har'`.
+  For example, the following command runs all workflows from the `test-file.yaml` Arazzo description and saves the logs to the `logs.har` file: `npx @redocly/cli@latest respect test-file.yaml --har-output='logs.har'`.
 
 ---
 
 - --json-output
 - string
-- Path for the JSON file for saving logs. For example, the following command runs all workflows from the `test-file.yaml` Arazzo description and saves the logs to the `logs.json` file:`npx @redocly/cli respect test-file.yaml --json-output='logs.json'`.
+- Path for the JSON file for saving logs. For example, the following command runs all workflows from the `test-file.yaml` Arazzo description and saves the logs to the `logs.json` file:`npx @redocly/cli@latest respect test-file.yaml --json-output='logs.json'`.
 
 ---
 
 - --input
 - string
 - Input parameters with values that are mapped to the workflow inputs description.
-  For example, the following command maps the "userEmail" and "userPassword" inputs and values to all workflows in the `test.yaml` Arazzo description: `npx @redocly/cli respect test.yaml --input userEmail=name@redocly.com --input userPassword=12345`.
+  For example, the following command maps the "userEmail" and "userPassword" inputs and values to all workflows in the `test.yaml` Arazzo description: `npx @redocly/cli@latest respect test.yaml --input userEmail=name@redocly.com --input userPassword=12345`.
   You can also use an environment variable to set the input, as in the following example: `REDOCLY_CLI_RESPECT_INPUT='userEmail=name@redocly.com,userPassword=12345' npm run cli respect test.yaml`
 
-  You can even include nested values, as in the following example command that maps the `nestedKey` input and value to all workflows in the `test-file.yaml` Arazzo description: `npx @redocly/cli respect test-file.yaml --input '{"key": "value", "nested": {"nestedKey": "nestedValue"}}'`.
-  You can also use an environment variable to set the input, as in the following example: `REDOCLY_CLI_RESPECT_INPUT='{"key":"value","nested":{"nestedKey":"nestedValue"}}' npx @redocly/cli respect test-file.yaml`
+  You can even include nested values, as in the following example command that maps the `nestedKey` input and value to all workflows in the `test-file.yaml` Arazzo description: `npx @redocly/cli@latest respect test-file.yaml --input '{"key": "value", "nested": {"nestedKey": "nestedValue"}}'`.
+  You can also use an environment variable to set the input, as in the following example: `REDOCLY_CLI_RESPECT_INPUT='{"key":"value","nested":{"nestedKey":"nestedValue"}}' npx @redocly/cli@latest respect test-file.yaml`
 
 ---
 
 - --server
 - string
 - Server overrides for the `sourceDescriptions` object.
-  For example, the following command runs all workflows from the `test-file.yaml` Arazzo description and instead of using the server listed in the API description, uses the server at `https://test.com`: `npx @redocly/cli respect test-file.yaml --server test=https://test.com`.
+  For example, the following command runs all workflows from the `test-file.yaml` Arazzo description and instead of using the server listed in the API description, uses the server at `https://test.com`: `npx @redocly/cli@latest respect test-file.yaml --server test=https://test.com`.
 
   You can also pass the server overrides as an environment variable, as in the following example:
   `REDOCLY_CLI_RESPECT_SERVER="test=https://test.com"`.
@@ -87,9 +87,9 @@ npx @redocly/cli respect <your-test-file | multiple files | files bash query> [-
 
 ## Examples
 
-- Run the tests by running the following command: `npx @redocly/cli respect <your-test-file>`.
-- Run multiple tests by running the following command: `npx @redocly/cli respect <your-test-file-one> <your-test-file-two>`.
-- Run multiple tests by running the following command with bash selector : `npx @redocly/cli respect $(find ./path-to-tests-folder -type f -name '*.arazzo.yaml')`.
+- Run the tests by running the following command: `npx @redocly/cli@latest respect <your-test-file>`.
+- Run multiple tests by running the following command: `npx @redocly/cli@latest respect <your-test-file-one> <your-test-file-two>`.
+- Run multiple tests by running the following command with bash selector : `npx @redocly/cli@latest respect $(find ./path-to-tests-folder -type f -name '*.arazzo.yaml')`.
 
 **Example output**
 

--- a/docs/guides/hide-specification-extensions.md
+++ b/docs/guides/hide-specification-extensions.md
@@ -133,7 +133,7 @@ In this step, two API snapshots are produced from the single source of truth. To
    ```bash
    redocly bundle external@latest -o dist/bundle-external.yaml
    // or
-   npx @redocly/cli bundle external@latest -o dist/bundle-external.yaml
+   npx @redocly/cli@latest bundle external@latest -o dist/bundle-external.yaml
    ```
 
    Inspect the file at `dist/external.yaml`.
@@ -144,7 +144,7 @@ In this step, two API snapshots are produced from the single source of truth. To
    ```bash
    redocly bundle internal@latest -o dist/bundle-internal.yaml
    // or
-   npx @redocly/cli bundle internal@latest -o dist/bundle-internal.yaml
+   npx @redocly/cli@latest bundle internal@latest -o dist/bundle-internal.yaml
    ```
 
    Inspect the file at `dist/internal.yaml`.

--- a/docs/guides/replace-servers-url.md
+++ b/docs/guides/replace-servers-url.md
@@ -163,7 +163,7 @@ extends:
 1. Run the following command to bundle the `original.yaml` API with the "backend" server URL.
 
 ```shell
-npx @redocly/cli bundle sample@v1-backend
+npx @redocly/cli@latest bundle sample@v1-backend
 ```
 
 2. Verify that the output shows the correct server URL.
@@ -184,7 +184,7 @@ servers:
 1. Run the following command bundles the `original.yaml` API with the "proxy" server URL.
 
 ```shell
-npx @redocly/cli bundle sample@v1-proxy
+npx @redocly/cli@latest bundle sample@v1-proxy
 ```
 
 2. Verify that the output shows the correct server URL.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ Running `redocly --version` confirms that the installation was successful, and t
 To run Redocly CLI with `npx`, the command looks like the following example:
 
 ```shell
-npx @redocly/cli <command> [options]
+npx @redocly/cli@latest <command> [options]
 ```
 
 For example, to run `redocly lint` on a file named `openapi.yaml`, use the following command:


### PR DESCRIPTION
## What/Why/How?

Add @latest to all npx redocly cli commands to avoid client issues with cashed npx packages.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
