### PR TITLE
refactor: use stderr for all output except for the output for program…

### DIFF
--- a/__tests__/build-docs/build-docs-with-config-option/snapshot.txt
+++ b/__tests__/build-docs/build-docs-with-config-option/snapshot.txt
@@ -1,5 +1,5 @@
+
 Found nested/redocly.yaml and using theme.openapi options
 Prerendering docs
 
 🎉 bundled successfully in: nested/redoc-static.html (36 KiB) [⏱ <test>ms].
-

--- a/__tests__/build-docs/simple-build-docs/snapshot.txt
+++ b/__tests__/build-docs/simple-build-docs/snapshot.txt
@@ -1,5 +1,5 @@
+
 Found undefined and using theme.openapi options
 Prerendering docs
 
 🎉 bundled successfully in: redoc-static.html (330 KiB) [⏱ <test>ms].
-

--- a/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot_3.txt
+++ b/__tests__/miscellaneous/resolve-refs-in-preprocessors/snapshot_3.txt
@@ -1,6 +1,3 @@
-
-Document: openapi.yaml stats:
-
 🚗 References: 3 
 📦 External Documents: 0 
 📈 Schemas: 1 
@@ -10,6 +7,9 @@ Document: openapi.yaml stats:
 🎣 Webhooks: 0 
 👷 Operations: 2 
 🔖 Tags: 0 
+
+Document: openapi.yaml stats:
+
 
 openapi.yaml: stats processed in <test>ms
 

--- a/__tests__/stats/stats-stylish/snapshot.txt
+++ b/__tests__/stats/stats-stylish/snapshot.txt
@@ -1,6 +1,3 @@
-
-Document: museum.yaml stats:
-
 🚗 References: 43 
 📦 External Documents: 0 
 📈 Schemas: 23 
@@ -10,6 +7,9 @@ Document: museum.yaml stats:
 🎣 Webhooks: 0 
 👷 Operations: 8 
 🔖 Tags: 3 
+
+Document: museum.yaml stats:
+
 
 museum.yaml: stats processed in <test>ms
 

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -1,4 +1,4 @@
-import { bundle, getTotals, getMergedConfig, Config } from '@redocly/openapi-core';
+import { bundle, getTotals, getMergedConfig, Config, logger } from '@redocly/openapi-core';
 
 import { BundleOptions, handleBundle } from '../../commands/bundle.js';
 import {
@@ -17,16 +17,12 @@ import { type Arguments } from 'yargs';
 describe('bundle', () => {
   let processExitMock: MockInstance;
   let exitCb: any;
-  let stderrWriteMock: any;
-  let stdoutWriteMock: any;
   beforeEach(async () => {
     processExitMock = vi.spyOn(process, 'exit').mockImplementation(vi.fn() as any);
     vi.spyOn(process, 'once').mockImplementation((_e, cb) => {
       exitCb = cb;
       return process.on(_e, cb);
     });
-    stderrWriteMock = vi.spyOn(process.stderr, 'write').mockImplementation(vi.fn());
-    stdoutWriteMock = vi.spyOn(process.stdout, 'write').mockImplementation(vi.fn());
 
     vi.mock('@redocly/openapi-core');
     vi.mocked(bundle).mockImplementation(
@@ -209,7 +205,7 @@ describe('bundle', () => {
 
       expect(saveBundle).toBeCalledTimes(1);
       expect(saveBundle).toHaveBeenCalledWith('output/foo.yaml', expect.any(String));
-      expect(process.stdout.write).toHaveBeenCalledTimes(1);
+      expect(logger.output).toHaveBeenCalledTimes(1);
     });
 
     it('should NOT store bundled API descriptions in the output files described in the apis section of config IF there is a positional api provided', async () => {
@@ -241,7 +237,7 @@ describe('bundle', () => {
       });
 
       expect(saveBundle).toBeCalledTimes(0);
-      expect(process.stdout.write).toHaveBeenCalledTimes(1);
+      expect(logger.output).toHaveBeenCalledTimes(1);
     });
 
     it('should store bundled API descriptions in the directory specified in argv IF multiple positional apis provided AND --output specified', async () => {

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -5,6 +5,7 @@ import {
   getTotals,
   formatProblems,
   doesYamlFileExist,
+  logger,
   type Totals,
 } from '@redocly/openapi-core';
 import {
@@ -183,7 +184,7 @@ describe('handleLint', () => {
         };
       });
       await commandWrapper(handleLint)(argvMock);
-      expect(process.stderr.write).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         `No configurations were provided -- using built in ${blue(
           'recommended'
         )} configuration by default.\n\n`

--- a/packages/cli/src/__tests__/spinner.test.ts
+++ b/packages/cli/src/__tests__/spinner.test.ts
@@ -3,15 +3,15 @@ import { Spinner } from '../utils/spinner.js';
 import * as process from 'node:process';
 
 describe('Spinner', () => {
-  const IS_TTY = process.stdout.isTTY;
+  const IS_TTY = process.stderr.isTTY;
 
   let writeMock: MockInstance;
   let spinner: Spinner;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    process.stdout.isTTY = true;
-    writeMock = vi.spyOn(process.stdout, 'write').mockImplementation(vi.fn());
+    process.stderr.isTTY = true;
+    writeMock = vi.spyOn(process.stderr, 'write').mockImplementation(vi.fn());
     spinner = new Spinner();
   });
 
@@ -20,7 +20,7 @@ describe('Spinner', () => {
   });
 
   afterAll(() => {
-    process.stdout.isTTY = IS_TTY;
+    process.stderr.isTTY = IS_TTY;
   });
 
   it('starts the spinner', () => {
@@ -42,7 +42,7 @@ describe('Spinner', () => {
   });
 
   it('should call write 1 times if CI set to true', () => {
-    process.stdout.isTTY = false;
+    process.stderr.isTTY = false;
     spinner.start('Loading');
     vi.advanceTimersByTime(300);
     expect(writeMock).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -462,6 +462,8 @@ describe('checkIfRulesetExist', () => {
   });
 
   it('should throw an error if rules are not provided', () => {
+    vi.mocked(red).mockImplementation((text) => text as string);
+
     const rules = {
       oas2: {},
       oas3_0: {},

--- a/packages/cli/src/auth/device-flow.ts
+++ b/packages/cli/src/auth/device-flow.ts
@@ -1,5 +1,6 @@
 import { blue, green } from 'colorette';
 import * as childProcess from 'node:child_process';
+import { logger } from '@redocly/openapi-core';
 import { ReuniteApiClient } from '../reunite/api/api-client.js';
 
 export type AuthToken = {
@@ -18,17 +19,17 @@ export class RedoclyOAuthDeviceFlow {
 
   async run() {
     const code = await this.getDeviceCode();
-    process.stdout.write(
+    logger.output(
       'Attempting to automatically open the SSO authorization page in your default browser.\n'
     );
-    process.stdout.write(
+    logger.output(
       'If the browser does not open or you wish to use a different device to authorize this request, open the following URL:\n\n'
     );
-    process.stdout.write(blue(code.verificationUri));
-    process.stdout.write(`\n\n`);
-    process.stdout.write(`Then enter the code:\n\n`);
-    process.stdout.write(blue(code.userCode));
-    process.stdout.write(`\n\n`);
+    logger.output(blue(code.verificationUri));
+    logger.output(`\n\n`);
+    logger.output(`Then enter the code:\n\n`);
+    logger.output(blue(code.userCode));
+    logger.output(`\n\n`);
 
     this.openBrowser(code.verificationUriComplete);
 
@@ -37,7 +38,7 @@ export class RedoclyOAuthDeviceFlow {
       code.interval,
       code.expiresIn
     );
-    process.stdout.write(green('✅ Logged in\n\n'));
+    logger.output(green('✅ Logged in\n\n'));
 
     return accessToken;
   }

--- a/packages/cli/src/auth/oauth-client.ts
+++ b/packages/cli/src/auth/oauth-client.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { mkdirSync, existsSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import * as crypto from 'node:crypto';
 import { Buffer } from 'node:buffer';
+import { logger } from '@redocly/openapi-core';
 import { type AuthToken, RedoclyOAuthDeviceFlow } from './device-flow.js';
 
 const SALT = '4618dbc9-8aed-4e27-aaf0-225f4603e5a4';
@@ -88,7 +89,7 @@ export class RedoclyOAuthClient {
         this.cipher.update(JSON.stringify(token), 'utf8', 'hex') + this.cipher.final('hex');
       writeFileSync(path.join(this.dir, 'auth.json'), encrypted);
     } catch (error) {
-      process.stderr.write('Error saving tokens:', error);
+      logger.error(`Error saving tokens: ${error}`);
     }
   }
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,3 +1,4 @@
+import { logger } from '@redocly/openapi-core';
 import { exitWithError } from '../utils/miscellaneous.js';
 import { RedoclyOAuthClient } from '../auth/oauth-client.js';
 import { getReuniteUrl } from '../reunite/api/index.js';
@@ -32,5 +33,5 @@ export async function handleLogout({ version }: CommandArgs<LogoutOptions>) {
   const oauthClient = new RedoclyOAuthClient('redocly-cli', version);
   oauthClient.logout();
 
-  process.stdout.write('Logged out from the Redocly account. ✋ \n');
+  logger.output('Logged out from the Redocly account. ✋ \n');
 }

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { default as redoc } from 'redoc';
 import { performance } from 'node:perf_hooks';
-import { getMergedConfig, isAbsoluteUrl } from '@redocly/openapi-core';
+import { getMergedConfig, isAbsoluteUrl, logger } from '@redocly/openapi-core';
 import { getObjectOrJSON, getPageHTML } from './utils.js';
 import {
   exitWithError,
@@ -55,7 +55,7 @@ export const handlerBuildCommand = async ({
     mkdirSync(dirname(options.output), { recursive: true });
     writeFileSync(options.output, pageHTML);
     const sizeInKiB = Math.ceil(Buffer.byteLength(pageHTML) / 1024);
-    process.stdout.write(
+    logger.info(
       `\n🎉 bundled successfully in: ${options.output} (${sizeInKiB} KiB) [⏱ ${elapsed}].\n`
     );
   } catch (e) {

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -5,8 +5,7 @@ import { ServerStyleSheet } from 'styled-components';
 import { default as handlebars } from 'handlebars';
 import { dirname, join, resolve } from 'node:path';
 import { existsSync, lstatSync, readFileSync } from 'node:fs';
-import { red } from 'colorette';
-import { isAbsoluteUrl } from '@redocly/openapi-core';
+import { isAbsoluteUrl, logger } from '@redocly/openapi-core';
 import { exitWithError } from '../../utils/miscellaneous.js';
 import { fileURLToPath } from 'node:url';
 
@@ -30,17 +29,15 @@ export function getObjectOrJSON(
           return JSON.parse(openapiOptions);
         }
       } catch (e) {
-        process.stderr.write(
-          red(
-            `Encountered error:\n\n${openapiOptions}\n\nis neither a file with a valid JSON object neither a stringified JSON object.`
-          )
+        logger.error(
+          `Encountered error:\n\n${openapiOptions}\n\nis neither a file with a valid JSON object neither a stringified JSON object.`
         );
         exitWithError(e);
       }
       break;
     default: {
       if (config) {
-        process.stdout.write(`Found ${config.configFile} and using theme.openapi options\n`);
+        logger.info(`Found ${config.configFile} and using theme.openapi options\n`);
 
         return config.theme.openapi ? config.theme.openapi : {}; // FIXME: ? theme is deprecated
       }
@@ -63,7 +60,7 @@ export async function getPageHTML(
   }: BuildDocsOptions,
   configPath?: string
 ) {
-  process.stdout.write('Prerendering docs\n');
+  logger.info('Prerendering docs\n');
 
   const apiUrl = redocOptions.specUrl || (isAbsoluteUrl(pathToApi) ? pathToApi : undefined);
   const store = await redoc.createStore(api, apiUrl, redocOptions);

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -1,7 +1,7 @@
 import { performance } from 'perf_hooks';
 import { blue, gray, green, yellow } from 'colorette';
 import { writeFileSync } from 'fs';
-import { formatProblems, getTotals, getMergedConfig, bundle } from '@redocly/openapi-core';
+import { formatProblems, getTotals, getMergedConfig, bundle, logger } from '@redocly/openapi-core';
 import {
   dumpBundle,
   getExecutionTime,
@@ -56,7 +56,7 @@ export async function handleBundle({
       styleguide.skipPreprocessors(argv['skip-preprocessor']);
       styleguide.skipDecorators(argv['skip-decorator']);
 
-      process.stderr.write(gray(`bundling ${formatPath(path)}...\n`));
+      logger.info(gray(`bundling ${formatPath(path)}...\n`));
 
       const {
         bundle: result,
@@ -87,7 +87,7 @@ export async function handleBundle({
             argv.ext || 'yaml',
             argv.dereferenced
           );
-          process.stdout.write(bundled);
+          logger.output(bundled);
         } else {
           const bundled = dumpBundle(sortTopLevelKeysForOas(result.parsed), ext, argv.dereferenced);
           saveBundle(outputFile, bundled);
@@ -106,9 +106,7 @@ export async function handleBundle({
 
       if (argv.metafile) {
         if (apis.length > 1) {
-          process.stderr.write(
-            yellow(`[WARNING] "--metafile" cannot be used with multiple apis. Skipping...`)
-          );
+          logger.warn(`[WARNING] "--metafile" cannot be used with multiple apis. Skipping...`);
         }
         {
           writeFileSync(argv.metafile, JSON.stringify(meta), 'utf-8');
@@ -118,20 +116,20 @@ export async function handleBundle({
       const elapsed = getExecutionTime(startedAt);
       if (fileTotals.errors > 0) {
         if (argv.force) {
-          process.stderr.write(
+          logger.info(
             `❓ Created a bundle for ${blue(formatPath(path))} at ${blue(
               outputFile || 'stdout'
             )} with errors ${green(elapsed)}.\n${yellow('Errors ignored because of --force')}.\n`
           );
         } else {
-          process.stderr.write(
+          logger.info(
             `❌ Errors encountered while bundling ${blue(
               formatPath(path)
             )}: bundle not created (use --force to ignore errors).\n`
           );
         }
       } else {
-        process.stderr.write(
+        logger.info(
           `📦 Created a bundle for ${blue(formatPath(path))} at ${blue(
             outputFile || 'stdout'
           )} ${green(elapsed)}.\n`
@@ -140,7 +138,7 @@ export async function handleBundle({
 
       const removedCount = meta.visitorsData?.['remove-unused-components']?.removedCount;
       if (removedCount) {
-        process.stderr.write(gray(`🧹 Removed ${removedCount} unused components.\n`));
+        logger.info(gray(`🧹 Removed ${removedCount} unused components.\n`));
       }
     } catch (e) {
       handleError(e, path);

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { logger } from '@redocly/openapi-core';
 import { getPlatformSpawnArgs, sanitizePath } from '../utils/platform.js';
 
 import type { CommandArgs } from '../wrapper.js';
@@ -12,7 +13,7 @@ export type EjectOptions = {
 } & VerifyConfigOptions;
 
 export const handleEject = async ({ argv }: CommandArgs<EjectOptions>) => {
-  process.stdout.write(`\nLaunching eject using NPX.\n\n`);
+  logger.info(`\nLaunching eject using NPX.\n\n`);
   const { npxExecutableName, sanitize, shell } = getPlatformSpawnArgs();
 
   const path = sanitize(argv.path, sanitizePath);
@@ -36,7 +37,7 @@ export const handleEject = async ({ argv }: CommandArgs<EjectOptions>) => {
   );
 
   child.on('error', (error) => {
-    process.stderr.write(`Eject launch failed: ${error.message}`);
+    logger.info(`Eject launch failed: ${error.message}`);
     throw new Error('Eject launch failed.');
   });
 };

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -10,6 +10,7 @@ import {
   bundleDocument,
   isRef,
   dequal,
+  logger,
 } from '@redocly/openapi-core';
 import {
   getFallbackApisOrExit,
@@ -189,7 +190,7 @@ export async function handleJoin({
     const componentsPrefix = getInfoPrefix(info, prefixComponentsWithInfoProp, COMPONENTS);
 
     if (openapi.hasOwnProperty('x-tagGroups')) {
-      process.stderr.write(yellow(`warning: x-tagGroups at ${blue(api)} will be skipped \n`));
+      logger.warn(`warning: x-tagGroups at ${blue(api)} will be skipped \n`);
     }
 
     const context = {
@@ -339,9 +340,7 @@ export async function handleJoin({
     const { externalDocs } = openapi;
     if (externalDocs) {
       if (joinedDef.hasOwnProperty('externalDocs')) {
-        process.stderr.write(
-          yellow(`warning: skip externalDocs from ${blue(path.basename(api))} \n`)
-        );
+        logger.warn(`warning: skip externalDocs from ${blue(path.basename(api))} \n`);
         return;
       }
       joinedDef['externalDocs'] = externalDocs;
@@ -403,7 +402,7 @@ export async function handleJoin({
         joinedDef.paths[path].hasOwnProperty(field) &&
         joinedDef.paths[path][field] !== fieldValue
       ) {
-        process.stderr.write(yellow(`warning: different ${field} values in ${path}\n`));
+        logger.warn(`warning: different ${field} values in ${path}\n`);
         return;
       }
       joinedDef.paths[path][field] = fieldValue;
@@ -691,17 +690,15 @@ function iteratePotentialConflicts(potentialConflicts: any, withoutXTagGroups?: 
 function duplicateTagDescriptionWarning(conflicts: [string, any][]) {
   const tagsKeys = conflicts.map(([tagName]) => `\`${tagName}\``);
   const joinString = yellow(', ');
-  process.stderr.write(
-    yellow(
-      `\nwarning: ${tagsKeys.length} conflict(s) on the ${red(
-        tagsKeys.join(joinString)
-      )} tags description.\n`
-    )
+  logger.warn(
+    `\nwarning: ${tagsKeys.length} conflict(s) on the ${red(
+      tagsKeys.join(joinString)
+    )} tags description.\n`
   );
 }
 
 function prefixTagSuggestion(conflictsLength: number) {
-  process.stderr.write(
+  logger.info(
     green(
       `\n${conflictsLength} conflict(s) on tags.\nSuggestion: please use ${blue(
         'prefix-tags-with-filename'
@@ -714,7 +711,7 @@ function prefixTagSuggestion(conflictsLength: number) {
 
 function showConflicts(key: string, conflicts: any) {
   for (const [path, files] of conflicts) {
-    process.stderr.write(yellow(`Conflict on ${key} : ${red(path)} in files: ${blue(files)} \n`));
+    logger.warn(`Conflict on ${key} : ${red(path)} in files: ${blue(files)} \n`);
   }
 }
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -8,6 +8,7 @@ import {
   lintConfig,
   pluralize,
   ConfigValidationError,
+  logger,
 } from '@redocly/openapi-core';
 import {
   checkIfRulesetExist,
@@ -69,13 +70,13 @@ export async function handleLint({
       styleguide.skipPreprocessors(argv['skip-preprocessor']);
 
       if (styleguide.recommendedFallback) {
-        process.stderr.write(
+        logger.info(
           `No configurations were provided -- using built in ${blue(
             'recommended'
           )} configuration by default.\n\n`
         );
       }
-      process.stderr.write(gray(`validating ${formatPath(path)}...\n`));
+      logger.info(gray(`validating ${formatPath(path)}...\n`));
       const results = await lint({
         ref: path,
         config: resolvedConfig,
@@ -102,7 +103,7 @@ export async function handleLint({
       }
 
       const elapsed = getExecutionTime(startedAt);
-      process.stderr.write(gray(`${formatPath(path)}: validated in ${elapsed}\n\n`));
+      logger.info(gray(`${formatPath(path)}: validated in ${elapsed}\n\n`));
     } catch (e) {
       handleError(e, path);
     }
@@ -110,7 +111,7 @@ export async function handleLint({
 
   if (argv['generate-ignore-file']) {
     config.styleguide.saveIgnore();
-    process.stderr.write(
+    logger.info(
       `Generated ignore file with ${totalIgnored} ${pluralize('problem', totalIgnored)}.\n\n`
     );
   } else {

--- a/packages/cli/src/commands/preview-project/index.ts
+++ b/packages/cli/src/commands/preview-project/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
+import { logger } from '@redocly/openapi-core';
 import { PRODUCT_NAMES, PRODUCT_PACKAGES } from './constants.js';
 import { getPlatformSpawnArgs } from '../../utils/platform.js';
 
@@ -14,14 +15,14 @@ export const previewProject = async ({ argv }: CommandArgs<PreviewProjectOptions
   const product = argv.product || tryGetProductFromPackageJson(projectDir);
 
   if (!isValidProduct(product)) {
-    process.stderr.write(`Invalid product ${product}.`);
+    logger.info(`Invalid product ${product}.`);
     throw new Error(`Project preview launch failed.`);
   }
 
   const productName = PRODUCT_NAMES[product];
   const packageName = PRODUCT_PACKAGES[product];
 
-  process.stdout.write(`\nLaunching preview of ${productName} ${plan} using NPX.\n\n`);
+  logger.info(`\nLaunching preview of ${productName} ${plan} using NPX.\n\n`);
   const { npxExecutableName, shell } = getPlatformSpawnArgs();
 
   const child = spawn(
@@ -35,7 +36,7 @@ export const previewProject = async ({ argv }: CommandArgs<PreviewProjectOptions
   );
 
   child.on('error', (error) => {
-    process.stderr.write(`Project preview launch failed: ${error.message}`);
+    logger.info(`Project preview launch failed: ${error.message}`);
     throw new Error(`Project preview launch failed.`);
   });
 };
@@ -58,12 +59,12 @@ const tryGetProductFromPackageJson = (projectDir: string): Product => {
 
       for (const [product, packageName] of Object.entries(PRODUCT_PACKAGES)) {
         if (packageJsonDeps[packageName]) {
-          process.stdout.write(`\n${packageName} detected in project's 'package.json'`);
+          logger.info(`\n${packageName} detected in project's 'package.json'`);
           return product as Product;
         }
       }
     } catch (error) {
-      process.stdout.write(`Invalid 'package.json': ${packageJsonPath}. Using Realm.`);
+      logger.info(`Invalid 'package.json': ${packageJsonPath}. Using Realm.`);
     }
   }
 

--- a/packages/cli/src/commands/split/__tests__/index.test.ts
+++ b/packages/cli/src/commands/split/__tests__/index.test.ts
@@ -20,7 +20,6 @@ describe('split', () => {
       const actual = await vi.importActual('node:process');
       return {
         ...actual,
-        stderr: { write: vi.fn() },
       };
     });
     vi.mock('node:fs', async () => {
@@ -42,6 +41,8 @@ describe('split', () => {
   it('should split the file and show the success message', async () => {
     const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/spec.json';
 
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
     await handleSplit({
       argv: {
         api: filePath,
@@ -52,7 +53,7 @@ describe('split', () => {
       version: 'cli-version',
     });
 
-    expect(process.stderr.write).toBeCalledTimes(2);
+    expect(vi.mocked(process.stderr.write)).toBeCalledTimes(2);
     expect(vi.mocked(process.stderr.write).mock.calls[0][0]).toBe(
       `🪓 Document: ${blue(filePath!)} ${green('is successfully split')}
     and all related files are saved to the directory: ${blue(openapiDir)} \n`

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -1,7 +1,6 @@
-import { red, blue, yellow, green } from 'colorette';
+import { red, blue, green } from 'colorette';
 import * as fs from 'node:fs';
-import * as process from 'node:process';
-import { parseYaml, slash, isRef, isTruthy, dequal } from '@redocly/openapi-core';
+import { parseYaml, slash, isRef, isTruthy, dequal, logger } from '@redocly/openapi-core';
 import * as path from 'node:path';
 import { performance } from 'perf_hooks';
 import {
@@ -53,7 +52,7 @@ export async function handleSplit({ argv, collectSpecData }: CommandArgs<SplitOp
   const openapi = readYaml(api) as Oas3Definition | Oas3_1Definition;
   collectSpecData?.(openapi);
   splitDefinition(openapi, outDir, separator, ext);
-  process.stderr.write(
+  logger.info(
     `🪓 Document: ${blue(api)} ${green('is successfully split')}
     and all related files are saved to the directory: ${blue(outDir)} \n`
   );
@@ -211,12 +210,10 @@ function implicitlyReferenceDiscriminator(
       continue;
     }
     if (mapping[name] && mapping[name] !== implicitMapping[name]) {
-      process.stderr.write(
-        yellow(
-          `warning: explicit mapping overlaps with local mapping entry ${red(name)} at ${blue(
-            filename
-          )}. Please check it.`
-        )
+      logger.warn(
+        `warning: explicit mapping overlaps with local mapping entry ${red(name)} at ${blue(
+          filename
+        )}. Please check it.`
       );
     }
     mapping[name] = implicitMapping[name];
@@ -375,12 +372,10 @@ function iterateComponents(
         );
 
         if (doesFileDiffer(filename, componentData)) {
-          process.stderr.write(
-            yellow(
-              `warning: conflict for ${componentName} - file already exists with different content: ${blue(
-                filename
-              )} ... Skip.\n`
-            )
+          logger.warn(
+            `warning: conflict for ${componentName} - file already exists with different content: ${blue(
+              filename
+            )} ... Skip.\n`
           );
         } else {
           writeToFileByExtension(componentData, filename);

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -10,6 +10,7 @@ import {
   walkDocument,
   Stats,
   bundle,
+  logger,
 } from '@redocly/openapi-core';
 import { getFallbackApisOrExit, printExecutionTime } from '../utils/miscellaneous.js';
 
@@ -38,7 +39,8 @@ const statsAccumulator: StatsAccumulator = {
 function printStatsStylish(statsAccumulator: StatsAccumulator) {
   for (const node in statsAccumulator) {
     const { metric, total, color } = statsAccumulator[node as StatsName];
-    process.stderr.write(colors[color](`${metric}: ${total} \n`));
+
+    logger.output(colors[color](`${metric}: ${total} \n`));
   }
 }
 
@@ -50,7 +52,8 @@ function printStatsJson(statsAccumulator: StatsAccumulator) {
       total: statsAccumulator[key as StatsName].total,
     };
   }
-  process.stdout.write(JSON.stringify(json, null, 2));
+
+  logger.output(JSON.stringify(json, null, 2));
 }
 
 function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
@@ -63,7 +66,8 @@ function printStatsMarkdown(statsAccumulator: StatsAccumulator) {
       statsAccumulator[key as StatsName].total +
       ' |\n';
   }
-  process.stdout.write(output);
+
+  logger.output(output);
 }
 
 function printStats(
@@ -74,7 +78,7 @@ function printStats(
 ) {
   switch (format) {
     case 'stylish':
-      process.stderr.write(`Document: ${colors.magenta(api)} stats:\n\n`);
+      logger.info(`Document: ${colors.magenta(api)} stats:\n\n`);
       printStatsStylish(statsAccumulator);
       printExecutionTime('stats', startedAt, api);
       break;

--- a/packages/cli/src/commands/translations.ts
+++ b/packages/cli/src/commands/translations.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { logger } from '@redocly/openapi-core';
 import { getPlatformSpawnArgs, sanitizeLocale, sanitizePath } from '../utils/platform.js';
 
 import type { CommandArgs } from '../wrapper.js';
@@ -10,7 +11,7 @@ export type TranslationsOptions = {
 } & VerifyConfigOptions;
 
 export const handleTranslations = async ({ argv }: CommandArgs<TranslationsOptions>) => {
-  process.stdout.write(`\nLaunching translate using NPX.\n\n`);
+  logger.info(`\nLaunching translate using NPX.\n\n`);
   const { npxExecutableName, sanitize, shell } = getPlatformSpawnArgs();
 
   const projectDir = sanitize(argv['project-dir'], sanitizePath);
@@ -26,7 +27,7 @@ export const handleTranslations = async ({ argv }: CommandArgs<TranslationsOptio
   );
 
   child.on('error', (error) => {
-    process.stderr.write(`Translate launch failed: ${error.message}`);
+    logger.info(`Translate launch failed: ${error.message}`);
     throw new Error(`Translate launch failed.`);
   });
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import * as dotenv from 'dotenv';
 import './utils/assert-node-version.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import * as colors from 'colorette';
+import { logger } from '@redocly/openapi-core';
 import { outputExtensions } from './types.js';
 import { handleStats } from './commands/stats.js';
 import { handleSplit } from './commands/split/index.js';
@@ -532,10 +532,8 @@ yargs(hideBin(process.argv))
       }),
     (argv) => {
       if (process.argv.some((arg) => arg.startsWith('--source-dir'))) {
-        process.stderr.write(
-          colors.red(
-            'Option --source-dir is deprecated and will be removed soon. Use --project-dir instead.\n'
-          )
+        logger.error(
+          'Option --source-dir is deprecated and will be removed soon. Use --project-dir instead.\n'
         );
       }
       commandWrapper(previewProject)(argv);

--- a/packages/cli/src/reunite/api/__tests__/api.client.test.ts
+++ b/packages/cli/src/reunite/api/__tests__/api.client.test.ts
@@ -357,7 +357,7 @@ describe('ApiClient', () => {
     it.each(endpointMocks)(
       'should report endpoint sunset in the past',
       async ({ responseBody, requestFn }) => {
-        vi.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);
+        vi.spyOn(process.stderr, 'write').mockImplementationOnce(() => true);
         const sunsetDate = new Date('2024-09-06T12:30:32.456Z');
 
         mockFetchResponse({
@@ -371,7 +371,7 @@ describe('ApiClient', () => {
         await requestFn();
         apiClient.reportSunsetWarnings();
 
-        expect(process.stdout.write).toHaveBeenCalledWith(
+        expect(process.stderr.write).toHaveBeenCalledWith(
           red(
             `The "push" command is not compatible with your version of Redocly CLI. Update to the latest version by running "npm install @redocly/cli@latest".\n\n`
           )
@@ -382,7 +382,7 @@ describe('ApiClient', () => {
     it.each(endpointMocks)(
       'should report endpoint sunset in the future',
       async ({ responseBody, requestFn }) => {
-        vi.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);
+        vi.spyOn(process.stderr, 'write').mockImplementationOnce(() => true);
         const sunsetDate = new Date(Date.now() + 1000 * 60 * 60 * 24);
 
         mockFetchResponse({
@@ -396,7 +396,7 @@ describe('ApiClient', () => {
         await requestFn();
         apiClient.reportSunsetWarnings();
 
-        expect(process.stdout.write).toHaveBeenCalledWith(
+        expect(process.stderr.write).toHaveBeenCalledWith(
           yellow(
             `The "push" command will be incompatible with your version of Redocly CLI after ${sunsetDate.toLocaleString()}. Update to the latest version by running "npm install @redocly/cli@latest".\n\n`
           )
@@ -405,7 +405,7 @@ describe('ApiClient', () => {
     );
 
     it('should report only expired resource', async () => {
-      vi.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);
+      vi.spyOn(process.stderr, 'write').mockImplementationOnce(() => true);
 
       mockFetchResponse({
         ok: true,
@@ -439,8 +439,8 @@ describe('ApiClient', () => {
 
       apiClient.reportSunsetWarnings();
 
-      expect(process.stdout.write).toHaveBeenCalledTimes(1);
-      expect(process.stdout.write).toHaveBeenCalledWith(
+      expect(process.stderr.write).toHaveBeenCalledTimes(1);
+      expect(process.stderr.write).toHaveBeenCalledWith(
         red(
           `The "push" command is not compatible with your version of Redocly CLI. Update to the latest version by running "npm install @redocly/cli@latest".\n\n`
         )

--- a/packages/cli/src/reunite/api/api-client.ts
+++ b/packages/cli/src/reunite/api/api-client.ts
@@ -1,4 +1,4 @@
-import { yellow, red } from 'colorette';
+import { logger } from '@redocly/openapi-core';
 import fetchWithTimeout, {
   type FetchWithTimeoutOptions,
   DEFAULT_FETCH_TIMEOUT,
@@ -335,18 +335,14 @@ export class ReuniteApi {
       const updateVersionMessage = `Update to the latest version by running "npm install @redocly/cli@latest".`;
 
       if (isSunsetExpired) {
-        process.stdout.write(
-          red(
-            `The "${this.command}" command is not compatible with your version of Redocly CLI. ${updateVersionMessage}\n\n`
-          )
+        logger.error(
+          `The "${this.command}" command is not compatible with your version of Redocly CLI. ${updateVersionMessage}\n\n`
         );
       } else {
-        process.stdout.write(
-          yellow(
-            `The "${
-              this.command
-            }" command will be incompatible with your version of Redocly CLI after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`
-          )
+        logger.warn(
+          `The "${
+            this.command
+          }" command will be incompatible with your version of Redocly CLI after ${sunsetDate.toLocaleString()}. ${updateVersionMessage}\n\n`
         );
       }
     }

--- a/packages/cli/src/reunite/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/reunite/commands/__tests__/push-status.test.ts
@@ -88,6 +88,7 @@ describe('handlePushStatus()', () => {
     vi.mock('@redocly/openapi-core', async () => {
       const actual = await vi.importActual('@redocly/openapi-core');
       return {
+        ...actual,
         pause: actual.pause,
       };
     });

--- a/packages/cli/src/reunite/commands/push-status.ts
+++ b/packages/cli/src/reunite/commands/push-status.ts
@@ -1,4 +1,5 @@
 import * as colors from 'colorette';
+import { logger } from '@redocly/openapi-core';
 import { printExecutionTime } from '../../utils/miscellaneous.js';
 import { Spinner } from '../../utils/spinner.js';
 import { DeploymentError } from '../utils.js';
@@ -188,7 +189,7 @@ function printPushStatusInfo({
   pushId: string;
   startedAt: number;
 }) {
-  process.stderr.write(
+  logger.info(
     `\nProcessed push-status for ${colors.yellow(organization)}, ${colors.yellow(
       projectId
     )} and pushID ${colors.yellow(pushId)}.\n`
@@ -212,10 +213,8 @@ function printPushStatus({
     return;
   }
   if (push.isOutdated || !push.hasChanges) {
-    process.stderr.write(
-      colors.yellow(
-        `Files not added to your project. Reason: ${push.isOutdated ? 'outdated' : 'no changes'}.\n`
-      )
+    logger.warn(
+      `Files not added to your project. Reason: ${push.isOutdated ? 'outdated' : 'no changes'}.\n`
     );
   } else {
     displayDeploymentAndBuildStatus({
@@ -232,15 +231,15 @@ function printScorecard(scorecard?: ScorecardItem[]) {
   if (!scorecard || scorecard.length === 0) {
     return;
   }
-  process.stdout.write(`\n${colors.magenta('Scorecard')}:`);
+  logger.output(`\n${colors.magenta('Scorecard')}:`);
   for (const scorecardItem of scorecard) {
-    process.stdout.write(`
+    logger.output(`
     ${colors.magenta('Name')}: ${scorecardItem.name}
     ${colors.magenta('Status')}: ${scorecardItem.status}
     ${colors.magenta('URL')}: ${colors.cyan(scorecardItem.url)}
     ${colors.magenta('Description')}: ${scorecardItem.description}\n`);
   }
-  process.stdout.write(`\n`);
+  logger.output(`\n`);
 }
 
 function displayDeploymentAndBuildStatus({
@@ -270,7 +269,8 @@ function displayDeploymentAndBuildStatus({
   }
 
   spinner.stop();
-  return process.stdout.write(message);
+
+  return logger.output(message);
 }
 
 function getMessage({

--- a/packages/cli/src/reunite/commands/push.ts
+++ b/packages/cli/src/reunite/commands/push.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { slash, pluralize } from '@redocly/openapi-core';
-import { green, yellow } from 'colorette';
+import { slash, pluralize, logger } from '@redocly/openapi-core';
+import { green } from 'colorette';
 import { exitWithError, printExecutionTime } from '../../utils/miscellaneous.js';
 import { handlePushStatus } from './push-status.js';
 import { ReuniteApi, getDomain, getApiKeys } from '../api/index.js';
@@ -77,7 +77,7 @@ export async function handlePush({
       mountPath,
     });
 
-    process.stderr.write(
+    logger.info(
       `Uploading to ${remote.mountPath} ${filesToUpload.length} ${pluralize(
         'file',
         filesToUpload.length
@@ -105,14 +105,14 @@ export async function handlePush({
     );
 
     filesToUpload.forEach((f) => {
-      process.stderr.write(green(`✓ ${f.name}\n`));
+      logger.info(green(`✓ ${f.name}\n`));
     });
 
-    process.stdout.write('\n');
-    process.stdout.write(`Push ID: ${id}\n`);
+    logger.info('\n');
+    logger.info(`Push ID: ${id}\n`);
 
     if (waitForDeployment) {
-      process.stdout.write('\n');
+      logger.info('\n');
 
       await handlePushStatus({
         argv: {
@@ -183,9 +183,7 @@ function collectFilesToPush(files: string[]): FileToUpload[] {
     const fileName = path.relative(fileDir, filePath);
 
     if (collectedFiles[fileName]) {
-      process.stdout.write(
-        yellow(`File ${collectedFiles[fileName]} is overwritten by ${filePath}\n`)
-      );
+      logger.warn(`File ${collectedFiles[fileName]} is overwritten by ${filePath}\n`);
     }
 
     collectedFiles[fileName] = filePath;

--- a/packages/cli/src/utils/assert-node-version.ts
+++ b/packages/cli/src/utils/assert-node-version.ts
@@ -1,16 +1,14 @@
 import * as process from 'node:process';
 import * as semver from 'semver';
-import { yellow } from 'colorette';
+import { logger } from '@redocly/openapi-core';
 import { engines } from './package.js';
 
 try {
   const range = engines?.node;
 
   if (typeof range === 'string' && !semver.satisfies(process.version, range)) {
-    process.stderr.write(
-      yellow(
-        `\n⚠️ Warning: failed to satisfy expected node version. Expected: "${range}", Current "${process.version}"\n\n`
-      )
+    logger.warn(
+      `\n⚠️ Warning: failed to satisfy expected node version. Expected: "${range}", Current "${process.version}"\n\n`
     );
   }
 } catch (e) {

--- a/packages/cli/src/utils/spinner.ts
+++ b/packages/cli/src/utils/spinner.ts
@@ -1,4 +1,5 @@
 import * as process from 'node:process';
+import { logger } from '@redocly/openapi-core';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -16,7 +17,7 @@ export class Spinner {
   }
 
   private showFrame() {
-    process.stdout.write('\r' + this.frames[this.currentFrame] + ' ' + this.message);
+    logger.info('\r' + this.frames[this.currentFrame] + ' ' + this.message);
     this.currentFrame = (this.currentFrame + 1) % this.frames.length;
   }
 
@@ -27,8 +28,8 @@ export class Spinner {
 
     this.message = message;
     // If we're not in a TTY, don't display the spinner.
-    if (!process.stdout.isTTY) {
-      process.stdout.write(`${message}...\n`);
+    if (!process.stderr.isTTY) {
+      logger.info(`${message}...\n`);
       return;
     }
 
@@ -43,7 +44,7 @@ export class Spinner {
     if (this.intervalId !== null) {
       clearInterval(this.intervalId);
       this.intervalId = null;
-      process.stdout.write('\r');
+      logger.info('\r');
     }
     this.message = '';
   }

--- a/packages/cli/src/utils/update-version-notifier.ts
+++ b/packages/cli/src/utils/update-version-notifier.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import * as process from 'node:process';
 import { existsSync, writeFileSync, readFileSync, statSync } from 'node:fs';
 import { compare } from 'semver';
+import { logger } from '@redocly/openapi-core';
 import fetch, { DEFAULT_FETCH_TIMEOUT } from './fetch-with-timeout.js';
 import { cyan, green, yellow } from 'colorette';
 import { cleanColors } from './miscellaneous.js';
@@ -85,7 +86,7 @@ const renderUpdateBanner = (current: string, latest: string) => {
     '',
     '',
   ].join('\n');
-  process.stderr.write(banner);
+  logger.info(banner);
 };
 
 const getLineWithPadding =

--- a/packages/core/src/__tests__/logger-browser.test.ts
+++ b/packages/core/src/__tests__/logger-browser.test.ts
@@ -18,14 +18,14 @@ describe('Logger in Browser', () => {
   });
 
   it('should call "console.log"', () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
 
     logger.info('info');
 
-    expect(log).toBeCalledTimes(1);
-    expect(log).toBeCalledWith('info');
+    expect(info).toBeCalledTimes(1);
+    expect(info).toBeCalledWith('info');
 
-    log.mockRestore();
+    info.mockRestore();
   });
 
   it('should call "console.warn"', () => {

--- a/packages/core/src/__tests__/output-browser.test.ts
+++ b/packages/core/src/__tests__/output-browser.test.ts
@@ -2,14 +2,14 @@
  * @vitest-environment jsdom
  */
 
-import { output } from '../output.js';
+import { logger } from '../logger.js';
 
 describe('output', () => {
   it('should ignore all parsable data in browser', () => {
     const spyingStdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     const data = '{ "errors" : [] }';
 
-    output.write(data);
+    logger.output(data);
 
     expect(spyingStdout).not.toBeCalled();
 

--- a/packages/core/src/__tests__/output.test.ts
+++ b/packages/core/src/__tests__/output.test.ts
@@ -1,11 +1,11 @@
-import { output } from '../output.js';
+import { logger } from '../logger.js';
 
 describe('output', () => {
   it('should write all parsable data to stdout', () => {
     const spyingStdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     const data = '{ "errors" : [] }';
 
-    output.write(data);
+    logger.output(data);
 
     expect(spyingStdout).toBeCalledTimes(1);
     expect(spyingStdout).toBeCalledWith(data);

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 import { colorOptions, colorize, logger } from '../logger.js';
-import { output } from '../output.js';
 import { getCodeframe, getLineColLocation } from './codeframes.js';
 import { env, isBrowser } from '../env.js';
 import { isAbsoluteUrl } from '../ref-utils.js';
@@ -140,45 +139,45 @@ export function formatProblems(
     case 'markdown': {
       const groupedByFile = groupByFiles(problems);
       for (const [file, { fileProblems }] of Object.entries(groupedByFile)) {
-        output.write(`## Lint: ${isAbsoluteUrl(file) ? file : path.relative(cwd, file)}\n\n`);
+        logger.output(`## Lint: ${isAbsoluteUrl(file) ? file : path.relative(cwd, file)}\n\n`);
 
-        output.write(`| Severity | Location | Problem | Message |\n`);
-        output.write(`|---|---|---|---|\n`);
+        logger.output(`| Severity | Location | Problem | Message |\n`);
+        logger.output(`|---|---|---|---|\n`);
         for (let i = 0; i < fileProblems.length; i++) {
           const problem = fileProblems[i];
-          output.write(`${formatMarkdown(problem)}\n`);
+          logger.output(`${formatMarkdown(problem)}\n`);
         }
-        output.write('\n');
+        logger.output('\n');
 
         if (totals.errors > 0) {
-          output.write(`Validation failed\nErrors: ${totals.errors}\n`);
+          logger.output(`Validation failed\nErrors: ${totals.errors}\n`);
         } else {
-          output.write('Validation successful\n');
+          logger.output('Validation successful\n');
         }
 
         if (totals.warnings > 0) {
-          output.write(`Warnings: ${totals.warnings}\n`);
+          logger.output(`Warnings: ${totals.warnings}\n`);
         }
 
-        output.write('\n');
+        logger.output('\n');
       }
       break;
     }
     case 'checkstyle': {
       const groupedByFile = groupByFiles(problems);
 
-      output.write('<?xml version="1.0" encoding="UTF-8"?>\n');
-      output.write('<checkstyle version="4.3">\n');
+      logger.output('<?xml version="1.0" encoding="UTF-8"?>\n');
+      logger.output('<checkstyle version="4.3">\n');
 
       for (const [file, { fileProblems }] of Object.entries(groupedByFile)) {
-        output.write(
+        logger.output(
           `<file name="${xmlEscape(isAbsoluteUrl(file) ? file : path.relative(cwd, file))}">\n`
         );
         fileProblems.forEach(formatCheckstyle);
-        output.write(`</file>\n`);
+        logger.output(`</file>\n`);
       }
 
-      output.write(`</checkstyle>\n`);
+      logger.output(`</checkstyle>\n`);
       break;
     }
     case 'codeclimate':
@@ -217,7 +216,7 @@ export function formatProblems(
         fingerprint: `${p.ruleId}${p.location.length > 0 ? '-' + p.location[0].pointer : ''}`,
       };
     });
-    output.write(JSON.stringify(issues, null, 2));
+    logger.output(JSON.stringify(issues, null, 2));
   }
 
   function outputJSON() {
@@ -255,7 +254,7 @@ export function formatProblems(
         return problem;
       }),
     };
-    output.write(JSON.stringify(resultObject, null, 2));
+    logger.output(JSON.stringify(resultObject, null, 2));
   }
 
   function getBgColor(problem: NormalizedProblem) {
@@ -316,7 +315,7 @@ export function formatProblems(
     const severity = problem.severity == 'warn' ? 'warning' : 'error';
     const message = xmlEscape(problem.message);
     const source = xmlEscape(problem.ruleId);
-    output.write(
+    logger.output(
       `<error line="${line}" column="${col}" severity="${severity}" message="${message}" source="${source}" />\n`
     );
   }
@@ -443,7 +442,7 @@ function outputForGithubActions(problems: NormalizedProblem[], cwd: string): voi
         endLine: location.end?.line,
         endColumn: location.end?.col,
       };
-      output.write(`::${command} ${formatProperties(properties)}::${escapeMessage(message)}\n`);
+      logger.output(`::${command} ${formatProperties(properties)}::${escapeMessage(message)}\n`);
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,3 +113,5 @@ export {
 } from './bundle.js';
 
 export { type Assertions, type Assertion } from './rules/common/assertions/index.js';
+
+export { logger } from './logger.js';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -15,21 +15,22 @@ export const colorize = new Proxy(colorette, {
     return (target as any)[prop];
   },
 });
-class Logger {
-  protected stderr(str: string) {
-    return process.stderr.write(str);
-  }
 
+class Logger {
   info(str: string) {
-    return isBrowser ? console.log(str) : this.stderr(str);
+    return isBrowser ? console.info(str) : process.stderr.write(str);
   }
 
   warn(str: string) {
-    return isBrowser ? console.warn(str) : this.stderr(colorize.yellow(str));
+    return isBrowser ? console.warn(str) : process.stderr.write(colorize.yellow(str));
   }
 
   error(str: string) {
-    return isBrowser ? console.error(str) : this.stderr(colorize.red(str));
+    return isBrowser ? console.error(str) : process.stderr.write(colorize.red(str));
+  }
+
+  output(str: string) {
+    return isBrowser ? console.info(str) : process.stdout.write(str);
   }
 }
 

--- a/packages/core/src/output.ts
+++ b/packages/core/src/output.ts
@@ -1,7 +1,0 @@
-import { isBrowser } from './env.js';
-
-export const output = {
-  write(str: string) {
-    return isBrowser ? undefined : process.stdout.write(str);
-  },
-};


### PR DESCRIPTION
## What/Why/How?

Refactor the CLI logger to use stderr for all text output except the output that the user may want to use programmatically - it is sent to stdout. Use in cli package the logger from openapi-core

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
