### PR TITLE
refactor: move https-proxy-agent out of the openapi-core package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13223,6 +13223,7 @@
         "form-data": "^4.0.0",
         "glob": "^11.0.1",
         "handlebars": "^4.7.6",
+        "https-proxy-agent": "^7.0.5",
         "mobx": "^6.0.4",
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.0.0",
@@ -13251,6 +13252,15 @@
         "npm": ">=10"
       }
     },
+    "packages/cli/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "packages/cli/node_modules/glob": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
@@ -13272,6 +13282,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/cli/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/cli/node_modules/jackspeak": {
@@ -13322,7 +13345,6 @@
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.22.0",
         "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "minimatch": "^10.0.1",
@@ -13340,28 +13362,6 @@
       "engines": {
         "node": ">=20",
         "npm": ">=10"
-      }
-    },
-    "packages/core/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/core/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "packages/respect-core": {
@@ -15871,6 +15871,7 @@
         "form-data": "^4.0.0",
         "glob": "^11.0.1",
         "handlebars": "^4.7.6",
+        "https-proxy-agent": "^7.0.5",
         "mobx": "^6.0.4",
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.0.0",
@@ -15883,6 +15884,11 @@
         "yargs": "17.0.1"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
+        },
         "glob": {
           "version": "11.0.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
@@ -15894,6 +15900,15 @@
             "minipass": "^7.1.2",
             "package-json-from-dist": "^1.0.0",
             "path-scurry": "^2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
           }
         },
         "jackspeak": {
@@ -15935,7 +15950,6 @@
         "@types/minimatch": "^5.1.2",
         "@types/pluralize": "^0.0.29",
         "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "json-schema-to-ts": "^3.1.0",
@@ -15943,22 +15957,6 @@
         "pluralize": "^8.0.0",
         "typescript": "5.5.3",
         "yaml-ast-parser": "0.0.43"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
-        },
-        "https-proxy-agent": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-          "requires": {
-            "agent-base": "^7.1.2",
-            "debug": "4"
-          }
-        }
       }
     },
     "@redocly/respect-core": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier": "npx prettier --write \"**/*.{ts,js,yaml,yml,json,md}\"",
     "prettier:check": "npx prettier --check \"**/*.{ts,js,yaml,yml,json,md}\"",
     "eslint": "eslint packages/**",
-    "clean": "rm -rf packages/**/lib packages/**/node_modules packages/**/*.tsbuildinfo package-lock.json node_modules dist && git checkout package-lock.json",
+    "clear": "rm -rf packages/**/lib packages/**/node_modules packages/**/*.tsbuildinfo package-lock.json node_modules dist && git checkout package-lock.json",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "compile": "tsc -b tsconfig.build.json && npm run respect:parser:generate && npm run build-docs:copy-assets",
     "prepare": "npm run compile",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "form-data": "^4.0.0",
     "glob": "^11.0.1",
     "handlebars": "^4.7.6",
+    "https-proxy-agent": "^7.0.5",
     "mobx": "^6.0.4",
     "pluralize": "^8.0.0",
     "react": "^17.0.0 || ^18.2.0 || ^19.0.0",

--- a/packages/cli/src/utils/fetch-with-timeout.ts
+++ b/packages/cli/src/utils/fetch-with-timeout.ts
@@ -1,4 +1,4 @@
-import { getProxyAgent } from '@redocly/openapi-core';
+import { getProxyAgent } from './proxy-agent.js';
 
 export const DEFAULT_FETCH_TIMEOUT = 3000;
 

--- a/packages/cli/src/utils/proxy-agent.ts
+++ b/packages/cli/src/utils/proxy-agent.ts
@@ -1,0 +1,6 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+export function getProxyAgent() {
+  const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  return proxy ? new HttpsProxyAgent(proxy) : undefined;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,8 +38,9 @@
     "node:fs": false,
     "node:path": "path-browserify",
     "node:os": false,
-    "colorette": false,
-    "https-proxy-agent": false
+    "node:url": false,
+    "node:module": false,
+    "colorette": false
   },
   "homepage": "https://github.com/Redocly/redocly-cli",
   "keywords": [
@@ -59,7 +60,6 @@
     "@redocly/ajv": "^8.11.2",
     "@redocly/config": "^0.22.0",
     "colorette": "^1.2.0",
-    "https-proxy-agent": "^7.0.5",
     "js-levenshtein": "^1.1.6",
     "js-yaml": "^4.1.0",
     "minimatch": "^10.0.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,6 @@ export {
   slash,
   doesYamlFileExist,
   isTruthy,
-  getProxyAgent,
   pause,
   isPlainObject,
   dequal,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -4,7 +4,6 @@ import { minimatch } from 'minimatch';
 import { parseYaml } from './js-yaml/index.js';
 import { env } from './env.js';
 import { logger, colorize } from './logger.js';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as pluralize1 from 'pluralize'; // FIXME: use correct import after migration to ESM
 const pluralizeOne = (pluralize1 as any).default || pluralize1; // FIXME: use correct import after migration to ESM
 
@@ -307,11 +306,6 @@ export async function pause(ms: number): Promise<void> {
 
 function getUpdatedFieldName(updatedField: string, updatedObject?: string) {
   return `${typeof updatedObject !== 'undefined' ? `${updatedObject}.` : ''}${updatedField}`;
-}
-
-export function getProxyAgent() {
-  const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
-  return proxy ? new HttpsProxyAgent(proxy) : undefined;
 }
 
 /**


### PR DESCRIPTION
## What/Why/How?

- Moved https-proxy-agent out of the openapi-core package
- Added browser stubs for "node:url" and    "node:module"
- Renamed script clean -> clear for clarity

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
