### PR TITLE
chore: update benchmark setup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ packages/respect-core/src/modules/runtime-expressions/abnf-parser.cjs
 benchmark/api-definitions/
 LICENSE.md
 snapshot*.txt
+.changeset/pre.json

--- a/benchmark/make-test-command.sh
+++ b/benchmark/make-test-command.sh
@@ -6,7 +6,7 @@ set -eo pipefail # Fail on script errors
 git clone https://github.com/Rebilly/api-definitions.git
 
 # Store the command into a text file:
-echo REDOCLY_SUPPRESS_UPDATE_NOTICE=true hyperfine -i --warmup 3 $(cat package.json | jq '.dependencies' | jq 'keys' | jq 'map("'\''node node_modules/" + . + "/bin/cli.js lint core@public --config=api-definitions/redocly.yaml'\''")' | jq 'join(" ")' | xargs) --export-markdown benchmark_check.md --export-json benchmark_check.json > test-command.txt
+echo REDOCLY_SUPPRESS_UPDATE_NOTICE=true hyperfine --warmup 3 $(cat package.json | jq '.dependencies' | jq 'keys' | jq 'map("'\''node node_modules/" + . + "/bin/cli.js lint --config=api-definitions/redocly.yaml --generate-ignore-file'\''")' | jq 'join(" ")' | xargs) --export-markdown benchmark_check.md --export-json benchmark_check.json > test-command.txt
 
 # Put the command in the test section of the package.json:
 cat package.json | jq ".scripts.test = \"$(cat test-command.txt)\"" > package.json


### PR DESCRIPTION
## What/Why/How?

- Made historical versions performance benchmark to fail on real failures.
- Updated prettier to ignore changeset config file.

## Reference

Discovered in a Release pipeline run: https://github.com/Redocly/redocly-cli/pull/2056

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
