### PR TITLE
feat(respect): implementing digest auth with x-security

### DIFF
--- a/packages/core/src/rules/respect/x-security-schema-required-values.ts
+++ b/packages/core/src/rules/respect/x-security-schema-required-values.ts
@@ -41,7 +41,7 @@ export const XSecuritySchemaRequiredValues: Arazzo1Rule = () => {
           const { type } = scheme;
           const authType = type === 'http' ? scheme.scheme : type;
 
-          if (authType === 'mutualTls') {
+          if (schemeName === 'mutualTLS') {
             logger.warn(
               'Please use CLI option to provide mutualTLS certificates for mutualTls authentication security schema.'
             );

--- a/packages/core/src/rules/respect/x-security-schema-required-values.ts
+++ b/packages/core/src/rules/respect/x-security-schema-required-values.ts
@@ -41,7 +41,7 @@ export const XSecuritySchemaRequiredValues: Arazzo1Rule = () => {
           const { type } = scheme;
           const authType = type === 'http' ? scheme.scheme : type;
 
-          if (schemeName === 'mutualTLS') {
+          if (authType === 'mutualTLS') {
             logger.warn(
               'Please use CLI option to provide mutualTLS certificates for mutualTls authentication security schema.'
             );

--- a/packages/core/src/typings/arazzo.ts
+++ b/packages/core/src/typings/arazzo.ts
@@ -1,4 +1,11 @@
-import type { Oas3SecurityScheme, ApiKeyAuth, BasicAuth, BearerAuth } from './openapi.js';
+import type {
+  Oas3SecurityScheme,
+  ApiKeyAuth,
+  BasicAuth,
+  BearerAuth,
+  OpenIDAuth,
+  OAuth2Auth,
+} from './openapi.js';
 
 export interface InfoObject {
   title: string;
@@ -60,7 +67,22 @@ export type ResolvedSecurity =
       };
     }
   | {
-      scheme: Exclude<Oas3SecurityScheme, ApiKeyAuth | BasicAuth | BearerAuth>;
+      scheme: OpenIDAuth;
+      values: {
+        accessToken: string;
+      };
+    }
+  | {
+      scheme: OAuth2Auth;
+      values: {
+        accessToken: string;
+      };
+    }
+  | {
+      scheme: Exclude<
+        Oas3SecurityScheme,
+        ApiKeyAuth | BasicAuth | BearerAuth | OpenIDAuth | OAuth2Auth
+      >;
       values: {
         accessToken: string;
       };

--- a/packages/respect-core/src/consts.ts
+++ b/packages/respect-core/src/consts.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_RESPECT_TIMEOUT = 3_600_000; // 1 hour in milliseconds
-export const DEFAULT_RESPECT_MAX_FETCH_TIMEOUT = 20_000; // 20 seconds in milliseconds
+export const DEFAULT_RESPECT_MAX_FETCH_TIMEOUT = 40_000; // 40 seconds in milliseconds
 export const DEFAULT_RESPECT_MAX_STEPS = 2_000;

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-security-parameters.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-security-parameters.test.ts
@@ -105,4 +105,17 @@ describe('getSecurityParameters', () => {
       value: 'Bearer oauth2-token',
     });
   });
+
+  it('should return undefined for unknown security scheme', () => {
+    const result = getSecurityParameters({
+      scheme: {
+        type: 'mutualTLS',
+      },
+      values: {
+        accessToken: 'mutual-tls-token',
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
+++ b/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
@@ -29,7 +29,7 @@ export async function callAPIAndAnalyzeResults({
   };
 
   try {
-    step.response = await ctx.apiClient.fetchResult(ctx, requestData);
+    step.response = await ctx.apiClient.fetchResult(ctx, step, requestData);
   } catch (error: any) {
     step.checks.push({
       name: CHECKS.NETWORK_ERROR,

--- a/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
+++ b/packages/respect-core/src/modules/flow-runner/call-api-and-analyze-results.ts
@@ -29,7 +29,7 @@ export async function callAPIAndAnalyzeResults({
   };
 
   try {
-    step.response = await ctx.apiClient.fetchResult(ctx, step, requestData);
+    step.response = await ctx.apiClient.fetchResult({ ctx, step, requestData, workflowId });
   } catch (error: any) {
     step.checks.push({
       name: CHECKS.NETWORK_ERROR,

--- a/packages/respect-core/src/modules/flow-runner/resolve-x-security-parameters.ts
+++ b/packages/respect-core/src/modules/flow-runner/resolve-x-security-parameters.ts
@@ -19,21 +19,23 @@ export function resolveXSecurityParameters(
     return [];
   }
 
-  return xSecurity.map((security) => {
-    const scheme =
-      'schemeName' in security
-        ? (operation?.securitySchemes?.[security.schemeName] as Oas3SecurityScheme)
-        : security.scheme;
+  return xSecurity
+    .map((security) => {
+      const scheme =
+        'schemeName' in security
+          ? (operation?.securitySchemes?.[security.schemeName] as Oas3SecurityScheme)
+          : security.scheme;
 
-    const values = Object.fromEntries(
-      Object.entries(security?.values ?? {}).map(([key, value]) => [
-        key,
-        evaluateRuntimeExpressionPayload({ payload: value, context: ctx }),
-      ])
-    );
+      const values = Object.fromEntries(
+        Object.entries(security?.values ?? {}).map(([key, value]) => [
+          key,
+          evaluateRuntimeExpressionPayload({ payload: value, context: ctx }),
+        ])
+      );
 
-    const resolvedSecurity = resolveXSecurity({ scheme, values });
+      const resolvedSecurity = resolveXSecurity({ scheme, values });
 
-    return getSecurityParameters(resolvedSecurity);
-  });
+      return getSecurityParameters(resolvedSecurity);
+    })
+    .filter((param): param is ParameterWithIn => param !== undefined);
 }

--- a/packages/respect-core/src/utils/__tests__/api-fetcher.test.ts
+++ b/packages/respect-core/src/utils/__tests__/api-fetcher.test.ts
@@ -157,9 +157,9 @@ describe('ApiFetcher', () => {
         parameters: [],
         requestBody: {},
       };
-      await expect(apiFetcher.fetchResult(ctx, step, requestData)).rejects.toThrowError(
-        'No server url provided'
-      );
+      await expect(
+        apiFetcher.fetchResult({ ctx, step, requestData, workflowId: 'test' })
+      ).rejects.toThrowError('No server url provided');
     });
   });
 });

--- a/packages/respect-core/src/utils/__tests__/api-fetcher.test.ts
+++ b/packages/respect-core/src/utils/__tests__/api-fetcher.test.ts
@@ -149,6 +149,7 @@ describe('ApiFetcher', () => {
     it('should throw an error if no serverUrl', async () => {
       const apiFetcher = new ApiFetcher({});
       const ctx = {} as any;
+      const step = {} as any;
       const requestData = {
         serverUrl: undefined,
         path: '/pets',
@@ -156,7 +157,7 @@ describe('ApiFetcher', () => {
         parameters: [],
         requestBody: {},
       };
-      await expect(apiFetcher.fetchResult(ctx, requestData)).rejects.toThrowError(
+      await expect(apiFetcher.fetchResult(ctx, step, requestData)).rejects.toThrowError(
         'No server url provided'
       );
     });

--- a/packages/respect-core/src/utils/__tests__/digest-auth/generate-digest-auth-header.test.ts
+++ b/packages/respect-core/src/utils/__tests__/digest-auth/generate-digest-auth-header.test.ts
@@ -1,0 +1,66 @@
+import { generateDigestAuthHeader } from '../../digest-auth/generate-digest-auth-header.js';
+
+describe('generateDigestAuthHeader', () => {
+  it('should generate a digest auth header', () => {
+    const header = generateDigestAuthHeader({
+      username: 'test',
+      password: 'test',
+      realm: 'test',
+      nonce: 'test',
+      qop: 'test',
+      opaque: 'test',
+      uri: 'test',
+      method: 'test',
+    });
+    expect(header).toBe(
+      'Digest username="test", realm="test", nonce="test", uri="test", qop=test, nc=00000001, cnonce="undefined", response="0ba4491f16f36950e4f932dba0ba1a25", algorithm=MD5, opaque="test"'
+    );
+  });
+
+  it('should throw an error if required parameters are missing', () => {
+    expect(() =>
+      generateDigestAuthHeader({
+        username: 'test',
+        password: 'test',
+        realm: 'test',
+        nonce: 'test',
+        qop: 'test',
+        uri: 'test',
+        method: 'test',
+      })
+    ).toThrow('Missing required digest auth parameters');
+  });
+
+  it('should use sha256 algorithm if algorithm is sha256', () => {
+    const header = generateDigestAuthHeader({
+      username: 'test',
+      password: 'test',
+      realm: 'test',
+      nonce: 'test',
+      qop: 'test',
+      opaque: 'test',
+      uri: 'test',
+      method: 'test',
+      algorithm: 'sha256',
+    });
+    expect(header).toBe(
+      'Digest username="test", realm="test", nonce="test", uri="test", qop=test, nc=00000001, cnonce="undefined", response="0ba4491f16f36950e4f932dba0ba1a25", algorithm=sha256, opaque="test"'
+    );
+  });
+
+  it('should use md5 algorithm if algorithm is not specified', () => {
+    const header = generateDigestAuthHeader({
+      username: 'test',
+      password: 'test',
+      realm: 'test',
+      nonce: 'test',
+      qop: 'test',
+      opaque: 'test',
+      uri: 'test',
+      method: 'test',
+    });
+    expect(header).toBe(
+      'Digest username="test", realm="test", nonce="test", uri="test", qop=test, nc=00000001, cnonce="undefined", response="0ba4491f16f36950e4f932dba0ba1a25", algorithm=MD5, opaque="test"'
+    );
+  });
+});

--- a/packages/respect-core/src/utils/__tests__/digest-auth/parse-www-authenticate-header.test.ts
+++ b/packages/respect-core/src/utils/__tests__/digest-auth/parse-www-authenticate-header.test.ts
@@ -1,0 +1,26 @@
+import { parseWwwAuthenticateHeader } from '../../digest-auth/parse-www-authenticate-header.js';
+
+describe('parseWwwAuthenticateHeader', () => {
+  it('should parse the www-authenticate header', () => {
+    const wwwAuthenticateHeader =
+      'Digest realm="me@smth.com", nonce="2115c839b5039f8221bf3e970f9ef06b", qop="auth", opaque="df88e8ed5ea8c53b1760e8e69dc1fce1", algorithm=MD5, stale=FALSE';
+    const result = parseWwwAuthenticateHeader(wwwAuthenticateHeader);
+    expect(result).toEqual({
+      realm: 'me@smth.com',
+      nonce: '2115c839b5039f8221bf3e970f9ef06b',
+      opaque: 'df88e8ed5ea8c53b1760e8e69dc1fce1',
+      qop: 'auth',
+      algorithm: 'MD5',
+    });
+  });
+
+  it('should parse the www-authenticate header when some fields are missing', () => {
+    const wwwAuthenticateHeader =
+      'Digest realm="me@smth.com", nonce="2115c839b5039f8221bf3e970f9ef06b"';
+    const result = parseWwwAuthenticateHeader(wwwAuthenticateHeader);
+    expect(result).toEqual({
+      realm: 'me@smth.com',
+      nonce: '2115c839b5039f8221bf3e970f9ef06b',
+    });
+  });
+});

--- a/packages/respect-core/src/utils/api-fetcher.ts
+++ b/packages/respect-core/src/utils/api-fetcher.ts
@@ -308,7 +308,7 @@ export class ApiFetcher implements IFetcher {
 
       const updatedHeaders = {
         ...headers,
-        Authorization: digestAuthHeader,
+        authorization: digestAuthHeader,
       };
 
       this.updateVerboseLogs({

--- a/packages/respect-core/src/utils/api-fetcher.ts
+++ b/packages/respect-core/src/utils/api-fetcher.ts
@@ -123,11 +123,17 @@ export class ApiFetcher implements IFetcher {
     return this.verboseResponseLogs;
   };
 
-  fetchResult = async (
-    ctx: TestContext,
-    step: Step,
-    requestData: RequestData
-  ): Promise<ResponseContext | never> => {
+  fetchResult = async ({
+    ctx,
+    step,
+    requestData,
+    workflowId,
+  }: {
+    ctx: TestContext;
+    step: Step;
+    requestData: RequestData;
+    workflowId: string;
+  }): Promise<ResponseContext | never> => {
     const { serverUrl, path, method, parameters, requestBody, openapiOperation } = requestData;
     if (!serverUrl?.url) {
       logger.error(bgRed(` No server url provided `));
@@ -310,6 +316,12 @@ export class ApiFetcher implements IFetcher {
         ...headers,
         authorization: digestAuthHeader,
       };
+
+      // Update the request headers in the step
+      const stepRequest = ctx.$workflows[workflowId].steps[step.stepId]?.request;
+      if (stepRequest) {
+        stepRequest.header = updatedHeaders;
+      }
 
       this.updateVerboseLogs({
         headerParams: updatedHeaders,

--- a/packages/respect-core/src/utils/api-fetcher.ts
+++ b/packages/respect-core/src/utils/api-fetcher.ts
@@ -8,6 +8,7 @@ import {
   type VerboseLog,
   type TestContext,
   type ResponseContext,
+  type Step,
 } from '../types.js';
 import { withHar } from '../utils/har-logs/index.js';
 import { isEmpty } from './is-empty.js';
@@ -18,6 +19,8 @@ import { collectSecretFields } from '../modules/flow-runner/index.js';
 import { createMtlsClient } from './mtls/create-mtls-client.js';
 import { DefaultLogger } from './logger/logger.js';
 import { DEFAULT_RESPECT_MAX_FETCH_TIMEOUT } from '../consts.js';
+import { parseWwwAuthenticateHeader } from './digest-auth/parse-www-authenticate-header.js';
+import { generateDigestAuthHeader } from './digest-auth/generate-digest-auth-header.js';
 
 import type { RequestData } from '../modules/flow-runner/index.js';
 
@@ -86,6 +89,16 @@ export class ApiFetcher implements IFetcher {
     return this.verboseLogs;
   };
 
+  updateVerboseLogs = (params: Partial<VerboseLog>) => {
+    if (!this.verboseLogs) {
+      throw new Error('Verbose logs not initialized');
+    }
+    this.verboseLogs = getVerboseLogs({
+      ...this.verboseLogs,
+      ...params,
+    });
+  };
+
   initVerboseResponseLogs = ({
     headerParams,
     host,
@@ -112,6 +125,7 @@ export class ApiFetcher implements IFetcher {
 
   fetchResult = async (
     ctx: TestContext,
+    step: Step,
     requestData: RequestData
   ): Promise<ResponseContext | never> => {
     const { serverUrl, path, method, parameters, requestBody, openapiOperation } = requestData;
@@ -232,7 +246,11 @@ export class ApiFetcher implements IFetcher {
     const wrappedFetch = this.harLogs ? withHar(this.fetch, { har: this.harLogs }) : fetch;
     const startTime = performance.now();
 
-    const result = await wrappedFetch(urlToFetch, {
+    let result;
+    let res;
+    let responseTime;
+
+    const fetchParams = {
       method: (method || 'get').toUpperCase() as OperationMethod,
       headers,
       ...(!isEmpty(requestBody) && {
@@ -245,9 +263,75 @@ export class ApiFetcher implements IFetcher {
         duplex: 'half',
       }),
       dispatcher: ctx.mtlsCerts ? createMtlsClient(urlToFetch, ctx.mtlsCerts) : undefined,
-    });
-    const responseTime = Math.ceil(performance.now() - startTime);
-    const res = await result.text();
+    };
+
+    const lastDigestSecurityScheme = step['x-security']
+      ?.slice()
+      .reverse()
+      .find(
+        (security) =>
+          'scheme' in security &&
+          security.scheme?.type === 'http' &&
+          security.scheme?.scheme === 'digest'
+      );
+
+    // FETCH WITH DIGEST AUTH
+    if (lastDigestSecurityScheme) {
+      // Digest auth perform two requests to establish the connection
+      // We need to wait for the second request to complete before returning the response
+      const first401Result = await wrappedFetch(urlToFetch, fetchParams);
+      const wwwAuthenticateHeader = first401Result.headers.get('www-authenticate');
+
+      if (!wwwAuthenticateHeader) {
+        throw new Error('No www-authenticate header');
+      }
+
+      const { realm, nonce, opaque, qop, algorithm, cnonce, nc } =
+        parseWwwAuthenticateHeader(wwwAuthenticateHeader);
+      const { username, password } = lastDigestSecurityScheme.values;
+      const uri = new URL(urlToFetch).pathname + new URL(urlToFetch).search;
+
+      const digestAuthHeader = generateDigestAuthHeader({
+        username: username as string,
+        password: password as string,
+        realm,
+        nonce,
+        opaque,
+        qop,
+        algorithm,
+        cnonce,
+        nc,
+        uri,
+        method: (method || 'get').toUpperCase(),
+        bodyContent: JSON.stringify(encodedBody) || '',
+      });
+
+      const updatedHeaders = {
+        ...headers,
+        Authorization: digestAuthHeader,
+      };
+
+      this.updateVerboseLogs({
+        headerParams: updatedHeaders,
+      });
+
+      result = await wrappedFetch(urlToFetch, {
+        ...fetchParams,
+        headers: updatedHeaders,
+      });
+
+      responseTime = Math.ceil(performance.now() - startTime);
+      res = await result.text();
+      // REGULAR FETCH
+    } else {
+      result = await wrappedFetch(urlToFetch, fetchParams);
+      responseTime = Math.ceil(performance.now() - startTime);
+      res = await result.text();
+    }
+
+    if (!result) {
+      throw new Error('Failed to fetch, no result received');
+    }
 
     const [responseContentType] = result.headers.get('content-type')?.split(';') || [
       'application/json',

--- a/packages/respect-core/src/utils/digest-auth/generate-digest-auth-header.ts
+++ b/packages/respect-core/src/utils/digest-auth/generate-digest-auth-header.ts
@@ -1,0 +1,142 @@
+import { createHash } from 'node:crypto';
+
+const DEFAULT_ALGORITHM = 'MD5';
+const DEFAULT_NC = '00000001';
+
+type DigestAuthType = {
+  username?: string;
+  password?: string;
+  method: string;
+  uri: string;
+  realm?: string;
+  nonce?: string;
+  opaque?: string;
+  qop?: string;
+  algorithm?: string;
+  nc?: string;
+  cnonce?: string;
+};
+
+type RequiredDigestAuthParams = {
+  username: string;
+  password: string;
+  realm: string;
+  nonce: string;
+  qop: string;
+  opaque: string;
+  uri: string;
+  method: string;
+};
+
+export function generateDigestAuthHeader({
+  username,
+  password,
+  nonce,
+  realm,
+  cnonce,
+  algorithm = DEFAULT_ALGORITHM,
+  qop,
+  nc = DEFAULT_NC,
+  opaque,
+  uri,
+  method,
+  bodyContent = '',
+}: DigestAuthType & { uri: string; method: string; bodyContent?: string }) {
+  const requiredParams = {
+    username,
+    password,
+    realm,
+    nonce,
+    qop,
+    opaque,
+    uri,
+    method,
+  };
+
+  const missingParams = Object.entries(requiredParams)
+    .filter(([_, value]) => !value)
+    .map(([key]) => key);
+
+  if (missingParams.length > 0) {
+    throw new Error(`Missing required digest auth parameters: ${missingParams.join(', ')}`);
+  }
+
+  const response = generateResponse({
+    ...(requiredParams as RequiredDigestAuthParams),
+    cnonce,
+    algorithm,
+    nc,
+    bodyContent,
+  });
+
+  const parts = [
+    `username="${username}"`,
+    `realm="${realm}"`,
+    `nonce="${nonce}"`,
+    `uri="${uri}"`,
+    `qop=${qop}`,
+    `nc=${nc}`,
+    `cnonce="${cnonce}"`,
+    `response="${response}"`,
+    `algorithm=${algorithm}`,
+  ];
+
+  if (opaque) {
+    parts.push(`opaque="${opaque}"`);
+  }
+
+  return `Digest ${parts.join(', ')}`;
+}
+
+export function generateResponse(
+  data: RequiredDigestAuthParams & {
+    cnonce?: string;
+    algorithm?: string;
+    nc?: string;
+    bodyContent: string;
+  }
+) {
+  const {
+    username,
+    password,
+    realm,
+    nonce,
+    cnonce,
+    algorithm = DEFAULT_ALGORITHM,
+    qop,
+    nc = DEFAULT_NC,
+    uri,
+    method,
+    bodyContent,
+  } = data;
+
+  const hashA1 = algorithm.endsWith('-sess')
+    ? getHashFunction(algorithm)
+        .update(
+          getHashFunction(algorithm).update(`${username}:${realm}:${password}`).digest('hex') +
+            `:${nonce}:${cnonce}`
+        )
+        .digest('hex')
+    : getHashFunction(algorithm).update(`${username}:${realm}:${password}`).digest('hex');
+
+  const hashA2 = qop.includes('auth-int')
+    ? getHashFunction(algorithm)
+        .update(`${method}:${uri}:${getHashFunction(algorithm).update(bodyContent).digest('hex')}`)
+        .digest('hex')
+    : getHashFunction(algorithm).update(`${method}:${uri}`).digest('hex');
+
+  return getHashFunction(algorithm)
+    .update(`${hashA1}:${nonce}:${nc}:${cnonce}:${qop}:${hashA2}`)
+    .digest('hex');
+}
+
+function getHashFunction(algorithm: string) {
+  const normalizedAlgorithm = algorithm.replace('-sess', '').toUpperCase();
+
+  switch (normalizedAlgorithm) {
+    case 'SHA-256':
+      return createHash('sha256');
+    default:
+      return createHash('md5');
+  }
+}

--- a/packages/respect-core/src/utils/digest-auth/parse-www-authenticate-header.ts
+++ b/packages/respect-core/src/utils/digest-auth/parse-www-authenticate-header.ts
@@ -1,0 +1,27 @@
+export function parseWwwAuthenticateHeader(wwwAuthenticateHeader: string): {
+  realm?: string;
+  nonce?: string;
+  opaque?: string;
+  qop?: string;
+  algorithm?: string;
+  cnonce?: string;
+  nc?: string;
+} {
+  const headerParts = wwwAuthenticateHeader
+    .replace('Digest ', '')
+    .split(',')
+    .map((part: string) => part.trim());
+
+  const keys = ['realm', 'nonce', 'opaque', 'qop', 'algorithm', 'cnonce', 'nc'];
+  const result = Object.fromEntries(
+    keys.map((key) => [
+      key,
+      headerParts
+        .find((part) => part.startsWith(`${key}=`))
+        ?.split('=')[1]
+        ?.replace(/"/g, ''),
+    ])
+  );
+
+  return result;
+}


### PR DESCRIPTION
## What/Why/How?
Adding support for `digest` auth scheme.

```
        x-security:
          - scheme:
              type: http
              scheme: digest
            values:
              username: dimaananskyi
              password: secret
```

This changes the way fetch performed when Step have `x-security` with `digest` scheme described.
In this case fetch will be called two times during Step execution to establish required data exchange.

`Authorization` header for `digest` will override other `Authorization` headers, that was described by other `x-security` schemes.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
