### PR TITLE
chore: remove the spec rule support in redocly.yaml

### DIFF
--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -172,7 +172,6 @@ const builtInRules = [
   ...builtInAsync3Rules,
   ...builtInArazzo1Rules,
   ...builtInOverlay1Rules,
-  'spec', // TODO: depricated in favor of struct
   'struct',
 ] as const;
 


### PR DESCRIPTION
## What/Why/How?

Error on the `spec` rule in Redocly config.

## Reference


This is a follow-up to https://github.com/Redocly/redocly-cli/pull/2080

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
