### PR TITLE
chore: remove separate coverage script

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
       - name: Unit Tests
-        run: npm run coverage
+        run: npm run unit
       - name: E2E Tests
         run: npm run e2e
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,8 +215,6 @@ To run tests from a single file, run: `npm run unit -- <path/to/your/file.test.t
 To run a specific test, use this command: `npm run unit -- -t 'Test name'`.
 To update snapshots, run `npm run unit -- -u`.
 
-To get coverage per package run `npm run coverage`.
-
 ### E2E tests
 
 Run e2e tests with this command: `npm run e2e`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "unit": "VITEST_SUITE=unit vitest run",
     "e2e": "VITEST_SUITE=e2e vitest run",
     "smoke:rebilly": "VITEST_SUITE=smoke-rebilly vitest run",
-    "coverage": "VITEST_SUITE=coverage vitest run",
     "prettier": "npx prettier --write \"**/*.{ts,js,yaml,yml,json,md}\"",
     "prettier:check": "npx prettier --check \"**/*.{ts,js,yaml,yml,json,md}\"",
     "eslint": "eslint packages/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,11 +6,6 @@ const configExtension: { [key: string]: ViteUserConfig } = {
   unit: defineConfig({
     test: {
       include: ['packages/*/src/**/*.test.ts'],
-    },
-  }),
-  coverage: defineConfig({
-    test: {
-      include: ['packages/*/src/**/*.test.ts'],
       coverage: {
         enabled: true,
         include: [


### PR DESCRIPTION
## What/Why/How?

Removed the separate coverage script in favor of `npm run unit`.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
