### PR TITLE
docs: fix wrong issue links

### DIFF
--- a/docs/@v1/decorators.md
+++ b/docs/@v1/decorators.md
@@ -32,7 +32,7 @@ Some common decorator use cases are already built in to Redocly. Check the list 
 
 Have an idea for a decorator?
 We might build it for you and give it to the world.
-Open a [GitHub issue](https://github.com/Redocly/redocly-cli/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=) and let us know.
+Open a [GitHub issue](https://github.com/Redocly/redocly-cli/issues) and let us know.
 
 ## Decorator configuration syntax
 

--- a/docs/@v1/guides/lint-arazzo.md
+++ b/docs/@v1/guides/lint-arazzo.md
@@ -11,7 +11,7 @@ While under development, this standard was also known as "OpenAPI Workflows".
 Redocly CLI offers support for checking that your Arazzo files are valid.
 
 {% admonition type="info" name="Experimental Arazzo support" %}
-This feature is at an early stage, please send us lots of [feedback](https://github.com/redocly/redocly-cli/issues/new)!
+This feature is at an early stage, please send us lots of [feedback](https://github.com/redocly/redocly-cli/issues)!
 {% /admonition %}
 
 ## Lint an Arazzo file

--- a/docs/@v1/guides/migrate-from-spectral.md
+++ b/docs/@v1/guides/migrate-from-spectral.md
@@ -61,7 +61,7 @@ It is also possible to configure additional rules for specific APIs using the [A
 
 ### Redocly rules and Spectral equivalents
 
-Included here is an attempt to map the simliar-but-not-identical naming of rules between the tools. If you spot anything that needs adding or updating, please [tell us](https://github.com/redocly/redocly-cli/issues/new)?
+Included here is an attempt to map the simliar-but-not-identical naming of rules between the tools. If you spot anything that needs adding or updating, please [tell us](https://github.com/redocly/redocly-cli/issues)?
 
 | Spectral rules                         | Redocly rules                                 |
 | -------------------------------------- | --------------------------------------------- |

--- a/docs/@v1/rules.md
+++ b/docs/@v1/rules.md
@@ -40,4 +40,4 @@ Severity settings determine how the rule is treated during the validation proces
 ## Rule ideas
 
 Redocly CLI supports [configurable rules](./rules/configurable-rules.md) and [custom plugins](./custom-plugins/index.md).
-However, if you have an idea for a built-in rule you believe benefits the greater API community, please [open an issue](https://github.com/Redocly/redocly-cli/issues/new) in the Redocly CLI repository.
+However, if you have an idea for a built-in rule you believe benefits the greater API community, please [open an issue](https://github.com/Redocly/redocly-cli/issues) in the Redocly CLI repository.

--- a/docs/@v2/decorators.md
+++ b/docs/@v2/decorators.md
@@ -32,7 +32,7 @@ Some common decorator use cases are already built in to Redocly. Check the list 
 
 Have an idea for a decorator?
 We might build it for you and give it to the world.
-Open a [GitHub issue](https://github.com/Redocly/redocly-cli/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=) and let us know.
+Open a [GitHub issue](https://github.com/Redocly/redocly-cli/issues) and let us know.
 
 ## Decorator configuration syntax
 

--- a/docs/@v2/guides/lint-arazzo.md
+++ b/docs/@v2/guides/lint-arazzo.md
@@ -11,7 +11,7 @@ While under development, this standard was also known as "OpenAPI Workflows".
 Redocly CLI offers support for checking that your Arazzo files are valid.
 
 {% admonition type="info" name="Experimental Arazzo support" %}
-This feature is at an early stage, please send us lots of [feedback](https://github.com/redocly/redocly-cli/issues/new)!
+This feature is at an early stage, please send us lots of [feedback](https://github.com/redocly/redocly-cli/issues)!
 {% /admonition %}
 
 ## Lint an Arazzo file

--- a/docs/@v2/guides/migrate-from-spectral.md
+++ b/docs/@v2/guides/migrate-from-spectral.md
@@ -61,7 +61,7 @@ It is also possible to configure additional rules for specific APIs using the [A
 
 ### Redocly rules and Spectral equivalents
 
-Included here is an attempt to map the simliar-but-not-identical naming of rules between the tools. If you spot anything that needs adding or updating, please [tell us](https://github.com/redocly/redocly-cli/issues/new)?
+Included here is an attempt to map the simliar-but-not-identical naming of rules between the tools. If you spot anything that needs adding or updating, please [tell us](https://github.com/redocly/redocly-cli/issues)?
 
 | Spectral rules                         | Redocly rules                                 |
 | -------------------------------------- | --------------------------------------------- |

--- a/docs/@v2/rules.md
+++ b/docs/@v2/rules.md
@@ -40,4 +40,4 @@ Severity settings determine how the rule is treated during the validation proces
 ## Rule ideas
 
 Redocly CLI supports [configurable rules](./rules/configurable-rules.md) and [custom plugins](./custom-plugins/index.md).
-However, if you have an idea for a built-in rule you believe benefits the greater API community, please [open an issue](https://github.com/Redocly/redocly-cli/issues/new) in the Redocly CLI repository.
+However, if you have an idea for a built-in rule you believe benefits the greater API community, please [open an issue](https://github.com/Redocly/redocly-cli/issues) in the Redocly CLI repository.


### PR DESCRIPTION
## What/Why/How?

The links are no longer valid. I think Github has changed the interface and we cannot refer to a specific type of template via a url like we did before: 
https://github.com/Redocly/redocly-cli/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
