### PR TITLE
feat(respect): hide in logs authorization header generated by x-security

### DIFF
--- a/__tests__/respect/x-security-basic-auth/__snapshots__/x-security-basic-auth.test.ts.snap
+++ b/__tests__/respect/x-security-basic-auth/__snapshots__/x-security-basic-auth.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should make request with Authorization header \`Basic ...\` 1`] = `
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Basic Sm9objoic29tZS1wYXNzd29yZCI=
+      authorization: ********
 
 
     Response status code: 200

--- a/__tests__/respect/x-security-bearer-auth/__snapshots__/x-security-bearer-auth.test.ts.snap
+++ b/__tests__/respect/x-security-bearer-auth/__snapshots__/x-security-bearer-auth.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should make request with Authorization header \`Bearer ...\` 1`] = `
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Bearer "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.LlTGHPZRXbci-y349jXXN0byQniQQqwKGybzQCFIgY0"
+      authorization: ********
 
 
     Response status code: 200

--- a/__tests__/respect/x-security-oauth2-auth/__snapshots__/x-security-oauth2-auth.test.ts.snap
+++ b/__tests__/respect/x-security-oauth2-auth/__snapshots__/x-security-oauth2-auth.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should make request with Authorization header \`Bearer ...\` using OAut
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Bearer oauth2-token
+      authorization: ********
 
 
     Response status code: 200

--- a/__tests__/respect/x-security-on-workflow-level-merged-to-steps/__snapshots__/x-security-on-workflow-level-merged-to-steps.test.ts.snap
+++ b/__tests__/respect/x-security-on-workflow-level-merged-to-steps/__snapshots__/x-security-on-workflow-level-merged-to-steps.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should merge x-security schemes on workflow level to steps 1`] = `
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Basic Sm9objpzb21lLXBhc3N3b3Jk
+      authorization: ********
 
 
     Response status code: 200
@@ -79,7 +79,7 @@ exports[`should merge x-security schemes on workflow level to steps 1`] = `
     Request Headers:
       content-type: application/json
       accept: application/json, application/problem+json
-      authorization: Basic Sm9objpzb21lLXBhc3N3b3Jk
+      authorization: ********
     Request Body:
       {
         "name": "Mermaid Treasure Identification and Analysis",

--- a/__tests__/respect/x-security-open-id-connect-auth/__snapshots__/x-security-open-id-connect-auth.test.ts.snap
+++ b/__tests__/respect/x-security-open-id-connect-auth/__snapshots__/x-security-open-id-connect-auth.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should make request with Authorization header \`Bearer ...\` using Open
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Bearer openIdConnect-token
+      authorization: ********
 
 
     Response status code: 200

--- a/__tests__/respect/x-security-resolve-scheme-name/__snapshots__/x-security-resolve-scheme-name.test.ts.snap
+++ b/__tests__/respect/x-security-resolve-scheme-name/__snapshots__/x-security-resolve-scheme-name.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should resolve securitySchemes described in x-security by schemeName 1`
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Basic Sm9objoic29tZS1wYXNzd29yZCI=
+      authorization: ********
 
 
     Response status code: 200
@@ -78,7 +78,7 @@ exports[`should resolve securitySchemes described in x-security by schemeName 1`
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Basic Sm9objoic29tZS1wYXNzd29yZCI=
+      authorization: ********
 
 
     Response status code: 200

--- a/__tests__/respect/x-security-scheme-apply-order/__snapshots__/x-security-scheme-apply-order.test.ts.snap
+++ b/__tests__/respect/x-security-scheme-apply-order/__snapshots__/x-security-scheme-apply-order.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should apply x-security schemes in Top-Down order, the Last one have bi
     Request URL: https://redocly.com/_mock/demo/openapi/museum-api/museum-hours
     Request Headers:
       accept: application/json, application/problem+json
-      authorization: Basic YmFzaWMtYXV0aC1zaG91bGQtYmUtaW4tZmluYWwtcmVzdWx0OiJzb21lLXBhc3N3b3JkIg==
+      authorization: ********
       x-api-key: api-key-auth-should-be-in-final-result
       cookie: X-API-KEY-WORKFLOW=workflow-api-key-auth; X-API-KEY=cookie-api-key-auth-should-be-in-final-result
 

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-security-parameters.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-security-parameters.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { getSecurityParameters } from '../../context-parser/get-security-parameters';
 
+import type { TestContext } from '../../../types';
+
 describe('getSecurityParameters', () => {
+  const ctx = {
+    secretFields: new Set(),
+  } as TestContext;
+
   it('should return security parameters for API Key Auth', () => {
-    const result = getSecurityParameters({
+    const result = getSecurityParameters(ctx, {
       scheme: {
         type: 'apiKey',
         in: 'query',
@@ -22,7 +28,7 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for Basic Auth', () => {
-    const result = getSecurityParameters({
+    const result = getSecurityParameters(ctx, {
       scheme: {
         type: 'http',
         scheme: 'basic',
@@ -41,7 +47,7 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for Bearer Auth', () => {
-    const result = getSecurityParameters({
+    const result = getSecurityParameters(ctx, {
       scheme: {
         type: 'http',
         scheme: 'bearer',
@@ -62,7 +68,7 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for OpenID Auth', () => {
-    const result = getSecurityParameters({
+    const result = getSecurityParameters(ctx, {
       scheme: {
         type: 'openIdConnect',
         openIdConnectUrl: 'https://example.com',
@@ -80,7 +86,7 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for OAuth2 Auth', () => {
-    const result = getSecurityParameters({
+    const result = getSecurityParameters(ctx, {
       scheme: {
         type: 'oauth2',
         flows: {
@@ -107,7 +113,7 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return undefined for unknown security scheme', () => {
-    const result = getSecurityParameters({
+    const result = getSecurityParameters(ctx, {
       scheme: {
         type: 'mutualTLS',
       },

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-security-parameters.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-security-parameters.test.ts
@@ -1,24 +1,27 @@
 import { describe, it, expect } from 'vitest';
-import { getSecurityParameters } from '../../context-parser/get-security-parameters';
+import { getSecurityParameter } from '../../context-parser/get-security-parameters';
 
 import type { TestContext } from '../../../types';
 
-describe('getSecurityParameters', () => {
+describe('getSecurityParameter', () => {
   const ctx = {
     secretFields: new Set(),
   } as TestContext;
 
   it('should return security parameters for API Key Auth', () => {
-    const result = getSecurityParameters(ctx, {
-      scheme: {
-        type: 'apiKey',
-        in: 'query',
-        name: 'api_key',
+    const result = getSecurityParameter(
+      {
+        scheme: {
+          type: 'apiKey',
+          in: 'query',
+          name: 'api_key',
+        },
+        values: {
+          value: '12345678-ABCD-90EF-GHIJ-1234567890KL',
+        },
       },
-      values: {
-        value: '12345678-ABCD-90EF-GHIJ-1234567890KL',
-      },
-    });
+      ctx
+    );
 
     expect(result).toEqual({
       in: 'query',
@@ -28,16 +31,19 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for Basic Auth', () => {
-    const result = getSecurityParameters(ctx, {
-      scheme: {
-        type: 'http',
-        scheme: 'basic',
+    const result = getSecurityParameter(
+      {
+        scheme: {
+          type: 'http',
+          scheme: 'basic',
+        },
+        values: {
+          username: 'username',
+          password: 'password',
+        },
       },
-      values: {
-        username: 'username',
-        password: 'password',
-      },
-    });
+      ctx
+    );
 
     expect(result).toEqual({
       in: 'header',
@@ -47,17 +53,20 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for Bearer Auth', () => {
-    const result = getSecurityParameters(ctx, {
-      scheme: {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
+    const result = getSecurityParameter(
+      {
+        scheme: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+        values: {
+          token:
+            'eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.LlTGHPZRXbci-y349jXXN0byQniQQqwKGybzQCFIgY0',
+        },
       },
-      values: {
-        token:
-          'eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.LlTGHPZRXbci-y349jXXN0byQniQQqwKGybzQCFIgY0',
-      },
-    });
+      ctx
+    );
 
     expect(result).toEqual({
       in: 'header',
@@ -68,15 +77,18 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for OpenID Auth', () => {
-    const result = getSecurityParameters(ctx, {
-      scheme: {
-        type: 'openIdConnect',
-        openIdConnectUrl: 'https://example.com',
+    const result = getSecurityParameter(
+      {
+        scheme: {
+          type: 'openIdConnect',
+          openIdConnectUrl: 'https://example.com',
+        },
+        values: {
+          accessToken: 'openid-token',
+        },
       },
-      values: {
-        accessToken: 'openid-token',
-      },
-    });
+      ctx
+    );
 
     expect(result).toEqual({
       in: 'header',
@@ -86,24 +98,27 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return security parameters for OAuth2 Auth', () => {
-    const result = getSecurityParameters(ctx, {
-      scheme: {
-        type: 'oauth2',
-        flows: {
-          authorizationCode: {
-            authorizationUrl: 'https://example.com/authorize',
-            tokenUrl: 'https://example.com/token',
-            scopes: {
-              read: 'Read access',
-              write: 'Write access',
+    const result = getSecurityParameter(
+      {
+        scheme: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://example.com/authorize',
+              tokenUrl: 'https://example.com/token',
+              scopes: {
+                read: 'Read access',
+                write: 'Write access',
+              },
             },
           },
         },
+        values: {
+          accessToken: 'oauth2-token',
+        },
       },
-      values: {
-        accessToken: 'oauth2-token',
-      },
-    });
+      ctx
+    );
 
     expect(result).toEqual({
       in: 'header',
@@ -113,12 +128,15 @@ describe('getSecurityParameters', () => {
   });
 
   it('should return undefined for unknown security scheme', () => {
-    const result = getSecurityParameters(ctx, {
-      scheme: {
-        type: 'mutualTLS',
+    const result = getSecurityParameter(
+      {
+        scheme: {
+          type: 'mutualTLS',
+        },
+        values: {},
       },
-      values: {},
-    });
+      ctx
+    );
 
     expect(result).toBeUndefined();
   });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/resolve-x-security-parameters.ts.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/resolve-x-security-parameters.ts.test.ts
@@ -1,8 +1,12 @@
 import { resolveXSecurityParameters } from '../../flow-runner/resolve-x-security-parameters.js';
 
-import type { Step, RuntimeExpressionContext } from 'respect-core/src/types.js';
+import type { Step, RuntimeExpressionContext, TestContext } from 'respect-core/src/types.js';
 
 describe('resolveXSecurityParameters', () => {
+  const ctx = {
+    secretFields: new Set(),
+  } as TestContext;
+
   it('should resolve x-security parameters', () => {
     const runtimeContext = {
       $steps: {
@@ -31,6 +35,7 @@ describe('resolveXSecurityParameters', () => {
     } as unknown as Step;
 
     const parameters = resolveXSecurityParameters({
+      ctx,
       runtimeContext,
       step,
     });
@@ -127,6 +132,7 @@ describe('resolveXSecurityParameters', () => {
     } as any;
 
     const parameters = resolveXSecurityParameters({
+      ctx,
       runtimeContext,
       step,
       operation,

--- a/packages/respect-core/src/modules/context-parser/get-security-parameters.ts
+++ b/packages/respect-core/src/modules/context-parser/get-security-parameters.ts
@@ -1,5 +1,3 @@
-import { addSecretFields } from '../flow-runner/context/create-test-context.js';
-
 import type {
   ApiKeyAuth,
   BasicAuth,
@@ -11,9 +9,9 @@ import type {
 import type { TestContext } from '../../types';
 import type { ParameterWithIn } from './parse-parameters';
 
-export function getSecurityParameters(
-  ctx: TestContext,
-  security: ResolvedSecurity
+export function getSecurityParameter(
+  security: ResolvedSecurity,
+  ctx: TestContext
 ): ParameterWithIn | undefined {
   if (isApiKeyAuth(security)) {
     return {

--- a/packages/respect-core/src/modules/context-parser/get-security-parameters.ts
+++ b/packages/respect-core/src/modules/context-parser/get-security-parameters.ts
@@ -24,27 +24,27 @@ export function getSecurityParameter(
   if (isBasicAuth(security)) {
     const { username, password } = security.values;
 
-    return getAuthHeader(ctx, `Basic ${btoa(`${username}:${password}`)}`);
+    return getAuthHeader(`Basic ${btoa(`${username}:${password}`)}`, ctx);
   }
 
   if (isBearerAuth(security)) {
-    return getAuthHeader(ctx, `Bearer ${security.values.token}`);
+    return getAuthHeader(`Bearer ${security.values.token}`, ctx);
   }
 
   if (isOpenIdConnectAuth(security)) {
     const { accessToken } = security.values;
-    return getAuthHeader(ctx, `Bearer ${accessToken}`);
+    return getAuthHeader(`Bearer ${accessToken}`, ctx);
   }
 
   if (isOAuth2Auth(security)) {
     const { accessToken } = security.values;
-    return getAuthHeader(ctx, `Bearer ${accessToken}`);
+    return getAuthHeader(`Bearer ${accessToken}`, ctx);
   }
 
   return undefined;
 }
 
-function getAuthHeader(ctx: TestContext, value: string): ParameterWithIn {
+function getAuthHeader(value: string, ctx: TestContext): ParameterWithIn {
   ctx.secretFields.add(value);
 
   return {

--- a/packages/respect-core/src/modules/context-parser/get-security-parameters.ts
+++ b/packages/respect-core/src/modules/context-parser/get-security-parameters.ts
@@ -47,8 +47,8 @@ export function getSecurityParameters(
 }
 
 function getAuthHeader(ctx: TestContext, value: string): ParameterWithIn {
-  // collect new calculated Authorization header value as secret field to mask it in the verbose logs
-  addSecretFields(ctx, value);
+  ctx.secretFields.add(value);
+
   return {
     in: 'header',
     name: 'Authorization',

--- a/packages/respect-core/src/modules/flow-runner/context/create-test-context.ts
+++ b/packages/respect-core/src/modules/flow-runner/context/create-test-context.ts
@@ -100,10 +100,6 @@ export async function createTestContext(
   return ctx;
 }
 
-export function addSecretFields(ctx: TestContext, secretField: string) {
-  ctx.secretFields?.add(secretField);
-}
-
 export function collectSecretFields(
   ctx: TestContext,
   schema: InputSchema | undefined,
@@ -115,7 +111,7 @@ export function collectSecretFields(
   const inputValue = getNestedValue(inputs, path);
 
   if (schema.format === 'password' && inputValue) {
-    addSecretFields(ctx, inputValue);
+    ctx.secretFields.add(inputValue);
   }
 
   if (schema.properties) {

--- a/packages/respect-core/src/modules/flow-runner/context/create-test-context.ts
+++ b/packages/respect-core/src/modules/flow-runner/context/create-test-context.ts
@@ -100,6 +100,10 @@ export async function createTestContext(
   return ctx;
 }
 
+export function addSecretFields(ctx: TestContext, secretField: string) {
+  ctx.secretFields?.add(secretField);
+}
+
 export function collectSecretFields(
   ctx: TestContext,
   schema: InputSchema | undefined,
@@ -111,7 +115,7 @@ export function collectSecretFields(
   const inputValue = getNestedValue(inputs, path);
 
   if (schema.format === 'password' && inputValue) {
-    ctx.secretFields?.add(inputValue);
+    addSecretFields(ctx, inputValue);
   }
 
   if (schema.properties) {

--- a/packages/respect-core/src/modules/flow-runner/prepare-request.ts
+++ b/packages/respect-core/src/modules/flow-runner/prepare-request.ts
@@ -145,6 +145,7 @@ export async function prepareRequest(
   const workflowLevelXSecurityParameters = activeWorkflow?.['x-security'] || [];
 
   const xSecurityParameters = resolveXSecurityParameters({
+    ctx: ctxWithInputs,
     runtimeContext: expressionContext,
     step,
     operation: openapiOperation as OperationDetails & {

--- a/packages/respect-core/src/modules/flow-runner/resolve-x-security-parameters.ts
+++ b/packages/respect-core/src/modules/flow-runner/resolve-x-security-parameters.ts
@@ -1,5 +1,5 @@
 import { evaluateRuntimeExpressionPayload } from '../runtime-expressions/index.js';
-import { getSecurityParameters } from '../context-parser/get-security-parameters.js';
+import { getSecurityParameter } from '../context-parser/get-security-parameters.js';
 import { validateXSecurityParameters } from './validate-x-security-parameters.js';
 
 import type { ExtendedSecurity } from '@redocly/openapi-core';
@@ -55,7 +55,7 @@ export function resolveXSecurityParameters({
     );
 
     const resolvedSecurity = validateXSecurityParameters({ scheme, values });
-    const param = getSecurityParameters(ctx, resolvedSecurity);
+    const param = getSecurityParameter(resolvedSecurity, ctx);
 
     if (param) {
       parameters.push(param);

--- a/packages/respect-core/src/modules/flow-runner/resolve-x-security-parameters.ts
+++ b/packages/respect-core/src/modules/flow-runner/resolve-x-security-parameters.ts
@@ -4,16 +4,18 @@ import { validateXSecurityParameters } from './validate-x-security-parameters.js
 
 import type { ExtendedSecurity } from '@redocly/openapi-core';
 import type { ParameterWithIn } from '../context-parser/index.js';
-import type { Step, RuntimeExpressionContext } from '../../types.js';
+import type { Step, RuntimeExpressionContext, TestContext } from '../../types.js';
 import type { OperationDetails } from '../description-parser/get-operation-from-description.js';
 import type { Oas3SecurityScheme } from 'core/src/typings/openapi.js';
 
 export function resolveXSecurityParameters({
+  ctx,
   runtimeContext,
   step,
   operation,
   workflowLevelXSecurityParameters,
 }: {
+  ctx: TestContext;
   runtimeContext: RuntimeExpressionContext;
   step: Step;
   operation?: OperationDetails & { securitySchemes: Record<string, Oas3SecurityScheme> };
@@ -53,7 +55,7 @@ export function resolveXSecurityParameters({
     );
 
     const resolvedSecurity = validateXSecurityParameters({ scheme, values });
-    const param = getSecurityParameters(resolvedSecurity);
+    const param = getSecurityParameters(ctx, resolvedSecurity);
 
     if (param) {
       parameters.push(param);

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -257,7 +257,7 @@ export type TestContext = RuntimeExpressionContext & {
   testDescription: TestDescription;
   harLogs: any;
   components?: Record<string, any>;
-  secretFields?: Set<string>;
+  secretFields: Set<string>;
   severity: Record<string, RuleSeverity>;
   mtlsCerts?: {
     clientCert?: string;


### PR DESCRIPTION
## What/Why/How?

- Hide generated by x-security Authorization headers (`basic`, `bearer`, `oath2`, `openIdConnect` )
- Hide header for `digest` only when username value is an input with format:`password`
- Hide params for `apiKey` only when value is an input with format:`password`

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
