### PR TITLE
fix: fixed the wrong validation of constructor property

### DIFF
--- a/.changeset/thick-planets-fail.md
+++ b/.changeset/thick-planets-fail.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Fixed the incorrect validation logic for the `constructor` property.
+Fixed incorrect validation logic for the `constructor` property.

--- a/.changeset/thick-planets-fail.md
+++ b/.changeset/thick-planets-fail.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed the incorrect validation logic for the `constructor` property.

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -74,6 +74,14 @@ describe('E2E', () => {
       const result = getCommandOutput(args, {}, { testPath });
       await expect(cleanupOutput(result)).toMatchFileSnapshot(join(testPath, 'snapshot_2.txt'));
     });
+
+    test('lint file with constructor property in schema', async () => {
+      const testPath = join(__dirname, 'fixtures/constructor-property');
+      const args = getParams(indexEntryPoint, ['lint', 'openapi.yaml']);
+
+      const result = getCommandOutput(args, {}, { testPath });
+      await expect(cleanupOutput(result)).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
+    });
   });
 
   describe('zero-config', () => {

--- a/__tests__/fixtures/constructor-property/openapi.yaml
+++ b/__tests__/fixtures/constructor-property/openapi.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+servers: 
+  - url: http://test.com:3000
+info:
+  title: Test API - Constructor Property
+  version: 1.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+components:
+  schemas:
+    SchemaWithConstructor:
+      type: object
+      properties:
+        id:
+          type: string
+        constructor:  # This is the property we are testing
+          type: object
+          description: "A property named constructor"
+          properties:
+            foo:
+              type: string
+paths:
+  /test:
+    get:
+      summary: Test endpoint
+      security: []
+      operationId: test
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaWithConstructor' 
+        '400':
+          description: Bad Request

--- a/__tests__/fixtures/constructor-property/openapi.yaml
+++ b/__tests__/fixtures/constructor-property/openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.0
-servers: 
+servers:
   - url: http://test.com:3000
 info:
   title: Test API - Constructor Property
@@ -14,9 +14,9 @@ components:
       properties:
         id:
           type: string
-        constructor:  # This is the property we are testing
+        constructor: # This is the property we are testing
           type: object
-          description: "A property named constructor"
+          description: 'A property named constructor'
           properties:
             foo:
               type: string
@@ -32,6 +32,6 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SchemaWithConstructor' 
+                $ref: '#/components/schemas/SchemaWithConstructor'
         '400':
           description: Bad Request

--- a/__tests__/fixtures/constructor-property/snapshot.txt
+++ b/__tests__/fixtures/constructor-property/snapshot.txt
@@ -1,0 +1,8 @@
+
+No configurations were provided -- using built in recommended configuration by default.
+
+validating openapi.yaml...
+openapi.yaml: validated in <test>ms
+
+Woohoo! Your API description is valid. 🎉
+

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -10,7 +10,7 @@ import {
   isExternalValue,
 } from './ref-utils.js';
 import { isNamedType, SpecExtension } from './types/index.js';
-import { readFileFromUrl, parseYaml, nextTick } from './utils.js';
+import { readFileFromUrl, parseYaml, nextTick, getOwn } from './utils.js';
 
 import type { YAMLNode, LoadOptions } from 'yaml-ast-parser';
 import type { NormalizedNodeType } from './types/index.js';
@@ -299,7 +299,7 @@ export async function resolveDocument(opts: {
 
       for (const propName of Object.keys(node)) {
         let propValue = node[propName];
-        let propType = type.properties[propName];
+        let propType = getOwn(type.properties, propName);
         if (propType === undefined) propType = type.additionalProperties;
         if (typeof propType === 'function') propType = propType(propValue, propName);
         if (propType === undefined) propType = unknownType;

--- a/packages/core/src/rules/common/no-required-schema-properties-undefined.ts
+++ b/packages/core/src/rules/common/no-required-schema-properties-undefined.ts
@@ -1,4 +1,5 @@
 import { isRef } from '../../ref-utils.js';
+import { getOwn } from '../../utils.js';
 
 import type { Oas2Rule, Oas3Rule } from '../../visitors.js';
 import type { Oas3Schema, Oas3_1Schema } from '../../typings/openapi.js';
@@ -41,7 +42,7 @@ export const NoRequiredSchemaPropertiesUndefined: Oas3Rule | Oas2Rule = () => {
         const allProperties = elevateProperties(schema);
 
         for (const [i, requiredProperty] of schema.required.entries()) {
-          if (!allProperties || allProperties[requiredProperty] === undefined) {
+          if (!allProperties || getOwn(allProperties, requiredProperty) === undefined) {
             report({
               message: `Required property '${requiredProperty}' is undefined.`,
               location: location.child(['required', i]),

--- a/packages/core/src/rules/common/scalar-property-missing-example.ts
+++ b/packages/core/src/rules/common/scalar-property-missing-example.ts
@@ -1,4 +1,5 @@
 import { SpecVersion } from '../../oas-types.js';
+import { getOwn } from '../../utils.js';
 
 import type { Oas2Rule, Oas3Rule } from '../../visitors.js';
 import type { UserContext } from '../../walk.js';
@@ -14,7 +15,7 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
       { report, location, oasVersion, resolve }: UserContext
     ) {
       for (const propName of Object.keys(properties)) {
-        const propSchema = resolve(properties[propName]).node;
+        const propSchema = resolve(getOwn(properties, propName)).node;
 
         if (!propSchema || !isScalarSchema(propSchema)) {
           continue;

--- a/packages/core/src/rules/common/struct.ts
+++ b/packages/core/src/rules/common/struct.ts
@@ -1,7 +1,7 @@
 import { isNamedType, SpecExtension } from '../../types/index.js';
 import { oasTypeOf, matchesJsonSchemaType, getSuggest, validateSchemaEnumType } from '../utils.js';
 import { isRef } from '../../ref-utils.js';
-import { isPlainObject } from '../../utils.js';
+import { getOwn, isPlainObject } from '../../utils.js';
 
 import type { UserContext } from '../../walk.js';
 import type {
@@ -102,7 +102,7 @@ export const Struct:
         const propLocation = location.child([propName]);
         let propValue = node[propName];
 
-        let propType = type.properties[propName];
+        let propType = getOwn(type.properties, propName);
         if (propType === undefined) propType = type.additionalProperties;
         if (typeof propType === 'function') propType = propType(propValue, propName);
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -47,7 +47,7 @@ type NormalizedResolveTypeFn = (value: any, key: string) => NormalizedPropType;
 export function listOf(typeName: string) {
   return {
     name: `${typeName}List`,
-    properties: Object.create(null),
+    properties: {},
     items: typeName,
   };
 }
@@ -55,14 +55,14 @@ export function listOf(typeName: string) {
 export function mapOf(typeName: string) {
   return {
     name: `${typeName}Map`,
-    properties: Object.create(null),
+    properties: {},
     additionalProperties: () => typeName,
   };
 }
 
 export const SpecExtension: NormalizedNodeType = {
   name: 'SpecExtension',
-  properties: Object.create(null),
+  properties: {},
   // skip validation of additional properties for unknown extensions
   additionalProperties: { resolvable: true },
 };
@@ -98,9 +98,7 @@ export function normalizeTypes(
     }
 
     if (type.properties) {
-      // make sure to create a object without prototype so we don't need to check for hasOwnProperty
-      // see https://github.com/Redocly/redocly-cli/issues/2104
-      const mappedProps: Record<string, any> = Object.create(null);
+      const mappedProps: Record<string, any> = {};
       for (const [propName, prop] of Object.entries(type.properties)) {
         mappedProps[propName] = resolveType(prop);
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -47,7 +47,7 @@ type NormalizedResolveTypeFn = (value: any, key: string) => NormalizedPropType;
 export function listOf(typeName: string) {
   return {
     name: `${typeName}List`,
-    properties: {},
+    properties: Object.create(null),
     items: typeName,
   };
 }
@@ -55,14 +55,14 @@ export function listOf(typeName: string) {
 export function mapOf(typeName: string) {
   return {
     name: `${typeName}Map`,
-    properties: {},
+    properties: Object.create(null),
     additionalProperties: () => typeName,
   };
 }
 
 export const SpecExtension: NormalizedNodeType = {
   name: 'SpecExtension',
-  properties: {},
+  properties: Object.create(null),
   // skip validation of additional properties for unknown extensions
   additionalProperties: { resolvable: true },
 };
@@ -98,7 +98,9 @@ export function normalizeTypes(
     }
 
     if (type.properties) {
-      const mappedProps: Record<string, any> = {};
+      // make sure to create a object without prototype so we don't need to check for hasOwnProperty
+      // see https://github.com/Redocly/redocly-cli/issues/2104
+      const mappedProps: Record<string, any> = Object.create(null);
       for (const [propName, prop] of Object.entries(type.properties)) {
         mappedProps[propName] = resolveType(prop);
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -296,6 +296,10 @@ export function dequal(foo: any, bar: any): boolean {
   return foo !== foo && bar !== bar;
 }
 
+export function getOwn(obj: Record<string, any>, key: string) {
+  return obj.hasOwnProperty(key) ? obj[key] : undefined;
+}
+
 export type CollectFn = (value: unknown) => void;
 
 export type StrictObject<T extends object> = T & { [key: string]: undefined };

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -1,5 +1,5 @@
 import { Location, isRef } from './ref-utils.js';
-import { pushStack, popStack } from './utils.js';
+import { pushStack, popStack, getOwn } from './utils.js';
 import { YamlParseError, makeRefId } from './resolve.js';
 import { isNamedType, SpecExtension } from './types/index.js';
 
@@ -308,7 +308,7 @@ export function walkDocument<T extends BaseVisitor>(opts: {
               loc = location; // properties on the same level as $ref should resolve against original location, not target
             }
 
-            let propType = type.properties[propName];
+            let propType = getOwn(type.properties, propName);
             if (propType === undefined) propType = type.additionalProperties;
             if (typeof propType === 'function') propType = propType(value, propName);
 


### PR DESCRIPTION
## What/Why/How?

Because we used regular objects we mistakenly were getting `constructor` property validated incorrectly.

## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/2104

## Testing
Added e2e.


## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
