### PR TITLE
chore: fix the lint-staged setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "**/*.{ts,js,yaml,yml,json,md}": [
       "prettier --write"
     ],
-    "packages/**/*": [
+    "packages/**/*.ts": [
       "eslint --fix"
     ]
   }


### PR DESCRIPTION
## What/Why/How?

Apply ESLint only to `.ts` files.

## Reference


Fixes https://github.com/Redocly/redocly-cli/actions/runs/15565514469/job/43828500912


## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
