### PR TITLE
fix: improve join command servers handling

### DIFF
--- a/.changeset/young-fishes-sing.md
+++ b/.changeset/young-fishes-sing.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Improved join command server handling for specifications with differing servers.

--- a/__tests__/join/with-metadata/snapshot.txt
+++ b/__tests__/join/with-metadata/snapshot.txt
@@ -10,9 +10,6 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-servers:
-  - url: http://redocly-example.com:8081
-  - url: http://redocly-example.com:8080
 tags:
   - name: user
     x-displayName: user
@@ -20,6 +17,12 @@ tags:
     x-displayName: pet
 paths:
   /GETUser/{userId}:
+    servers:
+      - url: /test
+      - url: /pets
+        description: another description
+      - url: /pet
+        description: some description
     summary: getUser
     description: getUser
     parameters:
@@ -29,12 +32,6 @@ paths:
         in: header
         schema:
           description: string
-    servers:
-      - url: /test
-      - url: /pets
-        description: another description
-      - url: /pet
-        description: some description
     post:
       tags:
         - user

--- a/packages/cli/src/__tests__/fixtures/join/documents.ts
+++ b/packages/cli/src/__tests__/fixtures/join/documents.ts
@@ -122,3 +122,43 @@ export const thirdDocument = {
     },
   },
 };
+
+export const serverAndPaths = {
+  openapi: '3.0.0',
+  info: {
+    title: 'First API',
+    version: '1.0.0',
+  },
+  servers: [
+    {
+      url: 'https://foo.com/api/v1/first',
+    },
+  ],
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'Get Foo',
+      },
+    },
+  },
+};
+
+export const anotherServerAndPaths = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Second API',
+    version: '1.0.0',
+  },
+  servers: [
+    {
+      url: 'https://foo.com/api/v1/second',
+    },
+  ],
+  paths: {
+    '/bar': {
+      get: {
+        summary: 'Get Bar',
+      },
+    },
+  },
+};

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -169,6 +169,19 @@ export async function handleJoin({
     }
   }
 
+  const firstDocServers = documents[0]?.parsed.servers;
+  const serversAreTheSame =
+    firstDocServers &&
+    documents.slice(1).every((doc) => {
+      // include only documents with paths
+      if (Object.keys(doc.parsed.paths || {}).length === 0) {
+        return true;
+      }
+      return doc.parsed.servers?.every((server: Oas3Server) =>
+        firstDocServers?.find((firstDocServer: Oas3Server) => firstDocServer.url === server.url)
+      );
+    });
+
   const joinedDef: any = {};
   const potentialConflicts = {
     tags: {},
@@ -178,6 +191,10 @@ export async function handleJoin({
   };
 
   addInfoSectionAndSpecVersion(documents, prefixComponentsWithInfoProp);
+
+  if (serversAreTheSame && firstDocServers) {
+    joinedDef.servers = firstDocServers;
+  }
 
   for (const document of documents) {
     const openapi = document.parsed;
@@ -205,9 +222,8 @@ export async function handleJoin({
     if (tags) {
       populateTags(context);
     }
-    collectServers(openapi);
     collectExternalDocs(openapi, context);
-    collectPaths(openapi, context);
+    collectPaths(openapi, context, serversAreTheSame);
     collectComponents(openapi, context);
     collectWebhooks(oasVersion!, openapi, context);
     if (componentsPrefix) {
@@ -319,20 +335,6 @@ export async function handleJoin({
     }
   }
 
-  function collectServers(openapi: Oas3Definition | Oas3_1Definition) {
-    const { servers } = openapi;
-    if (servers) {
-      if (!joinedDef.hasOwnProperty('servers')) {
-        joinedDef['servers'] = [];
-      }
-      for (const server of servers) {
-        if (!joinedDef.servers.some((s: any) => s.url === server.url)) {
-          joinedDef.servers.push(server);
-        }
-      }
-    }
-  }
-
   function collectExternalDocs(
     openapi: Oas3Definition | Oas3_1Definition,
     { api }: JoinDocumentContext
@@ -356,9 +358,10 @@ export async function handleJoin({
       potentialConflicts,
       tagsPrefix,
       componentsPrefix,
-    }: JoinDocumentContext
+    }: JoinDocumentContext,
+    serversAreTheSame: boolean
   ) {
-    const { paths } = openapi;
+    const { paths, servers: rootServers } = openapi;
     const operationsSet = new Set(keysOf<typeof OPENAPI3_METHOD>(OPENAPI3_METHOD));
     if (paths) {
       if (!joinedDef.hasOwnProperty('paths')) {
@@ -374,13 +377,17 @@ export async function handleJoin({
         }
 
         const pathItem = paths[path] as Oas3PathItem;
+        const servers = serversAreTheSame ? pathItem.servers : pathItem.servers || rootServers;
+        if (servers) {
+          collectPathServers(servers, path);
+        }
 
         for (const field of keysOf(pathItem)) {
           if (operationsSet.has(field as OPENAPI3_METHOD)) {
             collectPathOperation(pathItem, path, field as OPENAPI3_METHOD);
           }
           if (field === 'servers') {
-            collectPathServers(pathItem, path);
+            // already processed
           }
           if (field === 'parameters') {
             collectPathParameters(pathItem, path);
@@ -408,8 +415,8 @@ export async function handleJoin({
       joinedDef.paths[path][field] = fieldValue;
     }
 
-    function collectPathServers(pathItem: Oas3PathItem, path: string | number) {
-      if (!pathItem.servers) {
+    function collectPathServers(servers: Oas3Server[], path: string | number) {
+      if (!servers) {
         return;
       }
 
@@ -417,7 +424,7 @@ export async function handleJoin({
         joinedDef.paths[path].servers = [];
       }
 
-      for (const server of pathItem.servers) {
+      for (const server of servers) {
         let isFoundServer = false;
         for (const pathServer of joinedDef.paths[path].servers) {
           if (pathServer.url === server.url) {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,6 +5,6 @@
     "outDir": "lib"
   },
   "references": [{ "path": "../core" }, { "path": "../respect-core" }],
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/__tests__/fixtures/join/documents.ts1"],
   "exclude": ["lib", "**/__tests__", "**/*.test.ts"]
 }


### PR DESCRIPTION
## What/Why/How?
This pull request resolves an issue with the join command where it would incorrectly merge OpenAPI documents with different servers configurations, leading to a semantically invalid result.

The updated logic now handles server merging based on whether the input files share the same server definitions.

## Reference
Resolves https://github.com/Redocly/redocly-cli/issues/2118

## Testing

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
