### PR TITLE
fix: fix no-undefined-server-variable crashing on null in server list

### DIFF
--- a/.changeset/good-vans-sell.md
+++ b/.changeset/good-vans-sell.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed `no-undefined-server-variable` crash when encountering `null` values in the server list.

--- a/packages/core/src/rules/oas3/__tests__/no-undefined-server-variables.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-undefined-server-variables.test.ts
@@ -1,0 +1,26 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint.js';
+import { parseYamlToDocument, replaceSourceWithRef } from '../../../../__tests__/utils.js';
+import { BaseResolver } from '../../../resolve.js';
+import { createConfig } from '../../../config/index.js';
+
+describe('Oas3 no-undefined-server-variable', () => {
+  it('should not crash on null server', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.0.0
+          servers:
+            - null
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-undefined-server-variable': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/rules/oas3/no-undefined-server-variable.ts
+++ b/packages/core/src/rules/oas3/no-undefined-server-variable.ts
@@ -3,7 +3,7 @@ import type { Oas3Rule } from '../../visitors.js';
 export const NoUndefinedServerVariable: Oas3Rule = () => {
   return {
     Server(server, { report, location }) {
-      if (!server.url) return;
+      if (!server?.url) return;
       const urlVariables = server.url.match(/{[^}]+}/g)?.map((e) => e.slice(1, e.length - 1)) || [];
       const definedVariables = (server?.variables && Object.keys(server.variables)) || [];
 


### PR DESCRIPTION
## What/Why/How?

MERGE AFTER THIS: https://github.com/Redocly/redocly-cli/pull/2131

I noticed this rule crashes when the server list has null in it.
It happens when you are writing the yaml file from scratch and here the value is parsed as null:

```ayml
openapi: 3.1.0
servers:
  -
  # ^------------ cursor here, this is parsed as null
```

## Reference

Noticed while working with language server.

## Testing

Covered with unit test.

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [x] All new/updated code is covered with tests
- [x] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
