### PR TITLE
docs: update per-API settings for CLI v2

### DIFF
--- a/docs/@v2/configuration/api.yaml
+++ b/docs/@v2/configuration/api.yaml
@@ -105,10 +105,10 @@ additionalProperties:
     extends:
       type: array
       description: >-
-        Inherit configurations.
-        In case of conflict, priority goes to configurations further down the list.
-        Finally, explicit declarations inline takes precedence over configurations inherited through the `extends` feature.
-        Built in configurations include `recommended` and `minimal`.
+        Inherits configurations.
+        In case of conflicts, priority goes to configurations further down the list.
+        Explicit inline declarations take precedence over configurations inherited through the `extends` feature.
+        Built-in configurations include `recommended` and `minimal`.
       items:
         type: string
         example: recommended

--- a/docs/@v2/configuration/api.yaml
+++ b/docs/@v2/configuration/api.yaml
@@ -4,15 +4,13 @@ description: >-
   Lets you configure one or more API description files.
   This gives you the flexibility to reference specific files in commands, and configure each file at a granular level.
 additionalProperties:
-  x-additionalPropertiesName: '{name}@{version}'
+  x-additionalPropertiesName: '{name}'
   type: object
   title: API object
-  minItems: 1
   required:
     - root
   description: >-
-    Specifies the name and version of an API associated with the root API description with the pattern `{name}@{version}`.
-    If the version is omitted, Redocly apps interpret it as 'latest' by default.
+    Specifies the name of an API associated with the root API description.
   properties:
     root:
       type: string
@@ -104,18 +102,25 @@ additionalProperties:
                   - off
                 description: The severity level if the problem occurs.
             additionalProperties: true
-    theme:
+    extends:
+      type: array
+      description: >-
+        Inherit configurations.
+        In case of conflict, priority goes to configurations further down the list.
+        Finally, explicit declarations inline takes precedence over configurations inherited through the `extends` feature.
+        Built in configurations include `recommended` and `minimal`.
+      items:
+        type: string
+        example: recommended
+    openapi:
       type: object
-      properties:
-        openapi:
-          type: object
-          description: >-
-            Defines theming and functionality for an API description.
-            Supports the same format and options as the [root `openapi` object](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
-            API-level configuration always overrides the root configuration.
-        mockServer:
-          type: object
-          description: >-
-            Defines mock server behavior for an API description.
-            Supports the same format and options as the root `mockServer` object.
-            API-level configuration always overrides the root configuration.
+      description: >-
+        Defines theming and functionality for an API description.
+        Supports the same format and options as the [root `openapi` object](https://redocly.com/docs/api-reference-docs/configuration/functionality/).
+        API-level configuration always overrides the root configuration.
+    mockServer:
+      type: object
+      description: >-
+        Defines mock server behavior for an API description.
+        Supports the same format and options as the root `mockServer` object.
+        API-level configuration always overrides the root configuration.

--- a/docs/@v2/configuration/apis.md
+++ b/docs/@v2/configuration/apis.md
@@ -1,6 +1,6 @@
 # Per-API configuration
 
-The `apis` object is used to configure one or more APIs differently from the main configuration.
+Use the `apis` object to configure one or more APIs separately from the main configuration.
 Every API in the object is identified by its unique name.
 
 For every API listed in the object, you must provide the path to the OpenAPI description using the `root` property.

--- a/docs/@v2/configuration/apis.md
+++ b/docs/@v2/configuration/apis.md
@@ -1,9 +1,7 @@
 # Per-API configuration
 
-The `apis` object is used to configure one or more APIs.
-Every API in the object is identified by its name and version in the format `name@version`.
-The version is optional, and when not provided, Redocly apps interpret it as `latest` by default.
-Every `name@version` combination listed in the object must be unique.
+The `apis` object is used to configure one or more APIs differently from the main configuration.
+Every API in the object is identified by its unique name.
 
 For every API listed in the object, you must provide the path to the OpenAPI description using the `root` property.
 
@@ -13,7 +11,7 @@ If the same `rules`, `decorators`, or `preprocessors` are defined on `apis` and 
 
 For example, if you include the same `decorator` at the root level and for a specific API, but with different properties, the API-level settings replace the root ones.
 
-So if you have the following `redocly.yaml` configuration, adding `filter-in` and `plugin/change-title` at the root level and applying `plugin/change-title` with a different `title` property to the `storefront@latest` API:
+So if you have the following `redocly.yaml` configuration, adding `filter-in` and `plugin/change-title` at the root level and applying `plugin/change-title` with a different `title` property to the `storefront` API:
 
 ```yaml
 decorators:
@@ -27,15 +25,15 @@ decorators:
 
 
 apis:
-  storefront@latest:
+  storefront:
     decorators:
       plugin/change-title:
         title: Storefront APIs
 ```
 
-The `plugin/change-title` decorator with the "Storefront APIs" `title` property is applied to the `storefront@latest` API with the value `Storefront APIs`, and the `filter-in` decorator is also applied to the `storefront@latest` API.
+The `plugin/change-title` decorator with the "Storefront APIs" `title` property is applied to the `storefront` API with the value `Storefront APIs`, and the `filter-in` decorator is also applied to the `storefront` API.
 
-For all other APIs, not including the `storefront@latest` API, `filter-in` and `plugin/change-title` with the "Core" `title` and `extraProperty` properties are applied.
+For all other APIs, not including the `storefront` API, `filter-in` and `plugin/change-title` with the "Core" `title` and `extraProperty` properties are applied.
 
 ## Patterned properties
 
@@ -49,7 +47,7 @@ For all other APIs, not including the `storefront@latest` API, `filter-in` and `
 
 ```yaml
 apis:
-  name@version:
+  name:
     root: ./openapi/openapi.yaml
     openapi: {}
     output: ./openapi/bundled.yaml

--- a/docs/@v2/configuration/index.md
+++ b/docs/@v2/configuration/index.md
@@ -33,17 +33,15 @@ apis:
       no-ambiguous-paths: error
   external@v1:
     root: ./openapi/external.yaml
-    theme:
-      openapi:
-        hideLogo: true
+    openapi:
+      hideLogo: true
 
-theme:
-  openapi:
-    schemaExpansionLevel: 2
-    generateCodeSamples:
-      languages:
-        - lang: curl
-        - lang: Python
+openapi:
+  schemaExpansionLevel: 2
+  generateCodeSamples:
+    languages:
+      - lang: curl
+      - lang: Python
 ```
 
 Read on to learn more about the various configuration sections and what you can do with each one.
@@ -232,12 +230,10 @@ Splitting a config file is possible by using references in a config similar to h
 ```yaml
 extends:
   - recommended
-
-theme:
-  openapi:
-    $ref: ./openapi-theme.yaml
-  mockServer:
-    $ref: ./mockserver.yaml
+openapi:
+  $ref: ./openapi-theme.yaml
+mockServer:
+  $ref: ./mockserver.yaml
 ```
 
 {% admonition type="info" %}

--- a/docs/@v2/guides/migrate-from-redoc-cli.md
+++ b/docs/@v2/guides/migrate-from-redoc-cli.md
@@ -63,7 +63,9 @@ redocly build-docs --theme.openapi.theme.sidebar.width='300px' openapi.yaml
 
 Configuration belongs in a file named `redocly.yaml`, or in a file name specified with the `--config` command-line parameter. You can read more about the [configuration file structure](../configuration/index.md) in the documentation, and changes between this and older versions are listed here.
 
-Options named `features.openapi.*` should be re-named to `openapi.*`, either at the top level of the configuration, or per API. So a configuration file to change one of the colours to a rather lurid purple would look something like the example below:
+Re-name options that begin with `features.openapi.*` to `openapi.*`.
+Do this either at the top level of the configuration, or per API.
+A configuration file to change one of the colours to a rather lurid purple would look something like the following example:
 
 ```yaml
 openapi:

--- a/docs/@v2/guides/migrate-from-redoc-cli.md
+++ b/docs/@v2/guides/migrate-from-redoc-cli.md
@@ -63,15 +63,14 @@ redocly build-docs --theme.openapi.theme.sidebar.width='300px' openapi.yaml
 
 Configuration belongs in a file named `redocly.yaml`, or in a file name specified with the `--config` command-line parameter. You can read more about the [configuration file structure](../configuration/index.md) in the documentation, and changes between this and older versions are listed here.
 
-Options named `features.openapi.*` should be re-prefixed to `theme.openapi.*`, either at the top level of the configuration, or per API. So a configuration file to change one of the colours to a rather lurid purple would look something like the example below:
+Options named `features.openapi.*` should be re-named to `openapi.*`, either at the top level of the configuration, or per API. So a configuration file to change one of the colours to a rather lurid purple would look something like the example below:
 
 ```yaml
-theme:
-  openapi:
-    theme:
-      colors:
-        primary:
-          main: '#ff00ff'
+openapi:
+  theme:
+    colors:
+      primary:
+        main: '#ff00ff'
 ```
 
 Define the base customization; older versions of the tools defaulted to using `recommended`, but this is no longer assumed. Set it in `redocly.yaml` like this:


### PR DESCRIPTION
## What/Why/How?

- Removed assuming `@latest` version in the `apis` section
- Removed `theme` section
- Added `extends` section in the `apis` config

## Reference

Resolves https://github.com/Redocly/redocly-cli/issues/1660
 
## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
