### PR TITLE
fix(project): cli consider residency setting from Redocly config file

### DIFF
--- a/.changeset/smart-bees-deny.md
+++ b/.changeset/smart-bees-deny.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed Redocly CLI to correctly read `residency` from the Redocly configuration file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13422,7 +13422,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.26.1",
+        "@redocly/config": "^0.26.2",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
@@ -16001,7 +16001,7 @@
       "version": "file:packages/core",
       "requires": {
         "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.26.1",
+        "@redocly/config": "^0.26.2",
         "@types/js-levenshtein": "^1.1.0",
         "@types/js-yaml": "^4.0.3",
         "@types/minimatch": "^5.1.2",

--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -43,9 +43,13 @@ describe('commandWrapper', () => {
     expect(handleLint).toHaveBeenCalledTimes(1);
     expect(sendTelemetry).toHaveBeenCalledTimes(1);
     expect(sendTelemetry).toHaveBeenCalledWith({
+      config: {
+        resolvedConfig: {
+          telemetry: 'on',
+        },
+      },
       argv: {},
       exit_code: 0,
-      has_config: false,
       spec_version: 'oas3_1',
       spec_keyword: 'openapi',
       spec_full_version: '3.1.0',
@@ -67,9 +71,13 @@ describe('commandWrapper', () => {
     expect(handleLint).toHaveBeenCalledTimes(1);
     expect(sendTelemetry).toHaveBeenCalledTimes(1);
     expect(sendTelemetry).toHaveBeenCalledWith({
+      config: {
+        resolvedConfig: {
+          telemetry: 'on',
+        },
+      },
       argv: {},
       exit_code: 0,
-      has_config: false,
       spec_version: undefined,
       spec_keyword: undefined,
       spec_full_version: undefined,

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -10,14 +10,14 @@ export type LoginOptions = {
   config?: string;
 };
 
-export async function handleLogin({ argv, version }: CommandArgs<LoginOptions>) {
+export async function handleLogin({ argv, version, config }: CommandArgs<LoginOptions>) {
+  const residency = argv.residency || config.rawConfig.residency;
+  const reuniteUrl = getReuniteUrl(residency);
   try {
-    const reuniteUrl = getReuniteUrl(argv.residency);
     const oauthClient = new RedoclyOAuthClient('redocly-cli', version);
     await oauthClient.login(reuniteUrl);
   } catch {
     if (argv.residency) {
-      const reuniteUrl = getReuniteUrl(argv.residency);
       exitWithError(`❌ Connection to ${reuniteUrl} failed.`);
     } else {
       exitWithError(`❌ Login failed. Please check your credentials and try again.`);

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -11,7 +11,7 @@ export type LoginOptions = {
 };
 
 export async function handleLogin({ argv, version, config }: CommandArgs<LoginOptions>) {
-  const residency = argv.residency || config.rawConfig.residency;
+  const residency = argv.residency || config?.rawConfig?.residency;
   const reuniteUrl = getReuniteUrl(residency);
   try {
     const oauthClient = new RedoclyOAuthClient('redocly-cli', version);

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -6,7 +6,7 @@ import { version } from './package.js';
 import { getReuniteUrl } from '../reunite/api/index.js';
 
 import type { ExitCode } from './miscellaneous.js';
-import type { ArazzoDefinition } from '@redocly/openapi-core';
+import type { ArazzoDefinition, Config } from '@redocly/openapi-core';
 import type { ExtendedSecurity } from 'respect-core/src/types.js';
 import type { Arguments } from 'yargs';
 import type { CommandOptions } from '../types.js';
@@ -34,19 +34,17 @@ export type Analytics = {
 };
 
 export async function sendTelemetry({
-  residency,
+  config,
   argv,
   exit_code,
-  has_config,
   spec_version,
   spec_keyword,
   spec_full_version,
   respect_x_security_auth_types,
 }: {
-  residency: string | undefined;
+  config: Config | undefined;
   argv: Arguments | undefined;
   exit_code: ExitCode;
-  has_config: boolean | undefined;
   spec_version: string | undefined;
   spec_keyword: string | undefined;
   spec_full_version: string | undefined;
@@ -62,6 +60,8 @@ export async function sendTelemetry({
       ...args
     } = argv;
     const event_time = new Date().toISOString();
+    const residency = (argv.residency as string) || config?.rawConfig?.residency;
+    const has_config = !!config?.rawConfig;
     const { RedoclyOAuthClient } = await import('../auth/oauth-client.js');
     const oauthClient = new RedoclyOAuthClient('redocly-cli', version);
     const reuniteUrl = getReuniteUrl(residency);

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -61,7 +61,6 @@ export async function sendTelemetry({
     } = argv;
     const event_time = new Date().toISOString();
     const residency = (argv.residency as string) || config?.rawConfig?.residency;
-    const has_config = !!config?.rawConfig;
     const { RedoclyOAuthClient } = await import('../auth/oauth-client.js');
     const oauthClient = new RedoclyOAuthClient('redocly-cli', version);
     const reuniteUrl = getReuniteUrl(residency);
@@ -80,7 +79,7 @@ export async function sendTelemetry({
       environment: process.env.REDOCLY_ENVIRONMENT,
       metadata: process.env.REDOCLY_CLI_TELEMETRY_METADATA,
       environment_ci: process.env.CI,
-      has_config: has_config ? 'yes' : 'no',
+      has_config: typeof config?.rawConfig === 'undefined' ? 'no' : 'yes',
       spec_version,
       spec_keyword,
       spec_full_version,

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -34,6 +34,7 @@ export type Analytics = {
 };
 
 export async function sendTelemetry({
+  residency,
   argv,
   exit_code,
   has_config,
@@ -42,6 +43,7 @@ export async function sendTelemetry({
   spec_full_version,
   respect_x_security_auth_types,
 }: {
+  residency: string | undefined;
   argv: Arguments | undefined;
   exit_code: ExitCode;
   has_config: boolean | undefined;
@@ -62,7 +64,7 @@ export async function sendTelemetry({
     const event_time = new Date().toISOString();
     const { RedoclyOAuthClient } = await import('../auth/oauth-client.js');
     const oauthClient = new RedoclyOAuthClient('redocly-cli', version);
-    const reuniteUrl = getReuniteUrl(argv.residency as string | undefined);
+    const reuniteUrl = getReuniteUrl(residency);
     const logged_in = await oauthClient.isAuthorized(reuniteUrl);
     const data: Analytics = {
       event: 'cli_command',

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -32,6 +32,7 @@ export function commandWrapper<T extends CommandOptions>(
     let specVersion: string | undefined;
     let specKeyword: string | undefined;
     let specFullVersion: string | undefined;
+    let config: Config | undefined;
     const respectXSecurityAuthTypes: string[] = [];
     const collectSpecData: CollectFn = (document) => {
       specVersion = detectSpec(document);
@@ -60,7 +61,7 @@ export function commandWrapper<T extends CommandOptions>(
       if (argv.config && !doesYamlFileExist(argv.config)) {
         exitWithError('Please provide a valid path to the configuration file.');
       }
-      const config: Config = await loadConfigAndHandleErrors(argv as Exact<T>, version);
+      config = await loadConfigAndHandleErrors(argv as Exact<T>, version);
       telemetry = config.resolvedConfig.telemetry;
       hasConfig = !!config.rawConfig;
       code = 1;
@@ -82,7 +83,9 @@ export function commandWrapper<T extends CommandOptions>(
       }
     } finally {
       if (process.env.REDOCLY_TELEMETRY !== 'off' && telemetry !== 'off') {
+        const residency = (argv.residency as string) || config?.rawConfig?.residency;
         await sendTelemetry({
+          residency,
           argv,
           exit_code: code,
           has_config: hasConfig,

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -27,7 +27,6 @@ export function commandWrapper<T extends CommandOptions>(
 ) {
   return async (argv: Arguments<T>) => {
     let code: ExitCode = 2;
-    let hasConfig;
     let telemetry;
     let specVersion: string | undefined;
     let specKeyword: string | undefined;
@@ -63,7 +62,6 @@ export function commandWrapper<T extends CommandOptions>(
       }
       config = await loadConfigAndHandleErrors(argv as Exact<T>, version);
       telemetry = config.resolvedConfig.telemetry;
-      hasConfig = !!config.rawConfig;
       code = 1;
       if (typeof commandHandler === 'function') {
         await commandHandler({ argv, config, version, collectSpecData });
@@ -83,12 +81,10 @@ export function commandWrapper<T extends CommandOptions>(
       }
     } finally {
       if (process.env.REDOCLY_TELEMETRY !== 'off' && telemetry !== 'off') {
-        const residency = (argv.residency as string) || config?.rawConfig?.residency;
         await sendTelemetry({
-          residency,
+          config,
           argv,
           exit_code: code,
-          has_config: hasConfig,
           spec_version: specVersion,
           spec_keyword: specKeyword,
           spec_full_version: specFullVersion,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.11.2",
-    "@redocly/config": "^0.26.1",
+    "@redocly/config": "^0.26.2",
     "colorette": "^1.2.0",
     "js-levenshtein": "^1.1.6",
     "js-yaml": "^4.1.0",

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -219,7 +219,8 @@ export type RawUniversalConfig = Omit<Partial<RedoclyConfig>, 'apis' | 'plugins'
 export type ResolvedConfig = Omit<RawUniversalConfig, 'apis' | 'plugins'> &
   ResolvedGovernanceConfig & {
     apis?: Record<string, ResolvedApiConfig>;
-  };
+    residency?: string;
+};
 
 export type ThemeConfig = {
   theme?: ThemeRawConfig; // TODO: deprecated

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -220,7 +220,7 @@ export type ResolvedConfig = Omit<RawUniversalConfig, 'apis' | 'plugins'> &
   ResolvedGovernanceConfig & {
     apis?: Record<string, ResolvedApiConfig>;
     residency?: string;
-};
+  };
 
 export type ThemeConfig = {
   theme?: ThemeRawConfig; // TODO: deprecated

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -219,7 +219,6 @@ export type RawUniversalConfig = Omit<Partial<RedoclyConfig>, 'apis' | 'plugins'
 export type ResolvedConfig = Omit<RawUniversalConfig, 'apis' | 'plugins'> &
   ResolvedGovernanceConfig & {
     apis?: Record<string, ResolvedApiConfig>;
-    residency?: string;
   };
 
 export type ThemeConfig = {


### PR DESCRIPTION
## What/Why/How?
CLI should consider [residency setting](https://redocly.com/docs/realm/config/residency) from redocly.yaml during login and token verification process.

## Reference
Closes: https://github.com/Redocly/redocly/issues/16251

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [x] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
