### PR TITLE
docs: update migrate-from-redoc-cli.md

### DIFF
--- a/docs/@v2/guides/migrate-from-redoc-cli.md
+++ b/docs/@v2/guides/migrate-from-redoc-cli.md
@@ -51,7 +51,7 @@ In both cases, the child options should work as before.
 
 ### Update command-line configuration
 
-Replace your existing `--options.theme.*` settings with a new prefix: `--theme.options.theme.*`.
+Replace your existing `--options.theme.*` settings with a new prefix: `--theme.openapi.theme.*`.
 
 For example if you used `redoc-cli build --options.theme.sidebar.width='300px' openapi.yaml` then the new command would be:
 


### PR DESCRIPTION
## What/Why/How?
corrects typo in name of new parameter name

Current docs say:
> Replace your existing `--options.theme.*` settings with a new prefix: `--theme.options.theme.*`.

But then the example code right below it shows:

```
redocly build-docs --theme.openapi.theme.sidebar.width='300px' openapi.yaml
```

The CLI help for `redocly build-docs` show the correct parameter format is `--theme.openapi.theme.*` not `--theme.options.theme`

```
      --theme              Redoc theme.openapi configuration. Use dot notation,
                           e.g. theme.openapi.nativeScrollbars
```
 

## Screenshots (optional)
![image](https://github.com/user-attachments/assets/02a10168-31a0-41de-b701-f6e292b144ce)


## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
