### PR TITLE
fix: fixed dotenv version at 16.4.7 to prevent unwanted output

### DIFF
--- a/.changeset/sharp-beds-try.md
+++ b/.changeset/sharp-beds-try.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Resolved an issue where `dotenv@16.6.0` injected an unintended message into the output.

--- a/docs/@v1/changelog.md
+++ b/docs/@v1/changelog.md
@@ -7,6 +7,13 @@ toc:
 
 <!-- do-not-remove -->
 
+## 1.34.4 (2025-06-27)
+
+### Patch Changes
+
+- Resolved an issue where `dotenv@16.6.0` injected an unintended message into the output.
+- Updated @redocly/respect-core to v1.34.4.
+
 ## 1.34.3 (2025-04-22)
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -13298,7 +13298,7 @@
         "abort-controller": "^3.0.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "form-data": "^4.0.0",
         "glob": "^11.0.1",
         "handlebars": "^4.7.6",
@@ -13455,7 +13455,7 @@
         "colorette": "^2.0.20",
         "concat-stream": "^2.0.0",
         "cookie": "^0.7.2",
-        "dotenv": "16.4.5",
+        "dotenv": "16.4.7",
         "form-data": "4.0.0",
         "jest-diff": "^29.3.1",
         "jest-matcher-utils": "^29.3.1",
@@ -13508,18 +13508,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "packages/respect-core/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "packages/respect-core/node_modules/jest-diff": {
@@ -15924,7 +15912,7 @@
         "abort-controller": "^3.0.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "form-data": "^4.0.0",
         "glob": "^11.0.1",
         "handlebars": "^4.7.6",
@@ -16032,7 +16020,7 @@
         "colorette": "^2.0.20",
         "concat-stream": "^2.0.0",
         "cookie": "^0.7.2",
-        "dotenv": "16.4.5",
+        "dotenv": "16.4.7",
         "form-data": "4.0.0",
         "jest-diff": "^29.3.1",
         "jest-matcher-utils": "^29.3.1",
@@ -16062,11 +16050,6 @@
           "version": "29.6.3",
           "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
           "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="
-        },
-        "dotenv": {
-          "version": "16.4.5",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
         },
         "jest-diff": {
           "version": "29.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "abort-controller": "^3.0.0",
     "chokidar": "^3.5.1",
     "colorette": "^1.2.0",
-    "dotenv": "^16.4.7",
+    "dotenv": "16.4.7",
     "form-data": "^4.0.0",
     "glob": "^11.0.1",
     "handlebars": "^4.7.6",

--- a/packages/respect-core/package.json
+++ b/packages/respect-core/package.json
@@ -48,7 +48,7 @@
     "colorette": "^2.0.20",
     "concat-stream": "^2.0.0",
     "cookie": "^0.7.2",
-    "dotenv": "16.4.5",
+    "dotenv": "16.4.7",
     "form-data": "4.0.0",
     "jest-diff": "^29.3.1",
     "jest-matcher-utils": "^29.3.1",


### PR DESCRIPTION
## What/Why/How?

Fixed dotenv at v16.4.7.

## Reference

The same fix for v1: https://github.com/Redocly/redocly-cli/pull/2149

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
