### PR TITLE
chore: fix otel hanging when there is a slow response

### DIFF
--- a/.changeset/rare-peaches-relax.md
+++ b/.changeset/rare-peaches-relax.md
@@ -1,5 +1,0 @@
----
-"@redocly/cli": patch
----
-
-Fixed an issue where Redocly CLI would freeze when there was no Internet connection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13293,7 +13293,6 @@
       "version": "2.0.0-next.2",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
         "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/sdk-trace-node": "2.0.1",
@@ -15901,7 +15900,6 @@
     "@redocly/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
         "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/sdk-trace-node": "2.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "Roman Hotsiy <roman@redocly.com> (https://redocly.com/)"
   ],
   "dependencies": {
-    "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
     "@opentelemetry/resources": "2.0.1",
     "@opentelemetry/sdk-trace-node": "2.0.1",

--- a/packages/cli/src/otel.ts
+++ b/packages/cli/src/otel.ts
@@ -1,6 +1,5 @@
-import { trace } from '@opentelemetry/api';
 import { resourceFromAttributes } from '@opentelemetry/resources';
-import { NodeTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { NodeTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { version } from './utils/package.js';
@@ -15,16 +14,14 @@ type Events = {
 const OTEL_TRACES_URL = process.env.OTEL_TRACES_URL || 'https://otel.cloud.redocly.com/v1/traces';
 
 export class OtelServerTelemetry {
-  provider: NodeTracerProvider | null = null;
-
-  init() {
-    this.provider = new NodeTracerProvider({
+  send<K extends keyof Events>(event: K, data: Events[K]): void {
+    const nodeTracerProvider = new NodeTracerProvider({
       resource: resourceFromAttributes({
         [ATTR_SERVICE_NAME]: `redocly-cli`,
         [ATTR_SERVICE_VERSION]: `@redocly/cli@${version}`,
       }),
       spanProcessors: [
-        new BatchSpanProcessor(
+        new SimpleSpanProcessor(
           new OTLPTraceExporter({
             url: OTEL_TRACES_URL,
             headers: {},
@@ -33,13 +30,11 @@ export class OtelServerTelemetry {
         ),
       ],
     });
-    this.provider.register();
-  }
 
-  async send<K extends keyof Events>(event: K, data: Events[K]): Promise<void> {
     const time = new Date();
     const eventId = crypto.randomUUID();
-    const span = trace.getTracer('CliTelemetry').startSpan(`event.${event}`, {
+    const tracer = nodeTracerProvider.getTracer('CliTelemetry');
+    const span = tracer.startSpan(`event.${event}`, {
       attributes: {
         'cloudevents.event_client.id': eventId,
         'cloudevents.event_client.type': event,
@@ -53,9 +48,6 @@ export class OtelServerTelemetry {
       }
     }
     span.end(time);
-    if (this.provider) {
-      await this.provider.forceFlush(); // waits for all spans to be sent or timeout
-    }
   }
 }
 

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -90,8 +90,7 @@ export async function sendTelemetry({
     };
 
     const { otelTelemetry } = await import('../otel.js');
-    otelTelemetry.init();
-    await otelTelemetry.send(data.command, data);
+    otelTelemetry.send(data.command, data);
   } catch (err) {
     // Do nothing.
   }


### PR DESCRIPTION
## What/Why/How?

~Used BatchSpanProcessor instead of SimpleSpanProcessor so `timeoutMillis` is taken into account and commands exit after `DEFAULT_FETCH_TIMEOUT`.~

Do not register the tracer provider globally and avoid using the global trace API.

## Reference

Resolves https://github.com/Redocly/redocly-cli/issues/2155 

## Testing

Tested locally.

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with redoc (internal)
- [ ] All new/updated code is covered with tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
