### PR TITLE
chore: speed up test by removing slow external call

### DIFF
--- a/packages/core/src/rules/__tests__/spec-ruleset.test.ts
+++ b/packages/core/src/rules/__tests__/spec-ruleset.test.ts
@@ -60,19 +60,6 @@ describe('spec ruleset', () => {
           "suggest": [],
         },
         {
-          "location": [
-            {
-              "pointer": "#/paths/~1pets?id/get/requestBody/content/application~1json/examples/foo/value",
-              "reportOnKey": true,
-              "source": "../../../../../resources/petstore-with-errors.yaml",
-            },
-          ],
-          "message": "Example object can have either \`value\` or \`externalValue\` fields.",
-          "ruleId": "no-example-value-and-externalValue",
-          "severity": "error",
-          "suggest": [],
-        },
-        {
           "from": undefined,
           "location": [
             {

--- a/resources/petstore-with-errors.yaml
+++ b/resources/petstore-with-errors.yaml
@@ -29,12 +29,10 @@ paths:
             example:
               summary: A foo example
               value: { 'foo': 'bar' }
-              externalValue: 'http://example.org/foo.json'
             examples:
               foo:
                 summary: A foo example
                 value: { 'foo': 'bar' }
-                externalValue: 'http://example.org/foo.json'
       tags:
         - pets
       parameters:


### PR DESCRIPTION
## What/Why/How?

One test is slow as example.com responds very slow.



## Check yourself

- [x] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
