### PR TITLE
chore!: remove processRawConfig from loadConfig

### DIFF
--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -20,15 +20,6 @@ vi.mock('node:path', async () => {
 });
 
 describe('loadConfig', () => {
-  it('should call callback if such passed', async () => {
-    const mockFn = vi.fn();
-    await loadConfig({
-      configPath: path.join(__dirname, './fixtures/load-redocly.yaml'),
-      processRawConfig: mockFn,
-    });
-    expect(mockFn).toHaveBeenCalled();
-  });
-
   it('should load config and lint it', async () => {
     const config = await loadConfig({
       configPath: path.join(__dirname, './fixtures/resolve-refs-in-config/config-with-refs.yaml'),
@@ -123,15 +114,11 @@ describe('loadConfig', () => {
 
   it('should bundle config with scorecards', async () => {
     const configPath = path.join(__dirname, './fixtures/load-redocly-with-scorecards.yaml');
-    let parsedConfig: any;
-    await loadConfig({
+    const config = await loadConfig({
       configPath,
-      processRawConfig: (args) => {
-        parsedConfig = args.parsed;
-      },
     });
 
-    expect(parsedConfig.scorecard).toMatchInlineSnapshot(`
+    expect(config.resolvedConfig.scorecard).toMatchInlineSnapshot(`
       {
         "ignoreNonCompliant": true,
         "levels": [

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -1,6 +1,5 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { ConfigValidationError } from './utils.js';
 import { resolveConfig } from './config-resolvers.js';
 import {
   BaseResolver,
@@ -22,17 +21,10 @@ export async function loadConfig(
   options: {
     configPath?: string;
     customExtends?: string[];
-    /** Deprecated */
-    processRawConfig?: RawConfigProcessor;
     externalRefResolver?: BaseResolver;
   } = {}
 ): Promise<Config> {
-  const {
-    configPath = findConfig(),
-    customExtends,
-    processRawConfig,
-    externalRefResolver,
-  } = options;
+  const { configPath = findConfig(), customExtends, externalRefResolver } = options;
 
   const resolver = externalRefResolver ?? new BaseResolver();
 
@@ -57,23 +49,6 @@ export async function loadConfig(
     resolvedRefMap: resolvedRefMap,
     plugins,
   });
-
-  // FIXME: remove processRawConfig
-  if (rawConfigDocument && resolvedRefMap && typeof processRawConfig === 'function') {
-    try {
-      await processRawConfig({
-        document: rawConfigDocument,
-        resolvedRefMap,
-        config,
-        parsed: resolvedConfig,
-      });
-    } catch (e) {
-      if (e instanceof ConfigValidationError) {
-        throw e;
-      }
-      throw new Error(`Error parsing config file at '${configPath}': ${e.message}`);
-    }
-  }
 
   return config;
 }

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -10,13 +10,6 @@ import {
 import { Config } from './config.js';
 import { type RawUniversalConfig } from './types.js';
 
-export type RawConfigProcessor = (params: {
-  document: Document;
-  resolvedRefMap: ResolvedRefMap;
-  config: Config;
-  parsed: Document['parsed'];
-}) => void | Promise<void>;
-
 export async function loadConfig(
   options: {
     configPath?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,7 +62,6 @@ export { type NormalizedNodeType, type NodeType, normalizeTypes } from './types/
 export { Stats } from './rules/other/stats.js';
 
 export {
-  type RawConfigProcessor, // FIXME: remove this
   type RawUniversalConfig,
   type RawUniversalApiConfig,
   type ResolvedConfig,


### PR DESCRIPTION
## What/Why/How?

Removed the deprecated `processRawConfig` from `loadConfig`. 
All the arguments that `processRawConfig` was receiving before, are in the `Config` instance now. 
There should be no user impact (expect for internal usage).

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
