### PR TITLE
chore: fix performance benchmark by adding the installation step

### DIFF
--- a/benchmark/make-test-command.sh
+++ b/benchmark/make-test-command.sh
@@ -4,6 +4,7 @@ set -eo pipefail # Fail on script errors
 
 # Clone the repo with test openapi files:
 git clone https://github.com/Rebilly/api-definitions.git
+cd api-definitions && npm install && cd ..
 
 # Store the command into a text file:
 echo REDOCLY_SUPPRESS_UPDATE_NOTICE=true hyperfine --warmup 3 $(cat package.json | jq '.dependencies' | jq 'keys' | jq 'map("'\''node node_modules/" + . + "/bin/cli.js lint --config=api-definitions/redocly.yaml --generate-ignore-file'\''")' | jq 'join(" ")' | xargs) --export-markdown benchmark_check.md --export-json benchmark_check.json > test-command.txt


### PR DESCRIPTION
## What/Why/How?
Fixed  performance benchmark by adding the installation step in the api-definitions repo.


## Reference

Related fix: https://github.com/Rebilly/api-definitions/pull/1902

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
