### PR TITLE
refactor!: replace enums with types

### DIFF
--- a/.changeset/funny-mayflies-knock.md
+++ b/.changeset/funny-mayflies-knock.md
@@ -2,4 +2,5 @@
 "@redocly/openapi-core": major
 ---
 
-Replaced `SpecVersion` and `SpecMajorVersion` enums with types.
+Replaced the `SpecVersion`, `SpecMajorVersion`, `OPENAPI3_METHOD`, and `OPENAPI3_COMPONENT` enums with types for improved flexibility and type safety.
+Removed the unused `OasVersion` enum.

--- a/.changeset/funny-mayflies-knock.md
+++ b/.changeset/funny-mayflies-knock.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": major
+---
+
+Replaced `SpecVersion` and `SpecMajorVersion` enums with types.

--- a/packages/cli/src/__tests__/commands/join.test.ts
+++ b/packages/cli/src/__tests__/commands/join.test.ts
@@ -4,7 +4,6 @@ import {
   detectSpec,
   getTotals,
   loadConfig,
-  type SpecVersion,
   type Document,
 } from '@redocly/openapi-core';
 import { handleJoin } from '../../commands/join.js';
@@ -83,7 +82,7 @@ describe('handleJoin', () => {
   });
 
   it('should proceed if glob expands to 2 or more APIs', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_1' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_1');
     vi.mocked(getFallbackApisOrExit).mockResolvedValueOnce([
       { path: 'first.yaml' },
       { path: 'second.yaml' },
@@ -132,7 +131,7 @@ describe('handleJoin', () => {
   });
 
   it('should call exitWithError because Only OpenAPI 3.0 and OpenAPI 3.1 are supported', async () => {
-    vi.mocked(detectSpec).mockReturnValueOnce('oas2_0' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValueOnce('oas2');
     await handleJoin({
       argv: {
         apis: ['first.yaml', 'second.yaml'],
@@ -147,8 +146,8 @@ describe('handleJoin', () => {
 
   it('should call exitWithError if mixing OpenAPI 3.0 and 3.1', async () => {
     vi.mocked(detectSpec)
-      .mockImplementationOnce(() => 'oas3_0' as SpecVersion)
-      .mockImplementationOnce(() => 'oas3_1' as SpecVersion);
+      .mockImplementationOnce(() => 'oas3_0')
+      .mockImplementationOnce(() => 'oas3_1');
     await handleJoin({
       argv: {
         apis: ['first.yaml', 'second.yaml'],
@@ -163,7 +162,7 @@ describe('handleJoin', () => {
   });
 
   it('should call writeToFileByExtension function', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_0' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_0');
     await handleJoin({
       argv: {
         apis: ['first.yaml', 'second.yaml'],
@@ -180,7 +179,7 @@ describe('handleJoin', () => {
   });
 
   it('should call writeToFileByExtension function for OpenAPI 3.1', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_1' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_1');
     await handleJoin({
       argv: {
         apis: ['first.yaml', 'second.yaml'],
@@ -197,7 +196,7 @@ describe('handleJoin', () => {
   });
 
   it('should call writeToFileByExtension function with custom output file', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_0' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_0');
     await handleJoin({
       argv: {
         apis: ['first.yaml', 'second.yaml'],
@@ -215,7 +214,7 @@ describe('handleJoin', () => {
   });
 
   it('should call writeToFileByExtension function with json file extension', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_0' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_0');
     await handleJoin({
       argv: {
         apis: ['first.json', 'second.yaml'],
@@ -232,7 +231,7 @@ describe('handleJoin', () => {
   });
 
   it('should call skipDecorators and skipPreprocessors', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_0' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_0');
     await handleJoin({
       argv: {
         apis: ['first.yaml', 'second.yaml'],
@@ -247,7 +246,7 @@ describe('handleJoin', () => {
   });
 
   it('should handle join with prefix-components-with-info-prop and null values', async () => {
-    vi.mocked(detectSpec).mockReturnValue('oas3_0' as SpecVersion);
+    vi.mocked(detectSpec).mockReturnValue('oas3_0');
 
     await handleJoin({
       argv: {

--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -3,7 +3,7 @@ import { loadConfigAndHandleErrors } from '../utils/miscellaneous.js';
 import { sendTelemetry } from '../utils/telemetry.js';
 import { commandWrapper } from '../wrapper.js';
 import { handleLint } from '../commands/lint.js';
-import { type Config, detectSpec, type SpecVersion } from '@redocly/openapi-core';
+import { type Config, detectSpec } from '@redocly/openapi-core';
 
 const originalFetch = global.fetch;
 
@@ -31,7 +31,7 @@ describe('commandWrapper', () => {
       return { resolvedConfig: { telemetry: 'on' } } as Config;
     });
     vi.mocked(detectSpec).mockImplementationOnce(() => {
-      return 'oas3_1' as SpecVersion;
+      return 'oas3_1';
     });
     vi.mocked(handleLint).mockImplementation(async ({ collectSpecData }) => {
       collectSpecData?.({ openapi: '3.1.0' });

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -2,7 +2,6 @@ import * as path from 'node:path';
 import { red, blue, yellow, green } from 'colorette';
 import { performance } from 'node:perf_hooks';
 import {
-  SpecVersion,
   BaseResolver,
   formatProblems,
   getTotals,
@@ -37,6 +36,7 @@ import type {
   Oas3PathItem,
   Oas3Server,
   Oas3Tag,
+  SpecVersion,
 } from '@redocly/openapi-core';
 import type { CommandArgs } from '../wrapper.js';
 import type { VerifyConfigOptions } from '../types.js';
@@ -153,7 +153,7 @@ export async function handleJoin({
     try {
       const version = detectSpec(document.parsed);
       collectSpecData?.(document.parsed);
-      if (version !== SpecVersion.OAS3_0 && version !== SpecVersion.OAS3_1) {
+      if (version !== 'oas3_0' && version !== 'oas3_1') {
         return exitWithError(
           `Only OpenAPI 3.0 and OpenAPI 3.1 are supported: ${blue(document.source.absoluteRef)}.`
         );
@@ -587,7 +587,7 @@ export async function handleJoin({
       componentsPrefix,
     }: JoinDocumentContext
   ) {
-    const webhooks = oasVersion === SpecVersion.OAS3_1 ? 'webhooks' : 'x-webhooks';
+    const webhooks = oasVersion === 'oas3_1' ? 'webhooks' : 'x-webhooks';
     const openapiWebhooks = openapi[webhooks];
     if (openapiWebhooks) {
       if (!joinedDef.hasOwnProperty(webhooks)) {

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -22,7 +22,7 @@ import {
   writeToFileByExtension,
 } from '../utils/miscellaneous.js';
 import { exitWithError } from '../utils/error.js';
-import { COMPONENTS, OPENAPI3_METHOD } from './split/types.js';
+import { COMPONENTS, type Oas3Method, OPENAPI3_METHOD_NAMES } from './split/types.js';
 import { crawl, startsWithComponents } from './split/index.js';
 
 import type {
@@ -360,7 +360,7 @@ export async function handleJoin({
     }: JoinDocumentContext
   ) {
     const { paths } = openapi;
-    const operationsSet = new Set(keysOf<typeof OPENAPI3_METHOD>(OPENAPI3_METHOD));
+    const operationsSet = new Set(OPENAPI3_METHOD_NAMES);
     if (paths) {
       if (!joinedDef.hasOwnProperty('paths')) {
         joinedDef['paths'] = {};
@@ -377,8 +377,8 @@ export async function handleJoin({
         const pathItem = paths[path] as Oas3PathItem;
 
         for (const field of keysOf(pathItem)) {
-          if (operationsSet.has(field as OPENAPI3_METHOD)) {
-            collectPathOperation(pathItem, path, field as OPENAPI3_METHOD);
+          if (operationsSet.has(field as Oas3Method)) {
+            collectPathOperation(pathItem, path, field as Oas3Method);
           }
           if (field === 'servers') {
             collectPathServers(pathItem, path);
@@ -474,7 +474,7 @@ export async function handleJoin({
     function collectPathOperation(
       pathItem: Oas3PathItem,
       path: string | number,
-      operation: OPENAPI3_METHOD
+      operation: Oas3Method
     ) {
       const pathOperation = pathItem[operation];
 

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -22,12 +22,7 @@ import {
   getAndValidateFileExtension,
 } from '../../utils/miscellaneous.js';
 import { exitWithError } from '../../utils/error.js';
-import {
-  OPENAPI3_COMPONENT,
-  COMPONENTS,
-  OPENAPI3_METHOD_NAMES,
-  OPENAPI3_COMPONENT_NAMES,
-} from './types.js';
+import { COMPONENTS, OPENAPI3_METHOD_NAMES, OPENAPI3_COMPONENT_NAMES } from './types.js';
 
 import type {
   Oas3Definition,
@@ -42,7 +37,7 @@ import type {
   OasRef,
   Referenced,
 } from '@redocly/openapi-core';
-import type { ComponentsFiles, Definition, RefObject } from './types.js';
+import type { ComponentsFiles, Definition, Oas3Component, RefObject } from './types.js';
 import type { CommandArgs } from '../../wrapper.js';
 import type { VerifyConfigOptions } from '../../types.js';
 
@@ -204,7 +199,7 @@ function implicitlyReferenceDiscriminator(
   schemaFiles: any
 ) {
   if (!obj.discriminator) return;
-  const defPtr = `#/${COMPONENTS}/${OPENAPI3_COMPONENT.Schemas}/${defName}`;
+  const defPtr = `#/${COMPONENTS}/${'schemas' as Oas3Component}/${defName}`;
   const implicitMapping: Record<string, string> = {};
   for (const [name, { inherits, filename: parentFilename }] of Object.entries(schemaFiles) as any) {
     if (inherits.indexOf(defPtr) > -1) {
@@ -233,7 +228,7 @@ function implicitlyReferenceDiscriminator(
 }
 
 function isNotSecurityComponentType(componentType: string) {
-  return componentType !== OPENAPI3_COMPONENT.SecuritySchemes;
+  return componentType !== 'securitySchemes';
 }
 
 function findComponentTypes(components: any) {
@@ -280,7 +275,7 @@ function gatherComponentsFiles(
   filename: string
 ) {
   let inherits: string[] = [];
-  if (componentType === OPENAPI3_COMPONENT.Schemas) {
+  if (componentType === 'schemas') {
     inherits = (
       (components?.[componentType]?.[componentName] as Oas3Schema | Oas3_1Schema)?.allOf || []
     )

--- a/packages/cli/src/commands/split/types.ts
+++ b/packages/cli/src/commands/split/types.ts
@@ -25,26 +25,15 @@ export const OPENAPI3_METHOD_NAMES = [
   'trace',
 ] as const;
 
-export enum OPENAPI3_COMPONENT {
-  Schemas = 'schemas',
-  Responses = 'responses',
-  Parameters = 'parameters',
-  Examples = 'examples',
-  Headers = 'headers',
-  RequestBodies = 'requestBodies',
-  Links = 'links',
-  Callbacks = 'callbacks',
-  SecuritySchemes = 'securitySchemes',
-}
-
-export const OPENAPI3_COMPONENT_NAMES: OPENAPI3_COMPONENT[] = [
-  OPENAPI3_COMPONENT.RequestBodies,
-  OPENAPI3_COMPONENT.Schemas,
-  OPENAPI3_COMPONENT.Responses,
-  OPENAPI3_COMPONENT.Parameters,
-  OPENAPI3_COMPONENT.Examples,
-  OPENAPI3_COMPONENT.Headers,
-  OPENAPI3_COMPONENT.Links,
-  OPENAPI3_COMPONENT.Callbacks,
-  OPENAPI3_COMPONENT.SecuritySchemes,
-];
+export type Oas3Component = typeof OPENAPI3_COMPONENT_NAMES[number];
+export const OPENAPI3_COMPONENT_NAMES = [
+  'schemas',
+  'responses',
+  'parameters',
+  'examples',
+  'headers',
+  'requestBodies',
+  'links',
+  'callbacks',
+  'securitySchemes',
+] as const;

--- a/packages/cli/src/commands/split/types.ts
+++ b/packages/cli/src/commands/split/types.ts
@@ -12,27 +12,18 @@ export const COMPONENTS = 'components';
 export const PATHS = 'paths';
 export const WEBHOOKS = 'webhooks';
 export const xWEBHOOKS = 'x-webhooks';
-export enum OPENAPI3_METHOD {
-  get = 'get',
-  put = 'put',
-  post = 'post',
-  delete = 'delete',
-  options = 'options',
-  head = 'head',
-  patch = 'patch',
-  trace = 'trace',
-}
 
-export const OPENAPI3_METHOD_NAMES: OPENAPI3_METHOD[] = [
-  OPENAPI3_METHOD.get,
-  OPENAPI3_METHOD.put,
-  OPENAPI3_METHOD.post,
-  OPENAPI3_METHOD.delete,
-  OPENAPI3_METHOD.options,
-  OPENAPI3_METHOD.head,
-  OPENAPI3_METHOD.patch,
-  OPENAPI3_METHOD.trace,
-];
+export type Oas3Method = typeof OPENAPI3_METHOD_NAMES[number];
+export const OPENAPI3_METHOD_NAMES = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+] as const;
 
 export enum OPENAPI3_COMPONENT {
   Schemas = 'schemas',

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -28,11 +28,6 @@ import type { OasRef } from './typings/openapi.js';
 import type { Document, ResolvedRefMap } from './resolve.js';
 import type { CollectFn } from './utils.js';
 
-export enum OasVersion {
-  Version2 = 'oas2',
-  Version3_0 = 'oas3_0',
-  Version3_1 = 'oas3_1',
-}
 export type CoreBundleOptions = {
   externalRefResolver?: BaseResolver;
   config: Config;

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -2,13 +2,7 @@ import { BaseResolver, resolveDocument, makeRefId, makeDocumentFromString } from
 import { normalizeVisitors } from './visitors.js';
 import { normalizeTypes } from './types/index.js';
 import { walkDocument } from './walk.js';
-import {
-  detectSpec,
-  getTypes,
-  getMajorSpecVersion,
-  SpecMajorVersion,
-  SpecVersion,
-} from './oas-types.js';
+import { detectSpec, getTypes, getMajorSpecVersion, type SpecMajorVersion } from './oas-types.js';
 import { isAbsoluteUrl, isExternalValue, isRef, refBaseName, replaceRef } from './ref-utils.js';
 import { initRules } from './config/rules.js';
 import { reportUnresolvedRef } from './rules/common/no-unresolved-refs.js';
@@ -56,7 +50,7 @@ export function collectConfigPlugins(
   const visitorsData: PluginsCollectorVisitorData = { plugins: [], rootConfigDir };
   const ctx: BundleContext = {
     problems: [],
-    oasVersion: SpecVersion.OAS3_0, // TODO: change it after we rename oasVersion to specVersion
+    oasVersion: 'oas3_0', // TODO: change it after we rename oasVersion to specVersion
     refTypes: new Map<string, NormalizedNodeType>(),
     visitorsData: {
       [PLUGINS_COLLECTOR_VISITOR_ID]: visitorsData,
@@ -82,7 +76,7 @@ export function bundleConfig(
   const visitorsData: ConfigBundlerVisitorData = { plugins };
   const ctx: BundleContext = {
     problems: [],
-    oasVersion: SpecVersion.OAS3_0,
+    oasVersion: 'oas3_0', // TODO: change it after we rename oasVersion to specVersion
     refTypes: new Map<string, NormalizedNodeType>(),
     visitorsData: {
       [CONFIG_BUNDLER_VISITOR_ID]: visitorsData,
@@ -200,7 +194,7 @@ export async function bundleDocument(opts: {
       severity: 'error',
       ruleId: 'remove-unused-components',
       visitor:
-        specMajorVersion === SpecMajorVersion.OAS2
+        specMajorVersion === 'oas2'
           ? RemoveUnusedComponentsOas2({})
           : RemoveUnusedComponentsOas3({}),
     });
@@ -266,7 +260,7 @@ export async function bundleDocument(opts: {
 
 export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) {
   switch (version) {
-    case SpecMajorVersion.OAS3:
+    case 'oas3':
       switch (typeName) {
         case 'Schema':
           return 'schemas';
@@ -289,7 +283,7 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
         default:
           return null;
       }
-    case SpecMajorVersion.OAS2:
+    case 'oas2':
       switch (typeName) {
         case 'Schema':
           return 'definitions';
@@ -300,7 +294,7 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
         default:
           return null;
       }
-    case SpecMajorVersion.Async2:
+    case 'async2':
       switch (typeName) {
         case 'Schema':
           return 'schemas';
@@ -309,7 +303,7 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
         default:
           return null;
       }
-    case SpecMajorVersion.Async3:
+    case 'async3':
       switch (typeName) {
         case 'Schema':
           return 'schemas';
@@ -318,7 +312,7 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
         default:
           return null;
       }
-    case SpecMajorVersion.Arazzo1:
+    case 'arazzo1':
       switch (typeName) {
         case 'Root.workflows_items.parameters_items':
         case 'Root.workflows_items.steps_items.parameters_items':
@@ -326,15 +320,13 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
         default:
           return null;
       }
-    case SpecMajorVersion.Overlay1:
+    case 'overlay1':
       switch (typeName) {
         default:
           return null;
       }
   }
 }
-
-// function oas3Move
 
 function makeBundleVisitor(
   version: SpecMajorVersion,
@@ -402,22 +394,22 @@ function makeBundleVisitor(
     Root: {
       enter(root: any, ctx: UserContext) {
         rootLocation = ctx.location;
-        if (version === SpecMajorVersion.OAS3) {
+        if (version === 'oas3') {
           components = root.components = root.components || {};
-        } else if (version === SpecMajorVersion.OAS2) {
+        } else if (version === 'oas2') {
           components = root;
-        } else if (version === SpecMajorVersion.Async2) {
+        } else if (version === 'async2') {
           components = root.components = root.components || {};
-        } else if (version === SpecMajorVersion.Async3) {
+        } else if (version === 'async3') {
           components = root.components = root.components || {};
-        } else if (version === SpecMajorVersion.Arazzo1) {
+        } else if (version === 'arazzo1') {
           components = root.components = root.components || {};
         }
       },
     },
   };
 
-  if (version === SpecMajorVersion.OAS3) {
+  if (version === 'oas3') {
     visitor.DiscriminatorMapping = {
       leave(mapping: Record<string, string>, ctx: UserContext) {
         for (const name of Object.keys(mapping)) {
@@ -454,11 +446,7 @@ function makeBundleVisitor(
     components[componentType] = components[componentType] || {};
     const name = getComponentName(target, componentType, ctx);
     components[componentType][name] = target.node;
-    if (
-      version === SpecMajorVersion.OAS3 ||
-      version === SpecMajorVersion.Async2 ||
-      version === SpecMajorVersion.Async3
-    ) {
+    if (version === 'oas3' || version === 'async2' || version === 'async3') {
       return `#/components/${componentType}/${name}`;
     } else {
       return `#/${componentType}/${name}`;

--- a/packages/core/src/config/__tests__/config-resolvers.test.ts
+++ b/packages/core/src/config/__tests__/config-resolvers.test.ts
@@ -305,8 +305,8 @@ describe('resolveConfig', () => {
 
     const config = new Config(resolvedConfig, { plugins: [] });
 
-    expect(Array.isArray(config.rules[SpecVersion.OAS3_1].assertions)).toEqual(true);
-    expect(config.rules[SpecVersion.OAS3_1].assertions).toMatchObject([
+    expect(Array.isArray(config.rules.oas3_1.assertions)).toEqual(true);
+    expect(config.rules.oas3_1.assertions).toMatchObject([
       {
         subject: { type: 'PathItem', property: 'get' },
         message: 'Every path item must have a GET operation.',

--- a/packages/core/src/config/__tests__/config.test.ts
+++ b/packages/core/src/config/__tests__/config.test.ts
@@ -1,11 +1,11 @@
-import { SpecVersion } from '../../oas-types.js';
+import { type SpecVersion } from '../../oas-types.js';
 import { Config } from '../config.js';
 import * as utils from '../../utils.js';
 import * as jsYaml from '../../js-yaml/index.js';
 import * as fs from 'node:fs';
 import { ignoredFileStub } from './fixtures/ingore-file.js';
 import * as path from 'node:path';
-import { createConfig, type ResolvedConfig } from '../index.js';
+import { createConfig } from '../index.js';
 
 vi.mock('../../js-yaml/index.js', async () => {
   const actual = await vi.importActual('../../js-yaml/index.js');
@@ -193,13 +193,13 @@ describe('Config.extendTypes', () => {
 
   it('should call only oas3 types extension', () => {
     const config = new Config({}, { plugins });
-    config.extendTypes({}, SpecVersion.OAS3_0);
+    config.extendTypes({}, 'oas3_0');
     expect(oas3).toHaveBeenCalledTimes(1);
     expect(oas2).toHaveBeenCalledTimes(0);
   });
   it('should call only oas2 types extension', () => {
     const config = new Config({}, { plugins });
-    config.extendTypes({}, SpecVersion.OAS2);
+    config.extendTypes({}, 'oas2');
     expect(oas3).toHaveBeenCalledTimes(0);
     expect(oas2).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { parseYaml, stringifyYaml } from '../js-yaml/index.js';
 import { slash, doesYamlFileExist, isPlainObject } from '../utils.js';
-import { SpecVersion, SpecMajorVersion } from '../oas-types.js';
+import { specVersions } from '../oas-types.js';
 import { isBrowser } from '../env.js';
 import { getResolveConfig } from './utils.js';
 import { isAbsoluteUrl } from '../ref-utils.js';
@@ -17,6 +17,8 @@ import type {
   Async3RuleSet,
   Arazzo1RuleSet,
   Overlay1RuleSet,
+  SpecVersion,
+  SpecMajorVersion,
 } from '../oas-types.js';
 import type { NodeType } from '../types/index.js';
 import type {
@@ -87,48 +89,48 @@ export class Config {
     };
 
     this.rules = {
-      [SpecVersion.OAS2]: group({ ...resolvedConfig.rules, ...resolvedConfig.oas2Rules }),
-      [SpecVersion.OAS3_0]: group({ ...resolvedConfig.rules, ...resolvedConfig.oas3_0Rules }),
-      [SpecVersion.OAS3_1]: group({ ...resolvedConfig.rules, ...resolvedConfig.oas3_1Rules }),
-      [SpecVersion.Async2]: group({ ...resolvedConfig.rules, ...resolvedConfig.async2Rules }),
-      [SpecVersion.Async3]: group({ ...resolvedConfig.rules, ...resolvedConfig.async3Rules }),
-      [SpecVersion.Arazzo1]: group({ ...resolvedConfig.rules, ...resolvedConfig.arazzo1Rules }),
-      [SpecVersion.Overlay1]: group({ ...resolvedConfig.rules, ...resolvedConfig.overlay1Rules }),
+      oas2: group({ ...resolvedConfig.rules, ...resolvedConfig.oas2Rules }),
+      oas3_0: group({ ...resolvedConfig.rules, ...resolvedConfig.oas3_0Rules }),
+      oas3_1: group({ ...resolvedConfig.rules, ...resolvedConfig.oas3_1Rules }),
+      async2: group({ ...resolvedConfig.rules, ...resolvedConfig.async2Rules }),
+      async3: group({ ...resolvedConfig.rules, ...resolvedConfig.async3Rules }),
+      arazzo1: group({ ...resolvedConfig.rules, ...resolvedConfig.arazzo1Rules }),
+      overlay1: group({ ...resolvedConfig.rules, ...resolvedConfig.overlay1Rules }),
     };
 
     this.preprocessors = {
-      [SpecVersion.OAS2]: { ...resolvedConfig.preprocessors, ...resolvedConfig.oas2Preprocessors },
-      [SpecVersion.OAS3_0]: {
+      oas2: { ...resolvedConfig.preprocessors, ...resolvedConfig.oas2Preprocessors },
+      oas3_0: {
         ...resolvedConfig.preprocessors,
         ...resolvedConfig.oas3_0Preprocessors,
       },
-      [SpecVersion.OAS3_1]: {
+      oas3_1: {
         ...resolvedConfig.preprocessors,
         ...resolvedConfig.oas3_1Preprocessors,
       },
-      [SpecVersion.Async2]: {
+      async2: {
         ...resolvedConfig.preprocessors,
         ...resolvedConfig.async2Preprocessors,
       },
-      [SpecVersion.Async3]: {
+      async3: {
         ...resolvedConfig.preprocessors,
         ...resolvedConfig.async3Preprocessors,
       },
-      [SpecVersion.Arazzo1]: { ...resolvedConfig.arazzo1Preprocessors },
-      [SpecVersion.Overlay1]: {
+      arazzo1: { ...resolvedConfig.arazzo1Preprocessors },
+      overlay1: {
         ...resolvedConfig.preprocessors,
         ...resolvedConfig.overlay1Preprocessors,
       },
     };
 
     this.decorators = {
-      [SpecVersion.OAS2]: { ...resolvedConfig.decorators, ...resolvedConfig.oas2Decorators },
-      [SpecVersion.OAS3_0]: { ...resolvedConfig.decorators, ...resolvedConfig.oas3_0Decorators },
-      [SpecVersion.OAS3_1]: { ...resolvedConfig.decorators, ...resolvedConfig.oas3_1Decorators },
-      [SpecVersion.Async2]: { ...resolvedConfig.decorators, ...resolvedConfig.async2Decorators },
-      [SpecVersion.Async3]: { ...resolvedConfig.decorators, ...resolvedConfig.async3Decorators },
-      [SpecVersion.Arazzo1]: { ...resolvedConfig.arazzo1Decorators },
-      [SpecVersion.Overlay1]: {
+      oas2: { ...resolvedConfig.decorators, ...resolvedConfig.oas2Decorators },
+      oas3_0: { ...resolvedConfig.decorators, ...resolvedConfig.oas3_0Decorators },
+      oas3_1: { ...resolvedConfig.decorators, ...resolvedConfig.oas3_1Decorators },
+      async2: { ...resolvedConfig.decorators, ...resolvedConfig.async2Decorators },
+      async3: { ...resolvedConfig.decorators, ...resolvedConfig.async3Decorators },
+      arazzo1: { ...resolvedConfig.arazzo1Decorators },
+      overlay1: {
         ...resolvedConfig.decorators,
         ...resolvedConfig.overlay1Decorators,
       },
@@ -224,28 +226,28 @@ export class Config {
     for (const plugin of this.plugins) {
       if (plugin.typeExtension !== undefined) {
         switch (version) {
-          case SpecVersion.OAS3_0:
-          case SpecVersion.OAS3_1:
+          case 'oas3_0':
+          case 'oas3_1':
             if (!plugin.typeExtension.oas3) continue;
             extendedTypes = plugin.typeExtension.oas3(extendedTypes, version);
             break;
-          case SpecVersion.OAS2:
+          case 'oas2':
             if (!plugin.typeExtension.oas2) continue;
             extendedTypes = plugin.typeExtension.oas2(extendedTypes, version);
             break;
-          case SpecVersion.Async2:
+          case 'async2':
             if (!plugin.typeExtension.async2) continue;
             extendedTypes = plugin.typeExtension.async2(extendedTypes, version);
             break;
-          case SpecVersion.Async3:
+          case 'async3':
             if (!plugin.typeExtension.async3) continue;
             extendedTypes = plugin.typeExtension.async3(extendedTypes, version);
             break;
-          case SpecVersion.Arazzo1:
+          case 'arazzo1':
             if (!plugin.typeExtension.arazzo1) continue;
             extendedTypes = plugin.typeExtension.arazzo1(extendedTypes, version);
             break;
-          case SpecVersion.Overlay1:
+          case 'overlay1':
             if (!plugin.typeExtension.overlay1) continue;
             extendedTypes = plugin.typeExtension.overlay1(extendedTypes, version);
             break;
@@ -324,21 +326,21 @@ export class Config {
   // TODO: add default case for redocly.yaml
   getRulesForSpecVersion(version: SpecMajorVersion) {
     switch (version) {
-      case SpecMajorVersion.OAS3:
+      case 'oas3':
         // eslint-disable-next-line no-case-declarations
         const oas3Rules: Oas3RuleSet[] = [];
         this.plugins.forEach((p) => p.preprocessors?.oas3 && oas3Rules.push(p.preprocessors.oas3));
         this.plugins.forEach((p) => p.rules?.oas3 && oas3Rules.push(p.rules.oas3));
         this.plugins.forEach((p) => p.decorators?.oas3 && oas3Rules.push(p.decorators.oas3));
         return oas3Rules;
-      case SpecMajorVersion.OAS2:
+      case 'oas2':
         // eslint-disable-next-line no-case-declarations
         const oas2Rules: Oas2RuleSet[] = [];
         this.plugins.forEach((p) => p.preprocessors?.oas2 && oas2Rules.push(p.preprocessors.oas2));
         this.plugins.forEach((p) => p.rules?.oas2 && oas2Rules.push(p.rules.oas2));
         this.plugins.forEach((p) => p.decorators?.oas2 && oas2Rules.push(p.decorators.oas2));
         return oas2Rules;
-      case SpecMajorVersion.Async2:
+      case 'async2':
         // eslint-disable-next-line no-case-declarations
         const asyncApi2Rules: Async2RuleSet[] = [];
         this.plugins.forEach(
@@ -349,7 +351,7 @@ export class Config {
           (p) => p.decorators?.async2 && asyncApi2Rules.push(p.decorators.async2)
         );
         return asyncApi2Rules;
-      case SpecMajorVersion.Async3:
+      case 'async3':
         // eslint-disable-next-line no-case-declarations
         const asyncApi3Rules: Async3RuleSet[] = [];
         this.plugins.forEach(
@@ -360,7 +362,7 @@ export class Config {
           (p) => p.decorators?.async3 && asyncApi3Rules.push(p.decorators.async3)
         );
         return asyncApi3Rules;
-      case SpecMajorVersion.Arazzo1:
+      case 'arazzo1':
         // eslint-disable-next-line no-case-declarations
         const arazzo1Rules: Arazzo1RuleSet[] = [];
         this.plugins.forEach(
@@ -371,7 +373,7 @@ export class Config {
           (p) => p.decorators?.arazzo1 && arazzo1Rules.push(p.decorators.arazzo1)
         );
         return arazzo1Rules;
-      case SpecMajorVersion.Overlay1:
+      case 'overlay1':
         // eslint-disable-next-line no-case-declarations
         const overlay1Rules: Overlay1RuleSet[] = [];
         this.plugins.forEach(
@@ -387,7 +389,7 @@ export class Config {
 
   skipRules(rules?: string[]) {
     for (const ruleId of rules || []) {
-      for (const version of Object.values(SpecVersion)) {
+      for (const version of specVersions) {
         if (this.rules[version][ruleId]) {
           this.rules[version][ruleId] = 'off';
         } else if (Array.isArray(this.rules[version].assertions)) {
@@ -404,7 +406,7 @@ export class Config {
 
   skipPreprocessors(preprocessors?: string[]) {
     for (const preprocessorId of preprocessors || []) {
-      for (const version of Object.values(SpecVersion)) {
+      for (const version of specVersions) {
         if (this.preprocessors[version][preprocessorId]) {
           this.preprocessors[version][preprocessorId] = 'off';
         }
@@ -414,7 +416,7 @@ export class Config {
 
   skipDecorators(decorators?: string[]) {
     for (const decoratorId of decorators || []) {
-      for (const version of Object.values(SpecVersion)) {
+      for (const version of specVersions) {
         if (this.decorators[version][decoratorId]) {
           this.decorators[version][decoratorId] = 'off';
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,9 +93,9 @@ export {
 export { parseYaml, stringifyYaml } from './js-yaml/index.js';
 export { unescapePointer, isRef, isAbsoluteUrl, escapePointer } from './ref-utils.js';
 export {
-  SpecMajorVersion,
+  type SpecMajorVersion,
   getMajorSpecVersion,
-  SpecVersion,
+  type SpecVersion,
   detectSpec,
   getTypes,
 } from './oas-types.js';

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -5,7 +5,7 @@ import { walkDocument } from './walk.js';
 import { initRules } from './config/rules.js';
 import { normalizeTypes } from './types/index.js';
 import { releaseAjvInstance } from './rules/ajv.js';
-import { SpecVersion, getMajorSpecVersion, detectSpec, getTypes } from './oas-types.js';
+import { getMajorSpecVersion, detectSpec, getTypes } from './oas-types.js';
 import { createConfigTypes } from './types/redocly-yaml.js';
 import { Struct } from './rules/common/struct.js';
 import { NoUnresolvedRefs } from './rules/common/no-unresolved-refs.js';
@@ -132,7 +132,7 @@ export async function lintConfig(opts: {
 
   const ctx: WalkContext = {
     problems: [],
-    oasVersion: SpecVersion.OAS3_0, // TODO: use config-specific version; rename `oasVersion`
+    oasVersion: 'oas3_0', // TODO: use config-specific version; rename `oasVersion`
     visitorsData: {},
   };
 

--- a/packages/core/src/oas-types.ts
+++ b/packages/core/src/oas-types.ts
@@ -32,34 +32,27 @@ import type {
   Overlay1Rule,
 } from './visitors.js';
 
-// FIXME: replace enums with string literals (v2)
-export enum SpecVersion {
-  OAS2 = 'oas2',
-  OAS3_0 = 'oas3_0',
-  OAS3_1 = 'oas3_1',
-  Async2 = 'async2',
-  Async3 = 'async3',
-  Arazzo1 = 'arazzo1',
-  Overlay1 = 'overlay1',
-}
+export const specVersions = [
+  'oas2',
+  'oas3_0',
+  'oas3_1',
+  'async2',
+  'async3',
+  'arazzo1',
+  'overlay1',
+] as const;
+export type SpecVersion = typeof specVersions[number];
 
-export enum SpecMajorVersion {
-  OAS2 = 'oas2',
-  OAS3 = 'oas3',
-  Async2 = 'async2',
-  Async3 = 'async3',
-  Arazzo1 = 'arazzo1',
-  Overlay1 = 'overlay1',
-}
+export type SpecMajorVersion = 'oas2' | 'oas3' | 'async2' | 'async3' | 'arazzo1' | 'overlay1';
 
 const typesMap = {
-  [SpecVersion.OAS2]: Oas2Types,
-  [SpecVersion.OAS3_0]: Oas3Types,
-  [SpecVersion.OAS3_1]: Oas3_1Types,
-  [SpecVersion.Async2]: AsyncApi2Types,
-  [SpecVersion.Async3]: AsyncApi3Types,
-  [SpecVersion.Arazzo1]: Arazzo1Types,
-  [SpecVersion.Overlay1]: Overlay1Types,
+  oas2: Oas2Types,
+  oas3_0: Oas3Types,
+  oas3_1: Oas3_1Types,
+  async2: AsyncApi2Types,
+  async3: AsyncApi3Types,
+  arazzo1: Arazzo1Types,
+  overlay1: Overlay1Types,
 };
 
 export type RuleMap<Key extends string, RuleConfig, T> = Record<
@@ -121,15 +114,15 @@ export function detectSpec(root: unknown): SpecVersion {
   }
 
   if (typeof root.openapi === 'string' && root.openapi.startsWith('3.0')) {
-    return SpecVersion.OAS3_0;
+    return 'oas3_0';
   }
 
   if (typeof root.openapi === 'string' && root.openapi.startsWith('3.1')) {
-    return SpecVersion.OAS3_1;
+    return 'oas3_1';
   }
 
   if (root.swagger && root.swagger === '2.0') {
-    return SpecVersion.OAS2;
+    return 'oas2';
   }
 
   if (root.openapi || root.swagger) {
@@ -137,11 +130,11 @@ export function detectSpec(root: unknown): SpecVersion {
   }
 
   if (typeof root.asyncapi === 'string' && root.asyncapi.startsWith('2.')) {
-    return SpecVersion.Async2;
+    return 'async2';
   }
 
   if (typeof root.asyncapi === 'string' && root.asyncapi.startsWith('3.')) {
-    return SpecVersion.Async3;
+    return 'async3';
   }
 
   if (root.asyncapi) {
@@ -149,29 +142,29 @@ export function detectSpec(root: unknown): SpecVersion {
   }
 
   if (typeof root.arazzo === 'string' && VERSION_PATTERN.test(root.arazzo)) {
-    return SpecVersion.Arazzo1;
+    return 'arazzo1';
   }
 
   if (typeof root.overlay === 'string' && VERSION_PATTERN.test(root.overlay)) {
-    return SpecVersion.Overlay1;
+    return 'overlay1';
   }
 
   throw new Error(`Unsupported specification`);
 }
 
 export function getMajorSpecVersion(version: SpecVersion): SpecMajorVersion {
-  if (version === SpecVersion.OAS2) {
-    return SpecMajorVersion.OAS2;
-  } else if (version === SpecVersion.Async2) {
-    return SpecMajorVersion.Async2;
-  } else if (version === SpecVersion.Async3) {
-    return SpecMajorVersion.Async3;
-  } else if (version === SpecVersion.Arazzo1) {
-    return SpecMajorVersion.Arazzo1;
-  } else if (version === SpecVersion.Overlay1) {
-    return SpecMajorVersion.Overlay1;
+  if (version === 'oas2') {
+    return 'oas2';
+  } else if (version === 'async2') {
+    return 'async2';
+  } else if (version === 'async3') {
+    return 'async3';
+  } else if (version === 'arazzo1') {
+    return 'arazzo1';
+  } else if (version === 'overlay1') {
+    return 'overlay1';
   } else {
-    return SpecMajorVersion.OAS3;
+    return 'oas3';
   }
 }
 

--- a/packages/core/src/rules/common/scalar-property-missing-example.ts
+++ b/packages/core/src/rules/common/scalar-property-missing-example.ts
@@ -1,4 +1,3 @@
-import { SpecVersion } from '../../oas-types.js';
 import { getOwn } from '../../utils.js';
 
 import type { Oas2Rule, Oas3Rule } from '../../visitors.js';
@@ -27,7 +26,7 @@ export const ScalarPropertyMissingExample: Oas3Rule | Oas2Rule = () => {
         ) {
           report({
             message: `Scalar property should have "example"${
-              oasVersion === SpecVersion.OAS3_1 ? ' or "examples"' : ''
+              oasVersion === 'oas3_1' ? ' or "examples"' : ''
             } defined.`,
             location: location.child(propName).key(),
           });

--- a/packages/core/src/rules/oas3/no-server-variables-empty-enum.ts
+++ b/packages/core/src/rules/oas3/no-server-variables-empty-enum.ts
@@ -1,17 +1,14 @@
 import type { Oas3Server } from '../../typings/openapi.js';
 import type { Oas3Rule } from '../../visitors.js';
 
-enum enumError {
-  empty = 'empty',
-  invalidDefaultValue = 'invalidDefaultValue',
-}
+type EnumError = 'empty' | 'invalidDefaultValue';
 
 export const NoServerVariablesEmptyEnum: Oas3Rule = () => {
   return {
     Root(root, { report, location }) {
       if (!root.servers || root.servers.length === 0) return;
 
-      const invalidVariables: enumError[] = [];
+      const invalidVariables: EnumError[] = [];
 
       if (Array.isArray(root.servers)) {
         for (const server of root.servers) {
@@ -26,13 +23,13 @@ export const NoServerVariablesEmptyEnum: Oas3Rule = () => {
       }
 
       for (const invalidVariable of invalidVariables) {
-        if (invalidVariable === enumError.empty) {
+        if (invalidVariable === 'empty') {
           report({
             message: 'Server variable with `enum` must be a non-empty array.',
             location: location.child(['servers']).key(),
           });
         }
-        if (invalidVariable === enumError.invalidDefaultValue) {
+        if (invalidVariable === 'invalidDefaultValue') {
           report({
             message:
               'Server variable define `enum` and `default`. `enum` must include default value',
@@ -44,22 +41,22 @@ export const NoServerVariablesEmptyEnum: Oas3Rule = () => {
   };
 };
 
-function checkEnumVariables(server: Oas3Server): enumError[] | undefined {
+function checkEnumVariables(server: Oas3Server): EnumError[] | undefined {
   if (server.variables && Object.keys(server.variables).length === 0) return;
 
-  const errors: enumError[] = [];
+  const errors: EnumError[] = [];
   for (const variable in server.variables) {
     const serverVariable = server.variables[variable];
     if (!serverVariable.enum) continue;
 
     if (Array.isArray(serverVariable.enum) && serverVariable.enum?.length === 0)
-      errors.push(enumError.empty);
+      errors.push('empty');
 
     if (!serverVariable.default) continue;
 
     const defaultValue = server.variables[variable].default;
     if (serverVariable.enum && !serverVariable.enum.includes(defaultValue))
-      errors.push(enumError.invalidDefaultValue);
+      errors.push('invalidDefaultValue');
   }
   if (errors.length) return errors;
   return;

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { rootRedoclyConfigSchema } from '@redocly/config';
 import { listOf } from './index.js';
-import { SpecVersion, getTypes } from '../oas-types.js';
+import { specVersions, getTypes } from '../oas-types.js';
 import { isCustomRuleId, omit } from '../utils.js';
 import { getNodeTypesFromJSONSchema } from './json-schema-adapter.js';
 import { normalizeTypes } from '../types/index.js';
@@ -422,7 +422,7 @@ const Assert: NodeType = {
 };
 
 export function createConfigTypes(extraSchemas: JSONSchema, config?: Config) {
-  const nodeNames = Object.values(SpecVersion).flatMap((version) => {
+  const nodeNames = specVersions.flatMap((version) => {
     const types = config ? config.extendTypes(getTypes(version), version) : getTypes(version);
     return Object.keys(types);
   });


### PR DESCRIPTION
## What/Why/How?

Addressing FIXMES before 2.0 GA: 
- Replaced `SpecVersion`, `SpecMajorVersion`, `OPENAPI3_METHOD`, and `OPENAPI3_COMPONENT` enums with types
- Removed `OasVersion` enum



## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
