### PR TITLE
chore: exit the changeset pre mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@redocly/cli": "1.34.2",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,10 +68,9 @@ jobs:
           images: |
             redocly/cli
             ghcr.io/redocly/cli
-          # FIXME: replace `next` with `latest` before GA
           tags: |
             ${{ steps.get_version.outputs.value }}
-            next
+            latest
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
## What/Why/How?

Exiting the changeset pre mode. This is the last change before 2.0 GA.

## Reference

Docs: https://github.com/changesets/changesets/blob/main/docs/prereleases.md

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
