### PR TITLE
docs: make v2 the current version

### DIFF
--- a/docs/@v1/commands/generate-arazzo.md
+++ b/docs/@v1/commands/generate-arazzo.md
@@ -1,7 +1,7 @@
 ---
 slug:
-  - /docs/cli/commands/generate-arazzo
-  - /docs/respect/commands/generate-arazzo
+  - /docs/cli/v1/commands/generate-arazzo
+  - /docs/respect/v1/commands/generate-arazzo
 ---
 
 # `generate-arazzo`

--- a/docs/@v1/commands/respect.md
+++ b/docs/@v1/commands/respect.md
@@ -1,7 +1,7 @@
 ---
 slug:
-  - /docs/cli/commands/respect
-  - /docs/respect/commands/respect
+  - /docs/cli/v1/commands/respect
+  - /docs/respect/v1/commands/respect
 ---
 
 # `respect`

--- a/docs/@v1/rules/arazzo/struct.md
+++ b/docs/@v1/rules/arazzo/struct.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/arazzo/struct
+slug: /docs/cli/v1/rules/arazzo/struct
 ---
 
 # struct

--- a/docs/@v1/rules/built-in-rules.md
+++ b/docs/@v1/rules/built-in-rules.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/built-in-rules
+slug: /docs/cli/v1/rules/built-in-rules
 ---
 
 # Built-in rules

--- a/docs/@v1/rules/configurable-rules.md
+++ b/docs/@v1/rules/configurable-rules.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/configurable-rules
+slug: /docs/cli/v1/rules/configurable-rules
 ---
 
 # Configurable rules

--- a/docs/@v1/rules/minimal.md
+++ b/docs/@v1/rules/minimal.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/minimal
+slug: /docs/cli/v1/rules/minimal
 ---
 
 # Minimal ruleset

--- a/docs/@v1/rules/oas/array-parameter-serialization.md
+++ b/docs/@v1/rules/oas/array-parameter-serialization.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/array-parameter-serialization
+slug: /docs/cli/v1/rules/oas/array-parameter-serialization
 ---
 
 # array-parameter-serialization

--- a/docs/@v1/rules/oas/boolean-parameter-prefixes.md
+++ b/docs/@v1/rules/oas/boolean-parameter-prefixes.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/boolean-parameter-prefixes
+slug: /docs/cli/v1/rules/oas/boolean-parameter-prefixes
 ---
 
 # boolean-parameter-prefixes

--- a/docs/@v1/rules/oas/component-name-unique.md
+++ b/docs/@v1/rules/oas/component-name-unique.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/component-name-unique
+slug: /docs/cli/v1/rules/oas/component-name-unique
 ---
 
 # component-name-unique

--- a/docs/@v1/rules/oas/info-contact.md
+++ b/docs/@v1/rules/oas/info-contact.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/info-contact
+slug: /docs/cli/v1/rules/oas/info-contact
 ---
 
 # info-contact

--- a/docs/@v1/rules/oas/info-license-url.md
+++ b/docs/@v1/rules/oas/info-license-url.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/info-license-url
+slug: /docs/cli/v1/rules/oas/info-license-url
 ---
 
 # info-license-url

--- a/docs/@v1/rules/oas/info-license.md
+++ b/docs/@v1/rules/oas/info-license.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/info-license
+slug: /docs/cli/v1/rules/oas/info-license
 ---
 
 # info-license

--- a/docs/@v1/rules/oas/no-ambiguous-paths.md
+++ b/docs/@v1/rules/oas/no-ambiguous-paths.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-ambiguous-paths
+slug: /docs/cli/v1/rules/oas/no-ambiguous-paths
 ---
 
 # no-ambiguous-paths

--- a/docs/@v1/rules/oas/no-empty-servers.md
+++ b/docs/@v1/rules/oas/no-empty-servers.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-empty-servers
+slug: /docs/cli/v1/rules/oas/no-empty-servers
 ---
 
 # no-empty-servers

--- a/docs/@v1/rules/oas/no-enum-type-mismatch.md
+++ b/docs/@v1/rules/oas/no-enum-type-mismatch.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-enum-type-mismatch
+slug: /docs/cli/v1/rules/oas/no-enum-type-mismatch
 ---
 
 # no-enum-type-mismatch

--- a/docs/@v1/rules/oas/no-example-value-and-externalValue.md
+++ b/docs/@v1/rules/oas/no-example-value-and-externalValue.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-example-value-and-externalValue
+slug: /docs/cli/v1/rules/oas/no-example-value-and-externalValue
 ---
 
 # no-example-value-and-externalValue

--- a/docs/@v1/rules/oas/no-http-verbs-in-paths.md
+++ b/docs/@v1/rules/oas/no-http-verbs-in-paths.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-http-verbs-in-paths
+slug: /docs/cli/v1/rules/oas/no-http-verbs-in-paths
 ---
 
 # no-http-verbs-in-paths

--- a/docs/@v1/rules/oas/no-identical-paths.md
+++ b/docs/@v1/rules/oas/no-identical-paths.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-identical-paths
+slug: /docs/cli/v1/rules/oas/no-identical-paths
 ---
 
 # no-identical-paths

--- a/docs/@v1/rules/oas/no-invalid-media-type-examples.md
+++ b/docs/@v1/rules/oas/no-invalid-media-type-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-invalid-media-type-examples
+slug: /docs/cli/v1/rules/oas/no-invalid-media-type-examples
 ---
 
 # no-invalid-media-type-examples

--- a/docs/@v1/rules/oas/no-invalid-parameter-examples.md
+++ b/docs/@v1/rules/oas/no-invalid-parameter-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-invalid-parameter-examples
+slug: /docs/cli/v1/rules/oas/no-invalid-parameter-examples
 ---
 
 # no-invalid-parameter-examples

--- a/docs/@v1/rules/oas/no-invalid-schema-examples.md
+++ b/docs/@v1/rules/oas/no-invalid-schema-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-invalid-schema-examples
+slug: /docs/cli/v1/rules/oas/no-invalid-schema-examples
 ---
 
 # no-invalid-schema-examples

--- a/docs/@v1/rules/oas/no-path-trailing-slash.md
+++ b/docs/@v1/rules/oas/no-path-trailing-slash.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-path-trailing-slash
+slug: /docs/cli/v1/rules/oas/no-path-trailing-slash
 ---
 
 # no-path-trailing-slash

--- a/docs/@v1/rules/oas/no-required-schema-properties-undefined.md
+++ b/docs/@v1/rules/oas/no-required-schema-properties-undefined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-required-schema-properties-undefined
+slug: /docs/cli/v1/rules/oas/no-required-schema-properties-undefined
 ---
 
 # no-required-schema-properties-undefined

--- a/docs/@v1/rules/oas/no-schema-type-mismatch.md
+++ b/docs/@v1/rules/oas/no-schema-type-mismatch.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-schema-type-mismatch
+slug: /docs/cli/v1/rules/oas/no-schema-type-mismatch
 ---
 
 # no-schema-type-mismatch

--- a/docs/@v1/rules/oas/no-server-example-com.md
+++ b/docs/@v1/rules/oas/no-server-example-com.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-server-example-com
+slug: /docs/cli/v1/rules/oas/no-server-example-com
 ---
 
 # no-server-example.com

--- a/docs/@v1/rules/oas/no-server-trailing-slash.md
+++ b/docs/@v1/rules/oas/no-server-trailing-slash.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-server-trailing-slash
+slug: /docs/cli/v1/rules/oas/no-server-trailing-slash
 ---
 
 # no-server-trailing-slash

--- a/docs/@v1/rules/oas/no-server-variables-empty-enum.md
+++ b/docs/@v1/rules/oas/no-server-variables-empty-enum.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-server-variables-empty-enum
+slug: /docs/cli/v1/rules/oas/no-server-variables-empty-enum
 ---
 
 # no-server-variables-empty-enum

--- a/docs/@v1/rules/oas/no-undefined-server-variable.md
+++ b/docs/@v1/rules/oas/no-undefined-server-variable.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-undefined-server-variable
+slug: /docs/cli/v1/rules/oas/no-undefined-server-variable
 ---
 
 # no-undefined-server-variable

--- a/docs/@v1/rules/oas/no-unresolved-refs.md
+++ b/docs/@v1/rules/oas/no-unresolved-refs.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-unresolved-refs
+slug: /docs/cli/v1/rules/oas/no-unresolved-refs
 ---
 
 # no-unresolved-refs

--- a/docs/@v1/rules/oas/no-unused-components.md
+++ b/docs/@v1/rules/oas/no-unused-components.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/no-unused-components
+slug: /docs/cli/v1/rules/oas/no-unused-components
 ---
 
 # no-unused-components

--- a/docs/@v1/rules/oas/operation-2xx-response.md
+++ b/docs/@v1/rules/oas/operation-2xx-response.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-2xx-response
+slug: /docs/cli/v1/rules/oas/operation-2xx-response
 ---
 
 # operation-2xx-response

--- a/docs/@v1/rules/oas/operation-4xx-problem-details-rfc7807.md
+++ b/docs/@v1/rules/oas/operation-4xx-problem-details-rfc7807.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-4xx-problem-details-rfc7807
+slug: /docs/cli/v1/rules/oas/operation-4xx-problem-details-rfc7807
 ---
 
 # operation-4xx-problem-details-rfc7807

--- a/docs/@v1/rules/oas/operation-4xx-response.md
+++ b/docs/@v1/rules/oas/operation-4xx-response.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-4xx-response
+slug: /docs/cli/v1/rules/oas/operation-4xx-response
 ---
 
 # operation-4xx-response

--- a/docs/@v1/rules/oas/operation-description.md
+++ b/docs/@v1/rules/oas/operation-description.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-description
+slug: /docs/cli/v1/rules/oas/operation-description
 ---
 
 # operation-description

--- a/docs/@v1/rules/oas/operation-operationId-unique.md
+++ b/docs/@v1/rules/oas/operation-operationId-unique.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-operationId-unique
+slug: /docs/cli/v1/rules/oas/operation-operationId-unique
 ---
 
 # operation-operationId-unique

--- a/docs/@v1/rules/oas/operation-operationId-url-safe.md
+++ b/docs/@v1/rules/oas/operation-operationId-url-safe.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-operationId-url-safe
+slug: /docs/cli/v1/rules/oas/operation-operationId-url-safe
 ---
 
 # operation-operationId-url-safe

--- a/docs/@v1/rules/oas/operation-operationId.md
+++ b/docs/@v1/rules/oas/operation-operationId.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-operationId
+slug: /docs/cli/v1/rules/oas/operation-operationId
 ---
 
 # operation-operationId

--- a/docs/@v1/rules/oas/operation-parameters-unique.md
+++ b/docs/@v1/rules/oas/operation-parameters-unique.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-parameters-unique
+slug: /docs/cli/v1/rules/oas/operation-parameters-unique
 ---
 
 # operation-parameters-unique

--- a/docs/@v1/rules/oas/operation-singular-tag.md
+++ b/docs/@v1/rules/oas/operation-singular-tag.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-singular-tag
+slug: /docs/cli/v1/rules/oas/operation-singular-tag
 ---
 
 # operation-singular-tag

--- a/docs/@v1/rules/oas/operation-summary.md
+++ b/docs/@v1/rules/oas/operation-summary.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-summary
+slug: /docs/cli/v1/rules/oas/operation-summary
 ---
 
 # operation-summary

--- a/docs/@v1/rules/oas/operation-tag-defined.md
+++ b/docs/@v1/rules/oas/operation-tag-defined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/operation-tag-defined
+slug: /docs/cli/v1/rules/oas/operation-tag-defined
 ---
 
 # operation-tag-defined

--- a/docs/@v1/rules/oas/parameter-description.md
+++ b/docs/@v1/rules/oas/parameter-description.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/parameter-description
+slug: /docs/cli/v1/rules/oas/parameter-description
 ---
 
 # parameter-description

--- a/docs/@v1/rules/oas/path-declaration-must-exist.md
+++ b/docs/@v1/rules/oas/path-declaration-must-exist.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/path-declaration-must-exist
+slug: /docs/cli/v1/rules/oas/path-declaration-must-exist
 ---
 
 # path-declaration-must-exist

--- a/docs/@v1/rules/oas/path-excludes-patterns.md
+++ b/docs/@v1/rules/oas/path-excludes-patterns.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/path-excludes-patterns
+slug: /docs/cli/v1/rules/oas/path-excludes-patterns
 ---
 
 # path-excludes-patterns

--- a/docs/@v1/rules/oas/path-not-include-query.md
+++ b/docs/@v1/rules/oas/path-not-include-query.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/path-not-include-query
+slug: /docs/cli/v1/rules/oas/path-not-include-query
 ---
 
 # path-not-include-query

--- a/docs/@v1/rules/oas/path-parameters-defined.md
+++ b/docs/@v1/rules/oas/path-parameters-defined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/path-parameters-defined
+slug: /docs/cli/v1/rules/oas/path-parameters-defined
 ---
 
 # path-parameters-defined

--- a/docs/@v1/rules/oas/path-segment-plural.md
+++ b/docs/@v1/rules/oas/path-segment-plural.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/path-segment-plural
+slug: /docs/cli/v1/rules/oas/path-segment-plural
 ---
 
 # path-segment-plural

--- a/docs/@v1/rules/oas/paths-kebab-case.md
+++ b/docs/@v1/rules/oas/paths-kebab-case.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/paths-kebab-case
+slug: /docs/cli/v1/rules/oas/paths-kebab-case
 ---
 
 # paths-kebab-case

--- a/docs/@v1/rules/oas/request-mime-type.md
+++ b/docs/@v1/rules/oas/request-mime-type.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/request-mine-type
+slug: /docs/cli/v1/rules/oas/request-mine-type
 ---
 
 # request-mime-type

--- a/docs/@v1/rules/oas/required-string-property-missing-min-length.md
+++ b/docs/@v1/rules/oas/required-string-property-missing-min-length.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/required-string-property-missing-min-length
+slug: /docs/cli/v1/rules/oas/required-string-property-missing-min-length
 ---
 
 # required-string-property-missing-min-length

--- a/docs/@v1/rules/oas/response-contains-header.md
+++ b/docs/@v1/rules/oas/response-contains-header.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/response-contains-header
+slug: /docs/cli/v1/rules/oas/response-contains-header
 ---
 
 # response-contains-header

--- a/docs/@v1/rules/oas/response-contains-property.md
+++ b/docs/@v1/rules/oas/response-contains-property.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/response-contains-property
+slug: /docs/cli/v1/rules/oas/response-contains-property
 ---
 
 # response-contains-property

--- a/docs/@v1/rules/oas/response-mime-type.md
+++ b/docs/@v1/rules/oas/response-mime-type.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/response-mime-type
+slug: /docs/cli/v1/rules/oas/response-mime-type
 ---
 
 # response-mime-type

--- a/docs/@v1/rules/oas/scalar-property-missing-example.md
+++ b/docs/@v1/rules/oas/scalar-property-missing-example.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/scalar-property-missing-example
+slug: /docs/cli/v1/rules/oas/scalar-property-missing-example
 ---
 
 # scalar-property-missing-example

--- a/docs/@v1/rules/oas/security-defined.md
+++ b/docs/@v1/rules/oas/security-defined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/security-defined
+slug: /docs/cli/v1/rules/oas/security-defined
 ---
 
 # security-defined

--- a/docs/@v1/rules/oas/spec-components-invalid-map-name.md
+++ b/docs/@v1/rules/oas/spec-components-invalid-map-name.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/spec-components-invalid-map-name
+slug: /docs/cli/v1/rules/oas/spec-components-invalid-map-name
 ---
 
 # spec-components-invalid-map-name

--- a/docs/@v1/rules/oas/spec-strict-refs.md
+++ b/docs/@v1/rules/oas/spec-strict-refs.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/spec-strict-refs
+slug: /docs/cli/v1/rules/oas/spec-strict-refs
 ---
 
 # spec-strict-refs

--- a/docs/@v1/rules/oas/struct.md
+++ b/docs/@v1/rules/oas/struct.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/struct
+slug: /docs/cli/v1/rules/oas/struct
 ---
 
 # struct

--- a/docs/@v1/rules/oas/tag-description.md
+++ b/docs/@v1/rules/oas/tag-description.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/tag-description
+slug: /docs/cli/v1/rules/oas/tag-description
 ---
 
 # tag-description

--- a/docs/@v1/rules/oas/tags-alphabetical.md
+++ b/docs/@v1/rules/oas/tags-alphabetical.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/oas/tags-alphabetical
+slug: /docs/cli/v1/rules/oas/tags-alphabetical
 ---
 
 # tags-alphabetical

--- a/docs/@v1/rules/recommended.md
+++ b/docs/@v1/rules/recommended.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/recommended
+slug: /docs/cli/v1/rules/recommended
 ---
 
 # Recommended ruleset

--- a/docs/@v1/rules/respect/no-criteria-xpath.md
+++ b/docs/@v1/rules/respect/no-criteria-xpath.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/respect/no-criteria-xpath
+slug: /docs/cli/v1/rules/respect/no-criteria-xpath
 ---
 
 # no-criteria-xpath

--- a/docs/@v1/rules/spec-ruleset.md
+++ b/docs/@v1/rules/spec-ruleset.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/rules/spec
+slug: /docs/cli/v1/rules/spec
 ---
 
 # Spec ruleset

--- a/docs/@v2/commands/generate-arazzo.md
+++ b/docs/@v2/commands/generate-arazzo.md
@@ -1,6 +1,6 @@
 ---
 slug:
-  - /docs/cli/v2/commands/generate-arazzo
+  - /docs/cli/commands/generate-arazzo
 ---
 
 # `generate-arazzo`

--- a/docs/@v2/commands/respect.md
+++ b/docs/@v2/commands/respect.md
@@ -1,6 +1,6 @@
 ---
 slug:
-  - /docs/cli/v2/commands/respect
+  - /docs/cli/commands/respect
 ---
 
 # `respect`

--- a/docs/@v2/guides/migrate-to-v2.md
+++ b/docs/@v2/guides/migrate-to-v2.md
@@ -184,5 +184,5 @@ paths:
 
 ## Next steps
 
-- Explore the [changelog](https://redocly.com/docs/cli/v2/changelog) for detailed information about all changes.
-- Check out the v2 [documentation](https://redocly.com/docs/cli/v2/).
+- Explore the [changelog](https://redocly.com/docs/cli/changelog) for detailed information about all changes.
+- Check out the v2 [documentation](https://redocly.com/docs/cli/).

--- a/docs/@v2/rules/built-in-rules.md
+++ b/docs/@v2/rules/built-in-rules.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/built-in-rules
+slug: /docs/cli/rules/built-in-rules
 ---
 
 # Built-in rules

--- a/docs/@v2/rules/common/no-enum-type-mismatch.md
+++ b/docs/@v2/rules/common/no-enum-type-mismatch.md
@@ -1,7 +1,5 @@
 ---
-slug: 
-- /docs/cli/v2/rules/common/no-enum-type-mismatch
-- /docs/cli/v2/rules/oas/no-enum-type-mismatch
+slug: /docs/cli/rules/common/no-enum-type-mismatch
 ---
 
 # no-enum-type-mismatch

--- a/docs/@v2/rules/common/no-required-schema-properties-undefined.md
+++ b/docs/@v2/rules/common/no-required-schema-properties-undefined.md
@@ -1,7 +1,5 @@
 ---
-slug: 
-- /docs/cli/v2/rules/common/no-required-schema-properties-undefined
-- /docs/cli/v2/rules/oas/no-required-schema-properties-undefined
+slug: /docs/cli/rules/common/no-required-schema-properties-undefined
 ---
 
 # no-required-schema-properties-undefined

--- a/docs/@v2/rules/common/no-schema-type-mismatch.md
+++ b/docs/@v2/rules/common/no-schema-type-mismatch.md
@@ -1,7 +1,5 @@
 ---
-slug: 
-- /docs/cli/v2/rules/common/no-schema-type-mismatch
-- /docs/cli/v2/rules/oas/no-schema-type-mismatch
+slug: /docs/cli/rules/common/no-schema-type-mismatch
 ---
 
 # no-schema-type-mismatch

--- a/docs/@v2/rules/common/no-unresolved-refs.md
+++ b/docs/@v2/rules/common/no-unresolved-refs.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-unresolved-refs
+slug: /docs/cli/rules/oas/no-unresolved-refs
 ---
 
 # no-unresolved-refs

--- a/docs/@v2/rules/common/struct.md
+++ b/docs/@v2/rules/common/struct.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/common/struct
+slug: /docs/cli/rules/common/struct
 ---
 
 # struct

--- a/docs/@v2/rules/configurable-rules.md
+++ b/docs/@v2/rules/configurable-rules.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/configurable-rules
+slug: /docs/cli/rules/configurable-rules
 ---
 
 # Configurable rules

--- a/docs/@v2/rules/minimal.md
+++ b/docs/@v2/rules/minimal.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/minimal
+slug: /docs/cli/rules/minimal
 ---
 
 # Minimal ruleset

--- a/docs/@v2/rules/oas/array-parameter-serialization.md
+++ b/docs/@v2/rules/oas/array-parameter-serialization.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/array-parameter-serialization
+slug: /docs/cli/rules/oas/array-parameter-serialization
 ---
 
 # array-parameter-serialization

--- a/docs/@v2/rules/oas/boolean-parameter-prefixes.md
+++ b/docs/@v2/rules/oas/boolean-parameter-prefixes.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/boolean-parameter-prefixes
+slug: /docs/cli/rules/oas/boolean-parameter-prefixes
 ---
 
 # boolean-parameter-prefixes

--- a/docs/@v2/rules/oas/component-name-unique.md
+++ b/docs/@v2/rules/oas/component-name-unique.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/component-name-unique
+slug: /docs/cli/rules/oas/component-name-unique
 ---
 
 # component-name-unique

--- a/docs/@v2/rules/oas/info-contact.md
+++ b/docs/@v2/rules/oas/info-contact.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/info-contact
+slug: /docs/cli/rules/oas/info-contact
 ---
 
 # info-contact

--- a/docs/@v2/rules/oas/info-license.md
+++ b/docs/@v2/rules/oas/info-license.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/info-license
+slug: /docs/cli/rules/oas/info-license
 ---
 
 # info-license

--- a/docs/@v2/rules/oas/no-ambiguous-paths.md
+++ b/docs/@v2/rules/oas/no-ambiguous-paths.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-ambiguous-paths
+slug: /docs/cli/rules/oas/no-ambiguous-paths
 ---
 
 # no-ambiguous-paths

--- a/docs/@v2/rules/oas/no-duplicated-tag-names.md
+++ b/docs/@v2/rules/oas/no-duplicated-tag-names.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-duplicated-tag-names
+slug: /docs/cli/rules/oas/no-duplicated-tag-names
 ---
 
 # no-duplicated-tag-names

--- a/docs/@v2/rules/oas/no-empty-servers.md
+++ b/docs/@v2/rules/oas/no-empty-servers.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-empty-servers
+slug: /docs/cli/rules/oas/no-empty-servers
 ---
 
 # no-empty-servers

--- a/docs/@v2/rules/oas/no-example-value-and-externalValue.md
+++ b/docs/@v2/rules/oas/no-example-value-and-externalValue.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-example-value-and-externalValue
+slug: /docs/cli/rules/oas/no-example-value-and-externalValue
 ---
 
 # no-example-value-and-externalValue

--- a/docs/@v2/rules/oas/no-http-verbs-in-paths.md
+++ b/docs/@v2/rules/oas/no-http-verbs-in-paths.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-http-verbs-in-paths
+slug: /docs/cli/rules/oas/no-http-verbs-in-paths
 ---
 
 # no-http-verbs-in-paths

--- a/docs/@v2/rules/oas/no-identical-paths.md
+++ b/docs/@v2/rules/oas/no-identical-paths.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-identical-paths
+slug: /docs/cli/rules/oas/no-identical-paths
 ---
 
 # no-identical-paths

--- a/docs/@v2/rules/oas/no-invalid-media-type-examples.md
+++ b/docs/@v2/rules/oas/no-invalid-media-type-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-invalid-media-type-examples
+slug: /docs/cli/rules/oas/no-invalid-media-type-examples
 ---
 
 # no-invalid-media-type-examples

--- a/docs/@v2/rules/oas/no-invalid-parameter-examples.md
+++ b/docs/@v2/rules/oas/no-invalid-parameter-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-invalid-parameter-examples
+slug: /docs/cli/rules/oas/no-invalid-parameter-examples
 ---
 
 # no-invalid-parameter-examples

--- a/docs/@v2/rules/oas/no-invalid-schema-examples.md
+++ b/docs/@v2/rules/oas/no-invalid-schema-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-invalid-schema-examples
+slug: /docs/cli/rules/oas/no-invalid-schema-examples
 ---
 
 # no-invalid-schema-examples

--- a/docs/@v2/rules/oas/no-path-trailing-slash.md
+++ b/docs/@v2/rules/oas/no-path-trailing-slash.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-path-trailing-slash
+slug: /docs/cli/rules/oas/no-path-trailing-slash
 ---
 
 # no-path-trailing-slash

--- a/docs/@v2/rules/oas/no-server-example-com.md
+++ b/docs/@v2/rules/oas/no-server-example-com.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-server-example-com
+slug: /docs/cli/rules/oas/no-server-example-com
 ---
 
 # no-server-example.com

--- a/docs/@v2/rules/oas/no-server-trailing-slash.md
+++ b/docs/@v2/rules/oas/no-server-trailing-slash.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-server-trailing-slash
+slug: /docs/cli/rules/oas/no-server-trailing-slash
 ---
 
 # no-server-trailing-slash

--- a/docs/@v2/rules/oas/no-server-variables-empty-enum.md
+++ b/docs/@v2/rules/oas/no-server-variables-empty-enum.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-server-variables-empty-enum
+slug: /docs/cli/rules/oas/no-server-variables-empty-enum
 ---
 
 # no-server-variables-empty-enum

--- a/docs/@v2/rules/oas/no-undefined-server-variable.md
+++ b/docs/@v2/rules/oas/no-undefined-server-variable.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-undefined-server-variable
+slug: /docs/cli/rules/oas/no-undefined-server-variable
 ---
 
 # no-undefined-server-variable

--- a/docs/@v2/rules/oas/no-unused-components.md
+++ b/docs/@v2/rules/oas/no-unused-components.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/no-unused-components
+slug: /docs/cli/rules/oas/no-unused-components
 ---
 
 # no-unused-components

--- a/docs/@v2/rules/oas/nullable-type-sibling.md
+++ b/docs/@v2/rules/oas/nullable-type-sibling.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/nullable-type-sibling
+slug: /docs/cli/rules/oas/nullable-type-sibling
 ---
 
 # nullable-type-sibling

--- a/docs/@v2/rules/oas/operation-2xx-response.md
+++ b/docs/@v2/rules/oas/operation-2xx-response.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-2xx-response
+slug: /docs/cli/rules/oas/operation-2xx-response
 ---
 
 # operation-2xx-response

--- a/docs/@v2/rules/oas/operation-4xx-problem-details-rfc7807.md
+++ b/docs/@v2/rules/oas/operation-4xx-problem-details-rfc7807.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-4xx-problem-details-rfc7807
+slug: /docs/cli/rules/oas/operation-4xx-problem-details-rfc7807
 ---
 
 # operation-4xx-problem-details-rfc7807

--- a/docs/@v2/rules/oas/operation-4xx-response.md
+++ b/docs/@v2/rules/oas/operation-4xx-response.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-4xx-response
+slug: /docs/cli/rules/oas/operation-4xx-response
 ---
 
 # operation-4xx-response

--- a/docs/@v2/rules/oas/operation-description.md
+++ b/docs/@v2/rules/oas/operation-description.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-description
+slug: /docs/cli/rules/oas/operation-description
 ---
 
 # operation-description

--- a/docs/@v2/rules/oas/operation-operationId-unique.md
+++ b/docs/@v2/rules/oas/operation-operationId-unique.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-operationId-unique
+slug: /docs/cli/rules/oas/operation-operationId-unique
 ---
 
 # operation-operationId-unique

--- a/docs/@v2/rules/oas/operation-operationId-url-safe.md
+++ b/docs/@v2/rules/oas/operation-operationId-url-safe.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-operationId-url-safe
+slug: /docs/cli/rules/oas/operation-operationId-url-safe
 ---
 
 # operation-operationId-url-safe

--- a/docs/@v2/rules/oas/operation-operationId.md
+++ b/docs/@v2/rules/oas/operation-operationId.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-operationId
+slug: /docs/cli/rules/oas/operation-operationId
 ---
 
 # operation-operationId

--- a/docs/@v2/rules/oas/operation-parameters-unique.md
+++ b/docs/@v2/rules/oas/operation-parameters-unique.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-parameters-unique
+slug: /docs/cli/rules/oas/operation-parameters-unique
 ---
 
 # operation-parameters-unique

--- a/docs/@v2/rules/oas/operation-singular-tag.md
+++ b/docs/@v2/rules/oas/operation-singular-tag.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-singular-tag
+slug: /docs/cli/rules/oas/operation-singular-tag
 ---
 
 # operation-singular-tag

--- a/docs/@v2/rules/oas/operation-summary.md
+++ b/docs/@v2/rules/oas/operation-summary.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-summary
+slug: /docs/cli/rules/oas/operation-summary
 ---
 
 # operation-summary

--- a/docs/@v2/rules/oas/operation-tag-defined.md
+++ b/docs/@v2/rules/oas/operation-tag-defined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/operation-tag-defined
+slug: /docs/cli/rules/oas/operation-tag-defined
 ---
 
 # operation-tag-defined

--- a/docs/@v2/rules/oas/parameter-description.md
+++ b/docs/@v2/rules/oas/parameter-description.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/parameter-description
+slug: /docs/cli/rules/oas/parameter-description
 ---
 
 # parameter-description

--- a/docs/@v2/rules/oas/path-declaration-must-exist.md
+++ b/docs/@v2/rules/oas/path-declaration-must-exist.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/path-declaration-must-exist
+slug: /docs/cli/rules/oas/path-declaration-must-exist
 ---
 
 # path-declaration-must-exist

--- a/docs/@v2/rules/oas/path-not-include-query.md
+++ b/docs/@v2/rules/oas/path-not-include-query.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/path-not-include-query
+slug: /docs/cli/rules/oas/path-not-include-query
 ---
 
 # path-not-include-query

--- a/docs/@v2/rules/oas/path-parameters-defined.md
+++ b/docs/@v2/rules/oas/path-parameters-defined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/path-parameters-defined
+slug: /docs/cli/rules/oas/path-parameters-defined
 ---
 
 # path-parameters-defined

--- a/docs/@v2/rules/oas/path-segment-plural.md
+++ b/docs/@v2/rules/oas/path-segment-plural.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/path-segment-plural
+slug: /docs/cli/rules/oas/path-segment-plural
 ---
 
 # path-segment-plural

--- a/docs/@v2/rules/oas/paths-kebab-case.md
+++ b/docs/@v2/rules/oas/paths-kebab-case.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/paths-kebab-case
+slug: /docs/cli/rules/oas/paths-kebab-case
 ---
 
 # paths-kebab-case

--- a/docs/@v2/rules/oas/request-mime-type.md
+++ b/docs/@v2/rules/oas/request-mime-type.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/request-mine-type
+slug: /docs/cli/rules/oas/request-mine-type
 ---
 
 # request-mime-type

--- a/docs/@v2/rules/oas/required-string-property-missing-min-length.md
+++ b/docs/@v2/rules/oas/required-string-property-missing-min-length.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/required-string-property-missing-min-length
+slug: /docs/cli/rules/oas/required-string-property-missing-min-length
 ---
 
 # required-string-property-missing-min-length

--- a/docs/@v2/rules/oas/response-contains-header.md
+++ b/docs/@v2/rules/oas/response-contains-header.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/response-contains-header
+slug: /docs/cli/rules/oas/response-contains-header
 ---
 
 # response-contains-header

--- a/docs/@v2/rules/oas/response-contains-property.md
+++ b/docs/@v2/rules/oas/response-contains-property.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/response-contains-property
+slug: /docs/cli/rules/oas/response-contains-property
 ---
 
 # response-contains-property

--- a/docs/@v2/rules/oas/response-mime-type.md
+++ b/docs/@v2/rules/oas/response-mime-type.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/response-mime-type
+slug: /docs/cli/rules/oas/response-mime-type
 ---
 
 # response-mime-type

--- a/docs/@v2/rules/oas/scalar-property-missing-example.md
+++ b/docs/@v2/rules/oas/scalar-property-missing-example.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/scalar-property-missing-example
+slug: /docs/cli/rules/oas/scalar-property-missing-example
 ---
 
 # scalar-property-missing-example

--- a/docs/@v2/rules/oas/security-defined.md
+++ b/docs/@v2/rules/oas/security-defined.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/security-defined
+slug: /docs/cli/rules/oas/security-defined
 ---
 
 # security-defined

--- a/docs/@v2/rules/oas/spec-components-invalid-map-name.md
+++ b/docs/@v2/rules/oas/spec-components-invalid-map-name.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/spec-components-invalid-map-name
+slug: /docs/cli/rules/oas/spec-components-invalid-map-name
 ---
 
 # spec-components-invalid-map-name

--- a/docs/@v2/rules/oas/spec-strict-refs.md
+++ b/docs/@v2/rules/oas/spec-strict-refs.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/spec-strict-refs
+slug: /docs/cli/rules/oas/spec-strict-refs
 ---
 
 # spec-strict-refs

--- a/docs/@v2/rules/oas/tag-description.md
+++ b/docs/@v2/rules/oas/tag-description.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/tag-description
+slug: /docs/cli/rules/oas/tag-description
 ---
 
 # tag-description

--- a/docs/@v2/rules/oas/tags-alphabetical.md
+++ b/docs/@v2/rules/oas/tags-alphabetical.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/oas/tags-alphabetical
+slug: /docs/cli/rules/oas/tags-alphabetical
 ---
 
 # tags-alphabetical

--- a/docs/@v2/rules/recommended.md
+++ b/docs/@v2/rules/recommended.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/recommended
+slug: /docs/cli/rules/recommended
 ---
 
 # Recommended ruleset

--- a/docs/@v2/rules/respect/no-criteria-xpath.md
+++ b/docs/@v2/rules/respect/no-criteria-xpath.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/respect/no-criteria-xpath
+slug: /docs/cli/rules/respect/no-criteria-xpath
 ---
 
 # no-criteria-xpath

--- a/docs/@v2/rules/spec-ruleset.md
+++ b/docs/@v2/rules/spec-ruleset.md
@@ -1,5 +1,5 @@
 ---
-slug: /docs/cli/v2/rules/spec
+slug: /docs/cli/rules/spec
 ---
 
 # Spec ruleset

--- a/docs/versions.yaml
+++ b/docs/versions.yaml
@@ -1,6 +1,6 @@
-default: 'v1'
+default: 'v2'
 versions:
   - version: v1
-    name: 1.x (current)
+    name: 1.x (archive)
   - version: v2
-    name: 2.x (next)
+    name: 2.x (current)


### PR DESCRIPTION
## What/Why/How?

Make v2 the current version in the docs.

## Reference

Release PR: https://github.com/Redocly/redocly-cli/pull/2219.

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
