### PR TITLE
docs: update the v2 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Supports OpenAPI 3.1, 3.0 and OpenAPI 2.0 (legacy Swagger), AsyncAPI 3.0 and 2.6
 
 ![OpenAPI CLI toolset](./media/redocly-cli.gif)
 
+## Migration
+
+Migrating from Redocly CLI v1 to v2?
+Here's the [guide](https://redocly.com/docs/cli/guides/migrate-to-v2) to make the transition smoother.
+
 ## Usage
 
 ### Node

--- a/docs/@v2/guides/migrate-to-v2.md
+++ b/docs/@v2/guides/migrate-to-v2.md
@@ -16,6 +16,10 @@ This affects [plugins](../configuration/reference/plugins.md): update your plugi
 
 ### Configuration changes
 
+The only default configuration file name is now `redocly.yaml`.
+If you still use the legacy `.redocly.yaml`, please rename it.
+You can still use a different file name, but you must explicitly specify it with the `--config` flag.
+
 Several deprecated configuration options have been removed:
 
 ```yaml
@@ -119,11 +123,6 @@ rules:
 - **Legacy Registry**: Support for the legacy Redocly API Registry has been removed in favor of [Reunite](https://app.cloud.redocly.com/).
 - **Commands**: The `preview-docs` command has been removed - use `preview` instead.
 - **Labels**: The `labels` field in the `apis` section has been removed.
-
-### Config file name
-
-The only default configuration file name is now `redocly.yaml`.
-You can still use a different file name, but you must explicitly specify it with the `--config` flag.
 
 ## New features
 


### PR DESCRIPTION
## What/Why/How?

Updated the migration guide to highlight the config file name changes.

## Reference

Related: https://github.com/Redocly/openapi-starter/pull/81

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
