### PR TITLE
feat: made executionTimeout optional for exported respect-core run

### DIFF
--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -608,6 +608,7 @@ const basicCTX = {
     workflow: undefined,
     skip: undefined,
     verbose: true,
+    executionTimeout: 3_600_000,
     metadata: {
       _: [],
       files: ['runStepTest.yml'],

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -164,7 +164,10 @@ export async function runStep({
     return { shouldEnd: true };
   }
 
-  if (Timer.getInstance(ctx.options.executionTimeout).isTimedOut()) {
+  if (
+    ctx.options.executionTimeout &&
+    Timer.getInstance(ctx.options.executionTimeout).isTimedOut()
+  ) {
     step.checks.push({
       name: CHECKS.GLOBAL_TIMEOUT_ERROR,
       message: `Global Respect timer reached`,

--- a/packages/respect-core/src/run.ts
+++ b/packages/respect-core/src/run.ts
@@ -20,7 +20,7 @@ export type RespectOptions = {
   config: Config;
   maxSteps: number;
   maxFetchTimeout: number;
-  executionTimeout: number;
+  executionTimeout?: number;
   collectSpecData?: CollectFn;
   requestFileLoader: { getFileBody: (filePath: string) => Promise<Blob> };
   envVariables?: Record<string, string>;
@@ -34,7 +34,8 @@ export type RespectOptions = {
 export async function run(options: RespectOptions): Promise<RunFileResult[]> {
   const { files, executionTimeout, collectSpecData } = options;
 
-  Timer.getInstance(executionTimeout);
+  // Don't create a timer if executionTimeout is not set
+  executionTimeout && Timer.getInstance(executionTimeout);
 
   const testsRunProblemsStatus: boolean[] = [];
   const runAllFilesResult = [];

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -124,7 +124,7 @@ export type AppOptions = {
   severity?: string | string[];
   maxSteps: number;
   maxFetchTimeout: number;
-  executionTimeout: number;
+  executionTimeout?: number;
   config: Config;
   requestFileLoader: { getFileBody: (filePath: string) => Promise<Blob> };
   fetch: typeof fetch;


### PR DESCRIPTION
## What/Why/How?

As respect-core exported function can be used separately from CLI `executionTimeout` became optional setting.
E.G. => Replay does not need this functionality. 

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
