### PR TITLE
fix: pass externalRefResolver to nested workflow context

### DIFF
--- a/.changeset/quiet-experts-hope.md
+++ b/.changeset/quiet-experts-hope.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Ensure `externalRefResolver` option is correctly passed to nested workflow contexts.

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
@@ -332,6 +332,8 @@ describe('resolveWorkflowContext', async () => {
       maxSteps: 2000,
       maxFetchTimeout: 40_000,
       config,
+      server: undefined,
+      severity: undefined,
     },
     apiClient,
   } as any;
@@ -370,6 +372,7 @@ describe('resolveWorkflowContext', async () => {
         server: undefined,
         severity: undefined,
         verbose: undefined,
+        metadata: commonCtx.options.metadata,
       },
       apiClient
     );
@@ -397,6 +400,7 @@ describe('resolveWorkflowContext', async () => {
         server: undefined,
         severity: undefined,
         verbose: undefined,
+        metadata: commonCtx.options.metadata,
       },
       apiClient
     );
@@ -420,6 +424,7 @@ describe('resolveWorkflowContext', async () => {
         server: undefined,
         severity: undefined,
         verbose: undefined,
+        metadata: commonCtx.options.metadata,
       },
       apiClient
     );

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -251,7 +251,6 @@ export async function resolveWorkflowContext(
   ctx: TestContext,
   config: Config
 ) {
-  const { logger } = ctx.options;
   const sourceDescriptionId =
     workflowId && workflowId.startsWith('$sourceDescriptions.') && workflowId.split('.')[1];
 
@@ -263,6 +262,7 @@ export async function resolveWorkflowContext(
     ? await createTestContext(
         testDescription,
         {
+          ...ctx.options,
           filePath: findSourceDescriptionUrl(
             sourceDescriptionId,
             ctx.sourceDescriptions,
@@ -270,20 +270,7 @@ export async function resolveWorkflowContext(
           ),
           workflow: [resolvedWorkflow.workflowId],
           skip: undefined,
-          input: ctx.options.input || undefined,
-          server: ctx.options.server || undefined,
-          severity: ctx.options.severity || undefined,
-          verbose: ctx.options.verbose || undefined,
-          maxSteps: ctx.options.maxSteps,
-          maxFetchTimeout: ctx.options.maxFetchTimeout,
-          executionTimeout: ctx.options.executionTimeout,
           config,
-          requestFileLoader: ctx.options.requestFileLoader,
-          envVariables: ctx.options.envVariables,
-          logger,
-          fetch: ctx.options.fetch,
-          externalRefResolver: ctx.options?.externalRefResolver,
-          skipLint: ctx.options?.skipLint,
         },
         ctx.apiClient
       )

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -282,6 +282,8 @@ export async function resolveWorkflowContext(
           envVariables: ctx.options.envVariables,
           logger,
           fetch: ctx.options.fetch,
+          externalRefResolver: ctx.options?.externalRefResolver,
+          skipLint: ctx.options?.skipLint,
         },
         ctx.apiClient
       )


### PR DESCRIPTION
## What/Why/How?
Ensure `externalRefResolver`  and `skipLint` options are correctly passed to nested workflow contexts.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
