### PR TITLE
fix: correctly apply the openapi config options in build-docs

### DIFF
--- a/.changeset/purple-tips-fry.md
+++ b/.changeset/purple-tips-fry.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue where the `openapi` config options were ignored when running the `build-docs` command.

--- a/__tests__/build-docs/build-docs-with-disabled-search/config-with-alias.yaml
+++ b/__tests__/build-docs/build-docs-with-disabled-search/config-with-alias.yaml
@@ -1,0 +1,5 @@
+apis:
+  alias:
+    root: openapi.yaml
+    openapi:
+      disableSearch: true

--- a/__tests__/build-docs/build-docs-with-disabled-search/config.yaml
+++ b/__tests__/build-docs/build-docs-with-disabled-search/config.yaml
@@ -1,0 +1,2 @@
+openapi:
+  disableSearch: true

--- a/__tests__/build-docs/build-docs-with-disabled-search/openapi.yaml
+++ b/__tests__/build-docs/build-docs-with-disabled-search/openapi.yaml
@@ -1,0 +1,16 @@
+openapi: 3.1.0
+info:
+  title: Sample API
+  description: Test.
+  version: 1.0.0
+
+paths:
+  /test:
+    get:
+      summary: Test
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object

--- a/__tests__/build-docs/build-docs-with-disabled-search/snapshot.txt
+++ b/__tests__/build-docs/build-docs-with-disabled-search/snapshot.txt
@@ -2,17 +2,17 @@
 <html>
 
 <head>
-    <meta charset="utf8" />
-    <title>Sample API</title>
-    <!-- needed for adaptive design -->
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-        body {
-            padding: 0;
-            margin: 0;
-        }
-    </style>
-    <script src="https://cdn.redocly.com/redoc/v2.5.0/bundles/redoc.standalone.js"></script><style data-styled="true" data-styled-version="6.0.7">.daPKXi{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
+  <meta charset="utf8" />
+  <title>Sample API</title>
+  <!-- needed for adaptive design -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      padding: 0;
+      margin: 0;
+    }
+  </style>
+  <script src="https://cdn.redocly.com/redoc/v2.5.0/bundles/redoc.standalone.js"></script><style data-styled="true" data-styled-version="6.0.7">.daPKXi{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
 @media print,screen and (max-width: 75rem){.daPKXi{width:100%;padding:40px 40px;}}/*!sc*/
 data-styled.g4[id="sc-hLclGa"]{content:"daPKXi,"}/*!sc*/
 .cnGqGJ{padding:40px 0;}/*!sc*/
@@ -272,20 +272,13 @@ data-styled.g134[id="sc-jtrUWv"]{content:"iuiiOg,"}/*!sc*/
 .ktYOlr{background:#263238;position:absolute;top:0;bottom:0;right:0;width:calc((100% - 260px) * 0.4);}/*!sc*/
 @media print,screen and (max-width: 75rem){.ktYOlr{display:none;}}/*!sc*/
 data-styled.g135[id="sc-elITqc"]{content:"ktYOlr,"}/*!sc*/
-.eoWMdm{padding:5px 0;}/*!sc*/
-data-styled.g136[id="sc-kjokSJ"]{content:"eoWMdm,"}/*!sc*/
-.gngxjQ{width:calc(100% - 40px);box-sizing:border-box;margin:0 20px;padding:5px 10px 5px 20px;border:0;border-bottom:1px solid #e1e1e1;font-family:Roboto,sans-serif;font-weight:bold;font-size:13px;color:#333333;background-color:transparent;outline:none;}/*!sc*/
-data-styled.g137[id="sc-cLVjUO"]{content:"gngxjQ,"}/*!sc*/
-.kbgSHz{position:absolute;left:20px;height:1.8em;width:0.9em;}/*!sc*/
-.kbgSHz path{fill:#333333;}/*!sc*/
-data-styled.g138[id="sc-iJABxv"]{content:"kbgSHz,"}/*!sc*/
 </style>
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
 </head>
 
 <body>
-
-      <div id="redoc"><div class="sc-dvMDtO bOisjb redoc-wrap"><div class="sc-eVAmPc dilGZg menu-content" style="top:0px;height:calc(100vh - 0px)"><div role="search" class="sc-kjokSJ eoWMdm"><svg class="sc-iJABxv kbgSHz search-icon" version="1.1" viewBox="0 0 1000 1000" x="0px" xmlns="http://www.w3.org/2000/svg" y="0px"><path d="M968.2,849.4L667.3,549c83.9-136.5,66.7-317.4-51.7-435.6C477.1-25,252.5-25,113.9,113.4c-138.5,138.3-138.5,362.6,0,501C219.2,730.1,413.2,743,547.6,666.5l301.9,301.4c43.6,43.6,76.9,14.9,104.2-12.4C981,928.3,1011.8,893,968.2,849.4z M524.5,522c-88.9,88.7-233,88.7-321.8,0c-88.9-88.7-88.9-232.6,0-321.3c88.9-88.7,233-88.7,321.8,0C613.4,289.4,613.4,433.3,524.5,522z"></path></svg><input placeholder="Search..." aria-label="Search" type="text" class="sc-cLVjUO gngxjQ search-input" value=""/></div><div class="sc-kMbQoj ibNrgT scrollbar-container undefined"><ul role="menu" class="sc-ikzIVP eKenCK"><li tabindex="0" depth="2" data-item-id="operation/getMessage" role="menuitem" aria-label="Get a greeting message" aria-expanded="false" class="sc-tIxES bvSGWR"><label class="sc-bhFOXJ iRJxx -depth2"><span type="get" class="sc-WSdAm eEPUes operation-type get">get</span><span tabindex="0" width="calc(100% - 38px)" class="sc-eGknfI FOffJ">Get a greeting message</span></label></li></ul><div class="sc-hAIpwP kWGjHl"><a target="_blank" rel="noopener noreferrer" href="https://redocly.com/redoc/">API docs by Redocly</a></div></div></div><div class="sc-kTfErJ kQCezQ"><div class="sc-iqqmeU bQgvcX"><svg class="" style="transform:translate(2px, -4px) rotate(180deg);transition:transform 0.2s ease" viewBox="0 0 926.23699 573.74994" version="1.1" x="0px" y="0px" width="15" height="15"><g transform="translate(904.92214,-879.1482)"><path d="
+  
+      <div id="redoc"><div class="sc-dvMDtO bOisjb redoc-wrap"><div class="sc-eVAmPc dilGZg menu-content" style="top:0px;height:calc(100vh - 0px)"><div class="sc-kMbQoj ibNrgT scrollbar-container undefined"><ul role="menu" class="sc-ikzIVP eKenCK"><li tabindex="0" depth="2" data-item-id="/paths/~1test/get" role="menuitem" aria-label="Test" aria-expanded="false" class="sc-tIxES bvSGWR"><label class="sc-bhFOXJ iRJxx -depth2"><span type="get" class="sc-WSdAm eEPUes operation-type get">get</span><span tabindex="0" width="calc(100% - 38px)" class="sc-eGknfI FOffJ">Test</span></label></li></ul><div class="sc-hAIpwP kWGjHl"><a target="_blank" rel="noopener noreferrer" href="https://redocly.com/redoc/">API docs by Redocly</a></div></div></div><div class="sc-kTfErJ kQCezQ"><div class="sc-iqqmeU bQgvcX"><svg class="" style="transform:translate(2px, -4px) rotate(180deg);transition:transform 0.2s ease" viewBox="0 0 926.23699 573.74994" version="1.1" x="0px" y="0px" width="15" height="15"><g transform="translate(904.92214,-879.1482)"><path d="
           m -673.67664,1221.6502 -231.2455,-231.24803 55.6165,
           -55.627 c 30.5891,-30.59485 56.1806,-55.627 56.8701,-55.627 0.6894,
           0 79.8637,78.60862 175.9427,174.68583 l 174.6892,174.6858 174.6892,
@@ -303,11 +296,11 @@ data-styled.g138[id="sc-iJABxv"]{content:"kbgSHz,"}/*!sc*/
           55.627 l 55.6165,55.627 -231.245496,231.24803 c -127.185,127.1864
           -231.5279,231.248 -231.873,231.248 -0.3451,0 -104.688,
           -104.0616 -231.873,-231.248 z
-        " fill="currentColor"></path></g></svg></div></div><div class="sc-jtrUWv iuiiOg api-content"><div class="sc-eDnVMP cnGqGJ"><div class="sc-iBAaJG hptrmC"><div class="sc-hLclGa daPKXi api-info"><h1 class="sc-ftLKQv sc-csLglW ceXsZA gTGpPR">Sample API<!-- --> <span>(<!-- -->1.0.0<!-- -->)</span></h1><p>Download OpenAPI specification<!-- -->:</p><div class="sc-iJfdHH sc-cCIIiH bCGRPT cqZjzU"></div><div data-role="redoc-summary" html="" class="sc-iJfdHH sc-cCIIiH bCGRPT cqZjzU"></div><div data-role="redoc-description" html="" class="sc-iJfdHH sc-cCIIiH bCGRPT cqZjzU"></div></div></div></div><div id="operation/getMessage" data-section-id="operation/getMessage" class="sc-eDnVMP oSYUi"><div data-section-id="operation/getMessage" id="operation/getMessage" class="sc-iBAaJG hptrmC"><div class="sc-hLclGa daPKXi"><h2 class="sc-pqitP dPkvNG"><a class="sc-csmVar kZWguC" href="#operation/getMessage" aria-label="operation/getMessage"></a>Get a greeting message<!-- --> </h2><div><h3 class="sc-fHIGvW cBludx">Responses</h3><div><button class="sc-cbnPAL clcxbI"><svg class="sc-eLSjS fqhUrM" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0" aria-hidden="true"><polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon></svg><strong class="sc-fWzlon lmfYpR">200<!-- --> </strong><div html="&lt;p&gt;OK&lt;/p&gt;
-" class="sc-iJfdHH sc-cCIIiH sc-ciJnBw bCGRPT vnIkK cmhfIO"><p>OK</p>
-</div></button></div></div></div><div class="sc-jSwlEQ sc-gKHVLF hSOrl grVFKd"><div class="sc-fWYGfq drUdGD"><button class="sc-jWoQCg gwlEiQ"><span type="get" class="sc-eEyyFR epdPuq http-verb get">get</span><span class="sc-Fiojb kqFkUZ">/hello</span><svg class="sc-eLSjS eBBuGg" style="margin-right:-25px" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0" aria-hidden="true"><polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon></svg></button><div aria-hidden="true" class="sc-fnhmGq AyCLO"><div class="sc-lkMEiX hrtknQ"><div html="" class="sc-iJfdHH sc-cCIIiH bCGRPT fEPWkK"></div><div tabindex="0" role="button"><div class="sc-jmxxdg eiHFpW"><span>http://redocly-example.com</span>/hello</div></div></div></div></div><div><h3 class="sc-kDnyCx iOHJZc"> <!-- -->Response samples<!-- --> </h3><div class="sc-cwKisF jlrbNr" data-rttabs="true"><ul class="react-tabs__tab-list" role="tablist"><li class="tab-success react-tabs__tab--selected" role="tab" id="tab:R9pq:0" aria-selected="true" aria-disabled="false" aria-controls="panel:R9pq:0" tabindex="0" data-rttab="true">200</li></ul><div class="react-tabs__tab-panel react-tabs__tab-panel--selected" role="tabpanel" id="panel:R9pq:0" aria-labelledby="tab:R9pq:0"><div><div class="sc-cOqaIB cvDlVw"><span class="sc-bCnriq jYkKkv">Content type</span><div class="sc-dPOtYP jNTMxL">application/json</div></div><div class="sc-hTJqdO glNnHS"><div class="sc-cUfYYG cQziKA"><div class="sc-gisvNi kAIcUH"><button><div class="sc-jdkVqZ gGGecv">Copy</div></button></div><div tabindex="0" class="sc-iJfdHH bCGRPT sc-jOHGOj kmGcOs"><div class="redoc-json"><code><button class="collapser" aria-label="collapse"></button><span class="token punctuation">{</span><span class="ellipsis"></span><ul class="obj collapsible"><li><div class="hoverable "><span class="property token string">"message"</span>: <span class="token string">&quot;string&quot;</span></div></li></ul><span class="token punctuation">}</span></code></div></div></div></div></div></div></div></div></div></div></div></div><div class="sc-elITqc ktYOlr"></div></div></div>
+        " fill="currentColor"></path></g></svg></div></div><div class="sc-jtrUWv iuiiOg api-content"><div class="sc-eDnVMP cnGqGJ"><div class="sc-iBAaJG hptrmC"><div class="sc-hLclGa daPKXi api-info"><h1 class="sc-ftLKQv sc-csLglW ceXsZA gTGpPR">Sample API<!-- --> <span>(<!-- -->1.0.0<!-- -->)</span></h1><p>Download OpenAPI specification<!-- -->:</p><div class="sc-iJfdHH sc-cCIIiH bCGRPT cqZjzU"></div><div data-role="redoc-summary" html="" class="sc-iJfdHH sc-cCIIiH bCGRPT cqZjzU"></div><div data-role="redoc-description" html="&lt;p&gt;Test.&lt;/p&gt;
+" class="sc-iJfdHH sc-cCIIiH bCGRPT cqZjzU"><p>Test.</p>
+</div></div></div></div><div id="/paths/~1test/get" data-section-id="/paths/~1test/get" class="sc-eDnVMP oSYUi"><div class="sc-iBAaJG hptrmC"><div class="sc-hLclGa daPKXi"><h2 class="sc-pqitP dPkvNG"><a class="sc-csmVar kZWguC" href="#/paths/~1test/get" aria-label="/paths/~1test/get"></a>Test<!-- --> </h2><div><h3 class="sc-fHIGvW cBludx">Responses</h3><div><button class="sc-cbnPAL clcxbI"><svg class="sc-eLSjS fqhUrM" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0" aria-hidden="true"><polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon></svg><strong class="sc-fWzlon lmfYpR">200<!-- --> </strong><div html="" class="sc-iJfdHH sc-cCIIiH sc-ciJnBw bCGRPT vnIkK cmhfIO"></div></button></div></div></div><div class="sc-jSwlEQ sc-gKHVLF hSOrl grVFKd"><div class="sc-fWYGfq drUdGD"><button class="sc-jWoQCg gwlEiQ"><span type="get" class="sc-eEyyFR epdPuq http-verb get">get</span><span class="sc-Fiojb kqFkUZ">/test</span><svg class="sc-eLSjS eBBuGg" style="margin-right:-25px" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0" aria-hidden="true"><polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon></svg></button><div aria-hidden="true" class="sc-fnhmGq AyCLO"><div class="sc-lkMEiX hrtknQ"><div html="" class="sc-iJfdHH sc-cCIIiH bCGRPT fEPWkK"></div><div tabindex="0" role="button"><div class="sc-jmxxdg eiHFpW"><span></span>/test</div></div></div></div></div><div><h3 class="sc-kDnyCx iOHJZc"> <!-- -->Response samples<!-- --> </h3><div class="sc-cwKisF jlrbNr" data-rttabs="true"><ul class="react-tabs__tab-list" role="tablist"><li class="tab-success react-tabs__tab--selected" role="tab" id="tab:R9pq:0" aria-selected="true" aria-disabled="false" aria-controls="panel:R9pq:0" tabindex="0" data-rttab="true">200</li></ul><div class="react-tabs__tab-panel react-tabs__tab-panel--selected" role="tabpanel" id="panel:R9pq:0" aria-labelledby="tab:R9pq:0"><div><div class="sc-cOqaIB cvDlVw"><span class="sc-bCnriq jYkKkv">Content type</span><div class="sc-dPOtYP jNTMxL">application/json</div></div><div class="sc-hTJqdO glNnHS"><div class="sc-cUfYYG cQziKA"><div class="sc-gisvNi kAIcUH"><button><div class="sc-jdkVqZ gGGecv">Copy</div></button></div><div tabindex="0" class="sc-iJfdHH bCGRPT sc-jOHGOj kmGcOs"><div class="redoc-json"><code><span class="token punctuation">{ }</span></code></div></div></div></div></div></div></div></div></div></div></div></div><div class="sc-elITqc ktYOlr"></div></div></div>
       <script>
-      const __redoc_state = {"menu":{"activeItemIdx":-1},"spec":{"data":{"openapi":"3.1.0","servers":[{"url":"http://redocly-example.com"}],"info":{"title":"Sample API","version":"1.0.0"},"paths":{"/hello":{"get":{"operationId":"getMessage","security":[],"summary":"Get a greeting message","responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"$ref":"#/components/schemas/message-schema"}}}}}}}},"components":{"schemas":{"message-schema":{"type":"object","properties":{"message":{"type":"string"}}}}}}},"searchIndex":{"store":["operation/getMessage"],"index":{"version":"2.3.9","fields":["title","description"],"fieldVectors":[["title/0",[0,0.288,1,0.288]],["description/0",[2,0.288]]],"invertedIndex":[["greet",{"_index":0,"title":{"0":{}},"description":{}}],["hello",{"_index":2,"title":{},"description":{"0":{}}}],["messag",{"_index":1,"title":{"0":{}},"description":{}}]],"pipeline":[]}},"options":{"htmlTemplate":"../index.hbs"}};
+      const __redoc_state = {"menu":{"activeItemIdx":-1},"spec":{"data":{"openapi":"3.1.0","info":{"title":"Sample API","description":"Test.","version":"1.0.0"},"paths":{"/test":{"get":{"summary":"Test","responses":{"200":{"content":{"application/json":{"schema":{"type":"object"}}}}}}}},"components":{}}},"options":{"disableSearch":true}};
 
       var container = document.getElementById('redoc');
       Redoc.hydrate(__redoc_state, container);

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -708,7 +708,7 @@ describe('E2E', () => {
     });
 
     describe('build docs with disableSearch', () => {
-      test('build docs via an argv option', async () => {
+      test('build docs using an argv option', async () => {
         const testPath = join(folderPath, 'build-docs-with-disabled-search');
         const args = getParams(indexEntryPoint, [
           'build-docs',
@@ -728,7 +728,7 @@ describe('E2E', () => {
         await expect(output).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
       });
 
-      test('build docs via a config', async () => {
+      test('build docs using a config', async () => {
         const testPath = join(folderPath, 'build-docs-with-disabled-search');
         const args = getParams(indexEntryPoint, [
           'build-docs',
@@ -749,11 +749,31 @@ describe('E2E', () => {
         await expect(output).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
       });
 
-      test('build docs via an alias', async () => {
+      test('build docs using an alias', async () => {
         const testPath = join(folderPath, 'build-docs-with-disabled-search');
         const args = getParams(indexEntryPoint, [
           'build-docs',
           'alias',
+          '--config=config-with-alias.yaml',
+        ]);
+        const result = getCommandOutput(args, {}, { testPath });
+        expect(cleanupOutput(result)).toMatchInlineSnapshot(`
+          "
+          Found config-with-alias.yaml and using 'openapi' options
+          Prerendering docs
+
+          🎉 bundled successfully in: redoc-static.html (34 KiB) [⏱ <test>ms].
+          "
+        `);
+        const output = readFileSync(join(testPath, 'redoc-static.html'), 'utf8');
+        await expect(output).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
+      });
+
+      test('build docs using the file name (should use the alias config options)', async () => {
+        const testPath = join(folderPath, 'build-docs-with-disabled-search');
+        const args = getParams(indexEntryPoint, [
+          'build-docs',
+          'openapi.yaml',
           '--config=config-with-alias.yaml',
         ]);
         const result = getCommandOutput(args, {}, { testPath });

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -21,7 +21,7 @@ export const handlerBuildCommand = async ({
   const startedAt = performance.now();
 
   const apis = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
-  const { path: pathToApi } = apis[0];
+  const { path: pathToApi, alias } = apis[0];
 
   const options = {
     output: argv.o,
@@ -29,7 +29,7 @@ export const handlerBuildCommand = async ({
     disableGoogleFont: argv.disableGoogleFont,
     templateFileName: argv.template,
     templateOptions: argv.templateOptions || {},
-    redocOptions: getObjectOrJSON(argv.theme?.openapi, config, argv.api),
+    redocOptions: getObjectOrJSON(argv.theme?.openapi, config, alias),
   };
 
   const redocCurrentVersion = packageJson.dependencies.redoc;

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -40,7 +40,7 @@ export function getObjectOrJSON(
       break;
     default: {
       if (config?.configPath) {
-        logger.info(`Found ${config.configPath} and using theme.openapi options\n`);
+        logger.info(`Found ${config.configPath} and using 'openapi' options\n`);
         const apiConfig = alias ? config.resolvedConfig.apis?.[alias] : config.resolvedConfig;
         return apiConfig?.openapi ?? {};
       }


### PR DESCRIPTION
## What/Why/How?

Fixed an issue where the `openapi` config options were ignored when running the `build-docs` command.

## Reference

Resolves https://github.com/Redocly/redocly-cli/issues/2237

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
