### PR TITLE
fix: merge root and apis options correctly when creating config fromAlias

### DIFF
--- a/.changeset/thin-pandas-try.md
+++ b/.changeset/thin-pandas-try.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue where the root config was not properly merged with the `apis` config.

--- a/__tests__/build-docs/build-docs-with-disabled-search/config-with-apis-and-root-option.yaml
+++ b/__tests__/build-docs/build-docs-with-disabled-search/config-with-apis-and-root-option.yaml
@@ -1,0 +1,6 @@
+apis:
+  alias:
+    root: openapi.yaml
+
+openapi:
+  disableSearch: true

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -788,6 +788,26 @@ describe('E2E', () => {
         const output = readFileSync(join(testPath, 'redoc-static.html'), 'utf8');
         await expect(output).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
       });
+
+      test('build docs using a config with apis and a root option', async () => {
+        const testPath = join(folderPath, 'build-docs-with-disabled-search');
+        const args = getParams(indexEntryPoint, [
+          'build-docs',
+          'openapi.yaml',
+          '--config=config-with-apis-and-root-option.yaml',
+        ]);
+        const result = getCommandOutput(args, {}, { testPath });
+        expect(cleanupOutput(result)).toMatchInlineSnapshot(`
+          "
+          Found config-with-apis-and-root-option.yaml and using 'openapi' options
+          Prerendering docs
+
+          🎉 bundled successfully in: redoc-static.html (34 KiB) [⏱ <test>ms].
+          "
+        `);
+        const output = readFileSync(join(testPath, 'redoc-static.html'), 'utf8');
+        await expect(output).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
+      });
     });
   });
 

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -22,14 +22,13 @@ export const handlerBuildCommand = async ({
 
   const apis = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
   const { path: pathToApi, alias } = apis[0];
-
   const options = {
     output: argv.o,
     title: argv.title,
     disableGoogleFont: argv.disableGoogleFont,
     templateFileName: argv.template,
     templateOptions: argv.templateOptions || {},
-    redocOptions: getObjectOrJSON(argv.theme?.openapi, config, alias),
+    redocOptions: getObjectOrJSON(argv.theme?.openapi, config.forAlias(alias)),
   };
 
   const redocCurrentVersion = packageJson.dependencies.redoc;

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -18,8 +18,7 @@ const __internalDirname = import.meta.url
 
 export function getObjectOrJSON(
   openapiOptions: string | Record<string, unknown>,
-  config: Config,
-  alias?: string
+  config: Config
 ): JSON | Record<string, unknown> | Config {
   switch (typeof openapiOptions) {
     case 'object':
@@ -41,8 +40,7 @@ export function getObjectOrJSON(
     default: {
       if (config?.configPath) {
         logger.info(`Found ${config.configPath} and using 'openapi' options\n`);
-        const apiConfig = alias ? config.resolvedConfig.apis?.[alias] : config.resolvedConfig;
-        return apiConfig?.openapi ?? {};
+        return config.resolvedConfig?.openapi ?? {};
       }
       return {};
     }

--- a/packages/core/src/config/__tests__/config.test.ts
+++ b/packages/core/src/config/__tests__/config.test.ts
@@ -125,12 +125,18 @@ describe('Config.forAlias', () => {
           "overlay1Decorators": {},
           "overlay1Preprocessors": {},
           "overlay1Rules": {},
+          "plugins": undefined,
           "preprocessors": {},
-          "root": "resources/pets.yaml",
+          "resolve": {
+            "http": {
+              "headers": [],
+            },
+          },
           "rules": {
             "no-empty-servers": "error",
             "operation-summary": "warn",
           },
+          "telemetry": "on",
         },
         "resolvedRefMap": Map {},
         "rules": {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -144,13 +144,18 @@ export class Config {
       return this;
     }
 
-    return new Config(this.resolvedConfig.apis[alias], {
-      configPath: this.configPath,
-      document: this.document,
-      resolvedRefMap: this.resolvedRefMap,
-      alias,
-      plugins: this.plugins,
-    });
+    const { apis, ...rest } = this.resolvedConfig;
+    const { root: _root, output: _output, ...aliasConfig } = apis[alias];
+    return new Config(
+      { ...rest, ...aliasConfig },
+      {
+        configPath: this.configPath,
+        document: this.document,
+        resolvedRefMap: this.resolvedRefMap,
+        alias,
+        plugins: this.plugins,
+      }
+    );
   }
 
   resolveIgnore(ignoreFile?: string) {


### PR DESCRIPTION


## What/Why/How?

Fixed an issue where the root config was not properly merged with the `apis` config.
Previously, we were not merging the root options into those declared inside apis, e.g. when running `redocly build-docs openapi.yaml`, this works (the backgroundColor is applied):

```yaml
openapi:
  theme:
    sidebar:
      backgroundColor: "#FF0000"
```

while this doesn't:

```yaml
apis:
  example:
    root: openapi.yaml

openapi:
  theme:
    sidebar:
      backgroundColor: "#FF0000"
```

The reason is that we correctly detect an alias by the filename (`example`) and try to apply its options, but they are not merged with the root options we actually want to be applied.

## Reference

Resolves https://github.com/Redocly/redocly-cli/issues/2253

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
