### PR TITLE
fix: resolve wildcard pattern params from CLI

### DIFF
--- a/.changeset/spotty-trains-bake.md
+++ b/.changeset/spotty-trains-bake.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Resolve wildcard pattern params from CLI
+Fixed an issue where wildcard file patterns were not recognized in the Docker image.

--- a/.changeset/spotty-trains-bake.md
+++ b/.changeset/spotty-trains-bake.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Resolve wildcard pattern params from CLI

--- a/packages/cli/src/utils/miscellaneous.ts
+++ b/packages/cli/src/utils/miscellaneous.ts
@@ -5,7 +5,6 @@ import { hasMagic, glob } from 'glob';
 import * as fs from 'node:fs';
 import * as readline from 'node:readline';
 import { Writable } from 'node:stream';
-import { promisify } from 'node:util';
 import * as process from 'node:process';
 import {
   ResolveError,
@@ -28,8 +27,6 @@ import { handleLintConfig } from '../commands/lint.js';
 
 import type { Config, Oas3Definition, Oas2Definition, Exact } from '@redocly/openapi-core';
 import type { Totals, Entrypoint, OutputExtension, CommandArgv } from '../types.js';
-
-const globPromise = promisify(glob.glob);
 
 export type ExitCode = 0 | 1 | 2;
 
@@ -99,9 +96,9 @@ async function expandGlobsInEntrypoints(argApis: string[], config: Config) {
         const shouldResolveGlob = hasMagic(aliasOrPath) && !isAbsoluteUrl(aliasOrPath);
 
         if (shouldResolveGlob) {
-          const data = (await globPromise(aliasOrPath, {
+          const data = await glob(aliasOrPath, {
             cwd: getConfigDirectory(config),
-          })) as string[];
+          });
 
           return data.map((g: string) => getAliasOrPath(config, g));
         }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -54,12 +54,12 @@ export function isNotEmptyObject(obj: unknown): boolean {
   return isPlainObject(obj) && !isEmptyObject(obj);
 }
 
-export function isEmptyArray(value: unknown) {
+export function isEmptyArray(value: unknown): value is [] {
   return Array.isArray(value) && value.length === 0;
 }
 
-export function isNotEmptyArray<T>(args?: T[]): boolean {
-  return !!args && Array.isArray(args) && !!args.length;
+export function isNotEmptyArray<T>(args?: T[]): args is [T, ...T[]] {
+  return Array.isArray(args) && !!args.length;
 }
 
 export async function readFileFromUrl(url: string, config: HttpResolveConfig) {


### PR DESCRIPTION
## What/Why/How?

Make wildcard pattern params work in CLI.

## Reference

Fixes #2261 

## Testing

Run any command accepting multiple files by passing a wildcard format param.

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
