### PR TITLE
feat: respect verbose logs to show response headers

### DIFF
--- a/.changeset/wise-jars-suffer.md
+++ b/.changeset/wise-jars-suffer.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Improve Respect verbose logs to display response headers.
+Improved Respect verbose logs to display response headers.

--- a/.changeset/wise-jars-suffer.md
+++ b/.changeset/wise-jars-suffer.md
@@ -1,0 +1,6 @@
+---
+"@redocly/respect-core": patch
+"@redocly/cli": patch
+---
+
+Improve Respect verbose logs to display response headers.

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -18,6 +18,7 @@ export function getCommandOutput(
     env: {
       ...process.env,
       NODE_ENV: 'test',
+      REDOCLY_SNAPSHOT_TEST: 'true',
       NO_COLOR: 'TRUE',
       FORCE_COLOR: '0',
       ...env,

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -18,7 +18,6 @@ export function getCommandOutput(
     env: {
       ...process.env,
       NODE_ENV: 'test',
-      REDOCLY_SNAPSHOT_TEST: 'true',
       NO_COLOR: 'TRUE',
       FORCE_COLOR: '0',
       ...env,

--- a/__tests__/respect/consider-severity-in-next-step-execution/__snapshots__/consider-severity-in-next-step-execution.test.ts.snap
+++ b/__tests__/respect/consider-severity-in-next-step-execution/__snapshots__/consider-severity-in-next-step-execution.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should not follow the default behavior to break and return if onFailure
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -88,6 +89,7 @@ exports[`should not follow the default behavior to break and return if onFailure
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -225,6 +227,7 @@ exports[`should not follow the default behavior to break and return if onFailure
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/implicit/__snapshots__/implicit.test.ts.snap
+++ b/__tests__/respect/implicit/__snapshots__/implicit.test.ts.snap
@@ -31,6 +31,7 @@ exports[`should implicitly add content type header based on requestBody.content 
 
     Response status code: 204
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {}
 
@@ -65,6 +66,7 @@ exports[`should implicitly add content type header based on requestBody.content 
 
     Response status code: 400
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "type": "http://example.com",

--- a/__tests__/respect/inputs-with-cli-and-env/__snapshots__/inputs-with-cli-and-env.test.ts.snap
+++ b/__tests__/respect/inputs-with-cli-and-env/__snapshots__/inputs-with-cli-and-env.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should use inputs from CLI and env 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -94,6 +95,7 @@ exports[`should use inputs from CLI and env 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "message": "Museum general entry ticket purchased",
@@ -119,6 +121,7 @@ exports[`should use inputs from CLI and env 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -207,6 +210,7 @@ exports[`should use inputs from CLI and env 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",

--- a/__tests__/respect/mask-input-secrets/__snapshots__/mask-input-secrets.test.ts.snap
+++ b/__tests__/respect/mask-input-secrets/__snapshots__/mask-input-secrets.test.ts.snap
@@ -19,6 +19,7 @@ exports[`should hide sensitive input values 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -93,6 +94,7 @@ exports[`should hide sensitive input values 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -242,6 +244,7 @@ exports[`should hide sensitive input values 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",

--- a/__tests__/respect/outputs-access-syntax-variations/__snapshots__/outputs-access-syntax-variations.test.ts.snap
+++ b/__tests__/respect/outputs-access-syntax-variations/__snapshots__/outputs-access-syntax-variations.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should resolve outputs access syntax variations 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -94,6 +95,7 @@ exports[`should resolve outputs access syntax variations 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "message": "Museum general entry ticket purchased",
@@ -123,6 +125,7 @@ exports[`should resolve outputs access syntax variations 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -268,6 +271,7 @@ exports[`should resolve outputs access syntax variations 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",
@@ -301,6 +305,7 @@ exports[`should resolve outputs access syntax variations 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "6744a0da-4121-49cd-8479-f8cc20526495",

--- a/__tests__/respect/replacements/__snapshots__/replacements.test.ts.snap
+++ b/__tests__/respect/replacements/__snapshots__/replacements.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should replace values in the request body 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "6744a0da-4121-49cd-8479-f8cc20526495",
@@ -55,6 +56,7 @@ exports[`should replace values in the request body 1`] = `
 
     Response status code: 400
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "type": "object",
@@ -78,6 +80,7 @@ exports[`should replace values in the request body 1`] = `
 
     Response status code: 400
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "type": "object",
@@ -101,6 +104,7 @@ exports[`should replace values in the request body 1`] = `
 
     Response status code: 400
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "type": "object",

--- a/__tests__/respect/reusable-components/__snapshots__/reusable-components.test.ts.snap
+++ b/__tests__/respect/reusable-components/__snapshots__/reusable-components.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -86,6 +87,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -159,6 +161,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -235,6 +238,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -388,6 +392,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",
@@ -421,6 +426,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/severity-error-level/__snapshots__/severity-error-level.test.ts.snap
+++ b/__tests__/respect/severity-error-level/__snapshots__/severity-error-level.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should use error severity level 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -99,6 +100,7 @@ exports[`should use error severity level 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",
@@ -139,6 +141,7 @@ exports[`should use error severity level 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",

--- a/__tests__/respect/severity-off-level/__snapshots__/severity-off-level.test.ts.snap
+++ b/__tests__/respect/severity-off-level/__snapshots__/severity-off-level.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should use off severity level 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -99,6 +100,7 @@ exports[`should use off severity level 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",
@@ -139,6 +141,7 @@ exports[`should use off severity level 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",

--- a/__tests__/respect/severity-warn-level/__snapshots__/severity-warn-level.test.ts.snap
+++ b/__tests__/respect/severity-warn-level/__snapshots__/severity-warn-level.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should use warn severity level 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -99,6 +100,7 @@ exports[`should use warn severity level 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",
@@ -139,6 +141,7 @@ exports[`should use warn severity level 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",

--- a/__tests__/respect/x-security-api-key-auth/__snapshots__/x-security-api-key-auth.test.ts.snap
+++ b/__tests__/respect/x-security-api-key-auth/__snapshots__/x-security-api-key-auth.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should make request with X-API-KEY in header 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/x-security-basic-auth/__snapshots__/x-security-basic-auth.test.ts.snap
+++ b/__tests__/respect/x-security-basic-auth/__snapshots__/x-security-basic-auth.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should make request with Authorization header \`Basic ...\` 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/x-security-bearer-auth/__snapshots__/x-security-bearer-auth.test.ts.snap
+++ b/__tests__/respect/x-security-bearer-auth/__snapshots__/x-security-bearer-auth.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should make request with Authorization header \`Bearer ...\` 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/x-security-oauth2-auth/__snapshots__/x-security-oauth2-auth.test.ts.snap
+++ b/__tests__/respect/x-security-oauth2-auth/__snapshots__/x-security-oauth2-auth.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should make request with Authorization header \`Bearer ...\` using OAut
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/x-security-on-workflow-level-merged-to-steps/__snapshots__/x-security-on-workflow-level-merged-to-steps.test.ts.snap
+++ b/__tests__/respect/x-security-on-workflow-level-merged-to-steps/__snapshots__/x-security-on-workflow-level-merged-to-steps.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should merge x-security schemes on workflow level to steps 1`] = `
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -95,6 +96,7 @@ exports[`should merge x-security schemes on workflow level to steps 1`] = `
 
     Response status code: 201
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       {
         "eventId": "dad4bce8-f5cb-4078-a211-995864315e39",

--- a/__tests__/respect/x-security-open-id-connect-auth/__snapshots__/x-security-open-id-connect-auth.test.ts.snap
+++ b/__tests__/respect/x-security-open-id-connect-auth/__snapshots__/x-security-open-id-connect-auth.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should make request with Authorization header \`Bearer ...\` using Open
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/x-security-resolve-scheme-name/__snapshots__/x-security-resolve-scheme-name.test.ts.snap
+++ b/__tests__/respect/x-security-resolve-scheme-name/__snapshots__/x-security-resolve-scheme-name.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should resolve securitySchemes described in x-security by schemeName 1`
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {
@@ -83,6 +84,7 @@ exports[`should resolve securitySchemes described in x-security by schemeName 1`
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/__tests__/respect/x-security-scheme-apply-order/__snapshots__/x-security-scheme-apply-order.test.ts.snap
+++ b/__tests__/respect/x-security-scheme-apply-order/__snapshots__/x-security-scheme-apply-order.test.ts.snap
@@ -17,6 +17,7 @@ exports[`should apply x-security schemes in Top-Down order, the Last one have bi
 
     Response status code: 200
     Response time: <test> ms
+    Response Headers: <response headers test>
     Response Body:
       [
         {

--- a/packages/respect-core/src/modules/__tests__/flow-runner/call-api-and-analyze-results.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/call-api-and-analyze-results.test.ts
@@ -339,6 +339,7 @@ describe('callAPIAndAnalyzeResults', () => {
       },
     ],
     $outputs: {},
+    secretFields: new Set(),
   } as unknown as TestContext;
 
   it('should call API and return checks result', async () => {

--- a/packages/respect-core/src/modules/__tests__/logger-output/mask-secrets.test.ts
+++ b/packages/respect-core/src/modules/__tests__/logger-output/mask-secrets.test.ts
@@ -31,6 +31,8 @@ describe('findPotentiallySecretObjectFields', () => {
           color: 'red',
         },
       },
+      'set-cookie':
+        'accessToken=34567890; Max-Age=3600; Path=/; Expires=Wed, 20 Aug 2025 16:16:44 GMT; HttpOnly; SameSite=Strict',
     };
 
     const result = findPotentiallySecretObjectFields(obj);
@@ -41,6 +43,7 @@ describe('findPotentiallySecretObjectFields', () => {
       'id_token901',
       'some_client_secret',
       'password123',
+      '34567890',
     ]);
   });
 });

--- a/packages/respect-core/src/modules/__tests__/logger-output/mask-secrets.test.ts
+++ b/packages/respect-core/src/modules/__tests__/logger-output/mask-secrets.test.ts
@@ -32,7 +32,8 @@ describe('findPotentiallySecretObjectFields', () => {
         },
       },
       'set-cookie':
-        'accessToken=34567890; Max-Age=3600; Path=/; Expires=Wed, 20 Aug 2025 16:16:44 GMT; HttpOnly; SameSite=Strict',
+        'accessToken=34567890; Max-Age=3600; password=somesecret111 Path=/; Expires=Wed, 20 Aug 2025 16:16:44 GMT; HttpOnly; SameSite=Strict',
+      'set-cookie2': 'accessToken=34567890w',
     };
 
     const result = findPotentiallySecretObjectFields(obj);
@@ -44,6 +45,8 @@ describe('findPotentiallySecretObjectFields', () => {
       'some_client_secret',
       'password123',
       '34567890',
+      'somesecret111',
+      '34567890w',
     ]);
   });
 });

--- a/packages/respect-core/src/modules/logger-output/display-checks.ts
+++ b/packages/respect-core/src/modules/logger-output/display-checks.ts
@@ -128,7 +128,7 @@ function displayVerboseLogs({
   const responseOutput = [
     gray(indent('Response status code: ' + blue(statusCode as number), 4)),
     gray(indent('Response time: ' + blue(responseTime as number), 4) + ' ms'),
-    process.env.REDOCLY_SNAPSHOT_TEST === 'true'
+    !isBrowser && process.env.NODE_ENV === 'test'
       ? gray(indent('Response Headers: <response headers test>', 4))
       : headersString && gray(responseHeadersString) + '\n' + gray(headersString),
     body && gray(responseBodyString),

--- a/packages/respect-core/src/modules/logger-output/display-checks.ts
+++ b/packages/respect-core/src/modules/logger-output/display-checks.ts
@@ -128,7 +128,6 @@ function displayVerboseLogs({
   const responseOutput = [
     gray(indent('Response status code: ' + blue(statusCode as number), 4)),
     gray(indent('Response time: ' + blue(responseTime as number), 4) + ' ms'),
-    // Replace response headers section with static placeholder only for snapshots
     process.env.REDOCLY_SNAPSHOT_TEST === 'true'
       ? gray(indent('Response Headers: <response headers test>', 4))
       : headersString && gray(responseHeadersString) + '\n' + gray(headersString),

--- a/packages/respect-core/src/modules/logger-output/display-checks.ts
+++ b/packages/respect-core/src/modules/logger-output/display-checks.ts
@@ -128,8 +128,10 @@ function displayVerboseLogs({
   const responseOutput = [
     gray(indent('Response status code: ' + blue(statusCode as number), 4)),
     gray(indent('Response time: ' + blue(responseTime as number), 4) + ' ms'),
-    headersString && gray(responseHeadersString),
-    headersString && gray(headersString),
+    // Replace response headers section with static placeholder only for snapshots
+    process.env.REDOCLY_SNAPSHOT_TEST === 'true'
+      ? gray(indent('Response Headers: <response headers test>', 4))
+      : headersString && gray(responseHeadersString) + '\n' + gray(headersString),
     body && gray(responseBodyString),
     body && bodyString,
   ]

--- a/packages/respect-core/src/modules/logger-output/mask-secrets.ts
+++ b/packages/respect-core/src/modules/logger-output/mask-secrets.ts
@@ -101,6 +101,16 @@ export function findPotentiallySecretObjectFields(
         }
       }
 
+      if (typeof value === 'string' && value.trim()) {
+        for (const tokenKey of tokenKeys) {
+          const pattern = new RegExp(`${tokenKey}=([^;\\s]+)`, 'i');
+          const match = value.match(pattern);
+          if (match && match[1]) {
+            foundTokens.push(match[1]);
+          }
+        }
+      }
+
       if (value && typeof value === 'object') {
         searchInObject(value);
       }

--- a/packages/respect-core/src/modules/logger-output/mask-secrets.ts
+++ b/packages/respect-core/src/modules/logger-output/mask-secrets.ts
@@ -103,10 +103,10 @@ export function findPotentiallySecretObjectFields(
 
       if (typeof value === 'string' && value.trim()) {
         for (const tokenKey of tokenKeys) {
-          const pattern = new RegExp(`${tokenKey}=([^;\\s]+)`, 'i');
-          const match = value.match(pattern);
-          if (match && match[1]) {
-            foundTokens.push(match[1]);
+          const match = value.match(new RegExp(`${tokenKey}=([^;\\s]+)`, 'i'));
+          const [, secretValue] = match || [];
+          if (secretValue) {
+            foundTokens.push(secretValue);
           }
         }
       }

--- a/packages/respect-core/src/utils/api-fetcher.ts
+++ b/packages/respect-core/src/utils/api-fetcher.ts
@@ -216,7 +216,7 @@ export class ApiFetcher implements IFetcher {
     }
 
     // Mask the secrets in the header params and the body
-    const maskedHeaderParams = maskSecrets(headers, ctx.secretFields || new Set());
+    const maskedHeaderParams = maskSecrets(headers, ctx.secretFields);
     let maskedBody;
 
     if (encodedBody instanceof FormData) {
@@ -226,17 +226,17 @@ export class ApiFetcher implements IFetcher {
         if (value instanceof File) {
           maskedFormData.append(key, value);
         } else {
-          const maskedValue = maskSecrets(value, ctx.secretFields || new Set());
+          const maskedValue = maskSecrets(value, ctx.secretFields);
           maskedFormData.append(key, maskedValue);
         }
       }
       maskedBody = maskedFormData;
     } else if (isJsonContentType(contentType) && encodedBody) {
-      maskedBody = maskSecrets(JSON.parse(encodedBody), ctx.secretFields || new Set());
+      maskedBody = maskSecrets(JSON.parse(encodedBody), ctx.secretFields);
     } else {
       maskedBody = encodedBody;
     }
-    const maskedPathParams = maskSecrets(pathWithSearchParams, ctx.secretFields || new Set());
+    const maskedPathParams = maskSecrets(pathWithSearchParams, ctx.secretFields);
 
     // Start of the verbose logs
     this.initVerboseLogs({
@@ -335,7 +335,7 @@ export class ApiFetcher implements IFetcher {
       }
 
       this.updateVerboseLogs({
-        headerParams: maskSecrets(updatedHeaders, ctx.secretFields || new Set()),
+        headerParams: maskSecrets(updatedHeaders, ctx.secretFields),
       });
 
       fetchResult = await customFetch(urlToFetch, {
@@ -384,7 +384,7 @@ export class ApiFetcher implements IFetcher {
     }
 
     const maskedResponseBody = isJsonContentType(responseContentType)
-      ? maskSecrets(transformedBody, ctx.secretFields || new Set())
+      ? maskSecrets(transformedBody, ctx.secretFields)
       : transformedBody;
 
     const responseHeaders = Object.fromEntries(fetchResult.headers?.entries() || []);
@@ -403,7 +403,7 @@ export class ApiFetcher implements IFetcher {
       path: pathWithSearchParams || '',
       statusCode: fetchResult.status,
       responseTime,
-      headerParams: maskSecrets(responseHeaders, ctx.secretFields || new Set()),
+      headerParams: maskSecrets(responseHeaders, ctx.secretFields),
     });
 
     return {

--- a/packages/respect-core/src/utils/api-fetcher.ts
+++ b/packages/respect-core/src/utils/api-fetcher.ts
@@ -387,6 +387,13 @@ export class ApiFetcher implements IFetcher {
       ? maskSecrets(transformedBody, ctx.secretFields || new Set())
       : transformedBody;
 
+    const responseHeaders = Object.fromEntries(fetchResult.headers?.entries() || []);
+    const foundResponseHeadersSecrets = findPotentiallySecretObjectFields(responseHeaders);
+
+    for (const secretItem of foundResponseHeadersSecrets) {
+      ctx.secretFields.add(secretItem);
+    }
+
     this.initVerboseResponseLogs({
       body: isJsonContentType(responseContentType)
         ? JSON.stringify(maskedResponseBody)
@@ -396,6 +403,7 @@ export class ApiFetcher implements IFetcher {
       path: pathWithSearchParams || '',
       statusCode: fetchResult.status,
       responseTime,
+      headerParams: maskSecrets(responseHeaders, ctx.secretFields || new Set()),
     });
 
     return {


### PR DESCRIPTION
## What/Why/How?

Respect verbose logs to show `Response headers`.

JSON logs example:
```json
              "response": {
                "statusCode": 200,
                "body": {
                  "fox": "🦊",
                  "name": "fox",
                  "token": "********_token",
                  "access_token": "********",
                  "accessToken": "********",
                  "id_token": "********",
                  "AccessToken": "tttt",
                  "idToken": "44444",
                  "nested": {
                    "access-token": "iikikikik",
                    "password": "********"
                  }
                },
                "headers": {
                  "connection": "keep-alive",
                  "content-length": "267",
                  "content-type": "application/json; charset=utf-8",
                  "date": "Wed, 20 Aug 2025 15:57:23 GMT",
                  "etag": "W/\"10b-lfhzU7sGBlghKk8S2Fkue5Urako\"",
                  "keep-alive": "timeout=5",
                  "set-cookie": "accessToken=********; Max-Age=3600; Path=/; Expires=Wed, 20 Aug 2025 16:57:23 GMT; HttpOnly; SameSite=Strict",
                  "x-powered-by": "Express"
                },
                "time": 2
              },
```

Har logs:
```
        "response": {
          "headers": [
            {
              "name": "connection",
              "value": "keep-alive"
            },
            {
              "name": "content-length",
              "value": "267"
            },
            {
              "name": "content-type",
              "value": "application/json; charset=utf-8"
            },
            {
              "name": "date",
              "value": "Wed, 20 Aug 2025 16:01:18 GMT"
            },
            {
              "name": "etag",
              "value": "W/\"10b-lfhzU7sGBlghKk8S2Fkue5Urako\""
            },
            {
              "name": "keep-alive",
              "value": "timeout=5"
            },
            {
              "name": "set-cookie",
              "value": "accessToken=********; Max-Age=3600; Path=/; Expires=Wed, 20 Aug 2025 17:01:18 GMT; HttpOnly; SameSite=Strict"
            },
            {
              "name": "x-powered-by",
              "value": "Express"
            }
          ],
}
```

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2156

## Testing

## Screenshots (optional)
<img width="954" height="611" alt="Screenshot 2025-08-20 at 18 56 14" src="https://github.com/user-attachments/assets/1a1eaf7a-fa9a-422a-af63-b346b345ee77" />

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
