### PR TITLE
chore: export AsyncAPI types externally

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -6,7 +6,8 @@ import { detectSpec, getTypes, getMajorSpecVersion, type SpecMajorVersion } from
 import { isAbsoluteUrl, isExternalValue, isRef, refBaseName, replaceRef } from './ref-utils.js';
 import { initRules } from './config/rules.js';
 import { reportUnresolvedRef } from './rules/common/no-unresolved-refs.js';
-import { dequal, isTruthy } from './utils.js';
+import { isTruthy } from './utils.js';
+import { dequal } from './dequal.js';
 import { RemoveUnusedComponents as RemoveUnusedComponentsOas2 } from './decorators/oas2/remove-unused-components.js';
 import { RemoveUnusedComponents as RemoveUnusedComponentsOas3 } from './decorators/oas3/remove-unused-components.js';
 import { NormalizedConfigTypes } from './types/redocly-yaml.js';

--- a/packages/core/src/dequal.ts
+++ b/packages/core/src/dequal.ts
@@ -1,0 +1,36 @@
+/**
+ * Checks if two objects are deeply equal.
+ * Borrowed the source code from https://github.com/lukeed/dequal.
+ */
+export function dequal(foo: any, bar: any): boolean {
+  let ctor, len;
+  if (foo === bar) return true;
+
+  if (foo && bar && (ctor = foo.constructor) === bar.constructor) {
+    if (ctor === Date) return foo.getTime() === bar.getTime();
+    if (ctor === RegExp) return foo.toString() === bar.toString();
+
+    if (ctor === Array) {
+      if ((len = foo.length) === bar.length) {
+        while (len-- && dequal(foo[len], bar[len]));
+      }
+      return len === -1;
+    }
+
+    if (!ctor || typeof foo === 'object') {
+      len = 0;
+      for (ctor in foo) {
+        if (
+          Object.prototype.hasOwnProperty.call(foo, ctor) &&
+          ++len &&
+          !Object.prototype.hasOwnProperty.call(bar, ctor)
+        )
+          return false;
+        if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor])) return false;
+      }
+      return Object.keys(bar).length === len;
+    }
+  }
+
+  return foo !== foo && bar !== bar;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,20 +9,14 @@ export {
   pause,
   isPlainObject,
   isString,
-  dequal,
   pluralize,
   isEmptyObject,
   isNotEmptyArray,
   isNotEmptyObject,
 } from './utils.js';
+export { dequal } from './dequal.js';
 export { Oas3_1Types } from './types/oas3_1.js';
 export { Arazzo1Types } from './types/arazzo.js';
-export type {
-  ArazzoDefinition,
-  ExtendedOperation,
-  ExtendedSecurity,
-  ResolvedSecurity,
-} from './typings/arazzo.js';
 export { Oas3Types } from './types/oas3.js';
 export { Oas2Types } from './types/oas2.js';
 export { AsyncApi2Types } from './types/asyncapi2.js';
@@ -60,6 +54,12 @@ export type {
 export type { Oas2Definition } from './typings/swagger.js';
 export type { Async3Definition } from './typings/asyncapi3.js';
 export type { Async2Definition } from './typings/asyncapi.js';
+export type {
+  ArazzoDefinition,
+  ExtendedOperation,
+  ExtendedSecurity,
+  ResolvedSecurity,
+} from './typings/arazzo.js';
 export type { StatsAccumulator, StatsName } from './typings/common.js';
 export { type NormalizedNodeType, type NodeType, normalizeTypes } from './types/index.js';
 export { Stats } from './rules/other/stats.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,8 @@ export type {
   Oas3SecurityRequirement,
 } from './typings/openapi.js';
 export type { Oas2Definition } from './typings/swagger.js';
+export type { Async3Definition } from './typings/asyncapi3.js';
+export type { Async2Definition } from './typings/asyncapi.js';
 export type { StatsAccumulator, StatsName } from './typings/common.js';
 export { type NormalizedNodeType, type NodeType, normalizeTypes } from './types/index.js';
 export { Stats } from './rules/other/stats.js';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -244,44 +244,6 @@ export async function pause(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// TODO: move to a separate file
-/**
- * Checks if two objects are deeply equal.
- * Borrowed the source code from https://github.com/lukeed/dequal.
- */
-export function dequal(foo: any, bar: any): boolean {
-  let ctor, len;
-  if (foo === bar) return true;
-
-  if (foo && bar && (ctor = foo.constructor) === bar.constructor) {
-    if (ctor === Date) return foo.getTime() === bar.getTime();
-    if (ctor === RegExp) return foo.toString() === bar.toString();
-
-    if (ctor === Array) {
-      if ((len = foo.length) === bar.length) {
-        while (len-- && dequal(foo[len], bar[len]));
-      }
-      return len === -1;
-    }
-
-    if (!ctor || typeof foo === 'object') {
-      len = 0;
-      for (ctor in foo) {
-        if (
-          Object.prototype.hasOwnProperty.call(foo, ctor) &&
-          ++len &&
-          !Object.prototype.hasOwnProperty.call(bar, ctor)
-        )
-          return false;
-        if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor])) return false;
-      }
-      return Object.keys(bar).length === len;
-    }
-  }
-
-  return foo !== foo && bar !== bar;
-}
-
 export function getOwn(obj: Record<string, any>, key: string) {
   return obj.hasOwnProperty(key) ? obj[key] : undefined;
 }


### PR DESCRIPTION
## What/Why/How?

Export AsyncAPI descriptions types to be able to refer to them externally and slightly rearranged exports.

 

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
