### PR TITLE
fix: fix the push command mistakingly requiring the --max-execution-time option

### DIFF
--- a/.changeset/lazy-jobs-follow.md
+++ b/.changeset/lazy-jobs-follow.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed `push` and `push-status` commands mistakenly requiring the `--max-execution-time` option.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -190,7 +190,6 @@ yargs(hideBin(process.argv))
           'max-execution-time': {
             description: 'Maximum execution time in seconds.',
             type: 'number',
-            coerce: validatePositiveNumber('max-execution-time'),
           },
           'continue-on-deploy-failures': {
             description: 'Command does not fail even if the deployment fails.',
@@ -295,7 +294,6 @@ yargs(hideBin(process.argv))
           'max-execution-time': {
             description: 'Maximum execution time in seconds.',
             type: 'number',
-            coerce: validatePositiveNumber('max-execution-time'),
           },
           'wait-for-deployment': {
             description: 'Wait for build to finish.',


### PR DESCRIPTION


## What/Why/How?

Fixed `push` and `push-status` commands mistakenly requiring the `--max-execution-time` option.
This has been broken since v2.

## Reference

Discovered internally

## Testing

Tested manually

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [ ] The security impact of the change has been considered
- [ ] Code follows company security practices and guidelines
