### PR TITLE
docs: add a reminder for updating the related documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 - [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
 - [ ] All new/updated code is covered by tests
 - [ ] New package installed? - Tested in different environments (browser/node)
+- [ ] Documentation update considered
 
 ## Security
 


### PR DESCRIPTION
## What/Why/How?
Added a check for updating the related documentation.
This should serve as a reminder to keep the documentation in sync with the code changes.

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
