### PR TITLE
fix: add support for plugins in browser env

### DIFF
--- a/.changeset/stupid-kids-heal.md
+++ b/.changeset/stupid-kids-heal.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Added support for lint plugins in the browser environment.

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -93,7 +93,10 @@ export async function resolveConfig({
   let rootConfigDir: string = '';
   if (isBrowser) {
     // In browser, we don't support plugins from config file yet
-    resolvedPlugins = [defaultPlugin];
+    const instantiatedPlugins = ((config as RawUniversalConfig)?.plugins || []).filter(
+      (p) => !isString(p)
+    ) as Plugin[];
+    resolvedPlugins = [...instantiatedPlugins, defaultPlugin];
   } else {
     rootConfigDir = path.dirname(configPath ?? '');
     pluginsOrPaths = collectConfigPlugins(rootDocument, resolvedRefMap, rootConfigDir);


### PR DESCRIPTION
## What/Why/How?

Allow to pass plugins as instances in browser-env. 

## Reference
Noticed while working on browser-based editor powered by openapi-core.

## Testing

Tested manually in customer repo.

## Screenshots (optional)

## Check yourself

- [x] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
