### PR TITLE
chore: save residency as a part of the credentials

### DIFF
--- a/packages/cli/src/auth/__tests__/device-flow.test.ts
+++ b/packages/cli/src/auth/__tests__/device-flow.test.ts
@@ -54,7 +54,10 @@ describe('RedoclyOAuthDeviceFlow', () => {
       } as Response);
 
       const result = await flow.refreshToken('old-refresh-token');
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual({
+        ...mockResponse,
+        residency: mockBaseUrl,
+      });
     });
 
     it('throws error when refresh fails', async () => {

--- a/packages/cli/src/auth/device-flow.ts
+++ b/packages/cli/src/auth/device-flow.ts
@@ -8,6 +8,7 @@ export type Credentials = {
   access_token: string;
   refresh_token: string;
   expires_in: number;
+  residency?: string;
   token_type?: string; // from login response
 };
 
@@ -42,7 +43,7 @@ export class RedoclyOAuthDeviceFlow {
     );
     logger.output(green('✅ Logged in\n\n'));
 
-    return accessToken;
+    return this.withResidency(accessToken);
   }
 
   private openBrowser(url: string) {
@@ -93,11 +94,12 @@ export class RedoclyOAuthDeviceFlow {
     if (!response.access_token) {
       throw new Error('Failed to refresh token');
     }
-    return {
+
+    return this.withResidency({
       access_token: response.access_token,
       refresh_token: response.refresh_token,
       expires_in: response.expires_in,
-    };
+    });
   }
 
   private async pollingAccessToken(
@@ -175,5 +177,12 @@ export class RedoclyOAuthDeviceFlow {
       return { success: true };
     }
     return await response.json();
+  }
+
+  private withResidency(credentials: Credentials): Credentials {
+    return {
+      ...credentials,
+      residency: this.baseUrl,
+    };
   }
 }


### PR DESCRIPTION
## What/Why/How?

Save residency as a part of the credentials (neded to preserve login session for vs code extension)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
