### PR TITLE
chore: export config constants and refactor exports

### DIFF
--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -2,7 +2,7 @@ import {
   bundle,
   getTotals,
   logger,
-  Config,
+  createConfig,
   type ResolvedApiConfig,
   type ResolvedConfig,
 } from '@redocly/openapi-core';
@@ -160,7 +160,7 @@ describe('bundle', () => {
           } as ResolvedApiConfig,
         },
       };
-      const config = new Config(resolvedConfigMock);
+      const config = await createConfig(resolvedConfigMock);
 
       vi.mocked(getFallbackApisOrExit).mockResolvedValueOnce(
         Object.entries(resolvedConfigMock.apis!).map(([alias, { root, ...api }]) => ({
@@ -198,7 +198,7 @@ describe('bundle', () => {
           } as ResolvedApiConfig,
         },
       };
-      const config = new Config(resolvedConfigMock);
+      const config = await createConfig(resolvedConfigMock);
 
       vi.mocked(getFallbackApisOrExit).mockResolvedValueOnce(
         Object.entries(resolvedConfigMock.apis!).map(([alias, { root, ...api }]) => ({
@@ -233,7 +233,7 @@ describe('bundle', () => {
           } as ResolvedApiConfig,
         },
       };
-      const config = new Config(resolvedConfigMock);
+      const config = await createConfig(resolvedConfigMock);
 
       vi.mocked(getFallbackApisOrExit).mockResolvedValueOnce([{ path: 'openapi.yaml' }]);
       vi.mocked(getTotals).mockReturnValue({
@@ -266,7 +266,7 @@ describe('bundle', () => {
         },
       };
 
-      const config = new Config(resolvedConfigMock);
+      const config = await createConfig(resolvedConfigMock);
 
       vi.mocked(getFallbackApisOrExit).mockResolvedValueOnce(
         Object.entries(resolvedConfigMock.apis!).map(([alias, { root, ...api }]) => ({

--- a/packages/cli/src/__tests__/commands/generate-arazzo.test.ts
+++ b/packages/cli/src/__tests__/commands/generate-arazzo.test.ts
@@ -1,7 +1,7 @@
 import { GenerateArazzoCommandArgv, handleGenerateArazzo } from '../../commands/generate-arazzo.js';
 import { generate } from '@redocly/respect-core';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { Config } from '@redocly/openapi-core';
+import * as openapiCore from '@redocly/openapi-core';
 
 vi.mock('@redocly/respect-core', async () => {
   const actual = await vi.importActual<typeof import('@redocly/respect-core')>(
@@ -10,14 +10,6 @@ vi.mock('@redocly/respect-core', async () => {
   return {
     ...actual,
     generate: vi.fn(),
-  };
-});
-
-vi.mock('node:fs', async () => {
-  return {
-    writeFileSync: vi.fn(),
-    existsSync: vi.fn(() => true),
-    readFileSync: vi.fn(() => ''),
   };
 });
 
@@ -39,7 +31,7 @@ describe('handleGenerateArazzo', () => {
   });
 
   it('should call generate with the correct arguments', async () => {
-    const mockConfig = new Config({});
+    const mockConfig = await openapiCore.createConfig({});
     const commandArgs = {
       argv: {
         descriptionPath: 'openapi.yaml',
@@ -61,7 +53,7 @@ describe('handleGenerateArazzo', () => {
   });
 
   it('should use custom output file when provided', async () => {
-    const mockConfig = new Config({});
+    const mockConfig = await openapiCore.createConfig({});
     const commandArgs = {
       argv: {
         descriptionPath: 'openapi.yaml',
@@ -84,7 +76,7 @@ describe('handleGenerateArazzo', () => {
   });
 
   it('should throw an error if the openapi file is not valid', async () => {
-    const mockConfig = new Config({});
+    const mockConfig = await openapiCore.createConfig({});
     const commandArgs = {
       argv: {
         descriptionPath: 'openapi.yaml',

--- a/packages/cli/src/__tests__/commands/respect/respect.test.ts
+++ b/packages/cli/src/__tests__/commands/respect/respect.test.ts
@@ -1,6 +1,6 @@
 import { handleRespect, type RespectArgv } from '../../../commands/respect/index.js';
 import { run } from '@redocly/respect-core';
-import { Config } from '@redocly/openapi-core';
+import * as openapiCore from '@redocly/openapi-core';
 
 // Mock node:fs
 vi.mock('node:fs', async () => {
@@ -52,7 +52,7 @@ describe('handleRespect', () => {
     vi.clearAllMocks();
   });
   it('should call run with the correct arguments', async () => {
-    const mockConfig = new Config({});
+    const mockConfig = await openapiCore.createConfig({});
     const commandArgs = {
       argv: {
         files: ['test.arazzo.yaml'],

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -5,4 +5,3 @@ export * from './builtIn.js';
 export * from './load.js';
 export * from './utils.js';
 export * from './config-resolvers.js';
-export * from './constants.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,4 @@
 export {
-  type CollectFn,
-  type Exact,
   keysOf,
   readFileFromUrl,
   slash,
@@ -13,6 +11,8 @@ export {
   isEmptyObject,
   isNotEmptyArray,
   isNotEmptyObject,
+  type CollectFn,
+  type Exact,
 } from './utils.js';
 export { dequal } from './utils/dequal.js';
 export { Oas3_1Types } from './types/oas3_1.js';
@@ -22,6 +22,100 @@ export { Oas2Types } from './types/oas2.js';
 export { AsyncApi2Types } from './types/asyncapi2.js';
 export { AsyncApi3Types } from './types/asyncapi3.js';
 export { ConfigTypes, createConfigTypes } from './types/redocly-yaml.js';
+export { normalizeTypes, type NormalizedNodeType, type NodeType } from './types/index.js';
+export { Stats } from './rules/other/stats.js';
+export {
+  loadConfig,
+  createConfig,
+  findConfig,
+  resolvePlugins,
+  ConfigValidationError,
+  Config, // FIXME: export it as a type
+  type RawUniversalConfig,
+  type RawUniversalApiConfig,
+  type ResolvedConfig,
+  type ResolvedApiConfig,
+  type Plugin,
+  type RuleConfig,
+  type RuleSeverity,
+} from './config/index.js';
+export * from './config/constants.js';
+export {
+  Source,
+  BaseResolver,
+  Document,
+  ResolveError,
+  YamlParseError,
+  resolveDocument,
+  makeDocumentFromString,
+  type ResolvedRefMap,
+} from './resolve.js';
+export { parseYaml, stringifyYaml } from './js-yaml/index.js';
+export {
+  unescapePointer,
+  isRef,
+  isAbsoluteUrl,
+  escapePointer,
+  type Location,
+} from './ref-utils.js';
+export {
+  detectSpec,
+  getMajorSpecVersion,
+  getTypes,
+  type SpecVersion,
+  type SpecMajorVersion,
+} from './oas-types.js';
+export {
+  normalizeVisitors,
+  type Oas3Visitor,
+  type Oas2Visitor,
+  type Async2Visitor,
+  type Async3Visitor,
+  type Arazzo1Visitor,
+  type Overlay1Visitor,
+  type Oas3Rule,
+  type Oas2Rule,
+  type Async2Rule,
+  type Async3Rule,
+  type Arazzo1Rule,
+  type Overlay1Rule,
+  type Oas3Decorator,
+  type Oas2Decorator,
+  type Async2Decorator,
+  type Async3Decorator,
+  type Arazzo1Decorator,
+  type Overlay1Decorator,
+  type Oas3Preprocessor,
+  type Oas2Preprocessor,
+  type Async2Preprocessor,
+  type Async3Preprocessor,
+  type Arazzo1Preprocessor,
+  type Overlay1Preprocessor,
+} from './visitors.js';
+export {
+  WalkContext,
+  NormalizedProblem,
+  ProblemSeverity,
+  LineColLocationObject,
+  LocationObject,
+  Loc,
+  walkDocument,
+  type UserContext,
+} from './walk.js';
+export { getAstNodeByPointer, getLineColLocation, getCodeframe } from './format/codeframes.js';
+export { formatProblems, getTotals, type OutputFormat, type Totals } from './format/format.js';
+export { lint, lint as validate, lintDocument, lintFromString, lintConfig } from './lint.js';
+export {
+  bundle,
+  bundleDocument,
+  mapTypeToComponent,
+  bundleFromString,
+  type BundleResult,
+} from './bundle.js';
+export { type Assertions, type Assertion } from './rules/common/assertions/index.js';
+export { logger, type LoggerInterface } from './logger.js';
+export { HandledError } from './utils/error.js';
+export { isBrowser } from './env.js';
 
 export type {
   Oas3Definition,
@@ -61,104 +155,3 @@ export type {
   ResolvedSecurity,
 } from './typings/arazzo.js';
 export type { StatsAccumulator, StatsName } from './typings/common.js';
-export { type NormalizedNodeType, type NodeType, normalizeTypes } from './types/index.js';
-export { Stats } from './rules/other/stats.js';
-
-export {
-  type RawUniversalConfig,
-  type RawUniversalApiConfig,
-  type ResolvedConfig,
-  type ResolvedApiConfig,
-  type Plugin,
-  type RuleConfig,
-  Config, // FIXME: export it as a type
-  IGNORE_FILE,
-  loadConfig,
-  findConfig,
-  CONFIG_FILE_NAME,
-  type RuleSeverity,
-  createConfig,
-  ConfigValidationError,
-  resolvePlugins,
-} from './config/index.js';
-
-export {
-  type ResolvedRefMap,
-  Source,
-  BaseResolver,
-  Document,
-  resolveDocument,
-  ResolveError,
-  YamlParseError,
-  makeDocumentFromString,
-} from './resolve.js';
-export { parseYaml, stringifyYaml } from './js-yaml/index.js';
-export {
-  unescapePointer,
-  isRef,
-  isAbsoluteUrl,
-  escapePointer,
-  type Location,
-} from './ref-utils.js';
-export {
-  type SpecMajorVersion,
-  getMajorSpecVersion,
-  type SpecVersion,
-  detectSpec,
-  getTypes,
-} from './oas-types.js';
-export {
-  normalizeVisitors,
-  type Oas3Visitor,
-  type Oas2Visitor,
-  type Async2Visitor,
-  type Async3Visitor,
-  type Arazzo1Visitor,
-  type Overlay1Visitor,
-  type Oas3Rule,
-  type Oas2Rule,
-  type Async2Rule,
-  type Async3Rule,
-  type Arazzo1Rule,
-  type Overlay1Rule,
-  type Oas3Decorator,
-  type Oas2Decorator,
-  type Async2Decorator,
-  type Async3Decorator,
-  type Arazzo1Decorator,
-  type Overlay1Decorator,
-  type Oas3Preprocessor,
-  type Oas2Preprocessor,
-  type Async2Preprocessor,
-  type Async3Preprocessor,
-  type Arazzo1Preprocessor,
-  type Overlay1Preprocessor,
-} from './visitors.js';
-
-export {
-  WalkContext,
-  walkDocument,
-  NormalizedProblem,
-  ProblemSeverity,
-  LineColLocationObject,
-  LocationObject,
-  Loc,
-  type UserContext,
-} from './walk.js';
-
-export { getAstNodeByPointer, getLineColLocation, getCodeframe } from './format/codeframes.js';
-export { formatProblems, OutputFormat, getTotals, Totals } from './format/format.js';
-export { lint, lint as validate, lintDocument, lintFromString, lintConfig } from './lint.js';
-export {
-  type BundleResult,
-  bundle,
-  bundleDocument,
-  mapTypeToComponent,
-  bundleFromString,
-} from './bundle.js';
-
-export { type Assertions, type Assertion } from './rules/common/assertions/index.js';
-
-export { logger, type LoggerInterface } from './logger.js';
-export { HandledError } from './utils/error.js';
-export { isBrowser } from './env.js';


### PR DESCRIPTION
## What/Why/How?

- Exported all from config/constants.ts
- Removed usage of `new Config` in the code (it's going to be exported only as a type)
- Regrouped exports for better readability
 
## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
