### PR TITLE
fix: return on invalid ref pointer in remove-unused-components for OAS2

### DIFF
--- a/.changeset/eager-things-train.md
+++ b/.changeset/eager-things-train.md
@@ -1,5 +1,6 @@
 ---
 "@redocly/openapi-core": patch
+"@redocly/cli": patch
 ---
 
 Fixed undefined variable used in the `remove-unused-components` decorator, which prevented an invalid reference error from being reported.

--- a/packages/core/src/decorators/oas2/__tests__/fixtures/handle-invalid-ref/schemas.yaml
+++ b/packages/core/src/decorators/oas2/__tests__/fixtures/handle-invalid-ref/schemas.yaml
@@ -1,0 +1,2 @@
+Something:
+  type: string

--- a/packages/core/src/decorators/oas2/__tests__/fixtures/handle-invalid-ref/swagger.yaml
+++ b/packages/core/src/decorators/oas2/__tests__/fixtures/handle-invalid-ref/swagger.yaml
@@ -1,0 +1,14 @@
+swagger: '2.0'
+info:
+  title: API
+  version: '1.0.0'
+paths:
+  /pets:
+    get:
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: 'schemas.yaml#/Something.fail'

--- a/packages/core/src/decorators/oas2/__tests__/remove-unused-components.test.ts
+++ b/packages/core/src/decorators/oas2/__tests__/remove-unused-components.test.ts
@@ -1,6 +1,7 @@
+import * as path from 'node:path';
 import { outdent } from 'outdent';
 import { parseYamlToDocument } from '../../../../__tests__/utils.js';
-import { bundleDocument } from '../../../bundle.js';
+import { bundleDocument, bundle } from '../../../bundle.js';
 import { BaseResolver } from '../../../resolve.js';
 import { createConfig } from '../../../config/index.js';
 
@@ -225,5 +226,17 @@ describe('oas2 remove-unused-components', () => {
         },
       },
     });
+  });
+
+  it('should report invalid ref errors', async () => {
+    const { problems } = await bundle({
+      ref: path.join(__dirname, 'fixtures/handle-invalid-ref/swagger.yaml'),
+      config: await createConfig({}),
+      removeUnusedComponents: true,
+    });
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0].ruleId).toEqual('bundler');
+    expect(problems[0].message).toEqual("Can't resolve $ref");
   });
 });

--- a/packages/core/src/decorators/oas2/remove-unused-components.ts
+++ b/packages/core/src/decorators/oas2/remove-unused-components.ts
@@ -61,6 +61,8 @@ export const RemoveUnusedComponents: Oas2Decorator = () => {
           if (!resolvedRef.location) return;
 
           const [fileLocation, localPointer] = resolvedRef.location.absolutePointer.split('#', 2);
+          if (!localPointer) return;
+
           const componentLevelLocalPointer = localPointer.split('/').slice(0, 3).join('/');
           const pointer = `${fileLocation}#${componentLevelLocalPointer}`;
 


### PR DESCRIPTION
## What/Why/How?
Return on invalid ref pointer in remove-unused-components for OAS2.

## Reference
https://github.com/Redocly/redocly-cli/pull/2286
## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
