### PR TITLE
feat: improve telemetry insights for spec version detection

### DIFF
--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -28,7 +28,7 @@ export function commandWrapper<T extends CommandArgv>(
   return async (argv: Arguments<T>) => {
     let code: ExitCode = 2;
     let telemetry;
-    let specVersion: string | undefined = 'unknown';
+    let specVersion: string = 'unknown';
     let specKeyword: string | undefined;
     let specFullVersion: string | undefined;
     let config: Config | undefined;


### PR DESCRIPTION
## What/Why/How?
Added new logic inside telemetry sender to send an `undefined` keyword only if spec version is not detected and send `unknown` keyword in other cases (ex., error occurred).

## Reference
Closes: [#18266](https://github.com/Redocly/redocly/issues/18266)

## Testing
Created unit test and tested manually.
## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
