### PR TITLE
chore: mocked fs operations for generate arazzo tests

### DIFF
--- a/packages/cli/src/__tests__/commands/generate-arazzo.test.ts
+++ b/packages/cli/src/__tests__/commands/generate-arazzo.test.ts
@@ -2,6 +2,7 @@ import { GenerateArazzoCommandArgv, handleGenerateArazzo } from '../../commands/
 import { generate } from '@redocly/respect-core';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import * as openapiCore from '@redocly/openapi-core';
+import { writeFileSync } from 'node:fs';
 
 vi.mock('@redocly/respect-core', async () => {
   const actual = await vi.importActual<typeof import('@redocly/respect-core')>(
@@ -23,6 +24,11 @@ vi.mock('@redocly/openapi-core', async () => {
     stringifyYaml: vi.fn(() => 'mocked yaml'),
   };
 });
+
+vi.mock('node:fs', () => ({
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+}));
 
 describe('handleGenerateArazzo', () => {
   beforeEach(() => {
@@ -50,6 +56,7 @@ describe('handleGenerateArazzo', () => {
       version: '1.0.0',
       config: mockConfig,
     });
+    expect(writeFileSync).toHaveBeenCalledWith('auto-generated.arazzo.yaml', 'mocked yaml');
   });
 
   it('should use custom output file when provided', async () => {
@@ -73,6 +80,8 @@ describe('handleGenerateArazzo', () => {
       version: '1.0.0',
       config: mockConfig,
     });
+
+    expect(writeFileSync).toHaveBeenCalledWith('custom.arazzo.yaml', 'mocked yaml');
   });
 
   it('should throw an error if the openapi file is not valid', async () => {
@@ -91,5 +100,6 @@ describe('handleGenerateArazzo', () => {
     await expect(handleGenerateArazzo(commandArgs)).rejects.toThrow(
       '❌  Failed to generate Arazzo description. Check the output file path you provided, or the OpenAPI file content.'
     );
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What/Why/How?
Two files were created on local machine tests run: 
<img width="654" height="102" alt="Screenshot 2025-09-30 at 18 56 34" src="https://github.com/user-attachments/assets/7dd1b59d-3e1d-470d-80d8-e4e4fd41d040" />

That was a side effect of not mocked fs operation for generate-arazzo tests.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [ ] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
