### PR TITLE
fix: no-http-verbs-in-paths should not error on the verb query

### DIFF
--- a/.changeset/giant-years-admire.md
+++ b/.changeset/giant-years-admire.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue where the `no-http-verbs-in-paths` rule was incorrectly flagging path names containing the verb `query`.

--- a/docs/@v2/rules/oas/no-http-verbs-in-paths.md
+++ b/docs/@v2/rules/oas/no-http-verbs-in-paths.md
@@ -30,7 +30,6 @@ List of HTTP verbs:
 - `delete`
 - `options`
 - `trace`
-- `query` (introduced in OpenAPI 3.2)
 
 ## API design principles
 

--- a/packages/core/src/rules/common/__tests__/no-http-verbs-in-paths.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-http-verbs-in-paths.test.ts
@@ -1,0 +1,63 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint.js';
+import { parseYamlToDocument, replaceSourceWithRef } from '../../../../__tests__/utils.js';
+import { createConfig } from '../../../config/index.js';
+import { BaseResolver } from '../../../resolve.js';
+
+describe('no-http-verbs-in-paths', () => {
+  it('should report on HTTP verbs in paths', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        paths:
+          /path/post:
+            get:
+              summary: Contains http verb post in the end
+          /get/path:
+            get: 
+              summary: Contains http verb get in the beginning
+          /path/query:
+            get:
+              summary: Should not report on query since it's not an http verb in OAS 3.1
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-http-verbs-in-paths': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "location": [
+            {
+              "pointer": "#/paths/~1path~1post",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "path \`/path/post\` should not contain http verb post",
+          "ruleId": "no-http-verbs-in-paths",
+          "severity": "error",
+          "suggest": [],
+        },
+        {
+          "location": [
+            {
+              "pointer": "#/paths/~1get~1path",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "path \`/get/path\` should not contain http verb get",
+          "ruleId": "no-http-verbs-in-paths",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/common/no-http-verbs-in-paths.ts
+++ b/packages/core/src/rules/common/no-http-verbs-in-paths.ts
@@ -5,7 +5,7 @@ import type { Oas2PathItem } from '../../typings/swagger.js';
 import type { Oas3PathItem } from '../../typings/openapi.js';
 import type { UserContext } from '../../walk.js';
 
-const httpMethods = ['get', 'head', 'post', 'put', 'patch', 'delete', 'options', 'trace', 'query'];
+const httpMethods = ['get', 'head', 'post', 'put', 'patch', 'delete', 'options', 'trace'];
 
 export const NoHttpVerbsInPaths: Oas3Rule | Oas2Rule = ({ splitIntoWords }) => {
   return {


### PR DESCRIPTION
## What/Why/How?

Fixed an issue where the `no-http-verbs-in-paths` rule was incorrectly flagging path names containing the verb `query`.

## Reference

Fixes https://redoc-ly.slack.com/archives/C013VB35DB4/p1760032419326879 (internal).

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
