### PR TITLE
chore: require Redocly config update before release

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 24
-          cache: npm
       - name: Check Redocly Config Version
         run: |
           LATEST_VERSION=$(npm view @redocly/config version)


### PR DESCRIPTION
## What/Why/How?

Added a check on Release PR that will fail if Redocly config package version is outdated.

## Reference

Intrernal discussion: https://redoc-ly.slack.com/archives/C02UHE7EL3E/p1761816060204409?thread_ts=1761785533.570059&cid=C02UHE7EL3E

## Testing

Should be tested on a Release PR.


## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
