### PR TITLE
fix(respect): reported wrong step status in on-failure workflow

### DIFF
--- a/.changeset/young-glasses-tickle.md
+++ b/.changeset/young-glasses-tickle.md
@@ -1,0 +1,5 @@
+---
+"@redocly/respect-core": patch
+---
+
+Fixed a bug where workflows triggered by `onFailure` actions with retries were shown with inaccurate results in the overall report.

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -334,6 +334,7 @@ export async function runStep({
               skipLineSeparator: true,
               invocationContext: `Retry action for step ${stepId}`,
               executedStepsCount,
+              retriesLeft: retriesLeft - 1,
             });
             ctx.executedSteps.push(stepWorkflowResult);
           } else if (targetStep) {

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -115,6 +115,7 @@ export async function runWorkflow({
   parentStepId,
   invocationContext,
   executedStepsCount,
+  retriesLeft,
 }: RunWorkflowInput): Promise<WorkflowExecutionResult> {
   const { logger } = ctx.options;
   const workflowStartTime = performance.now();
@@ -166,6 +167,7 @@ export async function runWorkflow({
         ctx,
         workflowId,
         executedStepsCount,
+        retriesLeft,
       });
 
       // When `end` action is used, we should not continue with the next steps

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -212,6 +212,7 @@ export type RunWorkflowInput = {
   skipLineSeparator?: boolean;
   invocationContext?: string;
   executedStepsCount: ExecutedStepsCount;
+  retriesLeft?: number;
 };
 
 export type ArrazoItemExecutionResult = StepExecutionResult | WorkflowExecutionResult;


### PR DESCRIPTION
## What/Why/How?

Fixed an issue when retry workflow step result was counted as failed step in general report while retry attempts were still available.

The replicate scenario is not ordinary.
API responce timeline :
 1. `create-organization` step - 500 - does not match successCriteria :x:
 2. Executes onFailure retry action workflow `delete-organization`
 3. The step inside workflow `delete-organization` - 500 - does not match successCriteria :x:
 4. Second retry attempt starts
 5. `create-organization` step - 201 - match successCriteria :white_check_mark:
 6. workflowId: delete-organization  :white_check_mark:
 7. The Failed state reported for this execution

The fix is to propagate `retriesLeft` into type `retry` workflow action.


```yaml
arazzo: 1.0.1
info:
  title: Test retry on failure
  version: 1.0.0
sourceDescriptions:
  - name: museum-api
    type: openapi
    url: resources/museum.yaml
workflows:
  - workflowId: create-organization
    steps:
      - stepId: create-organization
        x-operation:
          url: http://localhost:3030/create-organization
          method: POST
        successCriteria:
          - condition: $statusCode == 201
        onFailure:
          - name: delete-organization
            workflowId: delete-organization
            type: retry
            retryAfter: 2
            retryLimit: 2
  - workflowId: delete-organization
    steps:
      - stepId: delete-organization
        x-operation:
          url: http://localhost:3030/delete-organization
          method: DELETE
        successCriteria:
          - condition: $statusCode == 204
```

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2397

## Testing

```bash
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 
  Running workflow retry.arazzo.yaml / create-organization 
 
  ✗ POST http://localhost:3030/create-organization - step create-organization 

    Request URL: http://localhost:3030/create-organization/ 
 

    Response status code: 500
    Response time: 42 ms
    Response Headers:
      connection: keep-alive
      content-length: 21
      content-type: text/html; charset=utf-8
      date: Thu, 30 Oct 2025 17:26:43 GMT
      etag: W/"15-/6VXivhc2MKdLfIkLcUE47K6aH0"
      keep-alive: timeout=5
      x-powered-by: Express
    Response Size: 21 bytes
    Response Body:
      Internal Server Error 
 
    ✗ success criteria check - $statusCode == 201
 
  Running failure action delete-organization for the step create-organization 
  Running workflow retry.arazzo.yaml / delete-organization 
 
  ✗ DELETE http://localhost:3030/delete-organization - step delete-organization 

    Request URL: http://localhost:3030/delete-organization/ 
 

    Response status code: 404
    Response time: 5 ms
    Response Headers:
      connection: keep-alive
      content-length: 9
      content-type: text/html; charset=utf-8
      date: Thu, 30 Oct 2025 17:26:43 GMT
      etag: W/"9-0gXL1ngzMqISxa6S1zx3F4wtLyg"
      keep-alive: timeout=5
      x-powered-by: Express
    Response Size: 9 bytes
    Response Body:
      Not Found 
 
    ✗ success criteria check - $statusCode == 204
 

  Retrying step create-organization (1/2)
 
  ✓ POST http://localhost:3030/create-organization - step create-organization 

    Request URL: http://localhost:3030/create-organization/ 
 

    Response status code: 201
    Response time: 3 ms
    Response Headers:
      connection: keep-alive
      content-length: 34
      content-type: text/html; charset=utf-8
      date: Thu, 30 Oct 2025 17:26:43 GMT
      etag: W/"22-g8bjSAiOWGVfroI2nlbYFLgruO4"
      keep-alive: timeout=5
      x-powered-by: Express
    Response Size: 34 bytes
    Response Body:
      Organization created successfully. 
 
    ✓ success criteria check - $statusCode == 201
 
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 
  Running workflow retry.arazzo.yaml / get-fox 
 
  ✓ GET http://localhost:3030/fox - step get-fox 

    Request URL: http://localhost:3030/fox/ 
 

    Response status code: 200
    Response time: 4 ms
    Response Headers:
      connection: keep-alive
      content-length: 267
      content-type: application/json; charset=utf-8
      date: Thu, 30 Oct 2025 17:26:43 GMT
      etag: W/"10b-lfhzU7sGBlghKk8S2Fkue5Urako"
      keep-alive: timeout=5
      set-cookie: accessToken=********; Max-Age=3600; Path=/; Expires=Thu, 30 Oct 2025 18:26:43 GMT; HttpOnly; SameSite=Strict
      x-powered-by: Express
    Response Size: 267 bytes
    Response Body:
      {
        "fox": "🦊",
        "name": "fox",
      } 
 
    ✓ success criteria check - $statusCode == 200
 
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 
  Running workflow retry.arazzo.yaml / delete-organization 
 
  ✓ DELETE http://localhost:3030/delete-organization - step delete-organization 

    Request URL: http://localhost:3030/delete-organization/ 
 

    Response status code: 204
    Response time: 3 ms
    Response Headers:
      connection: keep-alive
      date: Thu, 30 Oct 2025 17:26:43 GMT
      etag: W/"22-elWW+0Pzn3J8f0gVuPiZIZufTRo"
      keep-alive: timeout=5
      x-powered-by: Express
    Response Body:
      {} 
 
    ✓ success criteria check - $statusCode == 204
 
 
  Summary for retry.arazzo.yaml
  
  Workflows: 3 passed, 3 total
  Steps: 2 passed, 2 total
  Checks: 2 passed, 2 total
  Time: 108ms 
 
 
┌───────────────────────────────────────────────────────────┬────────────┬─────────┬─────────┬──────────┐
│ Filename                                                  │ Workflows  │ Passed  │ Failed  │ Warnings │
├───────────────────────────────────────────────────────────┼────────────┼─────────┼─────────┼──────────┤
│ ✓ retry.arazzo.yaml                                       │ 3          │ 3       │ -       │ -        │
└───────────────────────────────────────────────────────────┴────────────┴─────────┴─────────┴──────────┘
```

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
