### PR TITLE
fix: add env variable for controls the limit of suggestions

### DIFF
--- a/.changeset/clever-hoops-speak.md
+++ b/.changeset/clever-hoops-speak.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": minor
 ---
 
-Added `REDOCLY_CLI_MAX_SUGGESTIONS` environment variable to limit displayed suggestions (default: 5).
+Added `REDOCLY_CLI_LINT_MAX_SUGGESTIONS` environment variable to limit displayed suggestions (default: 5).

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -335,11 +335,10 @@ Note that the default value is `100`.
 
 ### Limit the displayed suggestions count
 
-When lint errors include suggestions (such as "Did you mean: propertyName?"), you can control how many suggestions are displayed using the `REDOCLY_CLI_MAX_SUGGESTIONS` environment variable.
+When lint errors include suggestions (such as "Did you mean: propertyName?"), you can control how many suggestions are displayed using the `REDOCLY_CLI_LINT_MAX_SUGGESTIONS` environment variable.
 
 ```bash
-export REDOCLY_CLI_MAX_SUGGESTIONS=10
-redocly lint openapi.yaml
+REDOCLY_CLI_LINT_MAX_SUGGESTIONS=10 redocly lint openapi.yaml
 ```
 
 The default value is `5`. This is useful when working with rules that provide many suggestions (like typo corrections for property names), allowing you to see more or fewer alternatives as needed.

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -174,7 +174,7 @@ describe('format', () => {
     `);
   });
 
-  it('should limit suggestions based on REDOCLY_CLI_MAX_SUGGESTIONS constant', () => {
+  it('should limit suggestions based on REDOCLY_CLI_LINT_MAX_SUGGESTIONS constant', () => {
     const problems: NormalizedProblem[] = [
       {
         ruleId: 'test-rule',

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -41,7 +41,7 @@ const CODECLIMATE_SEVERITY_MAPPING = {
   warn: 'minor',
 };
 
-const MAX_SUGGEST = +(env.REDOCLY_CLI_MAX_SUGGESTIONS ?? 5);
+const MAX_SUGGEST = +(env.REDOCLY_CLI_LINT_MAX_SUGGESTIONS ?? 5);
 
 function severityToNumber(severity: ProblemSeverity) {
   return severity === 'error' ? 1 : 2;


### PR DESCRIPTION
## What/Why/How?
Added the `REDOCLY_CLI_MAX_SUGGESTIONS` environment variable to control the limit on the number of suggestions.
## Reference
Related [PR](https://github.com/Redocly/redocly/pull/18974)
## Testing

<img width="634" height="479" alt="Screenshot 2025-11-04 at 11 09 48" src="https://github.com/user-attachments/assets/6ac73eb6-94b6-4e33-b58f-a35c5e8e1614" />

<img width="609" height="504" alt="Screenshot 2025-11-04 at 11 09 35" src="https://github.com/user-attachments/assets/fc766dfc-73c5-4ca6-b87f-8ad31bce3b67" />

## Screen

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
