### PR TITLE
docs: add troubleshooting for npx cache

### DIFF
--- a/docs/@v2/commands/preview.md
+++ b/docs/@v2/commands/preview.md
@@ -71,7 +71,8 @@ This command starts the preview on port 8888, so you can access the docs at `htt
 
 ### Internal Server Error
 
-An "Internal Server Error" page when running the preview command is often caused by a corrupted or outdated npx cache. The preview command uses npx internally to launch product packages, and cached packages can sometimes cause issues.
+An **Internal Server Error** page when running the preview command is often caused by a corrupted or outdated npx cache.
+The preview command uses npx internally to launch product packages, and cached packages can sometimes cause issues.
 
 #### Clear the npx cache
 


### PR DESCRIPTION
## What/Why/How?
Sometimes the npx cache can cause an error for the `npx <product> preview` command. Updated documentation.

## Reference
Closes #2290
## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
