### PR TITLE
chore: updated docs for v1 and v2 with correct arazzo rules syntax

### DIFF
--- a/docs/@v1/guides/lint-arazzo.md
+++ b/docs/@v1/guides/lint-arazzo.md
@@ -73,14 +73,14 @@ run `redocly lint --generate-ignore-file` to add all problems to the ignore file
 Choose from the ready-made rulesets (`minimal`, `recommended` or `recommended-strict`), or go one better and configure the rules that suit your use case.
 There's a full [list of built-in rules for Arazzo](../rules/built-in-rules.md#arazzo-rules) to refer to.
 
-Add the rules to `redocly.yaml`, but for Arazzo specifications, the rules go in their own configuration section called `arazzoRules`.
+Add the rules to `redocly.yaml`, but for Arazzo specifications, the rules go in their own configuration section called `arazzo1Rules`.
 The following example shows configuration for the minimal ruleset with some additional rules configuration:
 
 ```yaml
 extends:
  - minimal
 
-arazzoRules:
+arazzo1Rules:
   sourceDescription-name-unique: warn
   respect-supported-versions: error
 ```

--- a/docs/@v2/guides/lint-arazzo.md
+++ b/docs/@v2/guides/lint-arazzo.md
@@ -73,14 +73,14 @@ run `redocly lint --generate-ignore-file` to add all problems to the ignore file
 Choose from the ready-made rulesets (`spec`, `minimal`, `recommended` or `recommended-strict`), or go one better and configure the rules that suit your use case.
 There's a full [list of built-in rules for Arazzo](../rules/built-in-rules.md#arazzo-rules) to refer to.
 
-Add the rules to `redocly.yaml`, but for Arazzo specifications, the rules go in their own configuration section called `arazzoRules`.
+Add the rules to `redocly.yaml`, but for Arazzo specifications, the rules go in their own configuration section called `arazzo1Rules`.
 The following example shows configuration for the minimal ruleset with some additional rules configuration:
 
 ```yaml
 extends:
  - minimal
 
-arazzoRules:
+arazzo1Rules:
   sourceDescription-name-unique: warn
   respect-supported-versions: error
 ```

--- a/docs/@v2/rules/respect/no-x-security-scheme-name-without-openapi.md
+++ b/docs/@v2/rules/respect/no-x-security-scheme-name-without-openapi.md
@@ -24,7 +24,7 @@ You must use an OpenAPI operation in a step to be able to reference `schemeName`
 An example configuration:
 
 ```yaml
-arazzoRules:
+arazzo1Rules:
   no-x-security-scheme-name-without-openapi: error
 ```
 
@@ -33,7 +33,7 @@ arazzoRules:
 Given the following configuration:
 
 ```yaml
-arazzoRules:
+arazzo1Rules:
   no-x-security-scheme-name-without-openapi: error
 ```
 

--- a/docs/@v2/rules/respect/x-security-scheme-required-values.md
+++ b/docs/@v2/rules/respect/x-security-scheme-required-values.md
@@ -24,7 +24,7 @@ Different OpenAPI `securitySchemes` have some required values, like `token` or `
 An example configuration:
 
 ```yaml
-arazzoRules:
+arazzo1Rules:
   x-security-schema-required-values: error
 ```
 
@@ -33,7 +33,7 @@ arazzoRules:
 Given the following configuration:
 
 ```yaml
-arazzoRules:
+arazzo1Rules:
   x-security-schema-required-values: error
 ```
 


### PR DESCRIPTION
## What/Why/How?

Some docs were still describing outdated `arazzoRules` instead of `arazzo1Rules` syntax.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
