### PR TITLE
chore: improve performance by skipping unnecessary JSON pointer (un)escaping

### DIFF
--- a/.changeset/rare-planes-leave.md
+++ b/.changeset/rare-planes-leave.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Improved overall performance by skipping unnecessary JSON pointer escaping and unescaping.

--- a/packages/core/src/ref-utils.ts
+++ b/packages/core/src/ref-utils.ts
@@ -41,7 +41,8 @@ export class Location {
 }
 
 export function unescapePointerFragment(fragment: string): string {
-  const unescaped = fragment.replace(/~1/g, '/').replace(/~0/g, '~');
+  const unescaped =
+    fragment.indexOf('~') === -1 ? fragment : fragment.replaceAll('~1', '/').replaceAll('~0', '~');
 
   try {
     return decodeURIComponent(unescaped);
@@ -52,6 +53,8 @@ export function unescapePointerFragment(fragment: string): string {
 
 export function escapePointerFragment<T extends string | number>(fragment: T): T {
   if (typeof fragment === 'number') return fragment;
+  if (fragment.indexOf('/') === -1 && fragment.indexOf('~') === -1) return fragment;
+
   return fragment.replaceAll('~', '~0').replaceAll('/', '~1') as T;
 }
 


### PR DESCRIPTION
## What/Why/How?

Improved overall performance by skipping unnecessary JSON pointer escaping and unescaping.

## Testing

Testing in our products: https://github.com/Redocly/redocly/pull/20092

## Check yourself

- [x] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
