### PR TITLE
docs: update the apis section

### DIFF
--- a/docs/@v2/configuration/reference/apis.md
+++ b/docs/@v2/configuration/reference/apis.md
@@ -14,9 +14,9 @@ If your project contains multiple APIs, the `apis` configuration section allows 
 
 ---
 
-- `{name}@{version}`
+- `{name}`
 - [API object](#api-object)
-- **REQUIRED**. Each API needs a name and optionally a version. Supports alphanumeric characters and underscores.
+- **REQUIRED**. Each API needs a name. Supports alphanumeric characters and underscores.
 
 {% /table %}
 
@@ -66,7 +66,7 @@ The following example shows a simple `redocly.yaml` configuration file with sett
 
 ```yaml
 apis:
-  orders@v3:
+  orders:
     root: orders/openapi.yaml
     rules:
       tags-alphabetical: error


### PR DESCRIPTION
## What/Why/How?

Noticed that we still have `name@version` in apis  (was removed in CLI V2) when answering https://github.com/Redocly/redocly-cli/issues/2504.


## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
