### PR TITLE
fix: improve lint formatting for markdown to handle multiline error messages

### DIFF
--- a/.changeset/orange-books-clap.md
+++ b/.changeset/orange-books-clap.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue where multi-line lint error messages could break Markdown formatting.

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -145,6 +145,44 @@ describe('format', () => {
     `);
   });
 
+  it('should replace newlines with <br> in markdown messages', () => {
+    const problems: NormalizedProblem[] = [
+      {
+        ruleId: 'multiline-rule',
+        severity: 'error',
+        message:
+          "multiline-rule filed because the Response  didn't meet the assertions: \n- Response does not describe header Deprecation\n- Response does not describe header Sunset",
+        location: [
+          {
+            source: { absoluteRef: 'openapi.yaml' } as Source,
+            start: { line: 10, col: 5 },
+            end: { line: 10, col: 15 },
+          } as LocationObject,
+        ],
+        suggest: [],
+      },
+    ];
+
+    formatProblems(problems, {
+      format: 'markdown',
+      version: '2.0.0',
+      totals: getTotals(problems),
+    });
+
+    expect(output).toMatchInlineSnapshot(`
+      "## Lint: openapi.yaml
+
+      | Severity | Location | Problem | Message |
+      |---|---|---|---|
+      | error | line 10:5 | [multiline-rule](https://redocly.com/docs/cli/rules/multiline-rule/) | multiline-rule filed because the Response  didn't meet the assertions: <br>- Response does not describe header Deprecation<br>- Response does not describe header Sunset |
+
+      Validation failed
+      Errors: 1
+
+      "
+    `);
+  });
+
   it('should format problems with suggestions in github-actions format', () => {
     const problems = [
       {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -249,7 +249,7 @@ export type RawUniversalApiConfig = ApiConfig &
 
 export type ResolvedApiConfig = ApiConfig & Required<ResolvedGovernanceConfig>;
 
-export type RawUniversalConfig = Omit<Partial<RedoclyConfig>, 'apis' | 'plugins'> &
+export type RawUniversalConfig = Omit<RedoclyConfig, 'apis' | 'plugins'> &
   RawGovernanceConfig & {
     plugins?: (string | Plugin)[];
     apis?: Record<string, RawUniversalApiConfig>;

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -307,7 +307,10 @@ export function formatProblems(
     const { start } = problem.location[0];
     return `| ${severityName} | line ${`${start.line}:${start.col}`} | [${
       problem.ruleId
-    }](https://redocly.com/docs/cli/rules/${problem.ruleId}/) | ${problem.message} |`;
+    }](https://redocly.com/docs/cli/rules/${problem.ruleId}/) | ${problem.message.replaceAll(
+      '\n',
+      '<br>'
+    )} |`;
   }
 
   function formatCheckstyle(problem: OnlyLineColProblem) {


### PR DESCRIPTION

## What/Why/How?
Fixed an issue where multi-line lint error messages could break Markdown formatting.

Also, removed a redundant type modification.
## Reference
Fixes https://github.com/Redocly/redocly-cli/issues/2509
 

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
