### PR TITLE
fix: rollback multi-line lint error messages fix

### DIFF
--- a/.changeset/sweet-signs-watch.md
+++ b/.changeset/sweet-signs-watch.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Reverted the fix for handling multi-line lint error messages in Markdown formatting.

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -145,44 +145,6 @@ describe('format', () => {
     `);
   });
 
-  it('should replace newlines with <br> in markdown messages', () => {
-    const problems: NormalizedProblem[] = [
-      {
-        ruleId: 'multiline-rule',
-        severity: 'error',
-        message:
-          "multiline-rule filed because the Response  didn't meet the assertions: \n- Response does not describe header Deprecation\n- Response does not describe header Sunset",
-        location: [
-          {
-            source: { absoluteRef: 'openapi.yaml' } as Source,
-            start: { line: 10, col: 5 },
-            end: { line: 10, col: 15 },
-          } as LocationObject,
-        ],
-        suggest: [],
-      },
-    ];
-
-    formatProblems(problems, {
-      format: 'markdown',
-      version: '2.0.0',
-      totals: getTotals(problems),
-    });
-
-    expect(output).toMatchInlineSnapshot(`
-      "## Lint: openapi.yaml
-
-      | Severity | Location | Problem | Message |
-      |---|---|---|---|
-      | error | line 10:5 | [multiline-rule](https://redocly.com/docs/cli/rules/multiline-rule/) | multiline-rule filed because the Response  didn't meet the assertions: <br>- Response does not describe header Deprecation<br>- Response does not describe header Sunset |
-
-      Validation failed
-      Errors: 1
-
-      "
-    `);
-  });
-
   it('should format problems with suggestions in github-actions format', () => {
     const problems = [
       {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -249,7 +249,7 @@ export type RawUniversalApiConfig = ApiConfig &
 
 export type ResolvedApiConfig = ApiConfig & Required<ResolvedGovernanceConfig>;
 
-export type RawUniversalConfig = Omit<RedoclyConfig, 'apis' | 'plugins'> &
+export type RawUniversalConfig = Omit<Partial<RedoclyConfig>, 'apis' | 'plugins'> &
   RawGovernanceConfig & {
     plugins?: (string | Plugin)[];
     apis?: Record<string, RawUniversalApiConfig>;

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -307,10 +307,7 @@ export function formatProblems(
     const { start } = problem.location[0];
     return `| ${severityName} | line ${`${start.line}:${start.col}`} | [${
       problem.ruleId
-    }](https://redocly.com/docs/cli/rules/${problem.ruleId}/) | ${problem.message.replaceAll(
-      '\n',
-      '<br>'
-    )} |`;
+    }](https://redocly.com/docs/cli/rules/${problem.ruleId}/) | ${problem.message} |`;
   }
 
   function formatCheckstyle(problem: OnlyLineColProblem) {


### PR DESCRIPTION
## What/Why/How?

Rollback multi-line lint error messages fix to review formatting.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
