### PR TITLE
feat(respect): added support for runtime expression in the url property of  the x-operation

### DIFF
--- a/.changeset/light-deer-send.md
+++ b/.changeset/light-deer-send.md
@@ -1,0 +1,5 @@
+---
+"@redocly/respect-core": minor
+---
+
+Added support for runtime expressions in the `url` property of the Respect `x-operation` extension.

--- a/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/get-server-url.test.ts
@@ -161,6 +161,23 @@ describe('getServerUrl', () => {
     expect(result).toEqual({ url: 'http:/localhost:3000/test' });
   });
 
+  it('should resolve runtime expression in "x-operation" url', () => {
+    const ctx = {
+      $steps: {
+        test: { outputs: { upload_url: 'http://localhost:3000/test' } },
+      },
+      options: {
+        logger,
+      },
+    } as unknown as TestContext;
+    const result = getServerUrl({
+      ctx,
+      descriptionName: '',
+      xOperation: { url: '$steps.test.outputs.upload_url', method: 'get' },
+    });
+    expect(result).toEqual({ url: 'http://localhost:3000/test' });
+  });
+
   it('should return x-serverUrl when available when descriptionName is not provided and there is only one sourceDescription', () => {
     const ctx: TestContext = {
       sourceDescriptions: [

--- a/packages/respect-core/src/modules/flow-runner/get-server-url.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-server-url.ts
@@ -1,5 +1,6 @@
 import { getValueFromContext } from '../context-parser/index.js';
 import { formatCliInputs } from './inputs/index.js';
+import { evaluateRuntimeExpressionPayload } from '../runtime-expressions/evaluate.js';
 
 import type { ExtendedOperation, TestContext } from '../../types.js';
 import type { OperationDetails } from '../description-parser/index.js';
@@ -31,7 +32,13 @@ export function getServerUrl({
   xOperation,
 }: GetServerUrlInput): { url: string } | undefined {
   if (!descriptionName && xOperation?.url) {
-    return { url: xOperation?.url };
+    const resolvedUrl = evaluateRuntimeExpressionPayload({
+      payload: xOperation?.url,
+      context: ctx,
+      logger: ctx.options.logger,
+    });
+
+    return { url: resolvedUrl };
   }
 
   // Handle server overrides from command line `server` option


### PR DESCRIPTION
## What/Why/How?

Added support for runtime expressions in the `url` property of the Respect `x-operation` extension.
Covering this reported scenario:
```yaml
  steps:
      - stepId: initiate-upload
        operationId: $sourceDescriptions.openapi.InitiateUpload
        outputs:
          upload_url: $response.body#/upload_url
      - stepId: "upload-to-s3"
        x-operation:
          url: $steps.initiate-upload.outputs.upload_url
          method: put
```

- [x] Added support for runtime expressions evaluation in `x-operation` `url`.
- [x] Updated documentation => https://github.com/Redocly/website/pull/231.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2506

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
