### PR TITLE
feat(filter-in): add applyTo option to limit filtering to specific node types

### DIFF
--- a/.changeset/filter-in-applyto.md
+++ b/.changeset/filter-in-applyto.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": minor
+"@redocly/cli": minor
+---
+
+Added `applyTo` option to `filter-in` decorator to limit filtering to specific node types. This allows users to avoid accidentally filtering schema properties when filtering operations by tags.

--- a/packages/core/src/decorators/common/filters/filter-in.ts
+++ b/packages/core/src/decorators/common/filters/filter-in.ts
@@ -4,13 +4,20 @@ import type { Oas2Decorator, Oas3Decorator } from '../../../visitors.js';
 
 const DEFAULT_STRATEGY = 'any';
 
-export const FilterIn: Oas3Decorator | Oas2Decorator = ({ property, value, matchStrategy }) => {
+export const FilterIn: Oas3Decorator | Oas2Decorator = ({
+  property,
+  value,
+  matchStrategy,
+  applyTo,
+}) => {
   const strategy = matchStrategy || DEFAULT_STRATEGY;
   const filterInCriteria = (item: any) =>
     item?.[property] && !checkIfMatchByStrategy(item?.[property], value, strategy);
 
+  const visitor = applyTo || 'any';
+
   return {
-    any: {
+    [visitor]: {
       enter: (node, ctx) => {
         filter(node, ctx, filterInCriteria);
       },


### PR DESCRIPTION
## What/Why/How?

When using `filter-in` with `property: tags` to filter operations by tag, the decorator filters _any_ schema properties that happen to be named "tags", which can case undesirable results in cases such as this:

```yaml
# configuration
filter-in:
  property: tags
  value: App

# schema
openapi: 3.0.0
paths:
  /events:
    get:
      tags:
        - App
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Event'
components:
  schemas:
    Event:
      type: object
      properties:
        id:
          type: string
        tags:  # <-- This property gets incorrectly filtered out!
          type: array
          items:
            type: string
          description: User-defined tags for the event
```

This PR adds an `applyTo` option that lets users specify which node type the filter applies to (e.g., `PathItem`). 
This prevents unintended filtering of schema properties while still allowing filtering at the operation level:

```yaml
filter-in:
  property: tags
  value: App
  applyTo: PathItem
```

## Testing

Added a test case that verifies:
- Operations with the correct tag are included
- Operations with wrong tags are filtered out
- Schema properties named "tags" are preserved (not filtered)

## Check yourself

- [x] Have you added a changeset for your changes?
- [x] Have you added tests?