### PR TITLE
fix: do not fail linting when examples structure is invalid

### DIFF
--- a/.changeset/neat-bars-tie.md
+++ b/.changeset/neat-bars-tie.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue where improperly structured OpenAPI examples caused the linter to fail.

--- a/packages/core/src/rules/common/__tests__/no-invalid-parameter-examples.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-invalid-parameter-examples.test.ts
@@ -111,4 +111,38 @@ describe('no-invalid-parameter-examples', () => {
       ]
     `);
   });
+
+  it('should not crash when examples in not an object', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.2.0
+        paths:
+          /:
+            get:
+              parameters:
+                - name: foo
+                  in: query
+                  schema:
+                    type: string
+                  examples: Wrong multiple example
+                - name: bar
+                  in: query
+                  schema:
+                    type: string
+                  examples: 
+                    test: Wrong nested example
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({
+        rules: { 'no-invalid-parameter-examples': 'error' },
+      }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/core/src/rules/common/__tests__/no-invalid-schema-examples.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-invalid-schema-examples.test.ts
@@ -138,4 +138,36 @@ describe('no-invalid-schema-examples', () => {
       ]
     `);
   });
+
+  it('should not crash when examples in not an array', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.2.0
+        paths:
+          /:
+            get:
+              responses:
+                200:
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          foo:
+                            type: string
+                            examples: Wrong multiple example
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({
+        rules: { 'no-invalid-schema-examples': 'error' },
+      }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/core/src/rules/common/no-invalid-parameter-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-parameter-examples.ts
@@ -1,5 +1,6 @@
 import { validateExample } from '../utils.js';
 import { isDefined } from '../../utils/is-defined.js';
+import { isPlainObject } from '../../utils/is-plain-object.js';
 
 import type { UserContext } from '../../walk.js';
 import type { Oas3Parameter } from '../../typings/openapi.js';
@@ -18,9 +19,9 @@ export const NoInvalidParameterExamples: any = (opts: any) => {
           );
         }
 
-        if (parameter.examples) {
+        if (isPlainObject(parameter.examples)) {
           for (const [key, example] of Object.entries(parameter.examples)) {
-            if ('value' in example) {
+            if (isPlainObject(example) && 'value' in example) {
               validateExample(
                 example.value,
                 parameter.schema!,

--- a/packages/core/src/rules/common/no-invalid-schema-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-schema-examples.ts
@@ -11,7 +11,7 @@ export const NoInvalidSchemaExamples: Oas3Rule | Oas2Rule = (opts: any) => {
       leave(schema: Oas3_1Schema | Oas3Schema, ctx: UserContext) {
         const examples = (schema as Oas3_1Schema).examples;
 
-        if (examples) {
+        if (Array.isArray(examples)) {
           for (const example of examples) {
             validateExample(
               example,

--- a/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
+++ b/packages/core/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
@@ -793,4 +793,39 @@ describe('no-invalid-media-type-examples', () => {
       ]
     `);
   });
+
+  it('should not crash when examples in not an object', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.2.0
+        paths:
+          /:
+            get:
+              responses:
+                200:
+                  content:
+                    application/json:
+                      schema:
+                        type: string
+                      examples: Wrong multiple example
+                    application+nested/json:
+                      schema:
+                        type: string
+                      examples: 
+                        test: Wrong nested example
+
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({
+        rules: { 'no-invalid-media-type-examples': 'error' },
+      }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -1,6 +1,7 @@
 import { isRef } from '../../ref-utils.js';
 import { validateExample } from '../utils.js';
 import { isDefined } from '../../utils/is-defined.js';
+import { isPlainObject } from '../../utils/is-plain-object.js';
 
 import type { Oas3Rule } from '../../visitors.js';
 import type { Location } from '../../ref-utils.js';
@@ -18,7 +19,7 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
 
         if (isDefined(mediaType.example)) {
           resolveAndValidateExample(mediaType.example, location.child('example'));
-        } else if (mediaType.examples) {
+        } else if (isPlainObject(mediaType.examples)) {
           for (const exampleName of Object.keys(mediaType.examples)) {
             resolveAndValidateExample(
               mediaType.examples[exampleName],


### PR DESCRIPTION
## What/Why/How?

Fixed an issue where improperly structured OpenAPI examples caused the linter to fail.

## Reference

Discovered internally.

 

## Check yourself

- [x] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
