### PR TITLE
chore(deps): remove `ts-loader` package 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
       ],
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
-        "@types/mark.js": "^8.11.5",
-        "@types/marked": "^4.0.3",
         "@types/node": "^22.15.3",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
         "@typescript-eslint/parser": "^8.54.0",
@@ -1711,29 +1709,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
-    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -2805,12 +2780,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/@types/configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-c/QCznvk7bLKGhHETj29rqKufui3jaAxjBhK4R2zUrMG5UG0qTwfWYxBoUbH8JCyDjdCWMIxPJ7/Fdz1UcAnWg==",
-      "dev": true
-    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -2831,15 +2800,6 @@
       "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-      "dev": true,
-      "dependencies": {
-        "@types/sizzle": "*"
-      }
     },
     "node_modules/@types/js-levenshtein": {
       "version": "1.1.1",
@@ -2871,21 +2831,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/mark.js": {
-      "version": "8.11.8",
-      "resolved": "https://registry.npmjs.org/@types/mark.js/-/mark.js-8.11.8.tgz",
-      "integrity": "sha512-BoWCd9ydi1hZxDfu/lF0v1hHMsNUjuxZEDJsdHlmm6GlKk4qxlLya7D3FS81QmabwFbYPpoDOh9603JESUkHbA==",
-      "dev": true,
-      "dependencies": {
-        "@types/jquery": "*"
-      }
-    },
-    "node_modules/@types/marked": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
-      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==",
       "dev": true
     },
     "node_modules/@types/mdast": {
@@ -2966,12 +2911,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
     },
     "node_modules/@types/stylis": {
       "version": "4.2.7",
@@ -3869,13 +3808,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4214,13 +4146,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -9665,17 +9590,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/spawndamnit": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
@@ -11337,7 +11251,6 @@
       },
       "devDependencies": {
         "@redocly/cli-otel": "^0.0.4",
-        "@types/configstore": "^5.0.1",
         "@types/cookie": "0.6.0",
         "@types/har-format": "^1.2.16",
         "@types/pluralize": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
   "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
-    "@types/mark.js": "^8.11.5",
-    "@types/marked": "^4.0.3",
     "@types/node": "^22.15.3",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,6 @@
   },
   "devDependencies": {
     "@redocly/cli-otel": "^0.0.4",
-    "@types/configstore": "^5.0.1",
     "@types/cookie": "0.6.0",
     "@types/har-format": "^1.2.16",
     "@types/pluralize": "^0.0.29",


### PR DESCRIPTION
## What/Why/How?
`ts-loader` is not used in the project, as is `webpack`.
## Reference
close https://github.com/Redocly/redocly-cli/pull/2542
## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [ ] Documentation update considered

## Security

- [ ] The security impact of the change has been considered
- [ ] Code follows company security practices and guidelines
