### PR TITLE
chore: disable oxfmt for CHANGELOG.md

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -18,7 +18,8 @@
     "tests/e2e/**/*.yaml",
     "tests/smoke/**/*.yaml",
     "*.hbs",
-    "*.toml"
+    "*.toml",
+    "CHANGELOG.md"
   ],
   // "experimentalSortImports": {
   //   "groups": [["builtin"], ["external"], ["parent", "sibling", "index", "object"], ["type"]],


### PR DESCRIPTION
## What/Why/How?

Disable `oxfmt` for `CHANGELOG.md`

## Reference

- https://github.com/Redocly/redocly-cli/pull/2557/changes#diff-49d0ad40360a133ac46b22c6bd4bbc1a1e4b37054e94244dccbe314d4d847955R404
- https://github.com/Redocly/redocly-cli/actions/runs/21904533655/job/63241190920?pr=2557

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
