### PR TITLE
fix: issue assigning list response to the output

### DIFF
--- a/.changeset/hungry-spies-stand.md
+++ b/.changeset/hungry-spies-stand.md
@@ -1,0 +1,5 @@
+---
+"@redocly/respect-core": patch
+---
+
+Resolved an issue in Respect where the response list with nested object was not correctly assigned to the output.

--- a/packages/respect-core/src/modules/__tests__/runtime-expressions/evaluate.test.ts
+++ b/packages/respect-core/src/modules/__tests__/runtime-expressions/evaluate.test.ts
@@ -96,6 +96,16 @@ const runtimeExpressionContext = {
                 'Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.',
               dates: ['2023-12-15', '2023-12-22'],
               price: 0,
+              items: [
+                {
+                  name: 'item1',
+                  description: 'item1 description',
+                },
+                {
+                  name: 'item2',
+                  description: 'item2 description',
+                },
+              ],
             },
             statusCode: 201,
             header: {
@@ -229,7 +239,16 @@ const runtimeExpressionContext = {
       eventDescription: 'Join us as we review and classify a rare collection of 20 thingamabobs.',
       dates: ['2023-12-15', '2023-12-22'],
       price: 0,
-      items: [],
+      items: [
+        {
+          name: 'item1',
+          description: 'item1 description',
+        },
+        {
+          name: 'item2',
+          description: 'item2 description',
+        },
+      ],
       device_code: '123',
       piNumber: 3.14,
     },
@@ -394,7 +413,16 @@ describe('evaluateRuntimeExpressionPayload', () => {
       eventDescription: 'Join us as we review and classify a rare collection of 20 thingamabobs.',
       dates: ['2023-12-15', '2023-12-22'],
       price: 0,
-      items: [],
+      items: [
+        {
+          name: 'item1',
+          description: 'item1 description',
+        },
+        {
+          name: 'item2',
+          description: 'item2 description',
+        },
+      ],
       piNumber: 3.14,
     });
   });
@@ -638,5 +666,19 @@ describe('evaluateRuntimeExpression', () => {
     expect(evaluateRuntimeExpression(expression1, runtimeExpressionContext, logger)).toEqual(true);
     expect(evaluateRuntimeExpression(expression2, runtimeExpressionContext, logger)).toEqual(true);
     expect(evaluateRuntimeExpression(expression3, runtimeExpressionContext, logger)).toEqual(false);
+  });
+
+  it('should evaluate list runtime expression value', () => {
+    const expression = '$response.body#/items';
+    expect(evaluateRuntimeExpression(expression, runtimeExpressionContext, logger)).toEqual([
+      {
+        name: 'item1',
+        description: 'item1 description',
+      },
+      {
+        name: 'item2',
+        description: 'item2 description',
+      },
+    ]);
   });
 });

--- a/packages/respect-core/src/modules/flow-runner/schema/schema-checker.ts
+++ b/packages/respect-core/src/modules/flow-runner/schema/schema-checker.ts
@@ -20,7 +20,7 @@ const ajvStrict = new Ajv({
   validateSchema: false,
   discriminator: true,
   allowUnionTypes: true,
-  validateFormats: false,
+  validateFormats: true,
   logger: false,
   verbose: true,
   defaultUnevaluatedProperties: false,

--- a/packages/respect-core/src/modules/runtime-expressions/evaluate.ts
+++ b/packages/respect-core/src/modules/runtime-expressions/evaluate.ts
@@ -152,8 +152,17 @@ function normalizeExpression(expression: string, context: RuntimeExpressionConte
   // Normalize the expression for evaluation by replacing hyphens with underscores and converting to lowercase
   const normalizedSymbolsExpression = normalizeSymbolsExpression(modifiedJsExpression);
 
-  // Remove the curly braces surrounding the expression (if any)
-  const cleanedJsExpression = normalizedSymbolsExpression.replace(/{(.*?)}/g, '$1');
+  // Remove the curly braces surrounding the ENTIRE expression (if any), but not braces within JSON
+  let cleanedJsExpression = normalizedSymbolsExpression;
+
+  if (cleanedJsExpression.startsWith('{') && cleanedJsExpression.endsWith('}')) {
+    // A runtime expression wrapper has the form {$variable...} with no nested braces until the end
+    const potentialUnwrapped = cleanedJsExpression.slice(1, -1);
+    // Unwrap if it doesn't look like JSON (i.e., doesn't start with { or [)
+    if (!potentialUnwrapped.trim().startsWith('{') && !potentialUnwrapped.trim().startsWith('[')) {
+      cleanedJsExpression = potentialUnwrapped;
+    }
+  }
 
   // Convert numeric indices (e.g., `.0`) into square bracket notation (e.g., `[0]`)
   const expressionWithBrackets = convertNumericIndices(cleanedJsExpression);


### PR DESCRIPTION
## What/Why/How?

- [x] fix: issue assigning object list response to the output
```yaml
outputs:
  products: $response.body#/items
```

- [x] Change AJV setting for Respect schema check
```
validateFormats: true
```

## Reference

## Testing

tested internally => https://github.com/Redocly/redocly/actions/runs/22134093462/job/63981335759?pr=21051 

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
