### PR TITLE
fix: add error throw for invalid extends entries

### DIFF
--- a/packages/core/src/config/bundle-extends.ts
+++ b/packages/core/src/config/bundle-extends.ts
@@ -20,6 +20,18 @@ export function bundleExtends({
     return node;
   }
 
+  const invalidEntries = node.extends
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => typeof item !== 'string');
+
+  if (invalidEntries.length > 0) {
+    const positions = invalidEntries.map(({ index }) => index).join(', ');
+    throw new Error(
+      `Found ${invalidEntries.length} unresolvable "extends" entr${invalidEntries.length === 1 ? 'y' : 'ies'} ` +
+        `at position(s) [${positions}]. Each "extends" entry must be a resolvable preset name, file path, or URL.`
+    );
+  }
+
   const resolvedExtends = (node.extends || [])
     .map((presetItem: string) => {
       if (!isAbsoluteUrl(presetItem) && !path.extname(presetItem)) {


### PR DESCRIPTION
## What/Why/How?
Currently if we have invalid extends they come to bundle-extends as undefined and later while tryoing to resolve as refs trigger 
```
➜  redocly-cli git:(main) ✗ npx redocly lint openapi.yaml --config test/redocly.yaml
Something went wrong when processing :

  - Cannot read properties of undefined (reading 'startsWith')
  ```
  This causes not user-friendly error when loadConfig is used in portal build

## Reference
[Issue](https://github.com/orgs/Redocly/projects/81/views/1?pane=issue&itemId=141017093&issue=Redocly%7Credocly%7C19412)

## Testing
New error log
```
Something went wrong when processing :

  - Found 2 unresolvable "extends" entries at position(s) [1, 3]. Each "extends" entry must be a resolvable preset name, file path, or URL.
  ```

## Check yourself

- [] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [] All new/updated code is covered by tests
- [] New package installed? - Tested in different environments (browser/node)
- [] Documentation update considered

## Security

- [ ] The security impact of the change has been considered
- [ ] Code follows company security practices and guidelines
