### PR TITLE
chore: update @redocly/ajv to v8.18.0

### DIFF
--- a/.changeset/clever-dodos-visit.md
+++ b/.changeset/clever-dodos-visit.md
@@ -1,0 +1,7 @@
+---
+"@redocly/respect-core": patch
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Updated `@redocly/ajv` to `v8.18.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/@redocly/ajv": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12108,7 +12108,7 @@
         "@redocly/openapi-core": "2.20.0",
         "@redocly/respect-core": "2.20.0",
         "abort-controller": "^3.0.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "cookie": "^0.7.2",
@@ -12153,9 +12153,9 @@
     },
     "packages/cli/node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12185,9 +12185,9 @@
       "version": "2.20.0",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.17.4",
+        "@redocly/ajv": "^8.18.0",
         "@redocly/config": "^0.43.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -12211,9 +12211,9 @@
     },
     "packages/core/node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12245,9 +12245,9 @@
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "8.17.4",
+        "@redocly/ajv": "^8.18.0",
         "@redocly/openapi-core": "2.20.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
         "json-pointer": "^0.6.2",
@@ -12268,9 +12268,9 @@
     },
     "packages/respect-core/node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,7 @@
     "@redocly/openapi-core": "2.20.0",
     "@redocly/respect-core": "2.20.0",
     "abort-controller": "^3.0.0",
-    "ajv": "npm:@redocly/ajv@8.17.4",
+    "ajv": "npm:@redocly/ajv@8.18.0",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",
     "cookie": "^0.7.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,9 +52,9 @@
     "Roman Hotsiy <roman@redocly.com> (https://redocly.com/)"
   ],
   "dependencies": {
-    "@redocly/ajv": "^8.17.4",
+    "@redocly/ajv": "^8.18.0",
     "@redocly/config": "^0.43.0",
-    "ajv": "npm:@redocly/ajv@8.17.4",
+    "ajv": "npm:@redocly/ajv@8.18.0",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",
     "js-levenshtein": "^1.1.6",

--- a/packages/respect-core/package.json
+++ b/packages/respect-core/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "@noble/hashes": "^1.8.0",
-    "@redocly/ajv": "8.17.4",
+    "@redocly/ajv": "^8.18.0",
     "@redocly/openapi-core": "2.20.0",
-    "ajv": "npm:@redocly/ajv@8.17.4",
+    "ajv": "npm:@redocly/ajv@8.18.0",
     "better-ajv-errors": "^1.2.0",
     "colorette": "^2.0.20",
     "json-pointer": "^0.6.2",


### PR DESCRIPTION
## What/Why/How?

- update `@redocly/ajv` to `v8.18.0`
- tested snapshot in reunite (https://github.com/Redocly/redocly/actions/runs/22494108555/job/65164288863?pr=21298)

## Reference

- https://github.com/Redocly/ajv/pull/43
- https://github.com/Redocly/ajv/releases/tag/v8.18.0

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
