### PR TITLE
chore: update `minimatch` dependency

### DIFF
--- a/.changeset/wicked-melons-juggle.md
+++ b/.changeset/wicked-melons-juggle.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Updated `minimatch` dependency to v5.1.7.
+Updated `minimatch` dependency to v5.1.9.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9606,9 +9606,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
-      "integrity": "sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -13518,7 +13518,7 @@
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
         "js-yaml": "4.1.0",
-        "minimatch": "5.1.7",
+        "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
@@ -15336,7 +15336,7 @@
         "js-levenshtein": "1.1.6",
         "js-yaml": "4.1.0",
         "json-schema-to-ts": "^3.1.0",
-        "minimatch": "5.1.7",
+        "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "typescript": "5.5.3",
         "yaml-ast-parser": "0.0.43"
@@ -20684,9 +20684,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
-      "integrity": "sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "https-proxy-agent": "7.0.6",
     "js-levenshtein": "1.1.6",
     "js-yaml": "4.1.0",
-    "minimatch": "5.1.7",
+    "minimatch": "5.1.9",
     "pluralize": "8.0.0",
     "yaml-ast-parser": "0.0.43"
   },


### PR DESCRIPTION
## What/Why/How?
Updated `minimatch` dependency to v5.1.7. 

## Reference
Issue #2619

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
