### PR TITLE
chore: add major release guard job

### DIFF
--- a/.github/workflows/main-version-release-guard.yaml
+++ b/.github/workflows/main-version-release-guard.yaml
@@ -10,7 +10,6 @@ on:
     branches:
       - main
       - v1
-      
 
 jobs:
   check-major-version:


### PR DESCRIPTION
## What/Why/How?

Add a major release guard job.

In some cases, it’s possible to miss the correct version update in the changeset and unintentionally publish a major release. To make this action more deliberate, let’s introduce an additional (non-blocking) check to help surface such situations and ensure the version bump is intentional.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
