### PR TITLE
chore: bump undici

### DIFF
--- a/.changeset/wet-rice-like.md
+++ b/.changeset/wet-rice-like.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Updated `undici` to the `7.24.4` version to ensure improved performance, security, and compatibility.
+Updated `undici` to the `6.24.1` version to ensure improved performance, security, and compatibility.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12056,7 +12056,7 @@
         "simple-websocket": "^9.0.0",
         "styled-components": "6.3.9",
         "ulid": "^3.0.1",
-        "undici": "^7.24.4",
+        "undici": "^6.24.1",
         "yargs": "17.0.1"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "simple-websocket": "^9.0.0",
     "styled-components": "6.3.9",
     "ulid": "^3.0.1",
-    "undici": "^7.24.4",
+    "undici": "^6.24.1",
     "yargs": "17.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What/Why/How?

Updates undici from 6.23.0 to 6.24.1.

## Reference

https://github.com/Redocly/redocly-cli/pull/2658

## Testing

Internal => https://github.com/Redocly/redocly/pull/21645

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [ ] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
