### PR TITLE
fix: do not show the message about missing configuration when the --extends option is provided

### DIFF
--- a/.changeset/swift-heads-end.md
+++ b/.changeset/swift-heads-end.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue where a message about a missing configuration was shown even though the `--extends` option was provided.

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -205,5 +205,17 @@ describe('handleLint', () => {
         )} configuration by default.\n\n`
       );
     });
+
+    it('should not suggest recommended fallback if --extends is provided', async () => {
+      vi.mocked(loadConfigAndHandleErrors).mockImplementation(async () => {
+        return await loadConfig({});
+      });
+      await commandWrapper(handleLint)({ ...argvMock, extends: ['some/path'] });
+      expect(logger.info).not.toHaveBeenCalledWith(
+        `No configurations were provided -- using built in ${blue(
+          'recommended'
+        )} configuration by default.\n\n`
+      );
+    });
   });
 });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -66,7 +66,7 @@ export async function handleLint({
       aliasConfig.skipRules(argv['skip-rule']);
       aliasConfig.skipPreprocessors(argv['skip-preprocessor']);
 
-      if (typeof config.document?.parsed === 'undefined') {
+      if (typeof config.document?.parsed === 'undefined' && !argv.extends) {
         logger.info(
           `No configurations were provided -- using built in ${blue(
             'recommended'


### PR DESCRIPTION


## What/Why/How?

Fixed an issue where a message about a missing configuration was shown even though the `--extends` option was provided.
 


## Reference

Closes https://github.com/Redocly/redocly-cli/issues/2684.

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
