### PR TITLE
fix: support content type wildcard checks

### DIFF
--- a/.changeset/huge-buttons-rescue.md
+++ b/.changeset/huge-buttons-rescue.md
@@ -1,0 +1,5 @@
+---
+"@redocly/respect-core": patch
+---
+
+Handled content type wildcards in response validation to improve Respect's accuracy when matching described content types.

--- a/packages/respect-core/src/modules/__tests__/flow-runner/schema/schema-checker.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/schema/schema-checker.test.ts
@@ -3,7 +3,12 @@ import { logger } from '@redocly/openapi-core';
 import type { StepCallContext, TestContext } from '../../../../types.js';
 import { cleanColors } from '../../../../utils/clean-colors.js';
 import { DEFAULT_SEVERITY_CONFIGURATION } from '../../../checks/severity.js';
-import { CHECKS, checkSchema, statusCodeDiff } from '../../../flow-runner/index.js';
+import {
+  CHECKS,
+  checkSchema,
+  statusCodeDiff,
+  resolveContentByType,
+} from '../../../flow-runner/index.js';
 
 describe('checkSchema', () => {
   const stepCallCtx = {
@@ -420,6 +425,41 @@ describe('checkSchema', () => {
     expect(result).toEqual([]);
   });
 
+  it('should match content type against wildcard in description', () => {
+    const wildcardDescriptionOperation = {
+      ...descriptionOperation,
+      responses: {
+        '200': {
+          description: 'successful operation',
+          content: {
+            'application/*': {
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    breed: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = checkSchema({
+      stepCallCtx,
+      descriptionOperation: wildcardDescriptionOperation,
+      ctx,
+    });
+
+    const contentTypeCheck = result.find((c) => c.name === CHECKS.CONTENT_TYPE_CHECK);
+    expect(contentTypeCheck?.passed).toBe(true);
+
+    const schemaCheck = result.find((c) => c.name === CHECKS.SCHEMA_CHECK);
+    expect(schemaCheck).toBeDefined();
+  });
+
   it('should check content type from description', () => {
     const stepCallCtx = {
       $request: {
@@ -521,5 +561,95 @@ describe('statusCodeDiff', () => {
     expect(cleanColors(statusCodeDiff(202, [200, 201]))).toBe(
       'Expected value to be in the list:\n  200, 201\nReceived:\n  202'
     );
+  });
+});
+
+describe('resolveContentByType', () => {
+  it('should return undefined when content is undefined', () => {
+    expect(resolveContentByType(undefined, 'application/json')).toBeUndefined();
+  });
+
+  it('should return exact match by content type', () => {
+    const content = {
+      'application/json': { schema: { type: 'object' } },
+      'text/plain': { schema: { type: 'string' } },
+    };
+    expect(resolveContentByType(content, 'application/json')).toEqual({
+      schema: { type: 'object' },
+    });
+  });
+
+  it('should match */* wildcard pattern', () => {
+    const content = {
+      '*/*': { schema: { type: 'string' } },
+    };
+    expect(resolveContentByType(content, 'application/json')).toEqual({
+      schema: { type: 'string' },
+    });
+    expect(resolveContentByType(content, 'text/plain')).toEqual({
+      schema: { type: 'string' },
+    });
+  });
+
+  it('should match type/* wildcard pattern', () => {
+    const content = {
+      'application/*': { schema: { type: 'object' } },
+    };
+    expect(resolveContentByType(content, 'application/json')).toEqual({
+      schema: { type: 'object' },
+    });
+    expect(resolveContentByType(content, 'application/xml')).toEqual({
+      schema: { type: 'object' },
+    });
+    expect(resolveContentByType(content, 'text/plain')).toBeUndefined();
+  });
+
+  it('should prefer exact match over wildcard', () => {
+    const content = {
+      'application/json': { schema: { type: 'object' } },
+      '*/*': { schema: { type: 'string' } },
+    };
+    expect(resolveContentByType(content, 'application/json')).toEqual({
+      schema: { type: 'object' },
+    });
+  });
+
+  it('should return undefined when no pattern matches', () => {
+    const content = {
+      'application/json': { schema: { type: 'object' } },
+      'text/*': { schema: { type: 'string' } },
+    };
+    expect(resolveContentByType(content, 'image/png')).toBeUndefined();
+  });
+
+  it('should return first matching wildcard when multiple wildcards match', () => {
+    const content = {
+      'application/*': { schema: { type: 'object' } },
+      '*/*': { schema: { type: 'string' } },
+    };
+    const result = resolveContentByType(content, 'application/json');
+    expect(result).toEqual({ schema: { type: 'object' } });
+  });
+
+  it('should match */subtype wildcard pattern', () => {
+    const content = {
+      '*/json': { schema: { type: 'object' } },
+    };
+    expect(resolveContentByType(content, 'application/json')).toEqual({
+      schema: { type: 'object' },
+    });
+    expect(resolveContentByType(content, 'text/json')).toEqual({
+      schema: { type: 'object' },
+    });
+    expect(resolveContentByType(content, 'application/xml')).toBeUndefined();
+  });
+
+  it('should match content type case-insensitively', () => {
+    const content = {
+      'Application/JSON': { schema: { type: 'object' } },
+    };
+    expect(resolveContentByType(content, 'application/json')).toEqual({
+      schema: { type: 'object' },
+    });
   });
 });

--- a/packages/respect-core/src/modules/checks/severity.ts
+++ b/packages/respect-core/src/modules/checks/severity.ts
@@ -1,6 +1,6 @@
 import type { RuleSeverity } from '@redocly/openapi-core';
 
-import { formatCliInputs } from '../flow-runner/index.js';
+import { formatCliInputs } from '../flow-runner/inputs/format-cli-inputs.js';
 import type { CHECKS } from './checks.js';
 
 export const DEFAULT_SEVERITY_CONFIGURATION: {

--- a/packages/respect-core/src/modules/flow-runner/schema/schema-checker.ts
+++ b/packages/respect-core/src/modules/flow-runner/schema/schema-checker.ts
@@ -1,4 +1,5 @@
 import Ajv, { type JSONSchemaType } from '@redocly/ajv/dist/2020.js';
+import type { Oas3Responses } from '@redocly/openapi-core';
 import { blue, dim, red, yellow, green } from 'colorette';
 
 import {
@@ -67,7 +68,7 @@ function checkSchemaFromDescription({
     descriptionOperation?.responses['default'];
 
   const schemaFromDescription = $response?.contentType
-    ? descriptionResponseByCode?.content?.[$response.contentType]?.schema
+    ? resolveContentByType(descriptionResponseByCode?.content, $response.contentType)?.schema
     : undefined;
   const isSchemaWithCircularRef = checkCircularRefsInSchema(schemaFromDescription);
 
@@ -138,6 +139,44 @@ function checkStatusCodeFromDescription({
   });
 }
 
+function contentTypeMatchesPattern(contentType: string, pattern: string): boolean {
+  const normalizedPattern = pattern.toLowerCase();
+  const normalizedContentType = contentType.toLowerCase();
+
+  if (normalizedPattern === '*/*') return true;
+  if (normalizedPattern === normalizedContentType) return true;
+
+  const [patternType, patternSubtype] = normalizedPattern.split('/');
+  const [actualType, actualSubtype] = normalizedContentType.split('/');
+
+  if (patternType === '*') {
+    return patternSubtype === '*' || patternSubtype === actualSubtype;
+  }
+
+  if (patternSubtype === '*') {
+    return patternType === actualType;
+  }
+
+  return false;
+}
+
+type ResponseContent = NonNullable<Oas3Responses[string]['content']>;
+
+export function resolveContentByType(
+  content: ResponseContent | undefined,
+  contentType: string
+): ResponseContent[string] | undefined {
+  if (!content) return undefined;
+  if (content[contentType]) return content[contentType];
+
+  for (const pattern of Object.keys(content)) {
+    if (contentTypeMatchesPattern(contentType, pattern)) {
+      return content[pattern];
+    }
+  }
+  return undefined;
+}
+
 function checkContentTypeFromDescription({
   checks,
   descriptionOperation,
@@ -154,7 +193,12 @@ function checkContentTypeFromDescription({
     return;
   }
 
-  if (responseContentType && !possibleContentTypesFromDescription.includes(responseContentType)) {
+  if (
+    responseContentType &&
+    !possibleContentTypesFromDescription.some((pattern) =>
+      contentTypeMatchesPattern(responseContentType, pattern)
+    )
+  ) {
     checks.push({
       name: CHECKS.CONTENT_TYPE_CHECK,
       passed: false,


### PR DESCRIPTION
## What/Why/How?

Considering content type in Respect content type check.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2697
Closes: https://github.com/Redocly/redocly/issues/15696

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code changed? - Tested with Redoc/Realm/Reunite (internal)
- [x] All new/updated code is covered by tests
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines
