### PR TITLE
chore: update @redocly/config to v0.46.0

### DIFF
--- a/.changeset/few-ties-watch.md
+++ b/.changeset/few-ties-watch.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Updated `@redocly/config` to `v0.46.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2712,9 +2712,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.45.0.tgz",
-      "integrity": "sha512-V+wNusPQUaYV1c5s9iptfKQ2Ggno4bMeiyXdNILxqZS87gttwPfqlqHKHKFyz006voS3JsR295cbpx3GlsIxKg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.46.0.tgz",
+      "integrity": "sha512-FZEprNEkmLITKKdv5blIai1qiCcc4dn5+96AjWnmFQmH/oz/OyBiXBSi752/M+Wmype7aH2uRywSCuYlu4CgVA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -12130,7 +12130,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.45.0",
+        "@redocly/config": "^0.46.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.0",
-    "@redocly/config": "^0.45.0",
+    "@redocly/config": "^0.46.0",
     "ajv": "npm:@redocly/ajv@8.18.0",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -248,9 +248,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "overlay1Preprocessors": "Preprocessors",
       "overlay1Rules": "Rules",
       "preprocessors": "Preprocessors",
-      "rbac": {
-        "type": "object",
-      },
+      "rbac": "rootRedoclyConfigSchema.apis_additionalProperties.rbac",
       "root": {
         "type": "string",
       },
@@ -427,7 +425,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "ocean",
           "indigo",
           "iris",
-          "default",
         ],
         "type": "string",
       },
@@ -1475,7 +1472,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "ocean",
           "indigo",
           "iris",
-          "default",
         ],
         "type": "string",
       },
@@ -2393,9 +2389,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "preprocessors": {
         "type": "object",
       },
-      "rbac": {
-        "type": "object",
-      },
+      "rbac": "rootRedoclyConfigSchema.apis_additionalProperties.rbac",
       "root": {
         "type": "string",
       },
@@ -5336,6 +5330,16 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
     "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.apis_additionalProperties.rbac": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
     "items": undefined,
     "properties": {},
     "required": undefined,
@@ -9969,7 +9973,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "ocean",
           "indigo",
           "iris",
-          "default",
         ],
         "type": "string",
       },
@@ -10881,9 +10884,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "preprocessors": {
         "type": "object",
       },
-      "rbac": {
-        "type": "object",
-      },
+      "rbac": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.rbac",
       "root": {
         "type": "string",
       },
@@ -13824,6 +13825,16 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
     "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.rbac": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
     "items": undefined,
     "properties": {},
     "required": undefined,
@@ -24476,7 +24487,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "ocean",
           "indigo",
           "iris",
-          "default",
         ],
         "type": "string",
       },


### PR DESCRIPTION
## What/Why/How?
- Updated `@redocly/config` to v0.46.0.
- Updated test snapshot.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump plus snapshot updates; no core runtime logic changes, with risk mainly limited to downstream behavior changes introduced by `@redocly/config@0.46.0`.
> 
> **Overview**
> Updates `@redocly/openapi-core` to use `@redocly/config@0.46.0` (including lockfile updates) and adds a changeset to publish this as a patch.
> 
> Refreshes `redocly-yaml` snapshot expectations to match the new config schema output (notably `rbac` schema shape/references and removal of the `default` theme color enum value).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d02c21d705e5ef2153697e350e5f4e9715b1c7a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->