### PR TITLE
docs: clarify the join behaviour change in the changelog

### DIFF
--- a/docs/@v2/changelog.md
+++ b/docs/@v2/changelog.md
@@ -589,7 +589,8 @@ toc:
 
 - Fixed an issue where the root config was not properly merged with the `apis` config.
 - Resolved an issue that caused configuration parsing to fail when the config value was set to `null`.
-- Improved join command server handling for specifications with differing servers.
+- Improved `join` command server handling for specifications with differing servers.
+  **Warning**: this change may break workflows that relied on root-level server inheritance.
 - Updated @redocly/respect-core to v2.0.5.
 
 ## 2.0.4 (2025-08-12)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -582,7 +582,8 @@
 
 - Fixed an issue where the root config was not properly merged with the `apis` config.
 - Resolved an issue that caused configuration parsing to fail when the config value was set to `null`.
-- Improved join command server handling for specifications with differing servers.
+- Improved `join` command server handling for specifications with differing servers.
+  **Warning**: this change may break workflows that relied on root-level server inheritance.
 - Updated @redocly/respect-core to v2.0.5.
 
 ## 2.0.4


### PR DESCRIPTION
## What/Why/How?

Clarified in the changelog that the join command behaviour changed.

## Reference

Related change: https://github.com/Redocly/redocly-cli/pull/2635.

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies a previously shipped `join` behavior change; no runtime code or dependencies are modified.
> 
> **Overview**
> Clarifies the `2.0.5` changelog entry for the `join` command by adding an explicit **warning** that the improved server-handling behavior may break workflows relying on root-level server inheritance.
> 
> Applies the same note to both the public docs changelog (`docs/@v2/changelog.md`) and the package changelog (`packages/cli/CHANGELOG.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97880b908088c9ee46f341558ebbfabcc87fb5e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->