### PR TITLE
fix: enhance linting process to preserve existing files

### DIFF
--- a/.changeset/rotten-wombats-cry.md
+++ b/.changeset/rotten-wombats-cry.md
@@ -1,5 +1,5 @@
 ---
-"@redocly/cli": major
+"@redocly/cli": minor
 ---
 
 redocly lint api1.yaml --generate-ignore-file updates only entries related to api1.yaml and its referenced files

--- a/.changeset/rotten-wombats-cry.md
+++ b/.changeset/rotten-wombats-cry.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": major
+---
+
+redocly lint api1.yaml --generate-ignore-file updates only entries related to api1.yaml and its referenced files

--- a/.changeset/rotten-wombats-cry.md
+++ b/.changeset/rotten-wombats-cry.md
@@ -2,4 +2,4 @@
 "@redocly/cli": minor
 ---
 
-redocly lint api1.yaml --generate-ignore-file updates only entries related to api1.yaml and its referenced files
+Changed lint behavior with the `--generate-ignore-file` option — now it updates only the entries related to the file being linted, leaving other files' entries untouched.

--- a/.changeset/rotten-wombats-cry.md
+++ b/.changeset/rotten-wombats-cry.md
@@ -2,4 +2,6 @@
 "@redocly/cli": minor
 ---
 
-Changed lint behavior with the `--generate-ignore-file` option — now it updates only the entries related to the file being linted, leaving other files' entries untouched.
+Changed `lint` behavior with the `--generate-ignore-file` option.
+Now `lint` updates only the entries related to the file being linted.
+Other files' entries are unchanged.

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -372,6 +372,12 @@ The errors in the ignore file `.redocly.lint-ignore.yaml` are ignored when the `
 
 If you run:
 
+```bash
+redocly lint api1.yaml --generate-ignore-file
+```
+
+Only the ignore entries related to api1.yaml are updated.
+Ignore entries for other API descriptions remain unchanged.
 
 To generate an ignore file for multiple API descriptions, pass them as arguments:
 

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -352,7 +352,8 @@ This option is useful when you have an API design standard, but have some except
 It allows for highly granular control.
 
 {% admonition type="warning" %}
-This command updates ignore entries only for the API descriptions passed to the command. Existing entries for other API descriptions are preserved.
+This command updates ignore entries only for the API descriptions passed to the command.
+Existing entries for other API descriptions are preserved.
 {% /admonition %}
 
 The following command runs `lint` and adds all the errors to an ignore file:
@@ -369,13 +370,8 @@ Generated ignore file with 3 problems.
 
 The errors in the ignore file `.redocly.lint-ignore.yaml` are ignored when the `lint` command is run.
 
-if you run:
+If you run:
 
-```bash
-redocly lint api1.yaml --generate-ignore-file
-```
-
-only ignore entries related to `api1.yaml` are updated. Ignore entries for other API descriptions remain unchanged.
 
 To generate an ignore file for multiple API descriptions, pass them as arguments:
 

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -352,7 +352,7 @@ This option is useful when you have an API design standard, but have some except
 It allows for highly granular control.
 
 {% admonition type="warning" %}
-This command overwrites an existing ignore file.
+This command updates ignore entries only for the API descriptions passed to the command. Existing entries for other API descriptions are preserved.
 {% /admonition %}
 
 The following command runs `lint` and adds all the errors to an ignore file:
@@ -368,6 +368,14 @@ Generated ignore file with 3 problems.
 </pre>
 
 The errors in the ignore file `.redocly.lint-ignore.yaml` are ignored when the `lint` command is run.
+
+if you run:
+
+```bash
+redocly lint api1.yaml --generate-ignore-file
+```
+
+only ignore entries related to `api1.yaml` are updated. Ignore entries for other API descriptions remain unchanged.
 
 To generate an ignore file for multiple API descriptions, pass them as arguments:
 

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -8,6 +8,7 @@ import {
   loadConfig,
 } from '@redocly/openapi-core';
 import { blue } from 'colorette';
+import { resolve } from 'node:path';
 import { performance } from 'perf_hooks';
 import { type MockInstance } from 'vitest';
 import { type Arguments } from 'yargs';
@@ -151,25 +152,57 @@ describe('handleLint', () => {
       expect(configFixture.skipPreprocessors).toHaveBeenCalledWith(['preprocessor']);
     });
 
-    it('should preserve existing ignore entries for unrelated files when `generate-ignore-file` is used', async () => {
-      const otherFileAbsRef = '/some/other/api.yaml';
+    it('should update only the linted file entries and preserve ignore entries for other files', async () => {
+      const barAbsRef = resolve('ignore-bar.yaml');
+      const fooAbsRef = resolve('ignore-foo.yaml');
+
       configFixture.ignore = {
-        [otherFileAbsRef]: { 'some-rule': new Set(['#/paths/~1foo']) },
+        [barAbsRef]: {
+          'no-empty-servers': new Set(['#/servers']),
+          'operation-summary': new Set(['#/paths/~1items/get/summary']),
+        },
+        [fooAbsRef]: {
+          'no-empty-servers': new Set(['#/servers']),
+        },
       };
+
+      vi.mocked(configFixture.addIgnore).mockImplementation((problem: any) => {
+        const loc = problem.location[0];
+        if (loc.pointer === undefined) return;
+        const fileIgnore = (configFixture.ignore[loc.source.absoluteRef] =
+          configFixture.ignore[loc.source.absoluteRef] || {});
+        const ruleIgnore = (fileIgnore[problem.ruleId] = fileIgnore[problem.ruleId] || new Set());
+        ruleIgnore.add(loc.pointer);
+      });
+
       vi.mocked(lint).mockResolvedValueOnce([
         {
-          ruleId: 'operation-operationId',
+          ruleId: 'no-empty-servers',
           severity: 1,
-          message: 'Missing operationId',
-          location: [
-            { source: { absoluteRef: '/absolute/openapi.yaml' }, pointer: '#/paths/~1bar' },
-          ],
+          message: 'Servers must not be empty',
+          location: [{ source: { absoluteRef: barAbsRef }, pointer: '#/servers' }],
           suggest: [],
           ignored: false,
         } as any,
       ]);
-      await commandWrapper(handleLint)({ ...argvMock, 'generate-ignore-file': true });
-      expect(configFixture.ignore[otherFileAbsRef]).toBeDefined();
+
+      await commandWrapper(handleLint)({
+        ...argvMock,
+        apis: ['ignore-bar.yaml'],
+        'generate-ignore-file': true,
+      });
+
+      expect(configFixture.ignore[fooAbsRef]).toEqual({
+        'no-empty-servers': new Set(['#/servers']),
+      });
+
+      expect(configFixture.ignore[barAbsRef]).toEqual({
+        'no-empty-servers': new Set(['#/servers']),
+      });
+
+      expect(configFixture.saveIgnore).toHaveBeenCalled();
+
+      configFixture.ignore = {};
     });
 
     it('should call formatProblems and getExecutionTime with argv', async () => {

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -114,7 +114,7 @@ describe('handleLint', () => {
       );
     });
 
-    it('should call mergedConfig with clear ignore if `generate-ignore-file` argv', async () => {
+    it('should call forAlias when `generate-ignore-file` argv is set', async () => {
       await commandWrapper(handleLint)({ ...argvMock, 'generate-ignore-file': true });
       expect(configFixture.forAlias).toHaveBeenCalledWith(undefined);
     });
@@ -149,6 +149,27 @@ describe('handleLint', () => {
       });
       expect(configFixture.skipRules).toHaveBeenCalledWith(['rule']);
       expect(configFixture.skipPreprocessors).toHaveBeenCalledWith(['preprocessor']);
+    });
+
+    it('should preserve existing ignore entries for unrelated files when `generate-ignore-file` is used', async () => {
+      const otherFileAbsRef = '/some/other/api.yaml';
+      configFixture.ignore = {
+        [otherFileAbsRef]: { 'some-rule': new Set(['#/paths/~1foo']) },
+      };
+      vi.mocked(lint).mockResolvedValueOnce([
+        {
+          ruleId: 'operation-operationId',
+          severity: 1,
+          message: 'Missing operationId',
+          location: [
+            { source: { absoluteRef: '/absolute/openapi.yaml' }, pointer: '#/paths/~1bar' },
+          ],
+          suggest: [],
+          ignored: false,
+        } as any,
+      ]);
+      await commandWrapper(handleLint)({ ...argvMock, 'generate-ignore-file': true });
+      expect(configFixture.ignore[otherFileAbsRef]).toBeDefined();
     });
 
     it('should call formatProblems and getExecutionTime with argv', async () => {

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -166,6 +166,11 @@ describe('handleLint', () => {
         },
       };
 
+      vi.mocked(configFixture.clearIgnoreForRef).mockImplementation((ref: string) => {
+        const absRef = resolve(ref);
+        delete configFixture.ignore[absRef];
+      });
+
       vi.mocked(configFixture.addIgnore).mockImplementation((problem: any) => {
         const loc = problem.location[0];
         if (loc.pointer === undefined) return;

--- a/packages/cli/src/__tests__/fixtures/config.ts
+++ b/packages/cli/src/__tests__/fixtures/config.ts
@@ -11,6 +11,7 @@ export const configFixture: Config = {
   },
   configPath: undefined,
   addIgnore: vi.fn(),
+  clearIgnoreForRef: vi.fn(),
   skipRules: vi.fn(),
   skipPreprocessors: vi.fn(),
   saveIgnore: vi.fn(),

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,7 +1,6 @@
 import {
   formatProblems,
   getTotals,
-  isAbsoluteUrl,
   lint,
   lintConfig,
   pluralize,
@@ -12,7 +11,6 @@ import {
   type OutputFormat,
 } from '@redocly/openapi-core';
 import { blue, gray } from 'colorette';
-import { resolve } from 'node:path';
 import { performance } from 'perf_hooks';
 import type { Arguments } from 'yargs';
 
@@ -94,8 +92,7 @@ export async function handleLint({
       totals.ignored += fileTotals.ignored;
 
       if (argv['generate-ignore-file']) {
-        const apiAbsRef = isAbsoluteUrl(path) ? path : resolve(path);
-        delete config.ignore[apiAbsRef];
+        config.clearIgnoreForRef(path);
         for (const m of results) {
           config.addIgnore(m);
           totalIgnored++;

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -9,7 +9,6 @@ import {
   logger,
   type Config,
   type Exact,
-  type NormalizedProblem,
   type OutputFormat,
 } from '@redocly/openapi-core';
 import { blue, gray } from 'colorette';
@@ -56,8 +55,6 @@ export async function handleLint({
 
   const totals: Totals = { errors: 0, warnings: 0, ignored: 0 };
   let totalIgnored = 0;
-  const ignoreFileResults: NormalizedProblem[] = [];
-  const lintedAbsRefs = new Set<string>();
 
   // TODO: use shared externalRef resolver, blocked by preprocessors now as they can mutate documents
   for (const { path: apiPath, alias } of apis) {
@@ -97,9 +94,10 @@ export async function handleLint({
       totals.ignored += fileTotals.ignored;
 
       if (argv['generate-ignore-file']) {
-        lintedAbsRefs.add(isAbsoluteUrl(apiPath) ? apiPath : resolvePath(apiPath));
+        const apiAbsRef = isAbsoluteUrl(apiPath) ? apiPath : resolvePath(apiPath);
+        delete config.ignore[apiAbsRef];
         for (const m of results) {
-          ignoreFileResults.push(m);
+          config.addIgnore(m);
           totalIgnored++;
         }
       } else {
@@ -120,22 +118,8 @@ export async function handleLint({
   }
 
   if (argv['generate-ignore-file']) {
-    for (const m of ignoreFileResults) {
-      const loc = m.location?.[0];
-      if (loc?.pointer !== undefined) {
-        lintedAbsRefs.add(loc.source.absoluteRef);
-      }
-    }
-    for (const absRef of lintedAbsRefs) {
-      delete config.ignore[absRef];
-    }
-    for (const m of ignoreFileResults) {
-      config.addIgnore(m);
-    }
     config.saveIgnore();
-    logger.info(
-      `Generated ignore file with ${totalIgnored} ${pluralize('problem', totalIgnored)}.\n\n`
-    );
+    logger.info(`Explicitly ignored ${totalIgnored} ${pluralize('problem', totalIgnored)}.\n\n`);
   } else {
     printLintTotals(totals, apis.length);
   }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -12,7 +12,7 @@ import {
   type OutputFormat,
 } from '@redocly/openapi-core';
 import { blue, gray } from 'colorette';
-import { resolve as resolvePath } from 'node:path';
+import { resolve } from 'node:path';
 import { performance } from 'perf_hooks';
 import type { Arguments } from 'yargs';
 
@@ -57,7 +57,7 @@ export async function handleLint({
   let totalIgnored = 0;
 
   // TODO: use shared externalRef resolver, blocked by preprocessors now as they can mutate documents
-  for (const { path: apiPath, alias } of apis) {
+  for (const { path, alias } of apis) {
     try {
       const startedAt = performance.now();
       const aliasConfig = config.forAlias(alias);
@@ -75,15 +75,15 @@ export async function handleLint({
         );
       }
       if (alias === undefined) {
-        logger.info(gray(`validating ${formatPath(apiPath)}...\n`));
+        logger.info(gray(`validating ${formatPath(path)}...\n`));
       } else {
         logger.info(
-          gray(`validating ${formatPath(apiPath)} using lint rules for api '${alias}'...\n`)
+          gray(`validating ${formatPath(path)} using lint rules for api '${alias}'...\n`)
         );
       }
 
       const results = await lint({
-        ref: apiPath,
+        ref: path,
         config: aliasConfig,
         collectSpecData,
       });
@@ -94,7 +94,7 @@ export async function handleLint({
       totals.ignored += fileTotals.ignored;
 
       if (argv['generate-ignore-file']) {
-        const apiAbsRef = isAbsoluteUrl(apiPath) ? apiPath : resolvePath(apiPath);
+        const apiAbsRef = isAbsoluteUrl(path) ? path : resolve(path);
         delete config.ignore[apiAbsRef];
         for (const m of results) {
           config.addIgnore(m);
@@ -111,9 +111,9 @@ export async function handleLint({
       }
 
       const elapsed = getExecutionTime(startedAt);
-      logger.info(gray(`${formatPath(apiPath)}: validated in ${elapsed}\n\n`));
+      logger.info(gray(`${formatPath(path)}: validated in ${elapsed}\n\n`));
     } catch (e) {
-      handleError(e, apiPath);
+      handleError(e, path);
     }
   }
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,6 +1,7 @@
 import {
   formatProblems,
   getTotals,
+  isAbsoluteUrl,
   lint,
   lintConfig,
   pluralize,
@@ -8,9 +9,11 @@ import {
   logger,
   type Config,
   type Exact,
+  type NormalizedProblem,
   type OutputFormat,
 } from '@redocly/openapi-core';
 import { blue, gray } from 'colorette';
+import { resolve as resolvePath } from 'node:path';
 import { performance } from 'perf_hooks';
 import type { Arguments } from 'yargs';
 
@@ -51,14 +54,13 @@ export async function handleLint({
     exitWithError('No APIs were provided.');
   }
 
-  if (argv['generate-ignore-file']) {
-    config.ignore = {}; // clear ignore
-  }
   const totals: Totals = { errors: 0, warnings: 0, ignored: 0 };
   let totalIgnored = 0;
+  const ignoreFileResults: NormalizedProblem[] = [];
+  const lintedAbsRefs = new Set<string>();
 
   // TODO: use shared externalRef resolver, blocked by preprocessors now as they can mutate documents
-  for (const { path, alias } of apis) {
+  for (const { path: apiPath, alias } of apis) {
     try {
       const startedAt = performance.now();
       const aliasConfig = config.forAlias(alias);
@@ -76,15 +78,15 @@ export async function handleLint({
         );
       }
       if (alias === undefined) {
-        logger.info(gray(`validating ${formatPath(path)}...\n`));
+        logger.info(gray(`validating ${formatPath(apiPath)}...\n`));
       } else {
         logger.info(
-          gray(`validating ${formatPath(path)} using lint rules for api '${alias}'...\n`)
+          gray(`validating ${formatPath(apiPath)} using lint rules for api '${alias}'...\n`)
         );
       }
 
       const results = await lint({
-        ref: path,
+        ref: apiPath,
         config: aliasConfig,
         collectSpecData,
       });
@@ -95,8 +97,9 @@ export async function handleLint({
       totals.ignored += fileTotals.ignored;
 
       if (argv['generate-ignore-file']) {
+        lintedAbsRefs.add(isAbsoluteUrl(apiPath) ? apiPath : resolvePath(apiPath));
         for (const m of results) {
-          config.addIgnore(m);
+          ignoreFileResults.push(m);
           totalIgnored++;
         }
       } else {
@@ -110,13 +113,25 @@ export async function handleLint({
       }
 
       const elapsed = getExecutionTime(startedAt);
-      logger.info(gray(`${formatPath(path)}: validated in ${elapsed}\n\n`));
+      logger.info(gray(`${formatPath(apiPath)}: validated in ${elapsed}\n\n`));
     } catch (e) {
-      handleError(e, path);
+      handleError(e, apiPath);
     }
   }
 
   if (argv['generate-ignore-file']) {
+    for (const m of ignoreFileResults) {
+      const loc = m.location?.[0];
+      if (loc?.pointer !== undefined) {
+        lintedAbsRefs.add(loc.source.absoluteRef);
+      }
+    }
+    for (const absRef of lintedAbsRefs) {
+      delete config.ignore[absRef];
+    }
+    for (const m of ignoreFileResults) {
+      config.addIgnore(m);
+    }
     config.saveIgnore();
     logger.info(
       `Generated ignore file with ${totalIgnored} ${pluralize('problem', totalIgnored)}.\n\n`

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -166,6 +166,12 @@ export class Config {
     );
   }
 
+  clearIgnoreForRef(ref: string) {
+    const dir = this.configPath ? path.dirname(this.configPath) : process.cwd();
+    const absRef = isAbsoluteUrl(ref) ? ref : path.resolve(dir, ref);
+    delete this.ignore[absRef];
+  }
+
   saveIgnore() {
     const dir = this.configPath ? path.dirname(this.configPath) : process.cwd();
     const ignoreFile = path.join(dir, IGNORE_FILE);


### PR DESCRIPTION
## What/Why/How?

- `redocly lint api1.yaml --generate-ignore-file` updates only entries related to api1.yaml and its referenced files

## Reference

- #2652

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines
