### PR TITLE
fix: resolve discriminator defaultMapping into components schemas when bundling

### DIFF
--- a/.changeset/seven-emus-grab.md
+++ b/.changeset/seven-emus-grab.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue where the `defaultMapping` discriminator was not resolved when bundling.
+Fixed an issue where the discriminator's `defaultMapping` property was not resolved when bundling.

--- a/.changeset/seven-emus-grab.md
+++ b/.changeset/seven-emus-grab.md
@@ -3,4 +3,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue where discriminator `defaultMapping` was not resolved when bundling.
+Fixed an issue where the `defaultMapping` discriminator was not resolved when bundling.

--- a/.changeset/seven-emus-grab.md
+++ b/.changeset/seven-emus-grab.md
@@ -1,0 +1,6 @@
+---
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Fixed an issue where discriminator `defaultMapping` was not resolved when bundling.

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -555,6 +555,38 @@ describe('bundle', () => {
     expect(problems).toHaveLength(0);
     expect(res.parsed).toMatchSnapshot();
   });
+
+  it('should bundle discriminator with defaultMapping and mapping as component names to the same document', async () => {
+    const document = outdent`
+      openapi: 3.2.0
+      components:
+        schemas:
+          Pet:
+            type: object
+            discriminator:
+              propertyName: kind
+              defaultMapping: Cat
+              mapping:
+                cat: Cat
+          Cat:
+            type: object
+            properties:
+              kind:
+                type: string
+
+    `;
+
+    const {
+      bundle: { parsed },
+      problems,
+    } = await bundleFromString({
+      source: document,
+      config: await createConfig({}),
+    });
+
+    expect(problems).toMatchInlineSnapshot(`[]`);
+    expect(parsed).toMatchInlineSnapshot(document);
+  });
 });
 
 describe('bundleFromString', () => {

--- a/packages/core/src/bundle/bundle-visitor.ts
+++ b/packages/core/src/bundle/bundle-visitor.ts
@@ -11,7 +11,7 @@ import {
 } from '../ref-utils.js';
 import { type ResolvedRefMap, type Document } from '../resolve.js';
 import { reportUnresolvedRef } from '../rules/common/no-unresolved-refs.js';
-import { type OasRef } from '../typings/openapi.js';
+import { type OasRef, type Oas3Discriminator } from '../typings/openapi.js';
 import { dequal } from '../utils/dequal.js';
 import { makeRefId } from '../utils/make-ref-id.js';
 import { type Oas3Visitor, type Oas2Visitor } from '../visitors.js';
@@ -205,19 +205,32 @@ export function makeBundleVisitor({
   };
 
   if (version === 'oas3') {
-    visitor.DiscriminatorMapping = {
-      leave(mapping: Record<string, string>, ctx: UserContext) {
-        for (const name of Object.keys(mapping)) {
-          const $ref = mapping[name];
-          const resolved = ctx.resolve({ $ref });
-          if (!resolved.location || resolved.node === undefined) {
-            reportUnresolvedRef(resolved, ctx.report, ctx.location.child(name));
-            return;
-          }
+    const componentType = mapTypeToComponent('Schema', version)!;
+    visitor.Discriminator = {
+      leave(discriminator: Oas3Discriminator, ctx: UserContext) {
+        if (typeof discriminator.defaultMapping !== 'string') return;
 
-          const componentType = mapTypeToComponent('Schema', version)!;
-          mapping[name] = saveComponent(componentType, resolved, ctx);
+        const resolved = ctx.resolve({ $ref: discriminator.defaultMapping });
+        if (!resolved.location || resolved.node === undefined) {
+          reportUnresolvedRef(resolved, ctx.report, ctx.location.child('defaultMapping'));
+          return;
         }
+
+        discriminator.defaultMapping = saveComponent(componentType, resolved, ctx);
+      },
+      DiscriminatorMapping: {
+        leave(mapping, ctx) {
+          for (const name of Object.keys(mapping)) {
+            const $ref = mapping[name];
+            const resolved = ctx.resolve({ $ref });
+            if (!resolved.location || resolved.node === undefined) {
+              reportUnresolvedRef(resolved, ctx.report, ctx.location.child(name));
+              return;
+            }
+
+            mapping[name] = saveComponent(componentType, resolved, ctx);
+          }
+        },
       },
     };
   }

--- a/packages/core/src/bundle/bundle-visitor.ts
+++ b/packages/core/src/bundle/bundle-visitor.ts
@@ -8,6 +8,7 @@ import {
   pointerBaseName,
   refBaseName,
   type Location,
+  isMappingRef,
 } from '../ref-utils.js';
 import { type ResolvedRefMap, type Document } from '../resolve.js';
 import { reportUnresolvedRef } from '../rules/common/no-unresolved-refs.js';
@@ -208,7 +209,12 @@ export function makeBundleVisitor({
     const componentType = mapTypeToComponent('Schema', version)!;
     visitor.Discriminator = {
       leave(discriminator: Oas3Discriminator, ctx: UserContext) {
-        if (typeof discriminator.defaultMapping !== 'string') return;
+        if (
+          typeof discriminator.defaultMapping !== 'string' ||
+          !isMappingRef(discriminator.defaultMapping)
+        ) {
+          return;
+        }
 
         const resolved = ctx.resolve({ $ref: discriminator.defaultMapping });
         if (!resolved.location || resolved.node === undefined) {
@@ -222,6 +228,9 @@ export function makeBundleVisitor({
         leave(mapping, ctx) {
           for (const name of Object.keys(mapping)) {
             const $ref = mapping[name];
+            if (!isMappingRef($ref)) {
+              continue;
+            }
             const resolved = ctx.resolve({ $ref });
             if (!resolved.location || resolved.node === undefined) {
               reportUnresolvedRef(resolved, ctx.report, ctx.location.child(name));

--- a/tests/e2e/bundle/bundle-oas3_2/components/schemas/Foo.yaml
+++ b/tests/e2e/bundle/bundle-oas3_2/components/schemas/Foo.yaml
@@ -1,0 +1,9 @@
+allOf:
+  - $ref: ./Used.yaml
+  - type: object
+    properties:
+      test:
+        type: string
+        const: foo
+    required:
+      - test

--- a/tests/e2e/bundle/bundle-oas3_2/components/schemas/Used.yaml
+++ b/tests/e2e/bundle/bundle-oas3_2/components/schemas/Used.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  base:
+    type: string
+discriminator:
+  propertyName: test
+  defaultMapping: ./Foo.yaml

--- a/tests/e2e/bundle/bundle-oas3_2/openapi.yaml
+++ b/tests/e2e/bundle/bundle-oas3_2/openapi.yaml
@@ -1,0 +1,6 @@
+openapi: 3.2.0
+info: {}
+servers: []
+paths:
+  /:
+    $ref: paths/_.yaml

--- a/tests/e2e/bundle/bundle-oas3_2/paths/_.yaml
+++ b/tests/e2e/bundle/bundle-oas3_2/paths/_.yaml
@@ -1,0 +1,7 @@
+get:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/Used.yaml

--- a/tests/e2e/bundle/bundle-oas3_2/redocly.yaml
+++ b/tests/e2e/bundle/bundle-oas3_2/redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./openapi.yaml

--- a/tests/e2e/bundle/bundle-oas3_2/snapshot.txt
+++ b/tests/e2e/bundle/bundle-oas3_2/snapshot.txt
@@ -1,0 +1,35 @@
+openapi: 3.2.0
+info: {}
+servers: []
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Used'
+components:
+  schemas:
+    Used:
+      type: object
+      properties:
+        base:
+          type: string
+      discriminator:
+        propertyName: test
+        defaultMapping: '#/components/schemas/Foo'
+    Foo:
+      allOf:
+        - $ref: '#/components/schemas/Used'
+        - type: object
+          properties:
+            test:
+              type: string
+              const: foo
+          required:
+            - test
+
+bundling openapi.yaml using configuration for api 'main'...
+📦 Created a bundle for openapi.yaml at stdout <test>ms.


### PR DESCRIPTION


## What/Why/How?

Fixed an issue where discriminator `defaultMapping` was not resolved when bundling.

## Reference

## Testing

Other tests passed [here](https://github.com/Redocly/redocly/pull/22459).

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is scoped to OAS3 bundling behavior for `discriminator.defaultMapping` and is covered by new unit and e2e tests, with minimal surface area outside bundling.
> 
> **Overview**
> Fixes bundling so OAS3 `discriminator.defaultMapping` is treated like `discriminator.mapping`: mapping-like values are now resolved and saved into `#/components/schemas/...` instead of being left as an unresolved string.
> 
> Adds regression coverage via a new unit test for component-name mappings and a new OAS 3.2 e2e fixture/snapshot verifying `defaultMapping` to an external schema is rewritten to an internal component ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa0ca698af1efe53792f69bd6b1c7c253b3d477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->