### PR TITLE
chore: update config to v0.48.0

### DIFF
--- a/.changeset/itchy-berries-say.md
+++ b/.changeset/itchy-berries-say.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Updated @redocly/config to v0.48.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2729,9 +2729,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.46.1.tgz",
-      "integrity": "sha512-dSdkB2wRLtvl3f7ayRu9vqVhUMjjRaxZlHgRbgOtPPXxn4uI/ciDO87h4CJb7Iet+OVpevpAU6gU8bo5qVbQxg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.0.tgz",
+      "integrity": "sha512-8W3wz+Q7y4e9klJWlYOvQWK5r7P2Mo589vcjtlT5coOxsyAdt53k8Vb8iAqnRiGWExbjBQmSbL2XbuU747Nf6Q==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -4704,9 +4704,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12627,7 +12627,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.46.1",
+        "@redocly/config": "^0.48.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.0",
-    "@redocly/config": "^0.46.1",
+    "@redocly/config": "^0.48.0",
     "ajv": "npm:@redocly/ajv@8.18.0",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -349,6 +349,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "codeSnippet": "rootRedoclyConfigSchema.codeSnippet",
       "colorMode": "rootRedoclyConfigSchema.colorMode",
+      "corsProxy": "rootRedoclyConfigSchema.corsProxy",
       "decorators": "Decorators",
       "developerOnboarding": "rootRedoclyConfigSchema.developerOnboarding",
       "entitiesCatalog": "rootRedoclyConfigSchema.entitiesCatalog",
@@ -1368,6 +1369,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "codeSnippet": "rootRedoclyConfigSchema.codeSnippet",
       "colorMode": "rootRedoclyConfigSchema.colorMode",
+      "corsProxy": "rootRedoclyConfigSchema.corsProxy",
       "decorators": {
         "type": "object",
       },
@@ -8279,6 +8281,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "target": {
         "type": "string",
       },
+      "trackingId": {
+        "type": "string",
+      },
     },
     "required": [
       "content",
@@ -8426,6 +8431,21 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "light",
           "dark",
         ],
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.corsProxy": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "allowedTargets": {
         "items": {
           "type": "string",
         },
@@ -9870,6 +9890,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "codeSnippet": "rootRedoclyConfigSchema.env_additionalProperties.codeSnippet",
       "colorMode": "rootRedoclyConfigSchema.env_additionalProperties.colorMode",
+      "corsProxy": "rootRedoclyConfigSchema.env_additionalProperties.corsProxy",
       "decorators": {
         "type": "object",
       },
@@ -16774,6 +16795,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "target": {
         "type": "string",
       },
+      "trackingId": {
+        "type": "string",
+      },
     },
     "required": [
       "content",
@@ -16917,6 +16941,21 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "modes": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.corsProxy": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "allowedTargets": {
         "items": {
           "type": "string",
         },


### PR DESCRIPTION
## What/Why/How?

- Updated redocly/config to v0.48.0.
- npm audit fix

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade changes the generated config schema and validation surface (new keys like `corsProxy` and `trackingId`), which could affect existing configs. Lockfile updates also pull in patched transitive deps (e.g., `basic-ftp`).
> 
> **Overview**
> Updates `@redocly/openapi-core` to use `@redocly/config` `v0.48.0` (with a changeset) and refreshes `package-lock.json` via `npm audit fix`.
> 
> Test snapshots are updated to reflect the new config schema output, including newly recognized config fields such as `corsProxy` and `trackingId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95d42641294239876e40a1d74d5711a4412898f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->