### PR TITLE
chore: update benchmark with 2.27.0

### DIFF
--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -22,6 +22,7 @@
     "cli-2.24.1": "npm:@redocly/cli@2.24.1",
     "cli-2.25.0": "npm:@redocly/cli@2.25.0",
     "cli-2.25.4": "npm:@redocly/cli@2.25.4",
+    "cli-2.27.0": "npm:@redocly/cli@2.27.0",
     "cli-latest": "npm:@redocly/cli@latest",
     "cli-next": "file:../../redocly-cli.tgz"
   },


### PR DESCRIPTION
## What/Why/How?

Update benchmark with 2.27.0 (version with performance improvements)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the performance benchmark package metadata to include an additional CLI version alias, with no production code changes.
> 
> **Overview**
> Updates the performance benchmark setup by adding `cli-2.27.0` to `tests/performance/package.json`’s `_enhancedDependencies`, enabling benchmarks to be run against Redocly CLI version 2.27.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279b8be9256526bebd5b6ac9a2b87fe3cf6e2a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->