### PR TITLE
docs: add missing guides to CLI guides landing

### DIFF
--- a/docs/@v1/guides/index.md
+++ b/docs/@v1/guides/index.md
@@ -73,4 +73,46 @@ How to change the OAuth2 token URL.
 How to create a custom decorator to hide OpenAPI specification extensions.
 {% /card %}
 
+{% card title="Configure API linting rules"
+    to="./configure-rules"
+  %}
+Combine built-in and custom rules to match your API's standards.
+{% /card %}
+
+{% card title="Set up tab completion"
+    to="./autocomplete"
+  %}
+Generate shell completions for the `redocly` command.
+{% /card %}
+
+{% card title="Update Redocly CLI"
+    to="./update-cli"
+  %}
+Keep your Redocly CLI installation current with the latest features and fixes.
+{% /card %}
+
+{% card title="Migrate from openapi-cli"
+    to="./migrate-from-openapi-cli"
+  %}
+Upgrade from the deprecated openapi-cli by replacing it with `redocly`.
+{% /card %}
+
+{% card title="Migrate from redoc-cli"
+    to="./migrate-from-redoc-cli"
+  %}
+Replace the legacy redoc-cli commands with Redocly CLI equivalents.
+{% /card %}
+
+{% card title="Migrate from Spectral"
+    to="./migrate-from-spectral"
+  %}
+Switch from Spectral to Redocly CLI's linting and tooling.
+{% /card %}
+
+{% card title="Migrate from swagger-cli"
+    to="./migrate-from-swagger-cli"
+  %}
+Replace the deprecated swagger-cli package with Redocly CLI.
+{% /card %}
+
 {% /cards %}

--- a/docs/@v2/guides/index.md
+++ b/docs/@v2/guides/index.md
@@ -79,4 +79,52 @@ How to change the OAuth2 token URL.
 How to create a custom decorator to hide OpenAPI specification extensions.
 {% /card %}
 
+{% card title="Configure API linting rules"
+    to="./configure-rules"
+  %}
+Combine built-in and custom rules to match your API's standards.
+{% /card %}
+
+{% card title="Set up tab completion"
+    to="./autocomplete"
+  %}
+Generate shell completions for the `redocly` command.
+{% /card %}
+
+{% card title="Update Redocly CLI"
+    to="./update-cli"
+  %}
+Keep your Redocly CLI installation current with the latest features and fixes.
+{% /card %}
+
+{% card title="Migrate to Redocly CLI v2"
+    to="./migrate-to-v2"
+  %}
+Essential changes when upgrading from v1.x to v2.x.
+{% /card %}
+
+{% card title="Migrate from openapi-cli"
+    to="./migrate-from-openapi-cli"
+  %}
+Upgrade from the deprecated openapi-cli by replacing it with `redocly`.
+{% /card %}
+
+{% card title="Migrate from redoc-cli"
+    to="./migrate-from-redoc-cli"
+  %}
+Replace the legacy redoc-cli commands with Redocly CLI equivalents.
+{% /card %}
+
+{% card title="Migrate from Spectral"
+    to="./migrate-from-spectral"
+  %}
+Switch from Spectral to Redocly CLI's linting and tooling.
+{% /card %}
+
+{% card title="Migrate from swagger-cli"
+    to="./migrate-from-swagger-cli"
+  %}
+Replace the deprecated swagger-cli package with Redocly CLI.
+{% /card %}
+
 {% /cards %}


### PR DESCRIPTION
## What/Why/How?

Closes #1519. The CLI guides landing pages (`docs/@v2/guides/index.md` and `docs/@v1/guides/index.md`) were missing cards for several guides that exist in the directory. This PR adds cards for them using the existing `{% card %}` pattern, with one-line previews sourced from the first paragraph of each guide.

**v2 landing** gains 8 cards:
- Configure API linting rules
- Set up tab completion
- Update Redocly CLI
- Migrate to Redocly CLI v2
- Migrate from openapi-cli
- Migrate from redoc-cli
- Migrate from Spectral
- Migrate from swagger-cli

**v1 landing** gains 7 cards (same list minus the v2 migration card, which doesn't apply to v1 docs).

## Reference

- Issue: #1519 ("CLI docs have a landing page with guides on, but it's missing some of the migration guides and probably some other items. Update the page to include all guides and a little preview of what they are.")
- Files touched: `docs/@v1/guides/index.md`, `docs/@v2/guides/index.md`

## Testing

This is a docs-only change. No code paths, build scripts, or rules files were modified. The cards use the same `{% card title=... to="./..." %}...{% /card %}` syntax as the existing cards on the same pages, so the docs renderer handles them the same way.

Preview rendering is not locally previewable per the issue note ("this can't be previewed locally, but open a draft pull request to see the preview") — this PR is suitable for inspecting the rendered preview via your docs build.

## Screenshots (optional)

N/A — docs content only.

## Check yourself

- [x] This PR follows the contributing guide
- [x] All new/updated code is covered by tests (docs-only; N/A)
- [x] Core code changed? - N/A (docs only)
- [x] New package installed? - N/A
- [x] Documentation update has been considered (this IS a documentation update)

## Security

- [x] The security impact of the change has been considered (docs-only addition of existing internal links; no security surface)
- [x] Code follows company security practices and guidelines

Closes #1519

This contribution was developed with AI assistance (Codex).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds internal links on the guides landing pages; low risk aside from potential broken/incorrect guide paths or titles.
> 
> **Overview**
> Updates the CLI guides landing pages (`docs/@v1/guides/index.md`, `docs/@v2/guides/index.md`) to include **additional guide cards** that were previously missing.
> 
> Adds cards for configuration, autocomplete, updating the CLI, and several migration guides; v2 also includes a new card for *migrating to Redocly CLI v2*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d05efeaa074869dcb0ed051ceeb7411da116cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->