### PR TITLE
feat(score): add --suggestions for hotspot LLM prompts

### DIFF
--- a/docs/@v2/commands/score.md
+++ b/docs/@v2/commands/score.md
@@ -56,21 +56,22 @@ The command identifies the operations with the lowest scores and provides reason
 
 ```bash
 redocly score <api>
-redocly score <api> [--format=<option>]
+redocly score <api> [--format=<option>] [--suggestions]
 ```
 
 ## Options
 
-| Option               | Type    | Description                                                                                                                                    |
-| -------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| api                  | string  | **REQUIRED.** Path to the API description filename or alias that you want to score. Refer to [the API section](#specify-api) for more details. |
-| --config             | string  | Specify path to the [configuration file](../configuration/index.md).                                                                           |
-| --format             | string  | Format for the output.<br />**Possible values:** `stylish`, `json`. Default value is `stylish`.                                                |
-| --operation-details  | boolean | Print a per-operation metrics table sorted by property count.                                                                                  |
-| --debug-operation-id | string  | Print a detailed schema breakdown for a specific operation (by `operationId` or `METHOD /path`).                                               |
-| --help               | boolean | Show help.                                                                                                                                     |
-| --lint-config        | string  | Specify the severity level for the configuration file. <br/> **Possible values:** `warn`, `error`, `off`. Default value is `warn`.             |
-| --version            | boolean | Show version number.                                                                                                                           |
+| Option               | Type    | Description                                                                                                                                                   |
+| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| api                  | string  | **REQUIRED.** Path to the API description filename or alias that you want to score. Refer to [the API section](#specify-api) for more details.                |
+| --config             | string  | Specify path to the [configuration file](../configuration/index.md).                                                                                          |
+| --format             | string  | Format for the output.<br />**Possible values:** `stylish`, `json`. Default value is `stylish`.                                                               |
+| --operation-details  | boolean | Print a per-operation metrics table sorted by property count.                                                                                                 |
+| --debug-operation-id | string  | Print a detailed schema breakdown for a specific operation (by `operationId` or `METHOD /path`).                                                              |
+| --suggestions        | boolean | Append copy-paste prompts (for LLM-assisted editing) for each hotspot operation. Also adds a `suggestion` field per hotspot in JSON output. Default: `false`. |
+| --help               | boolean | Show help.                                                                                                                                                    |
+| --lint-config        | string  | Specify the severity level for the configuration file. <br/> **Possible values:** `warn`, `error`, `off`. Default value is `warn`.                            |
+| --version            | boolean | Show version number.                                                                                                                                          |
 
 ## Examples
 
@@ -131,3 +132,11 @@ redocly score openapi.yaml --format=json
 The JSON output includes the full data: top-level scores, subscores, per-operation raw metrics, per-operation scores, dependency depths, and hotspot details with reasoning.
 
 The JSON format is suitable for CI pipelines, quality gates, or feeding results into dashboards.
+
+### Suggestions (LLM prompts)
+
+With `--suggestions`, the command adds an **Agent prompts (copy/paste)** section after hotspots in stylish output. Each hotspot gets a fenced block containing a self-contained prompt you can paste into an assistant to improve that operation in your OpenAPI file.
+
+With `--format=json` and `--suggestions`, each hotspot object includes a `suggestion` string (the same prompt text). Structured `issues` codes are not included in JSON output.
+
+These prompts are advisory; review generated edits before committing them.

--- a/packages/cli/src/commands/score/__tests__/hotspots.test.ts
+++ b/packages/cli/src/commands/score/__tests__/hotspots.test.ts
@@ -69,6 +69,8 @@ describe('selectTopHotspots', () => {
     const result = selectTopHotspots(docMetrics, opScores, new Map([['op1', 0]]));
     expect(result.length).toBe(1);
     expect(result[0].reasons).toContain('High parameter count (10)');
+    expect(result[0].issues.some((i) => i.code === 'high_parameter_count')).toBe(true);
+    expect(result[0].issues.map((i) => i.message)).toEqual(result[0].reasons);
   });
 
   it('detects deep schema nesting', () => {

--- a/packages/cli/src/commands/score/__tests__/index.test.ts
+++ b/packages/cli/src/commands/score/__tests__/index.test.ts
@@ -189,4 +189,83 @@ describe('handleScore', () => {
     const output = mockOutput.mock.calls.map(([s]: [string]) => s).join('');
     expect(output).toContain('Hotspot');
   });
+
+  it('should strip issues from JSON hotspots by default', async () => {
+    mockedCollectMetrics.mockReturnValue({
+      metrics: makeDocumentMetrics(
+        new Map([
+          [
+            'complexOp',
+            makeTestMetrics({
+              path: '/complex',
+              method: 'post',
+              operationId: 'complexOp',
+              parameterCount: 10,
+              operationDescriptionPresent: false,
+            }),
+          ],
+        ])
+      ),
+      debugLogs: [],
+    });
+
+    await handleScore(createArgs({ format: 'json' }));
+    const parsed = JSON.parse(mockOutput.mock.calls[0][0]);
+    expect(parsed.hotspots.length).toBeGreaterThan(0);
+    expect(parsed.hotspots[0].issues).toBeUndefined();
+    expect(parsed.hotspots[0].suggestion).toBeUndefined();
+  });
+
+  it('should add suggestion to JSON hotspots when suggestions is true', async () => {
+    mockedCollectMetrics.mockReturnValue({
+      metrics: makeDocumentMetrics(
+        new Map([
+          [
+            'complexOp',
+            makeTestMetrics({
+              path: '/complex',
+              method: 'post',
+              operationId: 'complexOp',
+              parameterCount: 10,
+              operationDescriptionPresent: false,
+            }),
+          ],
+        ])
+      ),
+      debugLogs: [],
+    });
+
+    await handleScore(createArgs({ format: 'json', suggestions: true }));
+    const parsed = JSON.parse(mockOutput.mock.calls[0][0]);
+    expect(typeof parsed.hotspots[0].suggestion).toBe('string');
+    expect(parsed.hotspots[0].suggestion).toContain('test.yaml');
+    expect(parsed.hotspots[0].issues).toBeUndefined();
+  });
+
+  it('should print agent prompts section when suggestions is true', async () => {
+    mockedCollectMetrics.mockReturnValue({
+      metrics: makeDocumentMetrics(
+        new Map([
+          [
+            'complexOp',
+            makeTestMetrics({
+              path: '/complex',
+              method: 'post',
+              operationId: 'complexOp',
+              parameterCount: 10,
+              operationDescriptionPresent: false,
+            }),
+          ],
+        ])
+      ),
+      debugLogs: [],
+    });
+
+    await handleScore(createArgs({ suggestions: true }));
+
+    const output = mockOutput.mock.calls.map(([s]: [string]) => s).join('');
+    expect(output).toContain('Agent prompts (copy/paste)');
+    expect(output).toContain('test.yaml');
+    expect(output).toContain('```');
+  });
 });

--- a/packages/cli/src/commands/score/__tests__/suggestions.test.ts
+++ b/packages/cli/src/commands/score/__tests__/suggestions.test.ts
@@ -1,0 +1,46 @@
+import { buildHotspotAgentPrompt } from '../suggestions.js';
+import type { HotspotOperation } from '../types.js';
+
+function makeHotspot(overrides: Partial<HotspotOperation> = {}): HotspotOperation {
+  return {
+    path: '/widgets',
+    method: 'post',
+    operationId: 'createWidget',
+    agentReadinessScore: 42.5,
+    reasons: ['High parameter count (9)', 'Missing operation description'],
+    issues: [
+      { code: 'high_parameter_count', message: 'High parameter count (9)' },
+      { code: 'missing_operation_description', message: 'Missing operation description' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('buildHotspotAgentPrompt', () => {
+  it('includes document path, operation label, reasons, and focus guidance', () => {
+    const prompt = buildHotspotAgentPrompt('openapi/widgets.yaml', makeHotspot());
+    expect(prompt).toContain('openapi/widgets.yaml');
+    expect(prompt).toContain('POST /widgets');
+    expect(prompt).toContain('operationId: createWidget');
+    expect(prompt).toContain('High parameter count (9)');
+    expect(prompt).toContain('Missing operation description');
+    expect(prompt).toContain('Reduce or consolidate parameters');
+    expect(prompt).toContain('Add a concise `description`');
+    expect(prompt).toContain('42.5/100');
+  });
+
+  it('omits operationId clause when absent', () => {
+    const prompt = buildHotspotAgentPrompt(
+      'api.yaml',
+      makeHotspot({
+        operationId: undefined,
+        method: 'get',
+        reasons: ['Missing response examples'],
+        issues: [{ code: 'missing_response_examples', message: 'Missing response examples' }],
+      })
+    );
+    expect(prompt).toContain('GET /widgets');
+    expect(prompt).not.toContain('operationId:');
+    expect(prompt).toContain('example` or `examples`');
+  });
+});

--- a/packages/cli/src/commands/score/formatters/json.ts
+++ b/packages/cli/src/commands/score/formatters/json.ts
@@ -1,8 +1,21 @@
 import { logger } from '@redocly/openapi-core';
 
+import { buildHotspotAgentPrompt } from '../suggestions.js';
 import type { ScoreResult } from '../types.js';
 
-export function printScoreJson(result: ScoreResult): void {
+export function printScoreJson(
+  result: ScoreResult,
+  apiPath: string,
+  includeSuggestions: boolean
+): void {
+  const hotspots = result.hotspots.map((h) => {
+    const { issues: _issues, ...rest } = h;
+    if (!includeSuggestions) {
+      return rest;
+    }
+    return { ...rest, suggestion: buildHotspotAgentPrompt(apiPath, h) };
+  });
+
   const output = {
     agentReadiness: result.agentReadiness,
     discoverability: Math.round(result.discoverability * 100),
@@ -18,7 +31,7 @@ export function printScoreJson(result: ScoreResult): void {
     },
     operationScores: Object.fromEntries(result.operationScores),
     dependencyDepths: Object.fromEntries(result.dependencyDepths),
-    hotspots: result.hotspots,
+    hotspots,
   };
 
   logger.output(JSON.stringify(output, null, 2));

--- a/packages/cli/src/commands/score/formatters/stylish.ts
+++ b/packages/cli/src/commands/score/formatters/stylish.ts
@@ -1,15 +1,24 @@
 import { logger } from '@redocly/openapi-core';
 import { bold, cyan, green, red, white, yellow } from 'colorette';
 
+import { buildHotspotAgentPrompt } from '../suggestions.js';
 import type { DebugMediaTypeLog, ScoreResult } from '../types.js';
 import { median } from '../utils.js';
 
-export function printScoreStylish(result: ScoreResult, operationDetails = false): void {
+export function printScoreStylish(
+  result: ScoreResult,
+  operationDetails = false,
+  apiPath = '',
+  includeSuggestions = false
+): void {
   printScores(result);
   printSubscores(result);
   printRawMetricsSummary(result);
   if (operationDetails) printOperationDetails(result);
   printHotspots(result);
+  if (includeSuggestions && apiPath) {
+    printAgentPrompts(apiPath, result);
+  }
 }
 
 function scoreColor(score: number): (text: string) => string {
@@ -272,6 +281,27 @@ function printHotspots(result: ScoreResult): void {
     for (const reason of hotspot.reasons) {
       out(yellow(`    - ${reason}`));
     }
+    out('');
+  }
+}
+
+function printAgentPrompts(apiPath: string, result: ScoreResult): void {
+  if (result.hotspots.length === 0) {
+    return;
+  }
+
+  out('');
+  out(bold(white('  Agent prompts (copy/paste)')));
+  out('');
+
+  for (const hotspot of result.hotspots) {
+    const prompt = buildHotspotAgentPrompt(apiPath, hotspot);
+    out('```');
+    const lines = prompt.split('\n');
+    for (const line of lines) {
+      out(line);
+    }
+    out('```');
     out('');
   }
 }

--- a/packages/cli/src/commands/score/hotspots.ts
+++ b/packages/cli/src/commands/score/hotspots.ts
@@ -1,11 +1,105 @@
 import { DEFAULT_SCORING_CONSTANTS } from './constants.js';
 import type {
   DocumentMetrics,
+  HotspotIssue,
   HotspotOperation,
   OperationMetrics,
   OperationScores,
   ScoringConstants,
 } from './types.js';
+
+function getHotspotIssues(
+  metrics: OperationMetrics,
+  dependencyDepth: number,
+  constants: ScoringConstants
+): HotspotIssue[] {
+  const { thresholds } = constants;
+  const issues: HotspotIssue[] = [];
+
+  if (metrics.parameterCount > thresholds.maxParamsGood) {
+    issues.push({
+      code: 'high_parameter_count',
+      message: `High parameter count (${metrics.parameterCount})`,
+    });
+  }
+
+  const maxDepth = Math.max(metrics.maxRequestSchemaDepth, metrics.maxResponseSchemaDepth);
+  if (maxDepth > thresholds.maxDepthGood) {
+    issues.push({
+      code: 'deep_schema_nesting',
+      message: `Deep schema nesting (depth ${maxDepth})`,
+    });
+  }
+
+  if (metrics.anyOfCount > 0 && !metrics.hasDiscriminator) {
+    issues.push({
+      code: 'any_of_without_discriminator',
+      message: `Polymorphism (anyOf) without discriminator (${metrics.anyOfCount} anyOf)`,
+    });
+  } else if (metrics.polymorphismCount > thresholds.maxPolymorphismGood) {
+    issues.push({
+      code: 'high_polymorphism_count',
+      message: `High polymorphism count (${metrics.polymorphismCount})`,
+    });
+  }
+
+  const missingReqExample = metrics.requestBodyPresent && !metrics.requestExamplePresent;
+  const missingResExample = !metrics.responseExamplePresent;
+
+  if (missingReqExample && missingResExample) {
+    issues.push({
+      code: 'missing_request_and_response_examples',
+      message: 'Missing request and response examples',
+    });
+  } else if (missingReqExample) {
+    issues.push({
+      code: 'missing_request_body_examples',
+      message: 'Missing request body examples',
+    });
+  } else if (missingResExample) {
+    issues.push({
+      code: 'missing_response_examples',
+      message: 'Missing response examples',
+    });
+  }
+
+  if (metrics.totalErrorResponses > 0 && metrics.structuredErrorResponseCount === 0) {
+    issues.push({
+      code: 'no_structured_error_responses',
+      message: 'No structured error responses (4xx/5xx)',
+    });
+  }
+
+  if (!metrics.operationDescriptionPresent) {
+    issues.push({
+      code: 'missing_operation_description',
+      message: 'Missing operation description',
+    });
+  }
+
+  if (metrics.parameterCount > 0 && metrics.paramsWithDescription === 0) {
+    issues.push({
+      code: 'no_parameter_descriptions',
+      message: 'No parameter descriptions',
+    });
+  }
+
+  if (dependencyDepth > thresholds.maxDependencyDepthGood) {
+    issues.push({
+      code: 'high_dependency_depth',
+      message: `High dependency depth (${dependencyDepth})`,
+    });
+  }
+
+  if (metrics.ambiguousIdentifierCount > thresholds.maxAmbiguousGood) {
+    issues.push({
+      code: 'ambiguous_identifiers',
+      message: `Ambiguous identifiers (${metrics.ambiguousIdentifierCount})`,
+    });
+  }
+
+  return issues;
+}
 
 export function selectTopHotspots(
   documentMetrics: DocumentMetrics,
@@ -19,15 +113,16 @@ export function selectTopHotspots(
     const metrics = documentMetrics.operations.get(key);
     if (!metrics) continue;
 
-    const reasons = getHotspotReasons(metrics, dependencyDepths.get(key) ?? 0, constants);
-    if (reasons.length === 0) continue;
+    const issues = getHotspotIssues(metrics, dependencyDepths.get(key) ?? 0, constants);
+    if (issues.length === 0) continue;
 
     entries.push({
       path: metrics.path,
       method: metrics.method,
       operationId: metrics.operationId,
       agentReadinessScore: scores.agentReadiness,
-      reasons,
+      reasons: issues.map((i) => i.message),
+      issues,
     });
   }
 
@@ -37,61 +132,4 @@ export function selectTopHotspots(
   });
 
   return entries.slice(0, constants.hotspotLimit);
-}
-
-function getHotspotReasons(
-  metrics: OperationMetrics,
-  dependencyDepth: number,
-  constants: ScoringConstants
-): string[] {
-  const { thresholds } = constants;
-  const reasons: string[] = [];
-
-  if (metrics.parameterCount > thresholds.maxParamsGood) {
-    reasons.push(`High parameter count (${metrics.parameterCount})`);
-  }
-
-  const maxDepth = Math.max(metrics.maxRequestSchemaDepth, metrics.maxResponseSchemaDepth);
-  if (maxDepth > thresholds.maxDepthGood) {
-    reasons.push(`Deep schema nesting (depth ${maxDepth})`);
-  }
-
-  if (metrics.anyOfCount > 0 && !metrics.hasDiscriminator) {
-    reasons.push(`Polymorphism (anyOf) without discriminator (${metrics.anyOfCount} anyOf)`);
-  } else if (metrics.polymorphismCount > thresholds.maxPolymorphismGood) {
-    reasons.push(`High polymorphism count (${metrics.polymorphismCount})`);
-  }
-
-  const missingReqExample = metrics.requestBodyPresent && !metrics.requestExamplePresent;
-  const missingResExample = !metrics.responseExamplePresent;
-
-  if (missingReqExample && missingResExample) {
-    reasons.push('Missing request and response examples');
-  } else if (missingReqExample) {
-    reasons.push('Missing request body examples');
-  } else if (missingResExample) {
-    reasons.push('Missing response examples');
-  }
-
-  if (metrics.totalErrorResponses > 0 && metrics.structuredErrorResponseCount === 0) {
-    reasons.push('No structured error responses (4xx/5xx)');
-  }
-
-  if (!metrics.operationDescriptionPresent) {
-    reasons.push('Missing operation description');
-  }
-
-  if (metrics.parameterCount > 0 && metrics.paramsWithDescription === 0) {
-    reasons.push('No parameter descriptions');
-  }
-
-  if (dependencyDepth > thresholds.maxDependencyDepthGood) {
-    reasons.push(`High dependency depth (${dependencyDepth})`);
-  }
-
-  if (metrics.ambiguousIdentifierCount > thresholds.maxAmbiguousGood) {
-    reasons.push(`Ambiguous identifiers (${metrics.ambiguousIdentifierCount})`);
-  }
-
-  return reasons;
 }

--- a/packages/cli/src/commands/score/index.ts
+++ b/packages/cli/src/commands/score/index.ts
@@ -34,6 +34,7 @@ export type ScoreArgv = {
   format: OutputFormat;
   'operation-details'?: boolean;
   'debug-operation-id'?: string;
+  suggestions?: boolean;
 } & VerifyConfigOptions;
 
 export async function handleScore({ argv, config, collectSpecData }: CommandArgs<ScoreArgv>) {
@@ -92,6 +93,7 @@ export async function handleScore({ argv, config, collectSpecData }: CommandArgs
     startedAt,
     argv.format,
     !!argv['operation-details'],
+    !!argv.suggestions,
     debugOpId ? { operationId: debugOpId, logs: debugLogs } : undefined
   );
 }
@@ -102,17 +104,18 @@ function printScore(
   startedAt: number,
   format: string,
   operationDetails: boolean,
+  suggestions: boolean,
   debugData?: { operationId: string; logs: DebugMediaTypeLog[] }
 ): void {
   logger.info(`Document: ${colors.magenta(api)} score:\n`);
 
   switch (format) {
     case 'json':
-      printScoreJson(result);
+      printScoreJson(result, api, suggestions);
       break;
     case 'stylish':
     default:
-      printScoreStylish(result, operationDetails);
+      printScoreStylish(result, operationDetails, api, suggestions);
       break;
   }
 

--- a/packages/cli/src/commands/score/suggestions.ts
+++ b/packages/cli/src/commands/score/suggestions.ts
@@ -1,0 +1,89 @@
+import type { HotspotIssueCode, HotspotOperation } from './types.js';
+
+const FOCUS_BY_CODE: Record<HotspotIssueCode, string[]> = {
+  high_parameter_count: [
+    'Reduce or consolidate parameters where possible (e.g. move complex filters into a request body object).',
+    'Add clear descriptions and constraints (format, enum, pattern) for every parameter you keep.',
+  ],
+  deep_schema_nesting: [
+    'Flatten or extract nested objects into `components.schemas` and reference them to reduce depth.',
+    'Prefer clear property names and descriptions over deep anonymous nesting.',
+  ],
+  any_of_without_discriminator: [
+    'Add a `discriminator` (and consistent `propertyName` / mapping) so clients can tell which `anyOf` branch applies.',
+    'Document each branch and consider whether `oneOf` or separate operations would be clearer.',
+  ],
+  high_polymorphism_count: [
+    'Simplify composition (`oneOf` / `anyOf` / `allOf`) where possible; split variants into distinct schemas or operations if that matches the domain.',
+    'Ensure each variant is documented and, where appropriate, uses a discriminator.',
+  ],
+  missing_request_and_response_examples: [
+    'Add `example` or `examples` to request and success-response media types that match your schemas.',
+  ],
+  missing_request_body_examples: [
+    'Add `example` or `examples` under the request body media type so tools can show realistic payloads.',
+  ],
+  missing_response_examples: [
+    'Add `example` or `examples` under success (and key error) response media types.',
+  ],
+  no_structured_error_responses: [
+    'Define JSON (or other) response bodies for 4xx/5xx responses with schemas describing error codes, messages, and fields.',
+    'Add descriptions explaining when each error occurs.',
+  ],
+  missing_operation_description: [
+    'Add a concise `description` (and `summary` if useful) explaining purpose, side effects, and important caveats.',
+  ],
+  no_parameter_descriptions: [
+    'Add a `description` for every parameter, including defaults, valid ranges, and interaction with other parameters.',
+  ],
+  high_dependency_depth: [
+    'Review shared `$ref` chains across operations; extract reusable pieces but avoid forcing multi-step coupling where a single clearer contract is possible.',
+  ],
+  ambiguous_identifiers: [
+    'Rename generic parameter names (`id`, `name`, `type`, …) to domain-specific names or add strong descriptions and constraints.',
+  ],
+};
+
+function uniqueFocusLines(codes: Iterable<HotspotIssueCode>): string[] {
+  const seen = new Set<HotspotIssueCode>();
+  const lines: string[] = [];
+  for (const code of codes) {
+    if (seen.has(code)) continue;
+    seen.add(code);
+    for (const line of FOCUS_BY_CODE[code]) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+function operationLabel(hotspot: HotspotOperation): string {
+  const method = hotspot.method.toUpperCase();
+  const base = `${method} ${hotspot.path}`;
+  return hotspot.operationId ? `${base} (operationId: ${hotspot.operationId})` : base;
+}
+
+/**
+ * Single copy-paste prompt for an LLM to improve one operation in the OpenAPI document.
+ */
+export function buildHotspotAgentPrompt(apiPath: string, hotspot: HotspotOperation): string {
+  const bulletReasons = hotspot.reasons.map((r) => `- ${r}`).join('\n');
+  const focusLines = uniqueFocusLines(hotspot.issues.map((i) => i.code));
+  const focusBlock = focusLines.map((l) => `- ${l}`).join('\n');
+
+  return [
+    'You are helping improve an OpenAPI 3.x description for developer and AI-agent usability (clarity, examples, and schema structure).',
+    '',
+    `Document file: ${apiPath}`,
+    `Target operation: ${operationLabel(hotspot)}`,
+    `Current agent-readiness score for this operation (from Redocly CLI \`score\`, higher is better): ${hotspot.agentReadinessScore.toFixed(1)}/100`,
+    '',
+    'Issues detected:',
+    bulletReasons,
+    '',
+    'Please edit the OpenAPI in place to address these issues. Prioritize:',
+    focusBlock,
+    '',
+    'Keep changes coherent with the rest of the spec; preserve existing behavior contracts unless you are clearly fixing documentation or examples.',
+  ].join('\n');
+}

--- a/packages/cli/src/commands/score/types.ts
+++ b/packages/cli/src/commands/score/types.ts
@@ -55,12 +55,32 @@ export interface OperationScores {
   subscores: Subscores;
 }
 
+export type HotspotIssueCode =
+  | 'high_parameter_count'
+  | 'deep_schema_nesting'
+  | 'any_of_without_discriminator'
+  | 'high_polymorphism_count'
+  | 'missing_request_and_response_examples'
+  | 'missing_request_body_examples'
+  | 'missing_response_examples'
+  | 'no_structured_error_responses'
+  | 'missing_operation_description'
+  | 'no_parameter_descriptions'
+  | 'high_dependency_depth'
+  | 'ambiguous_identifiers';
+
+export interface HotspotIssue {
+  code: HotspotIssueCode;
+  message: string;
+}
+
 export interface HotspotOperation {
   path: string;
   method: string;
   operationId?: string;
   agentReadinessScore: number;
   reasons: string[];
+  issues: HotspotIssue[];
 }
 
 export interface ScoreResult {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -102,6 +102,12 @@ yargs(hideBin(process.argv))
             description: 'Print detailed schema breakdown for a specific operation.',
             type: 'string' as const,
           },
+          suggestions: {
+            description:
+              'Include copy-paste LLM prompts to improve hotspot operations (stylish and JSON output).',
+            type: 'boolean' as const,
+            default: false,
+          },
         }),
     (argv) => {
       commandWrapper(handleScore)(argv);
@@ -645,7 +651,7 @@ yargs(hideBin(process.argv))
             default: 'warn' as RuleSeverity,
           },
         })
-        .check((argv: any) => {
+        .check((argv: { theme?: { openapi?: unknown } }) => {
           if (argv.theme && !argv.theme?.openapi)
             throw new Error('Invalid option: theme.openapi not set.');
           return true;

--- a/tests/e2e/score/score-suggestions/snapshot.txt
+++ b/tests/e2e/score/score-suggestions/snapshot.txt
@@ -1,0 +1,59 @@
+
+  Scores
+
+  Agent Readiness:  88.2/100
+
+  Subscores
+
+  Parameter Simplicity     [█████████████████░░░] 86%
+  Schema Simplicity        [████████████████░░░░] 80%
+  Documentation Quality    [██████████████████░░] 90%
+  Constraint Clarity       [███████████░░░░░░░░░] 56%
+  Example Coverage         [██████████████████░░] 88%
+  Error Clarity            [████████████████████] 100%
+  Dependency Clarity       [███████████████░░░░░] 73%
+  Identifier Clarity       [████████████████████] 100%
+  Polymorphism Clarity     [████████████████████] 100%
+  Discoverability          [████████████████████] 99%
+
+  Raw Metrics Summary
+
+  Total operations: 8
+  Parameters/operation:      avg    1.4  median    1.0  min     0  max     4
+  Schema depth:              avg    1.6  median    2.0  min     0  max     3
+  Polymorphism/operation:    avg    0.0  median    0.0  min     0  max     0
+  Properties/operation:      avg    4.4  median    6.0  min     0  max     6
+  Operations with request examples: 3/8 (38%)
+  Operations with response examples: 7/8 (88%)
+  Operations with description: 8/8 (100%)
+
+  Top 1 Hotspot Operations
+
+  GET /tickets/{ticketId}/qr (getTicketCode)
+    Agent Readiness: 81.0
+    - Missing response examples
+
+
+  Agent prompts (copy/paste)
+
+```
+You are helping improve an OpenAPI 3.x description for developer and AI-agent usability (clarity, examples, and schema structure).
+
+Document file: museum.yaml
+Target operation: GET /tickets/{ticketId}/qr (operationId: getTicketCode)
+Current agent-readiness score for this operation (from Redocly CLI `score`, higher is better): 81.0/100
+
+Issues detected:
+- Missing response examples
+
+Please edit the OpenAPI in place to address these issues. Prioritize:
+- Add `example` or `examples` under success (and key error) response media types.
+
+Keep changes coherent with the rest of the spec; preserve existing behavior contracts unless you are clearly fixing documentation or examples.
+```
+
+
+Document: museum.yaml score:
+
+museum.yaml: score processed in <test>ms
+

--- a/tests/e2e/score/score.test.ts
+++ b/tests/e2e/score/score.test.ts
@@ -29,4 +29,11 @@ describe('score', () => {
     const result = getCommandOutput(args, { testPath });
     await expect(cleanupOutput(result)).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
   });
+
+  test('score should include agent prompts when --suggestions', async () => {
+    const snapshotPath = join(folderPath, 'score-suggestions', 'snapshot.txt');
+    const args = getParams(indexEntryPoint, ['score', 'museum.yaml', '--suggestions']);
+    const result = getCommandOutput(args, { testPath: join(folderPath, 'score-stylish') });
+    await expect(cleanupOutput(result)).toMatchFileSnapshot(snapshotPath);
+  });
 });


### PR DESCRIPTION
## What/Why/How?

**What:** Adds optional `--suggestions` to the experimental `score` command. Hotspot detection now produces structured `issues` (stable codes plus the same human messages as before). When the flag is set, the CLI prints copy-paste LLM prompts per hotspot (stylish) and adds `hotspots[].suggestion` in JSON.

**Why:** Brings the score command closer to agent-readiness workflows where users paste actionable prompts into an assistant to improve their OpenAPI description.

**How:** `getHotspotIssues` in `hotspots.ts` is the single source of truth; `reasons` remains `issues.map((i) => i.message)`. New `suggestions.ts` implements `buildHotspotAgentPrompt`. JSON strips `issues` and only attaches `suggestion` when `--suggestions` is true so default JSON stays stable.

## Reference

OpenAPI 3.x `score` command; hotspot thresholds unchanged.

## Testing

- `packages/cli/src/commands/score/__tests__/` (hotspots, suggestions, index).
- E2E: `tests/e2e/score/score.test.ts` and `tests/e2e/score/score-suggestions/snapshot.txt`.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines
