### PR TITLE
fix: improve push command stability

### DIFF
--- a/.changeset/pretty-emus-follow.md
+++ b/.changeset/pretty-emus-follow.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Improved stability of the push command.
+Improved the stability of the `push` command.

--- a/.changeset/pretty-emus-follow.md
+++ b/.changeset/pretty-emus-follow.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Improved stability of the push command.

--- a/packages/cli/src/reunite/api/api-client.ts
+++ b/packages/cli/src/reunite/api/api-client.ts
@@ -2,7 +2,7 @@ import { logger } from '@redocly/openapi-core';
 import type { ReadStream } from 'node:fs';
 import type { Readable } from 'node:stream';
 
-import { DEFAULT_FETCH_TIMEOUT } from '../../utils/constants.js';
+import { DEFAULT_FETCH_TIMEOUT, SOURCE_FETCH_TIMEOUT } from '../../utils/constants.js';
 import fetchWithTimeout, { type FetchWithTimeoutOptions } from '../../utils/fetch-with-timeout.js';
 import { version } from '../../utils/package.js';
 import type {
@@ -125,7 +125,7 @@ class RemotesApi {
       const response = await this.client.request(
         `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/source`,
         {
-          timeout: DEFAULT_FETCH_TIMEOUT,
+          timeout: SOURCE_FETCH_TIMEOUT,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,4 +1,4 @@
 export const OTEL_URL = 'https://otel.cloud.redocly.com';
 export const OTEL_TRACES_URL = process.env.OTEL_TRACES_URL || `${OTEL_URL}/v1/traces`;
-export const DEFAULT_FETCH_TIMEOUT = 3000;
+export const DEFAULT_FETCH_TIMEOUT = 6000;
 export const ANONYMOUS_ID_CACHE_FILE = 'redocly-cli-anonymous-id';

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const OTEL_URL = 'https://otel.cloud.redocly.com';
 export const OTEL_TRACES_URL = process.env.OTEL_TRACES_URL || `${OTEL_URL}/v1/traces`;
-export const DEFAULT_FETCH_TIMEOUT = 6000;
+export const DEFAULT_FETCH_TIMEOUT = 3000;
+export const SOURCE_FETCH_TIMEOUT = 6000;
 export const ANONYMOUS_ID_CACHE_FILE = 'redocly-cli-anonymous-id';


### PR DESCRIPTION
## What/Why/How?

Improved push command stability by increasing default fetch timeout.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized timeout change plus a versioning changeset; minimal behavioral impact beyond waiting longer before failing on slow networks.
> 
> **Overview**
> Improves `push` stability by increasing the timeout used when fetching a project’s source/default branch (`getDefaultBranch`) from 3s to 6s via a new `SOURCE_FETCH_TIMEOUT` constant.
> 
> Adds a changeset to ship this as a patch release for `@redocly/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc6e06d3c4a830768445096d69d4ed459803cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->