### PR TITLE
fix: improve push command stability

### DIFF
--- a/.changeset/purple-pens-clap.md
+++ b/.changeset/purple-pens-clap.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Improved the stability of the `push` command.

--- a/packages/cli/src/reunite/api/api-client.ts
+++ b/packages/cli/src/reunite/api/api-client.ts
@@ -2,6 +2,7 @@ import { yellow, red } from 'colorette';
 import fetchWithTimeout, {
   type FetchWithTimeoutOptions,
   DEFAULT_FETCH_TIMEOUT,
+  SOURCE_FETCH_TIMEOUT,
 } from '../../utils/fetch-with-timeout';
 
 import type { ReadStream } from 'fs';
@@ -109,7 +110,7 @@ class RemotesApi {
       const response = await this.client.request(
         `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/source`,
         {
-          timeout: DEFAULT_FETCH_TIMEOUT,
+          timeout: SOURCE_FETCH_TIMEOUT,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/cli/src/utils/fetch-with-timeout.ts
+++ b/packages/cli/src/utils/fetch-with-timeout.ts
@@ -1,6 +1,7 @@
 import { getProxyAgent } from '@redocly/openapi-core';
 
 export const DEFAULT_FETCH_TIMEOUT = 3000;
+export const SOURCE_FETCH_TIMEOUT = 6000;
 
 export type FetchWithTimeoutOptions = RequestInit & {
   timeout?: number;


### PR DESCRIPTION
## What/Why/How?

Improved `push` command stability in V1

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small network-tuning change that only increases the timeout for fetching a project's source/default branch, reducing flaky `push` failures on slow responses.
> 
> **Overview**
> Improves `push` stability by increasing the fetch timeout specifically for the project `source` lookup used to determine the default branch (introducing `SOURCE_FETCH_TIMEOUT` and using it in `getDefaultBranch`).
> 
> Adds a changeset bumping `@redocly/cli` with a patch release note for this stability improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3d9cee249e0c6e23172fa8da8b7a4485e94c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->