### PR TITLE
docs: update changelogs with warning msg

### DIFF
--- a/docs/@v2/changelog.md
+++ b/docs/@v2/changelog.md
@@ -11,6 +11,8 @@ toc:
 
 ### Patch Changes
 
+- Made Respect's JSONPath criteria compliant with RFC 9535.
+  **Warning:** This update may affect existing workflows. Please review your usage for compatibility.
 - Fixed an issue where discriminator's `mapping` values written as bare local file names were not resolved during build.
 - Updated @redocly/openapi-core to v2.29.1.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Patch Changes
 
+- Made Respect's JSONPath criteria compliant with RFC 9535.
+  **Warning:** This update may affect existing workflows. Please review your usage for compatibility.
 - Fixed an issue where discriminator's `mapping` values written as bare local file names were not resolved during build.
 - Updated @redocly/openapi-core to v2.29.1.
 

--- a/packages/respect-core/CHANGELOG.md
+++ b/packages/respect-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patch Changes
 
 - Made Respect's JSONPath criteria compliant with RFC 9535.
+  **Warning:** This update may affect existing workflows. Please review your usage for compatibility.
 - Updated @redocly/openapi-core to v2.29.1.
 
 ## 2.29.0


### PR DESCRIPTION
## What/Why/How?

Add warning message to changelogs as followup to this [PR ](https://github.com/Redocly/redocly-cli/pull/2745).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add a warning note to existing changelog entries; no runtime behavior or dependencies are modified.
> 
> **Overview**
> Adds an explicit **compatibility warning** to the `2.29.1` changelog entries (docs site, `@redocly/cli`, and `@redocly/respect-core`) for the change that made Respect’s JSONPath criteria RFC 9535 compliant, calling out potential workflow impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85471c64754532d742c87c256daf0b4c517de460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->