### PR TITLE
chore: update @redocly/config to v0.48.1

### DIFF
--- a/.changeset/wet-animals-laugh.md
+++ b/.changeset/wet-animals-laugh.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Updated `@redocly/config` to `v0.48.0`.

--- a/.changeset/wet-animals-laugh.md
+++ b/.changeset/wet-animals-laugh.md
@@ -2,4 +2,4 @@
 "@redocly/openapi-core": patch
 ---
 
-Updated `@redocly/config` to `v0.48.0`.
+Updated `@redocly/config` to `v0.48.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2729,9 +2729,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.0.tgz",
-      "integrity": "sha512-8W3wz+Q7y4e9klJWlYOvQWK5r7P2Mo589vcjtlT5coOxsyAdt53k8Vb8iAqnRiGWExbjBQmSbL2XbuU747Nf6Q==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.1.tgz",
+      "integrity": "sha512-vq8GM3e0KiglqkwE5Lb9XayrmZY4dHCs21BsvV92yAZN68f1N9cZUuwY1SwnztPbH06dn9uLzubBl/JNfImqfA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -12627,7 +12627,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.48.0",
+        "@redocly/config": "^0.48.1",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.0",
-    "@redocly/config": "^0.48.0",
+    "@redocly/config": "^0.48.1",
     "ajv": "npm:@redocly/ajv@8.18.0",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",


### PR DESCRIPTION
## What/Why/How?
Updated `@redocly/config` to `v0.48.1`.

## Reference
Part of #2689 

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency patch bump with no functional code changes beyond version/lockfile updates.
> 
> **Overview**
> Updates `@redocly/openapi-core` to depend on `@redocly/config@0.48.1` (from `0.48.0`) and refreshes the lockfile accordingly.
> 
> Adds a changeset marking this as a patch release for `@redocly/openapi-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3684e4bdc2afb28b4e150e3adc874fad071a5019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->