### PR TITLE
fix: scope AJV instances per lintDocument call to fix concurrent validation

### DIFF
--- a/.changeset/fix-ajv-concurrent-lint.md
+++ b/.changeset/fix-ajv-concurrent-lint.md
@@ -1,0 +1,5 @@
+---
+"@redocly/openapi-core": patch
+---
+
+Fixed spurious "can't resolve reference" warnings when linting multiple APIs concurrently.

--- a/.changeset/fix-ajv-concurrent-lint.md
+++ b/.changeset/fix-ajv-concurrent-lint.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed spurious "can't resolve reference" warnings when linting multiple APIs concurrently.

--- a/packages/core/src/__tests__/fixtures/concurrent-lint/common.yaml
+++ b/packages/core/src/__tests__/fixtures/concurrent-lint/common.yaml
@@ -1,0 +1,12 @@
+openapi: '3.0.0'
+info:
+  title: Common
+  version: '1.0.0'
+paths: {}
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        message:
+          type: string

--- a/packages/core/src/__tests__/fixtures/concurrent-lint/spec-a.yaml
+++ b/packages/core/src/__tests__/fixtures/concurrent-lint/spec-a.yaml
@@ -1,0 +1,39 @@
+openapi: '3.0.0'
+info:
+  title: Service A
+  version: '1.0.0'
+servers:
+  - url: https://a.example.com
+security:
+  - BearerAuth: []
+paths:
+  /a:
+    post:
+      operationId: create_a
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Foo'
+            example:
+              name: 'test'
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: './common.yaml#/components/schemas/Error'
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Foo:
+      type: object
+      properties:
+        name:
+          type: string

--- a/packages/core/src/__tests__/fixtures/concurrent-lint/spec-b.yaml
+++ b/packages/core/src/__tests__/fixtures/concurrent-lint/spec-b.yaml
@@ -1,0 +1,39 @@
+openapi: '3.0.0'
+info:
+  title: Service B
+  version: '1.0.0'
+servers:
+  - url: https://b.example.com
+security:
+  - BearerAuth: []
+paths:
+  /b:
+    post:
+      operationId: create_b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bar'
+            example:
+              value: 42
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: './common.yaml#/components/schemas/Error'
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Bar:
+      type: object
+      properties:
+        value:
+          type: integer

--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -2003,6 +2003,26 @@ describe('lint', () => {
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should not produce spurious example validation errors when linting concurrently', async () => {
+    const config = await createConfig({
+      rules: { 'no-invalid-media-type-examples': 'error' },
+    });
+
+    const [resultsA, resultsB] = await Promise.all([
+      lint({
+        ref: path.join(__dirname, 'fixtures/concurrent-lint/spec-a.yaml'),
+        config,
+      }),
+      lint({
+        ref: path.join(__dirname, 'fixtures/concurrent-lint/spec-b.yaml'),
+        config,
+      }),
+    ]);
+
+    expect(resultsA).toHaveLength(0);
+    expect(resultsB).toHaveLength(0);
+  });
+
   it('should report no unresolved extends when scorecardClassic extends contains a ref to non existing preset', async () => {
     const testConfigContent = outdent`
       scorecardClassic:

--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -2004,6 +2004,26 @@ describe('lint', () => {
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should not produce spurious example validation errors when linting concurrently', async () => {
+    const config = await createConfig({
+      rules: { 'no-invalid-media-type-examples': 'error' },
+    });
+
+    const [resultsA, resultsB] = await Promise.all([
+      lint({
+        ref: path.join(__dirname, 'fixtures/concurrent-lint/spec-a.yaml'),
+        config,
+      }),
+      lint({
+        ref: path.join(__dirname, 'fixtures/concurrent-lint/spec-b.yaml'),
+        config,
+      }),
+    ]);
+
+    expect(resultsA).toHaveLength(0);
+    expect(resultsB).toHaveLength(0);
+  });
+
   it('should report no unresolved extends when scorecardClassic extends contains a ref to non existing preset', async () => {
     const testConfigContent = outdent`
       scorecardClassic:

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -5,7 +5,7 @@ import { initRules } from './config/rules.js';
 import { detectSpec, getMajorSpecVersion } from './detect-spec.js';
 import { getTypes } from './oas-types.js';
 import { BaseResolver, resolveDocument, makeDocumentFromString, type Document } from './resolve.js';
-import { releaseAjvInstance } from './rules/ajv.js';
+import { AjvValidator } from './rules/ajv.js';
 import { NoUnresolvedRefs } from './rules/common/no-unresolved-refs.js';
 import { Struct } from './rules/common/struct.js';
 import { normalizeTypes, type NodeType } from './types/index.js';
@@ -71,7 +71,7 @@ export async function lintDocument(opts: {
   customTypes?: Record<string, NodeType>;
   externalRefResolver: BaseResolver;
 }) {
-  releaseAjvInstance(); // FIXME: preprocessors can modify nodes which are then cached to ajv-instance by absolute path
+  const ajvValidator = new AjvValidator();
 
   const { document, customTypes, externalRefResolver, config } = opts;
   const specVersion = detectSpec(document.parsed);
@@ -87,6 +87,7 @@ export async function lintDocument(opts: {
     specVersion,
     config,
     visitorsData: {},
+    ajvValidator,
   };
 
   const preprocessors = initRules(rules, config, 'preprocessors', specVersion);
@@ -142,6 +143,7 @@ export async function lintConfig(opts: {
     specVersion: 'oas3_0', // TODO: use config-specific version
     config,
     visitorsData: {},
+    ajvValidator: new AjvValidator(),
   };
 
   const types = normalizeTypes(

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -5,7 +5,6 @@ import { initRules } from './config/rules.js';
 import { detectSpec, getMajorSpecVersion } from './detect-spec.js';
 import { getTypes } from './oas-types.js';
 import { BaseResolver, resolveDocument, makeDocumentFromString, type Document } from './resolve.js';
-import { releaseAjvInstance } from './rules/ajv.js';
 import { NoUnresolvedRefs } from './rules/common/no-unresolved-refs.js';
 import { Struct } from './rules/common/struct.js';
 import { normalizeTypes, type NodeType } from './types/index.js';
@@ -71,8 +70,6 @@ export async function lintDocument(opts: {
   customTypes?: Record<string, NodeType>;
   externalRefResolver: BaseResolver;
 }) {
-  releaseAjvInstance(); // FIXME: preprocessors can modify nodes which are then cached to ajv-instance by absolute path
-
   const { document, customTypes, externalRefResolver, config } = opts;
   const specVersion = detectSpec(document.parsed);
   const specMajorVersion = getMajorSpecVersion(specVersion);

--- a/packages/core/src/rules/__tests__/ajv.test.ts
+++ b/packages/core/src/rules/__tests__/ajv.test.ts
@@ -32,14 +32,13 @@ vi.mock('ajv-formats', () => {
 
 import { Location } from '../../ref-utils.js';
 import type { Source } from '../../resolve.js';
-import { validateJsonSchema, releaseAjvInstance } from '../ajv.js';
+import { AjvValidator } from '../ajv.js';
 
-describe('ajv configuration', () => {
+describe('AjvValidator', () => {
   const resolve = () => ({ node: undefined, location: undefined });
   const baseLocation = createBaseLocation();
 
   beforeEach(() => {
-    releaseAjvInstance();
     vi.clearAllMocks();
   });
 
@@ -48,9 +47,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -69,9 +69,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjv2020Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -92,9 +93,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'string' };
 
-      validateJsonSchema('test', schema, {
+      validator.validate('test', schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -112,9 +114,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjv2020Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'string' };
 
-      validateJsonSchema('test', schema, {
+      validator.validate('test', schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -131,9 +134,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'string' };
 
-      validateJsonSchema('test', schema, {
+      validator.validate('test', schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -158,9 +162,10 @@ describe('ajv configuration', () => {
       };
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -184,9 +189,10 @@ describe('ajv configuration', () => {
       };
       mockAjv2020Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,

--- a/packages/core/src/rules/__tests__/ajv.test.ts
+++ b/packages/core/src/rules/__tests__/ajv.test.ts
@@ -32,14 +32,14 @@ vi.mock('ajv-formats', () => {
 
 import { Location } from '../../ref-utils.js';
 import type { Source } from '../../resolve.js';
-import { validateJsonSchema, releaseAjvInstance } from '../ajv.js';
+import { AjvValidator } from '../ajv.js';
 
-describe('ajv configuration', () => {
+describe('AjvValidator', () => {
   const resolve = () => ({ node: undefined, location: undefined });
   const baseLocation = createBaseLocation();
 
   beforeEach(() => {
-    releaseAjvInstance();
+    vi.clearAllMocks();
   });
 
   describe('dialect selection by specVersion', () => {
@@ -47,9 +47,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -68,9 +69,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjv2020Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -91,9 +93,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'string' };
 
-      validateJsonSchema('test', schema, {
+      validator.validate('test', schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -111,9 +114,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjv2020Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'string' };
 
-      validateJsonSchema('test', schema, {
+      validator.validate('test', schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -130,9 +134,10 @@ describe('ajv configuration', () => {
       const mockAjvInstance = createMockAjvInstance();
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'string' };
 
-      validateJsonSchema('test', schema, {
+      validator.validate('test', schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -157,9 +162,10 @@ describe('ajv configuration', () => {
       };
       mockAjvDraft4Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,
@@ -183,9 +189,10 @@ describe('ajv configuration', () => {
       };
       mockAjv2020Constructor.mockReturnValue(mockAjvInstance);
 
+      const validator = new AjvValidator();
       const schema = { type: 'integer' };
 
-      validateJsonSchema(10, schema, {
+      validator.validate(10, schema, {
         schemaLoc: baseLocation,
         instancePath: '/example',
         resolve,

--- a/packages/core/src/rules/ajv.ts
+++ b/packages/core/src/rules/ajv.ts
@@ -14,13 +14,6 @@ import type { ResolveFn } from '../walk.js';
 
 type AjvDialect = '2020' | 'draft4';
 
-const ajvInstances: Partial<Record<AjvDialect, any>> = {};
-
-export function releaseAjvInstance() {
-  ajvInstances['2020'] = undefined;
-  ajvInstances['draft4'] = undefined;
-}
-
 function getSchemaIdKey(dialect: AjvDialect) {
   return dialect === 'draft4' ? 'id' : '$id';
 }
@@ -30,127 +23,137 @@ function getDialectBySpecVersion(specVersion: SpecVersion): AjvDialect {
   return '2020';
 }
 
-function getAjv(resolve: ResolveFn, dialect: AjvDialect): any {
-  if (!ajvInstances[dialect]) {
-    const schemaIdKey = getSchemaIdKey(dialect);
+export class AjvValidator {
+  private instances: Partial<Record<AjvDialect, any>> = {};
 
-    const options: Options = {
-      schemaId: schemaIdKey,
-      meta: true,
-      allErrors: true,
-      strictSchema: false,
-      inlineRefs: false,
-      validateSchema: false,
-      discriminator: true,
-      allowUnionTypes: true,
-      validateFormats: true,
-      passContext: true,
-      loadSchemaSync(base: string, $ref: string, $id: string) {
-        const decodedBase = decodeURI(base.split('#')[0]);
-        const resolvedRef = resolve({ $ref }, decodedBase);
-        if (!resolvedRef || !resolvedRef.location) return false;
+  validate(
+    data: unknown,
+    schema: Oas3Schema | Oas3_1Schema,
+    options: {
+      schemaLoc: Location;
+      instancePath: string;
+      resolve: ResolveFn;
+      allowAdditionalProperties: boolean;
+      ajvContext?: AjvContext;
+      specVersion: SpecVersion;
+    }
+  ): { valid: boolean; errors: (ErrorObject & { suggest?: string[] })[] } {
+    const { schemaLoc, instancePath, resolve, allowAdditionalProperties, ajvContext, specVersion } =
+      options;
 
-        return {
-          [schemaIdKey]: encodeURI(resolvedRef.location.source.absoluteRef) + '#' + $id,
-          ...resolvedRef.node,
-        };
-      },
-      logger: false,
-    };
-
-    ajvInstances[dialect] =
-      dialect === '2020' ? new (Ajv2020 as any)(options) : new (AjvDraft4 as any)(options);
-
-    (addFormats as any)(ajvInstances[dialect]);
-  }
-  return ajvInstances[dialect];
-}
-
-function getAjvValidator(
-  schema: Oas3Schema | Oas3_1Schema,
-  loc: Location,
-  resolve: ResolveFn,
-  allowAdditionalProperties: boolean,
-  dialect: AjvDialect
-): ValidateFunction | undefined {
-  const ajv = getAjv(resolve, dialect);
-  const $id = encodeURI(loc.absolutePointer);
-  const schemaIdKey = getSchemaIdKey(dialect);
-
-  if (!ajv.getSchema($id)) {
-    ajv.setDefaultUnevaluatedProperties(allowAdditionalProperties);
-    ajv.addSchema(
-      {
-        [schemaIdKey]: $id,
-        ...schema,
-      },
-      $id
+    const dialect = getDialectBySpecVersion(specVersion);
+    const validate = this.getValidator(
+      schema,
+      schemaLoc,
+      resolve,
+      allowAdditionalProperties,
+      dialect
     );
-  }
+    if (!validate) return { valid: true, errors: [] }; // unresolved refs are reported
 
-  return ajv.getSchema($id);
-}
-
-export function validateJsonSchema(
-  data: unknown,
-  schema: Oas3Schema | Oas3_1Schema,
-  options: {
-    schemaLoc: Location;
-    instancePath: string;
-    resolve: ResolveFn;
-    allowAdditionalProperties: boolean;
-    ajvContext?: AjvContext;
-    specVersion: SpecVersion;
-  }
-): { valid: boolean; errors: (ErrorObject & { suggest?: string[] })[] } {
-  const { schemaLoc, instancePath, resolve, allowAdditionalProperties, ajvContext, specVersion } =
-    options;
-
-  const dialect = getDialectBySpecVersion(specVersion);
-  const validate = getAjvValidator(schema, schemaLoc, resolve, allowAdditionalProperties, dialect);
-  if (!validate) return { valid: true, errors: [] }; // unresolved refs are reported
-
-  const dataCxt = {
-    instancePath,
-    parentData: { fake: {} },
-    parentDataProperty: 'fake',
-    rootData: {},
-    dynamicAnchors: {},
-  };
-  const valid = validate.call(ajvContext ?? {}, data, dataCxt);
-
-  return {
-    valid: !!valid,
-    errors: (validate.errors || []).map(beatifyErrorMessage),
-  };
-
-  function beatifyErrorMessage(error: ErrorObject) {
-    let message = error.message;
-    const suggest: string[] | undefined =
-      error.keyword === 'enum' ? error.params.allowedValues : undefined;
-    if (suggest) {
-      message += ` ${suggest.map((e) => `"${e}"`).join(', ')}`;
-    }
-
-    if (error.keyword === 'type') {
-      message = `type ${message}`;
-    }
-
-    const relativePath = error.instancePath.substring(instancePath.length + 1);
-    const propName = relativePath.substring(relativePath.lastIndexOf('/') + 1);
-    if (propName) {
-      message = `\`${propName}\` property ${message}`;
-    }
-    if (error.keyword === 'additionalProperties' || error.keyword === 'unevaluatedProperties') {
-      const property = error.params.additionalProperty || error.params.unevaluatedProperty;
-      message = `${message} \`${property}\``;
-      error.instancePath += '/' + escapePointerFragment(property);
-    }
+    const dataCxt = {
+      instancePath,
+      parentData: { fake: {} },
+      parentDataProperty: 'fake',
+      rootData: {},
+      dynamicAnchors: {},
+    };
+    const valid = validate.call(ajvContext ?? {}, data, dataCxt);
 
     return {
-      ...error,
-      message,
-      suggest,
+      valid: !!valid,
+      errors: (validate.errors || []).map(beatifyErrorMessage),
     };
+
+    function beatifyErrorMessage(error: ErrorObject) {
+      let message = error.message;
+      const suggest: string[] | undefined =
+        error.keyword === 'enum' ? error.params.allowedValues : undefined;
+      if (suggest) {
+        message += ` ${suggest.map((e) => `"${e}"`).join(', ')}`;
+      }
+
+      if (error.keyword === 'type') {
+        message = `type ${message}`;
+      }
+
+      const relativePath = error.instancePath.substring(instancePath.length + 1);
+      const propName = relativePath.substring(relativePath.lastIndexOf('/') + 1);
+      if (propName) {
+        message = `\`${propName}\` property ${message}`;
+      }
+      if (error.keyword === 'additionalProperties' || error.keyword === 'unevaluatedProperties') {
+        const property = error.params.additionalProperty || error.params.unevaluatedProperty;
+        message = `${message} \`${property}\``;
+        error.instancePath += '/' + escapePointerFragment(property);
+      }
+
+      return {
+        ...error,
+        message,
+        suggest,
+      };
+    }
+  }
+
+  private getAjv(resolve: ResolveFn, dialect: AjvDialect): any {
+    if (!this.instances[dialect]) {
+      const schemaIdKey = getSchemaIdKey(dialect);
+
+      const options: Options = {
+        schemaId: schemaIdKey,
+        meta: true,
+        allErrors: true,
+        strictSchema: false,
+        inlineRefs: false,
+        validateSchema: false,
+        discriminator: true,
+        allowUnionTypes: true,
+        validateFormats: true,
+        passContext: true,
+        loadSchemaSync(base: string, $ref: string, $id: string) {
+          const decodedBase = decodeURI(base.split('#')[0]);
+          const resolvedRef = resolve({ $ref }, decodedBase);
+          if (!resolvedRef || !resolvedRef.location) return false;
+
+          return {
+            [schemaIdKey]: encodeURI(resolvedRef.location.source.absoluteRef) + '#' + $id,
+            ...resolvedRef.node,
+          };
+        },
+        logger: false,
+      };
+
+      this.instances[dialect] =
+        dialect === '2020' ? new (Ajv2020 as any)(options) : new (AjvDraft4 as any)(options);
+
+      (addFormats as any)(this.instances[dialect]);
+    }
+    return this.instances[dialect];
+  }
+
+  private getValidator(
+    schema: Oas3Schema | Oas3_1Schema,
+    loc: Location,
+    resolve: ResolveFn,
+    allowAdditionalProperties: boolean,
+    dialect: AjvDialect
+  ): ValidateFunction | undefined {
+    const ajv = this.getAjv(resolve, dialect);
+    const $id = encodeURI(loc.absolutePointer);
+    const schemaIdKey = getSchemaIdKey(dialect);
+
+    if (!ajv.getSchema($id)) {
+      ajv.setDefaultUnevaluatedProperties(allowAdditionalProperties);
+      ajv.addSchema(
+        {
+          [schemaIdKey]: $id,
+          ...schema,
+        },
+        $id
+      );
+    }
+
+    return ajv.getSchema($id);
   }
 }

--- a/packages/core/src/rules/common/no-invalid-parameter-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-parameter-examples.ts
@@ -3,9 +3,11 @@ import { isDefined } from '../../utils/is-defined.js';
 import { isPlainObject } from '../../utils/is-plain-object.js';
 import type { Oas2Rule, Oas3Rule } from '../../visitors.js';
 import type { UserContext } from '../../walk.js';
+import { AjvValidator } from '../ajv.js';
 import { validateExample } from '../utils.js';
 
 export const NoInvalidParameterExamples: Oas3Rule | Oas2Rule = (opts) => {
+  const validator = new AjvValidator();
   return {
     Parameter: {
       leave(parameter: Oas3Parameter, ctx: UserContext) {
@@ -16,6 +18,7 @@ export const NoInvalidParameterExamples: Oas3Rule | Oas2Rule = (opts) => {
             options: {
               location: ctx.location.child('example'),
               ctx,
+              validator,
               allowAdditionalProperties: !!opts.allowAdditionalProperties,
               ajvContext: { apiContext: 'request' },
             },
@@ -32,6 +35,7 @@ export const NoInvalidParameterExamples: Oas3Rule | Oas2Rule = (opts) => {
                 options: {
                   location: ctx.location.child(['examples', key]),
                   ctx,
+                  validator,
                   allowAdditionalProperties: !!opts.allowAdditionalProperties,
                   ajvContext: { apiContext: 'request' },
                 },

--- a/packages/core/src/rules/common/no-invalid-schema-examples.ts
+++ b/packages/core/src/rules/common/no-invalid-schema-examples.ts
@@ -2,9 +2,11 @@ import type { Oas3_1Schema, Oas3Schema } from '../../typings/openapi.js';
 import { isDefined } from '../../utils/is-defined.js';
 import type { Oas2Rule, Oas3Rule } from '../../visitors.js';
 import type { UserContext } from '../../walk.js';
+import { AjvValidator } from '../ajv.js';
 import { validateExample } from '../utils.js';
 
 export const NoInvalidSchemaExamples: Oas3Rule | Oas2Rule = (opts) => {
+  const validator = new AjvValidator();
   return {
     Schema: {
       leave(schema: Oas3_1Schema | Oas3Schema, ctx: UserContext) {
@@ -18,6 +20,7 @@ export const NoInvalidSchemaExamples: Oas3Rule | Oas2Rule = (opts) => {
               options: {
                 location: ctx.location.child(['examples', examples.indexOf(example)]),
                 ctx,
+                validator,
                 allowAdditionalProperties: !!opts.allowAdditionalProperties,
               },
               reference: 'https://redocly.com/docs/cli/rules/oas/no-invalid-schema-examples',
@@ -41,6 +44,7 @@ export const NoInvalidSchemaExamples: Oas3Rule | Oas2Rule = (opts) => {
             options: {
               location: ctx.location.child('example'),
               ctx,
+              validator,
               allowAdditionalProperties: !!opts.allowAdditionalProperties,
             },
             reference: 'https://redocly.com/docs/cli/rules/oas/no-invalid-schema-examples',

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -6,9 +6,12 @@ import { isDefined } from '../../utils/is-defined.js';
 import { isPlainObject } from '../../utils/is-plain-object.js';
 import type { Oas3Rule } from '../../visitors.js';
 import type { UserContext } from '../../walk.js';
+import { AjvValidator } from '../ajv.js';
 import { validateExample } from '../utils.js';
 
 export const ValidContentExamples: Oas3Rule = (opts) => {
+  const validator = new AjvValidator();
+
   const skip = (mediaType: Oas3MediaType) => {
     return mediaType.schema === undefined;
   };
@@ -48,6 +51,7 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
         options: {
           location,
           ctx,
+          validator,
           allowAdditionalProperties: !!opts.allowAdditionalProperties,
           ajvContext: context,
         },

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -12,7 +12,6 @@ import type {
 import type { Oas2Tag } from '../typings/swagger.js';
 import { isPlainObject } from '../utils/is-plain-object.js';
 import type { NonUndefined, UserContext } from '../walk.js';
-import { validateJsonSchema } from './ajv.js';
 
 export const resolveSchema = <T extends NonUndefined>(
   schemaOrRef: Referenced<T> | undefined,
@@ -161,7 +160,7 @@ export function validateExample(
   const { location, ctx, allowAdditionalProperties, ajvContext } = options;
   const { resolve, location: parentLocation, report, specVersion } = ctx;
   try {
-    const { valid, errors } = validateJsonSchema(example, schema, {
+    const { valid, errors } = ctx.ajvValidator.validate(example, schema, {
       schemaLoc: parentLocation.child('schema'),
       instancePath: location.pointer,
       resolve,

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -12,7 +12,7 @@ import type {
 import type { Oas2Tag } from '../typings/swagger.js';
 import { isPlainObject } from '../utils/is-plain-object.js';
 import type { NonUndefined, UserContext } from '../walk.js';
-import { validateJsonSchema } from './ajv.js';
+import type { AjvValidator } from './ajv.js';
 
 export const resolveSchema = <T extends NonUndefined>(
   schemaOrRef: Referenced<T> | undefined,
@@ -177,15 +177,16 @@ export function validateExample({
   options: {
     location: Location;
     ctx: UserContext;
+    validator: AjvValidator;
     allowAdditionalProperties: boolean;
     ajvContext?: AjvContext;
   };
   reference?: string;
 }) {
-  const { location, ctx, allowAdditionalProperties, ajvContext } = options;
+  const { location, ctx, validator, allowAdditionalProperties, ajvContext } = options;
   const { resolve, location: parentLocation, report, specVersion } = ctx;
   try {
-    const { valid, errors } = validateJsonSchema(example, schema, {
+    const { valid, errors } = validator.validate(example, schema, {
       schemaLoc: parentLocation.child('schema'),
       instancePath: location.pointer,
       resolve,

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -3,6 +3,7 @@ import { YamlParseError } from './errors/yaml-parse-error.js';
 import type { SpecVersion } from './oas-types.js';
 import { Location, isRef } from './ref-utils.js';
 import type { ResolveError, Source, ResolvedRefMap, Document } from './resolve.js';
+import type { AjvValidator } from './rules/ajv.js';
 import { isNamedType, SpecExtension, type NormalizedNodeType } from './types/index.js';
 import type { Referenced } from './typings/openapi.js';
 import { getOwn } from './utils/get-own.js';
@@ -49,6 +50,7 @@ export type UserContext = {
   specVersion: SpecVersion;
   config?: Config;
   getVisitorData: () => Record<string, unknown>;
+  ajvValidator: AjvValidator;
 };
 
 export type Loc = {
@@ -99,6 +101,7 @@ export type WalkContext = {
   config?: Config;
   visitorsData: Record<string, Record<string, unknown>>; // custom data store that visitors can use for various purposes
   refTypes?: Map<string, NormalizedNodeType>;
+  ajvValidator: AjvValidator;
 };
 
 function collectParents(ctx: VisitorLevelContext) {
@@ -199,6 +202,7 @@ export function walkDocument<T extends BaseVisitor>(opts: {
             specVersion: ctx.specVersion,
             config: ctx.config,
             getVisitorData: () => getVisitorDataFn(ruleId),
+            ajvValidator: ctx.ajvValidator,
           },
           { node: resolvedNode, location: resolvedLocation, error }
         );
@@ -416,6 +420,7 @@ export function walkDocument<T extends BaseVisitor>(opts: {
               specVersion: ctx.specVersion,
               config: ctx.config,
               getVisitorData: () => getVisitorDataFn(ruleId),
+              ajvValidator: ctx.ajvValidator,
             },
             { node: resolvedNode, location: resolvedLocation, error }
           );
@@ -452,6 +457,7 @@ export function walkDocument<T extends BaseVisitor>(opts: {
             ignoredNodes.add(`${currentLocation.absolutePointer}${currentLocation.pointer}`);
           },
           getVisitorData: () => getVisitorDataFn(ruleId),
+          ajvValidator: ctx.ajvValidator,
         },
         collectParents(context),
         context


### PR DESCRIPTION
## Summary

The global AJV singleton in `packages/core/src/rules/ajv.ts` captured a `resolve` closure from whichever document hit it first. When consumers like [`openapi-typescript`](https://github.com/openapi-ts/openapi-typescript) run `lintDocument` over multiple APIs concurrently via `Promise.all`, the second document's `resolve` was silently discarded, producing spurious warnings:

```
⚠ Example validation errored: can't resolve reference #/components/schemas/Foo
  from id .../spec.yaml#/paths/~1items/post/requestBody/content/application~1json/schema.
```

The warnings only appear when:
- Multiple APIs are linted concurrently
- A same-doc `$ref` has an `example`/`examples` sibling
- The spec contains a cross-file `$ref` (which is what triggers AJV's `loadSchemaSync`)

`redocly lint` itself wasn't affected because it processes APIs sequentially.

There was an earlier attempt at this fix in #2135 that went stale. This time I built a minimal repro that's checked in as a regression test.

## Fix

Refactored `rules/ajv.ts` from free functions + global singleton into an `AjvValidator` class. Each of the three example-validation rules (`no-invalid-media-type-examples`, `no-invalid-schema-examples`, `no-invalid-parameter-examples`) now creates its own `AjvValidator` in its factory closure. Since `initRules` invokes each factory once per `lintDocument` call, every call gets a fresh validator — no shared state across documents.

The walker (`walk.ts`) stays untouched; AJV is purely a JSON-schema-validation concern living inside the rules that need it.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared lint-time JSON Schema validation infrastructure used by multiple rules; behavior should be equivalent for sequential lint but affects ref resolution under concurrency.
> 
> **Overview**
> Fixes **false “can't resolve reference” / example validation errors** when multiple OpenAPI specs are linted in parallel (e.g. `Promise.all` over `lint`).
> 
> **AJV is no longer a process-wide singleton.** `rules/ajv.ts` is refactored to an **`AjvValidator` class** with per-instance AJV caches; the global `releaseAjvInstance()` hook and `validateJsonSchema` export are removed. **`lintDocument` no longer resets AJV** at the start of each run.
> 
> The three example rules (`no-invalid-media-type-examples`, `no-invalid-schema-examples`, `no-invalid-parameter-examples`) each construct **`new AjvValidator()` in their rule factory**, so every `initRules` / lint pass gets validators whose `loadSchemaSync` **`resolve` closure matches that document**—avoiding cross-document races when concurrent lints shared one AJV instance.
> 
> `validateExample` in `rules/utils.ts` now takes a **`validator`** and calls **`validator.validate(...)`** instead of the old module function.
> 
> **Regression coverage:** concurrent-lint fixtures (`spec-a` / `spec-b` + shared `common.yaml`) and a test that runs both specs with `no-invalid-media-type-examples` via `Promise.all` expecting zero issues. AJV unit tests target **`AjvValidator`** directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051ff9af243de1048daeeec324fe98a217bd8a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->