### PR TITLE
chore: remove `abort-controller` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4067,6 +4067,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -5964,6 +5966,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12351,7 +12355,6 @@
         "@redocly/cli-otel": "0.1.2",
         "@redocly/openapi-core": "2.30.0",
         "@redocly/respect-core": "2.30.0",
-        "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,6 @@
     "@redocly/cli-otel": "0.1.2",
     "@redocly/openapi-core": "2.30.0",
     "@redocly/respect-core": "2.30.0",
-    "abort-controller": "^3.0.0",
     "ajv": "npm:@redocly/ajv@8.18.0",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/cli/src/__tests__/fetch-with-timeout.test.ts
+++ b/packages/cli/src/__tests__/fetch-with-timeout.test.ts
@@ -1,4 +1,3 @@
-import AbortController from 'abort-controller';
 import { Agent, ProxyAgent } from 'undici';
 
 import fetchWithTimeout from '../utils/fetch-with-timeout.js';


### PR DESCRIPTION
## What/Why/How?

`abort-controller` dependency was only used in one test file and `AbortController` is available natively since Node 14.17.0

## Reference

https://replacements.fyi/abort-controller

https://developer.mozilla.org/en-US/docs/Web/API/AbortController

## Testing

Tests pass

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [ ] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines
