### PR TITLE
fix: increase default fetch timeout  for push command in v1

### DIFF
--- a/.changeset/six-bobcats-draw.md
+++ b/.changeset/six-bobcats-draw.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Increased the default fetch timeout used by the `push` command to better support slower uploads.

--- a/packages/cli/src/reunite/api/api-client.ts
+++ b/packages/cli/src/reunite/api/api-client.ts
@@ -2,7 +2,6 @@ import { yellow, red } from 'colorette';
 import fetchWithTimeout, {
   type FetchWithTimeoutOptions,
   DEFAULT_FETCH_TIMEOUT,
-  SOURCE_FETCH_TIMEOUT,
 } from '../../utils/fetch-with-timeout';
 
 import type { ReadStream } from 'fs';
@@ -110,7 +109,7 @@ class RemotesApi {
       const response = await this.client.request(
         `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/source`,
         {
-          timeout: SOURCE_FETCH_TIMEOUT,
+          timeout: DEFAULT_FETCH_TIMEOUT,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/cli/src/utils/fetch-with-timeout.ts
+++ b/packages/cli/src/utils/fetch-with-timeout.ts
@@ -1,7 +1,6 @@
 import { getProxyAgent } from '@redocly/openapi-core';
 
-export const DEFAULT_FETCH_TIMEOUT = 3000;
-export const SOURCE_FETCH_TIMEOUT = 6000;
+export const DEFAULT_FETCH_TIMEOUT = 6000;
 
 export type FetchWithTimeoutOptions = RequestInit & {
   timeout?: number;


### PR DESCRIPTION
## What/Why/How?

Increased the default fetch timeout used by the `push` command to better support slower uploads.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk constant/tuning change that only affects how long the CLI waits before aborting HTTP requests. Potential impact is limited to slower failure detection for genuinely hung requests.
> 
> **Overview**
> **Improves reliability of `push` workflows on slow networks** by increasing `DEFAULT_FETCH_TIMEOUT` from 3s to 6s.
> 
> Removes the separate `SOURCE_FETCH_TIMEOUT` and updates `getDefaultBranch` to use the shared default timeout. Adds a patch changeset documenting the timeout increase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573d8a0e109f260b14fb41f09d742a4a861707bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->