### PR TITLE
fix: increase default fetch timeout for push command

### DIFF
--- a/.changeset/sour-parrots-cheat.md
+++ b/.changeset/sour-parrots-cheat.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Increased the default fetch timeout used by the `push` command to better support slower uploads.

--- a/packages/cli/src/reunite/api/api-client.ts
+++ b/packages/cli/src/reunite/api/api-client.ts
@@ -2,7 +2,7 @@ import { logger } from '@redocly/openapi-core';
 import type { ReadStream } from 'node:fs';
 import type { Readable } from 'node:stream';
 
-import { DEFAULT_FETCH_TIMEOUT, SOURCE_FETCH_TIMEOUT } from '../../utils/constants.js';
+import { DEFAULT_FETCH_TIMEOUT } from '../../utils/constants.js';
 import fetchWithTimeout, { type FetchWithTimeoutOptions } from '../../utils/fetch-with-timeout.js';
 import { version } from '../../utils/package.js';
 import type {
@@ -125,7 +125,7 @@ class RemotesApi {
       const response = await this.client.request(
         `${this.domain}/api/orgs/${organizationId}/projects/${projectId}/source`,
         {
-          timeout: SOURCE_FETCH_TIMEOUT,
+          timeout: DEFAULT_FETCH_TIMEOUT,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,5 +1,4 @@
 export const OTEL_URL = 'https://otel.cloud.redocly.com';
 export const OTEL_TRACES_URL = process.env.OTEL_TRACES_URL || `${OTEL_URL}/v1/traces`;
-export const DEFAULT_FETCH_TIMEOUT = 3000;
-export const SOURCE_FETCH_TIMEOUT = 6000;
+export const DEFAULT_FETCH_TIMEOUT = 6000;
 export const ANONYMOUS_ID_CACHE_FILE = 'redocly-cli-anonymous-id';


### PR DESCRIPTION
## What/Why/How?

Increased the default fetch timeout used by the push command to better support slower uploads.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts client-side request timeouts, which may slightly delay failure detection but doesn’t change request payloads or auth logic.
> 
> **Overview**
> Increases the CLI’s default HTTP fetch timeout from 3s to 6s to better accommodate slower `push`-related uploads.
> 
> Removes the separate `SOURCE_FETCH_TIMEOUT` constant and standardizes `getDefaultBranch` to use `DEFAULT_FETCH_TIMEOUT`, making timeout behavior consistent across these API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d93172db7b0d421e2322cf242ae1a1daf3cd01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->