### PR TITLE
chore: add no-typeof-object code linting rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "import"],
+  "jsPlugins": ["./scripts/oxlint-redocly-plugin.js"],
   "categories": {
     "correctness": "error"
   },
@@ -48,7 +49,9 @@
       {
         "preferInline": true
       }
-    ]
+    ],
+
+    "oxlint-redocly-plugin/no-typeof-object": "warn"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -51,7 +51,7 @@
       }
     ],
 
-    "oxlint-redocly-plugin/no-typeof-object": "warn"
+    "oxlint-redocly-plugin/no-typeof-object": "error"
   },
   "overrides": [
     {

--- a/packages/cli/src/commands/respect/mtls/validate-mtls-command-option.ts
+++ b/packages/cli/src/commands/respect/mtls/validate-mtls-command-option.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from '@redocly/openapi-core';
+
 import type { MtlsConfig } from '../index.js';
 
 export function validateMtlsCommandOption(value: string | string[]): MtlsConfig | undefined {
@@ -26,25 +28,23 @@ function parseAndValidateMtlsConfig(value: string): MtlsConfig {
   try {
     const parsed = JSON.parse(value);
 
-    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    if (!isPlainObject(parsed)) {
       throw new Error(
         'mTLS config must be an object mapping domains to certificate configurations'
       );
     }
 
     for (const [domain, config] of Object.entries(parsed)) {
-      if (typeof config !== 'object' || Array.isArray(config)) {
+      if (!isPlainObject(config)) {
         throw new Error(`mTLS config for domain "${domain}" must be an object`);
       }
 
-      const certConfig = config as Record<string, unknown>;
-
-      validateCertField(certConfig, 'clientCert', domain, true);
-      validateCertField(certConfig, 'clientKey', domain, true);
-      validateCertField(certConfig, 'caCert', domain, false);
+      validateCertField(config, 'clientCert', domain, true);
+      validateCertField(config, 'clientKey', domain, true);
+      validateCertField(config, 'caCert', domain, false);
     }
 
-    return parsed;
+    return parsed as MtlsConfig;
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new Error(`Invalid JSON for --mtls option: ${error.message}`);

--- a/packages/core/src/bundle/bundle-visitor.ts
+++ b/packages/core/src/bundle/bundle-visitor.ts
@@ -12,7 +12,7 @@ import {
 } from '../ref-utils.js';
 import { type ResolvedRefMap, type Document } from '../resolve.js';
 import { reportUnresolvedRef } from '../rules/common/no-unresolved-refs.js';
-import { type OasRef, type Oas3Discriminator } from '../typings/openapi.js';
+import { type OasRef, type Oas3Discriminator, type Oas3Example } from '../typings/openapi.js';
 import { dequal } from '../utils/dequal.js';
 import { makeRefId } from '../utils/make-ref-id.js';
 import { type Oas3Visitor, type Oas2Visitor } from '../visitors.js';
@@ -181,7 +181,7 @@ export function makeBundleVisitor({
           }
 
           node.value = ctx.resolve({ $ref: node.externalValue }).node;
-          delete node.externalValue;
+          delete (node as Oas3Example).externalValue;
         }
       },
     },

--- a/packages/core/src/decorators/common/info-override.ts
+++ b/packages/core/src/decorators/common/info-override.ts
@@ -1,10 +1,11 @@
+import { isPlainObject } from '../../utils/is-plain-object.js';
 import type { Oas3Decorator, Oas2Decorator } from '../../visitors.js';
 
 export const InfoOverride: Oas3Decorator | Oas2Decorator = (newInfo) => {
   return {
     Info: {
       leave(info) {
-        if (typeof newInfo !== 'object' || Array.isArray(newInfo) || newInfo === null) {
+        if (!isPlainObject(newInfo)) {
           throw new Error(`"info-override" decorator should be called with an object`);
         }
         const { severity: _, ...rest } = newInfo;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,6 +157,7 @@ export type {
   OpenIDAuth,
   Oas3SecurityScheme,
   Oas3SecurityRequirement,
+  Oas3Example,
 } from './typings/openapi.js';
 export type { Oas2Definition } from './typings/swagger.js';
 export type { Async3Definition } from './typings/asyncapi3.js';

--- a/packages/core/src/lint-entity.ts
+++ b/packages/core/src/lint-entity.ts
@@ -188,7 +188,7 @@ export async function lintEntityWithScorecardLevel(
 
     if (entity.type === 'data-schema' && entity.metadata?.schema) {
       Object.values(apiRules).forEach((rule) => {
-        if (typeof rule === 'object' && rule.subject.type !== 'Schema') {
+        if (isPlainObject(rule) && isPlainObject(rule.subject) && rule.subject.type !== 'Schema') {
           throw new Error(
             `API rules for "data-schema" entity must target Schema subject, but found "${rule.subject.type}".`
           );

--- a/packages/core/src/ref-utils.ts
+++ b/packages/core/src/ref-utils.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 
 import type { Source } from './resolve.js';
-import type { OasRef } from './typings/openapi.js';
+import type { Oas3Example, OasRef } from './typings/openapi.js';
 import { isPlainObject } from './utils/is-plain-object.js';
 import { isTruthy } from './utils/is-truthy.js';
 import type { ResolveResult, UserContext } from './walk.js';
@@ -15,7 +15,7 @@ export function isRef(node: unknown): node is OasRef {
   return isPlainObject(node) && typeof node.$ref === 'string';
 }
 
-export function isExternalValue(node: unknown) {
+export function isExternalValue(node: unknown): node is Oas3Example & { externalValue: string } {
   return isPlainObject(node) && typeof node.externalValue === 'string';
 }
 

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -315,7 +315,7 @@ export async function resolveDocument(opts: {
           propType = resolvableScalarType;
         }
 
-        if (!isNamedType(propType) || typeof propValue !== 'object') {
+        if (!isNamedType(propType) || !(isPlainObject(propValue) || Array.isArray(propValue))) {
           continue;
         }
 
@@ -343,7 +343,7 @@ export async function resolveDocument(opts: {
       if (isExternalValue(node)) {
         const promise = followRef(
           rootNodeDocument,
-          { $ref: node.externalValue as string },
+          { $ref: node.externalValue },
           {
             prev: null,
             node,

--- a/packages/core/src/types/oas2.ts
+++ b/packages/core/src/types/oas2.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from '../utils/is-plain-object.js';
 import { listOf, mapOf, type NodeType } from './index.js';
 
 const responseCodeRegexp = /^[0-9][0-9Xx]{2}$/;
@@ -260,7 +261,7 @@ const Header: NodeType = {
     multipleOf: { type: 'number' },
   },
   required(value) {
-    if (value && typeof value === 'object' && 'type' in value && value.type === 'array') {
+    if (isPlainObject(value) && value.type === 'array') {
       return ['type', 'items'];
     } else {
       return ['type'];

--- a/packages/core/src/typings/openapi.ts
+++ b/packages/core/src/typings/openapi.ts
@@ -115,7 +115,7 @@ export interface Oas3Parameter<T extends Oas3Schema | Oas3_1Schema = Oas3Schema 
 }
 
 export interface Oas3Example {
-  value: unknown;
+  value?: unknown;
   dataValue?: unknown; // added in OAS 3.2
   serializedValue?: string; // added in OAS 3.2
   summary?: string;

--- a/packages/core/src/typings/openapi.ts
+++ b/packages/core/src/typings/openapi.ts
@@ -110,8 +110,8 @@ export interface Oas3Parameter<T extends Oas3Schema | Oas3_1Schema = Oas3Schema 
   allowReserved?: boolean;
   schema?: Referenced<T>;
   example?: unknown;
-  examples?: { [media: string]: Referenced<Oas3Example> };
-  content?: { [media: string]: Oas3MediaType<T> };
+  examples?: Record<string, Referenced<Oas3Example>>;
+  content?: Record<string, Oas3MediaType<T>>;
 }
 
 export interface Oas3Example {

--- a/packages/core/src/utils/dequal.ts
+++ b/packages/core/src/utils/dequal.ts
@@ -16,7 +16,7 @@ export function dequal(foo: any, bar: any): boolean {
       }
       return len === -1;
     }
-
+    // oxlint-disable-next-line oxlint-redocly-plugin/no-typeof-object
     if (!ctor || typeof foo === 'object') {
       len = 0;
       for (ctor in foo) {

--- a/packages/core/src/utils/is-plain-object.ts
+++ b/packages/core/src/utils/is-plain-object.ts
@@ -1,3 +1,4 @@
 export function isPlainObject<T = Record<string, unknown>>(value: unknown): value is T {
+  // oxlint-disable-next-line oxlint-redocly-plugin/no-typeof-object
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-example-value.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-example-value.ts
@@ -1,4 +1,4 @@
-import type { LoggerInterface } from '@redocly/openapi-core';
+import { isPlainObject, type LoggerInterface } from '@redocly/openapi-core';
 
 import type { Parameter } from '../../types.js';
 import { extractFirstExample } from '../description-parser/index.js';
@@ -7,9 +7,10 @@ import { generateTestDataFromJsonSchema } from './generate-test-data-from-json-s
 export function generateExampleValue(parameter: Parameter, logger: LoggerInterface) {
   if (parameter?.example) {
     return parameter.example;
-  } else if (parameter?.examples) {
+  } else if (isPlainObject(parameter?.examples)) {
     return extractFirstExample(parameter.examples);
   } else if (parameter?.schema) {
     return generateTestDataFromJsonSchema(parameter.schema, logger);
   }
+  return undefined;
 }

--- a/packages/respect-core/src/modules/description-parser/extract-first-example.ts
+++ b/packages/respect-core/src/modules/description-parser/extract-first-example.ts
@@ -1,6 +1,10 @@
-export function extractFirstExample(examples: Record<string, any> | undefined) {
-  if (typeof examples !== 'object') return;
-  const firstKey = Object.keys(examples)[0];
+import { isPlainObject, type Oas3Example } from '@redocly/openapi-core';
 
-  return firstKey ? examples[firstKey]?.value : undefined;
+export function extractFirstExample(examples: Record<string, Oas3Example> | undefined) {
+  if (isPlainObject(examples)) {
+    const firstKey = Object.keys(examples)[0];
+    return firstKey ? examples[firstKey]?.value : undefined;
+  } else {
+    return undefined;
+  }
 }

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -4,6 +4,7 @@ import type {
   RuleSeverity,
   LoggerInterface,
   BaseResolver,
+  Oas3Example,
 } from '@redocly/openapi-core';
 import type { FromSchema } from 'json-schema-to-ts';
 
@@ -58,7 +59,7 @@ export type AdditionalParameterProperties = {
   required?: boolean;
   schema?: Record<string, any>;
   example?: unknown;
-  examples?: Record<string, any> | unknown;
+  examples?: Record<string, Oas3Example>;
   allowReserved?: boolean;
 };
 type ExtendedParameter<T> = T & AdditionalParameterProperties;

--- a/scripts/oxlint-redocly-plugin.js
+++ b/scripts/oxlint-redocly-plugin.js
@@ -1,0 +1,66 @@
+/**
+ * Custom oxlint rule: disallow 'typeof ... object' comparison,
+ *
+ * Rationale: `typeof x === 'object'` is true for `null` and arrays as well, and is
+ * almost always a sign that a more precise check is wanted (e.g. an `isPlainObject`
+ * helper, `Array.isArray`, an explicit `!= null` guard, or an `'in'` check).
+ */
+
+const TYPEOF_STRING = 'object';
+const COMPARISON_OPS = new Set(['===', '==', '!==', '!=']);
+
+function isTypeofExpression(node) {
+  return node?.type === 'UnaryExpression' && node?.operator === 'typeof';
+}
+
+function isObjectStringLiteral(node) {
+  if (node?.type === 'Literal') {
+    return node.value === TYPEOF_STRING;
+  }
+  if (
+    node?.type === 'TemplateLiteral' &&
+    node?.expressions.length === 0 &&
+    node?.quasis.length === 1
+  ) {
+    return node.quasis[0].value.cooked === TYPEOF_STRING;
+  }
+  return false;
+}
+
+const noTypeofObject = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Disallow `typeof x === 'object'`; prefer a more precise check (isPlainObject helper, Array.isArray, != null guard, 'in' check).",
+    },
+    schema: [],
+    messages: {
+      noTypeofObject: "Avoid `typeof ... 'object'` comparison. Use `isPlainObject` helper instead.",
+    },
+  },
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (!COMPARISON_OPS.has(node.operator)) return;
+        const matches =
+          (isTypeofExpression(node.left) && isObjectStringLiteral(node.right)) ||
+          (isTypeofExpression(node.right) && isObjectStringLiteral(node.left));
+        if (matches) {
+          context.report({ node, messageId: 'noTypeofObject' });
+        }
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: {
+    name: 'oxlint-redocly-plugin',
+  },
+  rules: {
+    'no-typeof-object': noTypeofObject,
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
## What/Why/How?

- Added `no-typeof-object` code linting rule to prevent arrays accidentally slipping through `type ... 'object'` comparison.
- Refactored some affected code.
 
## Testing

E2E passed [here](https://github.com/Redocly/redocly/pull/22877).

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new custom lint rule and refactors several runtime validation/type-guard call sites (including resolver/bundler paths) to use `isPlainObject`, which could change behavior for edge cases involving `null`/arrays and `example.externalValue` handling.
> 
> **Overview**
> **Introduces a custom Oxlint plugin rule** `oxlint-redocly-plugin/no-typeof-object` (wired via `.oxlintrc.json`) to ban `typeof x === 'object'` comparisons and push callers toward more precise checks.
> 
> **Refactors affected code paths** to use `isPlainObject` instead of ad-hoc `typeof`/array checks (e.g., mTLS CLI option parsing, `InfoOverride`, entity rule validation, and OAS2 required-field logic), and updates core ref/external example handling with tighter typings (adds `Oas3Example` exports, narrows `isExternalValue`, and adjusts deletion/casting).
> 
> **Type updates**: loosens `Oas3Example.value` to optional and tightens `examples` shapes in `respect-core` to `Record<string, Oas3Example>` with safer extraction/undefined returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59b1cca0046573ea2e9753619297a1d7dd6476c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->