### PR TITLE
docs: update v1 changelog

### DIFF
--- a/docs/@v1/changelog.md
+++ b/docs/@v1/changelog.md
@@ -11,7 +11,7 @@ toc:
 
 ### Patch Changes
 
-- Updated handlebars to v4.7.9.
+- Updated Handlebars to v4.7.9.
 - Updated @redocly/openapi-core to v1.34.14.
 
 ## 1.34.13 (2026-04-27)

--- a/docs/@v1/changelog.md
+++ b/docs/@v1/changelog.md
@@ -7,6 +7,34 @@ toc:
 
 <!-- do-not-remove -->
 
+## 1.34.14 (2026-04-30)
+
+### Patch Changes
+
+- Updated handlebars to v4.7.9.
+- Updated @redocly/openapi-core to v1.34.14.
+
+## 1.34.13 (2026-04-27)
+
+### Patch Changes
+
+- Increased the default fetch timeout used by the `push` command to better support slower uploads.
+- Updated @redocly/openapi-core to v1.34.13.
+
+## 1.34.12 (2026-04-20)
+
+### Patch Changes
+
+- Improved the stability of the `push` command.
+- Updated @redocly/openapi-core to v1.34.12.
+
+## 1.34.11 (2026-03-16)
+
+### Patch Changes
+
+- Updated `undici` to the `6.24.1` version to ensure improved performance, security, and compatibility.
+- Updated @redocly/respect-core to v1.34.11.
+
 ## 1.34.10 (2026-03-02)
 
 ### Patch Changes


### PR DESCRIPTION
## What/Why/How?

update v1 changelog

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update with no runtime or build behavior changes.
> 
> **Overview**
> Updates the v1 CLI changelog (`docs/@v1/changelog.md`) by adding entries for versions **1.34.11–1.34.14**, documenting dependency bumps (Handlebars, `undici`, `@redocly/openapi-core`, `@redocly/respect-core`) and `push` command stability/timeout improvements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c646966b5287593a7f473903edde2109b1d0ea49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->