### PR TITLE
fix: mismatch in respect status code when har-output option used

### DIFF
--- a/.changeset/chilly-banks-act.md
+++ b/.changeset/chilly-banks-act.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed a status code mismatch that occurred when using the '--har-output' option in the Respect command.

--- a/.changeset/chilly-banks-act.md
+++ b/.changeset/chilly-banks-act.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed a status code mismatch that occurred when using the '--har-output' option in the Respect command.
+Fixed a status code mismatch that occurred when using the `--har-output` option in the `respect` command.

--- a/packages/cli/src/__tests__/commands/respect/har-logs/with-har.test.ts
+++ b/packages/cli/src/__tests__/commands/respect/har-logs/with-har.test.ts
@@ -5,12 +5,13 @@ describe('withHar', () => {
   it('should preserve the original response status', async () => {
     const har = createHarLog({ version: '1.0.0' });
     const dispatcher = { on: vi.fn() };
+    const originalResponse = new Response(JSON.stringify({ created: true }), {
+      status: 201,
+      statusText: 'Created',
+      headers: { 'content-type': 'application/json' },
+    });
     const baseFetch = vi.fn(async () => {
-      return new Response(JSON.stringify({ created: true }), {
-        status: 201,
-        statusText: 'Created',
-        headers: { 'content-type': 'application/json' },
-      });
+      return originalResponse;
     });
 
     const fetch = withHar(baseFetch as any, { har });
@@ -19,6 +20,7 @@ describe('withHar', () => {
       dispatcher,
     });
 
+    expect(response).toBe(originalResponse);
     expect(response.status).toBe(201);
     expect(response.statusText).toBe('Created');
     expect(await response.json()).toEqual({ created: true });
@@ -28,11 +30,12 @@ describe('withHar', () => {
   it('should return a bodyless response for no-content statuses', async () => {
     const har = createHarLog({ version: '1.0.0' });
     const dispatcher = { on: vi.fn() };
+    const originalResponse = new Response(null, {
+      status: 204,
+      statusText: 'No Content',
+    });
     const baseFetch = vi.fn(async () => {
-      return new Response(null, {
-        status: 204,
-        statusText: 'No Content',
-      });
+      return originalResponse;
     });
 
     const fetch = withHar(baseFetch as any, { har });
@@ -41,6 +44,7 @@ describe('withHar', () => {
       dispatcher,
     });
 
+    expect(response).toBe(originalResponse);
     expect(response.status).toBe(204);
     expect(response.statusText).toBe('No Content');
     expect(await response.text()).toBe('');

--- a/packages/cli/src/__tests__/commands/respect/har-logs/with-har.test.ts
+++ b/packages/cli/src/__tests__/commands/respect/har-logs/with-har.test.ts
@@ -1,0 +1,49 @@
+import { createHarLog } from '../../../../commands/respect/har-logs/har-logs.js';
+import { withHar } from '../../../../commands/respect/har-logs/with-har.js';
+
+describe('withHar', () => {
+  it('should preserve the original response status', async () => {
+    const har = createHarLog({ version: '1.0.0' });
+    const dispatcher = { on: vi.fn() };
+    const baseFetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ created: true }), {
+        status: 201,
+        statusText: 'Created',
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    const fetch = withHar(baseFetch as any, { har });
+    const response = await fetch('https://example.com/resources', {
+      method: 'POST',
+      dispatcher,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.statusText).toBe('Created');
+    expect(await response.json()).toEqual({ created: true });
+    expect(har.log.entries[0].response.status).toBe(201);
+  });
+
+  it('should return a bodyless response for no-content statuses', async () => {
+    const har = createHarLog({ version: '1.0.0' });
+    const dispatcher = { on: vi.fn() };
+    const baseFetch = vi.fn(async () => {
+      return new Response(null, {
+        status: 204,
+        statusText: 'No Content',
+      });
+    });
+
+    const fetch = withHar(baseFetch as any, { har });
+    const response = await fetch('https://example.com/resources', {
+      method: 'POST',
+      dispatcher,
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.statusText).toBe('No Content');
+    expect(await response.text()).toBe('');
+    expect(har.log.entries[0].response.status).toBe(204);
+  });
+});

--- a/packages/cli/src/commands/respect/har-logs/with-har.ts
+++ b/packages/cli/src/commands/respect/har-logs/with-har.ts
@@ -17,6 +17,7 @@ import { buildResponseCookies } from './helpers/build-response-cookies.js';
 import { getDuration } from './helpers/get-duration.js';
 
 const HAR_HEADER_NAME = 'x-har-request-id';
+const NULL_BODY_STATUS_CODES = new Set([204, 205, 304]);
 const harEntryMap = new Map<string, any>();
 export interface WithHar {
   <T extends typeof fetch>(baseFetch: T, defaults?: any): T;
@@ -213,8 +214,8 @@ export const withHar: WithHar = function <T extends typeof fetch>(
 
     const Response =
       defaults.Response || baseFetch.Response || global.Response || response.constructor;
-    const responseCopy = new Response(text, {
-      status: response.statusCode,
+    const responseCopy = new Response(NULL_BODY_STATUS_CODES.has(response.status) ? null : text, {
+      status: response.status,
       statusText: response.statusText || '',
       headers: response.headers,
       url: response.url,

--- a/packages/cli/src/commands/respect/har-logs/with-har.ts
+++ b/packages/cli/src/commands/respect/har-logs/with-har.ts
@@ -112,7 +112,7 @@ export const withHar: WithHar = function <T extends typeof fetch>(
 
     // Read from clones so HAR logging does not consume or reconstruct the real response.
     const responseTextClone = response.clone();
-    const responseBodyClone = response.clone();
+    const responseBufferClone = response.clone();
 
     // Update firstByte time when we get the response
     entry._timestamps.firstByte = process.hrtime();
@@ -150,7 +150,7 @@ export const withHar: WithHar = function <T extends typeof fetch>(
     }
 
     if (harEntry._compressed) {
-      const rawBody = await responseBodyClone.arrayBuffer();
+      const rawBody = await responseBufferClone.arrayBuffer();
       harEntry.response.content.size = rawBody.byteLength;
     } else {
       harEntry.response.content.size = text ? Buffer.byteLength(text) : -1;

--- a/packages/cli/src/commands/respect/har-logs/with-har.ts
+++ b/packages/cli/src/commands/respect/har-logs/with-har.ts
@@ -17,7 +17,6 @@ import { buildResponseCookies } from './helpers/build-response-cookies.js';
 import { getDuration } from './helpers/get-duration.js';
 
 const HAR_HEADER_NAME = 'x-har-request-id';
-const NULL_BODY_STATUS_CODES = new Set([204, 205, 304]);
 const harEntryMap = new Map<string, any>();
 export interface WithHar {
   <T extends typeof fetch>(baseFetch: T, defaults?: any): T;
@@ -111,14 +110,15 @@ export const withHar: WithHar = function <T extends typeof fetch>(
     // Make the request
     const response = await baseFetch(input, options);
 
-    // Need to clone response to get both text and arrayBuffer
-    const responseClone = response.clone();
+    // Read from clones so HAR logging does not consume or reconstruct the real response.
+    const responseTextClone = response.clone();
+    const responseBodyClone = response.clone();
 
     // Update firstByte time when we get the response
     entry._timestamps.firstByte = process.hrtime();
 
     // Get the response body and update received time
-    const text = await response.text();
+    const text = response.body === null ? '' : await responseTextClone.text();
     entry._timestamps.received = process.hrtime();
 
     const harEntry = harEntryMap.get(requestId);
@@ -150,7 +150,7 @@ export const withHar: WithHar = function <T extends typeof fetch>(
     }
 
     if (harEntry._compressed) {
-      const rawBody = await responseClone.arrayBuffer();
+      const rawBody = await responseBodyClone.arrayBuffer();
       harEntry.response.content.size = rawBody.byteLength;
     } else {
       harEntry.response.content.size = text ? Buffer.byteLength(text) : -1;
@@ -212,15 +212,7 @@ export const withHar: WithHar = function <T extends typeof fetch>(
       parent.pageref = entry.pageref;
     });
 
-    const Response =
-      defaults.Response || baseFetch.Response || global.Response || response.constructor;
-    const responseCopy = new Response(NULL_BODY_STATUS_CODES.has(response.status) ? null : text, {
-      status: response.status,
-      statusText: response.statusText || '',
-      headers: response.headers,
-      url: response.url,
-    });
-    responseCopy.harEntry = entry;
+    response.harEntry = entry;
 
     if (Array.isArray(har?.log?.entries)) {
       har.log.entries.push(...parents, entry);
@@ -233,6 +225,6 @@ export const withHar: WithHar = function <T extends typeof fetch>(
       onHarEntry(entry);
     }
 
-    return responseCopy;
+    return response;
   } as T;
 };


### PR DESCRIPTION
## What/Why/How?

- Fixed mismatch in respect status code when har-output option used.
- Handle empty body response.

## Reference

Closes: https://github.com/Redocly/redocly/issues/23084

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `respect` HAR logging fetch wrapper to stop reconstructing responses and to handle bodyless responses, which could subtly affect response streaming/consumption behavior. Covered by new tests, but touches request/response handling in a core command path.
> 
> **Overview**
> Fixes `respect --har-output` so HAR capture no longer alters the returned `Response` (preserving the original `status`/`statusText` and avoiding a status-code mismatch).
> 
> Updates `withHar` to read response data from `clone()`s (including special-casing `body === null` for no-content responses) and to attach `harEntry` directly to the original response. Adds new unit tests covering status preservation and 204/no-body behavior, and includes a patch changeset for `@redocly/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2c2585386173d3acd36284d7e7fcc795133e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->