### PR TITLE
fix: send query languages strings in request body payload

### DIFF
--- a/.changeset/silent-words-divide.md
+++ b/.changeset/silent-words-divide.md
@@ -2,4 +2,4 @@
 "@redocly/respect-core": patch
 ---
 
-Stopped evaluating query-language strings (JSONPath, XPath, SPARQL, OPA) in Respect request bodies as runtime expressions.
+Fixed an issue where query-language strings (JSONPath, XPath, SPARQL, OPA) in Respect request bodies were incorrectly treated as runtime expressions.

--- a/.changeset/silent-words-divide.md
+++ b/.changeset/silent-words-divide.md
@@ -1,0 +1,5 @@
+---
+"@redocly/respect-core": patch
+---
+
+Stopped evaluating query-language strings (JSONPath, XPath, SPARQL, OPA) in Respect request bodies as runtime expressions.

--- a/packages/respect-core/src/modules/__tests__/runtime-expressions/evaluate.test.ts
+++ b/packages/respect-core/src/modules/__tests__/runtime-expressions/evaluate.test.ts
@@ -339,6 +339,33 @@ describe('evaluateRuntimeExpressionPayload', () => {
     ).toEqual('2023-12-15');
   });
 
+  it('should not evaluate query-language strings as runtime expressions', () => {
+    const payload = {
+      jsonpath: "$.items[*].attributes[?(@.type=='foo')]",
+      xpath: '$bookstore/book[price>35]/title',
+      sparql: 'SELECT $item WHERE { $item <http://example.com/type> "foo" }',
+      opa: 'data.items[_].type == "foo"',
+    };
+
+    expect(
+      evaluateRuntimeExpressionPayload({ payload, context: runtimeExpressionContext, logger })
+    ).toEqual(payload);
+  });
+
+  it('should evaluate {$faker.*} wrapped expression embedded in object payload', () => {
+    const payload = { x: '{$faker.number.integer({ min: 5, max: 5 })}' };
+    expect(
+      evaluateRuntimeExpressionPayload({ payload, context: runtimeExpressionContext, logger })
+    ).toEqual({ x: '5' });
+  });
+
+  it('should evaluate {$faker.*} wrapped expression mixed with surrounding text', () => {
+    const payload = '{$faker.number.integer({ min: 5, max: 5 })} suffix';
+    expect(
+      evaluateRuntimeExpressionPayload({ payload, context: runtimeExpressionContext, logger })
+    ).toEqual('5 suffix');
+  });
+
   it('should evaluate $faker runtime expression value', () => {
     const payload = '$faker.number.integer({ min: 1, max: 10 })';
     expect(
@@ -352,13 +379,13 @@ describe('evaluateRuntimeExpressionPayload', () => {
 
   it('should evaluate $faker inside string runtime expression value', () => {
     const payload = 'Some text {$faker.number.integer({ min: 1, max: 10 })}';
-    expect(
-      typeof evaluateRuntimeExpressionPayload({
-        payload,
-        context: runtimeExpressionContext,
-        logger,
-      })
-    ).toBe('string');
+    const result = evaluateRuntimeExpressionPayload({
+      payload,
+      context: runtimeExpressionContext,
+      logger,
+    });
+    expect(typeof result).toBe('string');
+    expect(result).toMatch(/^Some text \d+$/);
   });
 
   it('should evaluate multiword runtime expression value', () => {
@@ -607,9 +634,9 @@ describe('evaluateRuntimeExpression', () => {
 
   it('should evaluate $faker inside string runtime expression value', () => {
     const payload = 'Some text {$faker.number.integer({ min: 1, max: 10 })}';
-    expect(typeof evaluateRuntimeExpression(payload, runtimeExpressionContext, logger)).toBe(
-      'string'
-    );
+    const result = evaluateRuntimeExpression(payload, runtimeExpressionContext, logger);
+    expect(typeof result).toBe('string');
+    expect(result).toMatch(/^Some text \d+$/);
   });
 
   it('should evaluete list runtime expression value', () => {

--- a/packages/respect-core/src/modules/runtime-expressions/evaluate.ts
+++ b/packages/respect-core/src/modules/runtime-expressions/evaluate.ts
@@ -240,6 +240,10 @@ function evaluateExpressionsInString(
   return expression.replace(regex, (match) => {
     const exprToEvaluate = match.trim();
 
+    if (!isValidRuntimeExpression(exprToEvaluate) && !exprToEvaluate.includes('$faker.')) {
+      return match;
+    }
+
     // For dollar expressions, include the leading $ when passing to evaluateRuntimeExpression
     const evaluatedValue = evaluateRuntimeExpression(exprToEvaluate, context, logger);
 
@@ -249,9 +253,29 @@ function evaluateExpressionsInString(
 }
 
 export function isPureRuntimeExpression(expression: string): boolean {
-  // Regular expression to match runtime expressions
-  const regex = /^\$[^\s{}]+(\([^)]*\))?$|^\{[^{}]*\}$/;
+  const trimmedExpression = expression.trim();
 
-  // Check if the expression matches the runtime expression format
-  return regex.test(expression.trim());
+  if (trimmedExpression.startsWith('$faker.')) {
+    return true;
+  }
+
+  if (
+    !(
+      (trimmedExpression.startsWith('$') && !/\s/.test(trimmedExpression)) ||
+      (trimmedExpression.startsWith('{') && trimmedExpression.endsWith('}'))
+    )
+  ) {
+    return false;
+  }
+
+  return isValidRuntimeExpression(trimmedExpression);
+}
+
+function isValidRuntimeExpression(expression: string): boolean {
+  try {
+    lintExpression(expression);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## What/Why/How?

Changed runtime-expression detection so it no longer relies on a broad regex that treats any $... string as an Arazzo runtime expression.

The new flow is:

1. For string payloads, `isPureRuntimeExpression()` first does only a light shape check.
2. It then calls the existing `lintExpression()` parser validation.
3. If the string is valid Arazzo grammar, it is evaluated normally.
4. If it looks like JSONPath/XPath/SPARQL/OPA and fails Arazzo validation, **it stays unchanged instead of throwing**.
5. Embedded replacements use the same validation guard before evaluating matches.

Added regression coverage to ensure query-language strings like $.items[*].attributes[?(@.type=='foo')] pass through as literal payload values, while normal runtime expressions still resolve.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2798

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts runtime-expression detection/evaluation for request-body strings, which could change when substitutions occur or when invalid expressions are left literal. Guarded by parser-based validation and expanded tests, but behavior changes may impact existing payload templating edge cases.
> 
> **Overview**
> Fixes Respect request-body handling so *query-language strings* (e.g. JSONPath/XPath/SPARQL/OPA that contain `$`) are no longer mistakenly parsed/evaluated as Arazzo runtime expressions.
> 
> Runtime-expression detection now uses `lintExpression()` validation (via a new `isValidRuntimeExpression()` guard) before evaluating both whole-string expressions (`isPureRuntimeExpression`) and embedded replacements (`evaluateExpressionsInString`), while preserving `$faker` evaluation. Tests add regression coverage for pass-through query strings and strengthen assertions for embedded `{$faker...}` replacements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb04f518627406e2d4538e9ab831190445cc6b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->