### PR TITLE
docs: add docs about duplicating rules and bundle components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,7 @@ The defaults are `off` or `warn` for `minimal` and `recommended` and `error` for
 Also add the rule to the built-in rules list in [the config types tree](./packages/core/src/types/redocly-yaml.ts).
 
 If the rule reflects a specification requirement, prefix it with `spec-` and add it to the [spec ruleset](./packages/core/src/config/spec.ts).
+If a rule already exists for another specification, reuse the existing name so the same concept stays discoverable across specs.
 
 Separately, open a merge request with the corresponding documentation changes.
 To make changes to documentation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ The defaults are `off` or `warn` for `minimal` and `recommended` and `error` for
 Also add the rule to the built-in rules list in [the config types tree](./packages/core/src/types/redocly-yaml.ts).
 
 If the rule reflects a specification requirement, prefix it with `spec-` and add it to the [spec ruleset](./packages/core/src/config/spec.ts).
-If a rule already exists for another specification, reuse the existing name so the same concept stays discoverable across specs.
+If a rule already exists for another specification flavor, reuse the existing name so the same concept stays discoverable across specs.
 
 Separately, open a merge request with the corresponding documentation changes.
 To make changes to documentation:

--- a/docs/@v2/commands/bundle.md
+++ b/docs/@v2/commands/bundle.md
@@ -10,7 +10,7 @@ Redocly CLI can help you combine separate API description files (such as if you 
 The `bundle` command pulls the relevant parts of an API description into a single file output in JSON or YAML format.
 
 The `bundle` command differs from the [`join`](./join.md) command.
-The `bundle` command takes a root OpenAPI file as input and follows the `$ref` mentions to include all the referenced components into a single output file.
+The `bundle` command takes a root OpenAPI file as input and follows the `$ref` mentions to include all the referenced components into a single output file. All components are automatically resolved and included without requiring explicit definitions.
 The `join` command can combine multiple OpenAPI files into a single unified API description file.
 
 The `bundle` command first executes preprocessors, then rules, then decorators.

--- a/docs/@v2/commands/bundle.md
+++ b/docs/@v2/commands/bundle.md
@@ -10,7 +10,8 @@ Redocly CLI can help you combine separate API description files (such as if you 
 The `bundle` command pulls the relevant parts of an API description into a single file output in JSON or YAML format.
 
 The `bundle` command differs from the [`join`](./join.md) command.
-The `bundle` command takes a root OpenAPI file as input and follows the `$ref` mentions to include all the referenced components into a single output file. All components are automatically resolved and included without requiring explicit definitions.
+The `bundle` command takes a root OpenAPI file as input and follows the `$ref` mentions to include all the referenced components into a single output file.
+All components are automatically resolved and included without requiring explicit definitions.
 The `join` command can combine multiple OpenAPI files into a single unified API description file.
 
 The `bundle` command first executes preprocessors, then rules, then decorators.


### PR DESCRIPTION
## What/Why/How?
- Added to `CONTRIBUTING.md` file sentence about naming convention, when rule already exists in other specs.
- Added to general docs sentence to bundle about manually adding `components`.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no runtime code or behavior modifications.
> 
> **Overview**
> Clarifies contributor guidance for built-in rule additions by recommending reusing existing rule names across specification flavors to keep concepts discoverable.
> 
> Updates the `bundle` command documentation to explicitly state that referenced `components` are resolved and included automatically, without needing manual definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59cacd5628773e7c637dd28692b13bbc8c725a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->