### PR TITLE
fix: hard crash in commands when no API provided

### DIFF
--- a/.changeset/tiny-plums-change.md
+++ b/.changeset/tiny-plums-change.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed an issue where the `build-docs` command crashed with an unclear error when no API was provided.

--- a/.changeset/tiny-plums-change.md
+++ b/.changeset/tiny-plums-change.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed an issue where the `build-docs` command crashed with an unclear error when no API was provided.
+Fixed a hard crash in `build-docs`, `stats`, and `score` when no API was provided either via the command argument or in the config. These commands — along with `bundle`, which previously exited silently with no output — now exit with a clear, consistent error message pointing the user to the missing input.

--- a/.changeset/tiny-plums-change.md
+++ b/.changeset/tiny-plums-change.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed a hard crash in `build-docs`, `stats`, and `score` when no API was provided either via the command argument or in the config. These commands — along with `bundle`, which previously exited silently with no output — now exit with a clear, consistent error message pointing the user to the missing input.
+Fixed a hard crash when no API is provided either via the command argument or in the config.

--- a/.changeset/tiny-plums-change.md
+++ b/.changeset/tiny-plums-change.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed a hard crash when no API is provided either via the command argument or in the config.
+Fixed a hard crash that happened when no API was provided either via the command argument or in the config.

--- a/.changeset/tiny-plums-change.md
+++ b/.changeset/tiny-plums-change.md
@@ -2,4 +2,4 @@
 "@redocly/cli": patch
 ---
 
-Fixed a hard crash that happened when no API was provided either via the command argument or in the config.
+Fixed hard crash that happened when no API was provided either via the command argument or in the config.

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -124,12 +124,6 @@ describe('handleLint', () => {
       await commandWrapper(handleLint)(argvMock);
       expect(checkIfRulesetExist).toHaveBeenCalledTimes(1);
     });
-
-    it('should fail if apis not provided', async () => {
-      await commandWrapper(handleLint)({ ...argvMock, apis: [] });
-      expect(getFallbackApisOrExit).toHaveBeenCalledTimes(1);
-      expect(exitWithError).toHaveBeenCalledWith('No APIs were provided.');
-    });
   });
 
   describe('loop through entrypoints and lint stage', () => {

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -142,6 +142,18 @@ describe('getFallbackApisOrExit', async () => {
     }
   });
 
+  it('should exit with error when no APIs are provided and config has no apis', async () => {
+    const apisConfig = await openapiCore.createConfig({ apis: {} });
+    expect.assertions(1);
+    try {
+      await getFallbackApisOrExit([], apisConfig);
+    } catch (e) {
+      expect(e.message).toEqual(
+        'No APIs were provided. Specify an API via the command argument or define one in your config.'
+      );
+    }
+  });
+
   it('should error if file from config do not exist', async () => {
     vi.spyOn(errorHandling, 'exitWithError');
     vi.mocked(fs.existsSync).mockImplementationOnce(() => false);

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -21,11 +21,6 @@ export const handlerBuildCommand = async ({
   const startedAt = performance.now();
 
   const apis = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
-
-  if (!apis.length) {
-    exitWithError('No APIs were provided.');
-  }
-
   const { path: pathToApi, alias } = apis[0];
   const options = {
     output: argv.o,

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -21,6 +21,11 @@ export const handlerBuildCommand = async ({
   const startedAt = performance.now();
 
   const apis = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
+
+  if (!apis.length) {
+    exitWithError('No APIs were provided.');
+  }
+
   const { path: pathToApi, alias } = apis[0];
   const options = {
     output: argv.o,

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -15,7 +15,7 @@ import { performance } from 'perf_hooks';
 import type { Arguments } from 'yargs';
 
 import type { CommandArgv, Totals, VerifyConfigOptions } from '../types.js';
-import { AbortFlowError, exitWithError } from '../utils/error.js';
+import { AbortFlowError } from '../utils/error.js';
 import { getCommandNameFromArgs } from '../utils/get-command-name-from-args.js';
 import {
   checkIfRulesetExist,
@@ -46,10 +46,6 @@ export async function handleLint({
   collectSpecData,
 }: CommandArgs<LintArgv>) {
   const apis = await getFallbackApisOrExit(argv.apis, config);
-
-  if (!apis.length) {
-    exitWithError('No APIs were provided.');
-  }
 
   const totals: Totals = { errors: 0, warnings: 0, ignored: 0 };
   let totalIgnored = 0;

--- a/packages/cli/src/commands/scorecard-classic/index.ts
+++ b/packages/cli/src/commands/scorecard-classic/index.ts
@@ -34,9 +34,6 @@ export async function handleScorecardClassic({
 }: CommandArgs<ScorecardClassicArgv>) {
   const startedAt = performance.now();
   const apis = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
-  if (!apis.length) {
-    exitWithError('No APIs were provided.');
-  }
 
   const projectUrl =
     argv['project-url'] ||

--- a/packages/cli/src/utils/miscellaneous.ts
+++ b/packages/cli/src/utils/miscellaneous.ts
@@ -57,6 +57,11 @@ export async function getFallbackApisOrExit(
     }
     exitWithError('Please provide a valid path.');
   }
+  if (!res.length) {
+    exitWithError(
+      'No APIs were provided. Specify an API via the command argument or define one in your config.'
+    );
+  }
   return res;
 }
 

--- a/packages/cli/src/utils/miscellaneous.ts
+++ b/packages/cli/src/utils/miscellaneous.ts
@@ -57,7 +57,7 @@ export async function getFallbackApisOrExit(
     }
     exitWithError('Please provide a valid path.');
   }
-  if (!res.length) {
+  if (res.length === 0) {
     exitWithError(
       'No APIs were provided. Specify an API via the command argument or define one in your config.'
     );


### PR DESCRIPTION
## What/Why/How?
Fixed a hard crash in `build-docs`, `stats`, and `score` when no API was provided either via the command argument or in the config. These commands — along with `bundle`, which previously exited silently with no output — now exit with a clear, consistent error message pointing the user to the missing input.

## Reference

## Testing
Locally

## Screenshots (optional)
**Before:**
<img width="734" height="65" alt="Screenshot 2026-05-14 at 11 12 34" src="https://github.com/user-attachments/assets/882085aa-e23d-467d-8264-3a4ae2b17823" />

**After:**
<img width="778" height="34" alt="Screenshot 2026-05-14 at 14 53 16" src="https://github.com/user-attachments/assets/de557b7f-33ad-4829-81fb-8a44497c5941" />


## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: centralizes an existing validation case into `getFallbackApisOrExit` with a clearer message, affecting only CLI argument/config error handling paths.
> 
> **Overview**
> Prevents CLI commands that rely on `getFallbackApisOrExit` from proceeding with an empty API list by making `getFallbackApisOrExit` exit with a clear, consistent message when neither CLI args nor config define any APIs.
> 
> Removes redundant `!apis.length` checks from `lint` and `scorecard-classic`, updates tests accordingly, and adds a changeset for a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3528571d4cef408a736ed6fcd940348ce1facf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->