### PR TITLE
chore: extend respect event

### DIFF
--- a/.changeset/common-toys-occur.md
+++ b/.changeset/common-toys-occur.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated `@redocly/config` to `v0.48.2`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2539,9 +2539,9 @@
       "link": true
     },
     "node_modules/@redocly/cli-otel": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.1.2.tgz",
-      "integrity": "sha512-Bg7BoO5t1x3lVK+KhA5aGPmeXpQmdf6WtTYHhelKJCsQ+tRMiJoFAQoKHoBHAoNxXrhlS3K9lKFLHGmtxsFQfA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.1.tgz",
+      "integrity": "sha512-TbC4bK2zLtU/O9I2pszHPP0rtJOvFhQmEwQ/FHxERPu71fgKG8POUDP2jSiGmsXE7NdGSHBKqnf+y9Acn2jq5g==",
       "license": "MIT",
       "dependencies": {
         "ulid": "^2.3.0"
@@ -2557,9 +2557,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.1.tgz",
-      "integrity": "sha512-vq8GM3e0KiglqkwE5Lb9XayrmZY4dHCs21BsvV92yAZN68f1N9cZUuwY1SwnztPbH06dn9uLzubBl/JNfImqfA==",
+      "version": "0.48.2",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.2.tgz",
+      "integrity": "sha512-DUHthTRdj+caAQWCtJae4yzvxaUDuwQkFsZFVaAEyORd8Bt8K2wYso61jYZuR/kQZaDejfUREtQTVVZ5VYTqgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -12276,7 +12276,7 @@
         "@opentelemetry/resources": "2.6.1",
         "@opentelemetry/sdk-trace-node": "2.6.1",
         "@opentelemetry/semantic-conventions": "1.40.0",
-        "@redocly/cli-otel": "0.1.2",
+        "@redocly/cli-otel": "0.3.1",
         "@redocly/openapi-core": "2.31.0",
         "@redocly/respect-core": "2.31.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
@@ -12544,7 +12544,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.48.1",
+        "@redocly/config": "^0.48.2",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "@opentelemetry/resources": "2.6.1",
     "@opentelemetry/sdk-trace-node": "2.6.1",
     "@opentelemetry/semantic-conventions": "1.40.0",
-    "@redocly/cli-otel": "0.1.2",
+    "@redocly/cli-otel": "0.3.1",
     "@redocly/openapi-core": "2.31.0",
     "@redocly/respect-core": "2.31.0",
     "ajv": "npm:@redocly/ajv@8.18.1",

--- a/packages/cli/src/__tests__/utils/telemetry.test.ts
+++ b/packages/cli/src/__tests__/utils/telemetry.test.ts
@@ -8,11 +8,13 @@ import {
   collectXSecurityAuthTypes,
   cacheAnonymousId,
   getCachedAnonymousId,
+  collectSourceDescriptionTypes,
+  collectCriterionObjectTypes,
 } from '../../utils/telemetry.js';
 
 describe('collectXSecurityAuthTypes', () => {
   it('should collect X-Security Auth types and schemeNames', () => {
-    const respectXSecurityAuthTypesAndSchemeName: string[] = [];
+    const respectXSecurityAuthTypesAndSchemeName = new Set<string>();
     const arazzoDocument = {
       workflows: [
         {
@@ -86,7 +88,7 @@ describe('collectXSecurityAuthTypes', () => {
       ],
     } as Partial<ArazzoDefinition>;
     collectXSecurityAuthTypes(arazzoDocument, respectXSecurityAuthTypesAndSchemeName);
-    expect(respectXSecurityAuthTypesAndSchemeName).toEqual([
+    expect([...respectXSecurityAuthTypesAndSchemeName]).toEqual([
       'basic',
       'apiKey',
       'bearer',
@@ -96,14 +98,14 @@ describe('collectXSecurityAuthTypes', () => {
   });
 
   it('should handle documents with no workflows', () => {
-    const respectXSecurityAuthTypesAndSchemeName: string[] = [];
+    const respectXSecurityAuthTypesAndSchemeName = new Set<string>();
     const arazzoDocument = {} as Partial<ArazzoDefinition>;
     collectXSecurityAuthTypes(arazzoDocument, respectXSecurityAuthTypesAndSchemeName);
-    expect(respectXSecurityAuthTypesAndSchemeName).toEqual([]);
+    expect([...respectXSecurityAuthTypesAndSchemeName]).toEqual([]);
   });
 
   it('should handle workflows with no x-security', () => {
-    const respectXSecurityAuthTypesAndSchemeName: string[] = [];
+    const respectXSecurityAuthTypesAndSchemeName = new Set<string>();
     const arazzoDocument = {
       workflows: [
         {
@@ -113,7 +115,131 @@ describe('collectXSecurityAuthTypes', () => {
       ],
     } as Partial<ArazzoDefinition>;
     collectXSecurityAuthTypes(arazzoDocument, respectXSecurityAuthTypesAndSchemeName);
-    expect(respectXSecurityAuthTypesAndSchemeName).toEqual([]);
+    expect([...respectXSecurityAuthTypesAndSchemeName]).toEqual([]);
+  });
+});
+
+describe('collectSourceDescriptionTypes', () => {
+  it('should collect source description types', () => {
+    const respectSourceDescriptionTypes = new Set<string>();
+    const arazzoDocument = {
+      sourceDescriptions: [
+        {
+          type: 'openapi',
+          url: 'https://example.com/openapi.yaml',
+        },
+        {
+          type: 'arazzo',
+          url: 'https://example.com/arazzo.yaml',
+        },
+        {
+          type: 'asyncapi',
+          url: 'https://example.com/asyncapi.yaml',
+        },
+      ],
+    } as Partial<ArazzoDefinition>;
+    collectSourceDescriptionTypes(arazzoDocument, respectSourceDescriptionTypes);
+    expect([...respectSourceDescriptionTypes]).toEqual(['openapi', 'arazzo', 'asyncapi']);
+  });
+
+  it('should handle documents with no source descriptions', () => {
+    const respectSourceDescriptionTypes = new Set<string>();
+    const arazzoDocument = {} as Partial<ArazzoDefinition>;
+    collectSourceDescriptionTypes(arazzoDocument, respectSourceDescriptionTypes);
+    expect([...respectSourceDescriptionTypes]).toEqual([]);
+  });
+});
+
+describe('collectCriterionObjectTypes', () => {
+  it('should collect criterion object types from all criteria locations', () => {
+    const respectCriterionObjectTypes = new Set<string>();
+    const arazzoDocument = {
+      workflows: [
+        {
+          workflowId: 'workflow1',
+          successActions: [
+            {
+              name: 'workflow-success',
+              type: 'end',
+              criteria: [{ condition: '$response.body.id', type: 'jsonpath' }],
+            },
+          ],
+          failureActions: [
+            {
+              name: 'workflow-failure',
+              type: 'end',
+              criteria: [{ condition: 'Problem', type: 'regex' }],
+            },
+          ],
+          steps: [
+            {
+              stepId: 'step1',
+              operationId: 'operation1',
+              successCriteria: [{ condition: '$statusCode == 200', type: 'simple' }],
+              onSuccess: [
+                {
+                  name: 'step-success',
+                  type: 'end',
+                  criteria: [
+                    {
+                      condition: '$.data',
+                      context: '$response.body',
+                      type: {
+                        type: 'jsonpath',
+                        version: 'draft-goessner-dispatch-jsonpath-00',
+                      },
+                    },
+                  ],
+                },
+              ],
+              onFailure: [
+                {
+                  name: 'step-failure',
+                  type: 'end',
+                  criteria: [
+                    {
+                      condition: '//error',
+                      context: '$response.body',
+                      type: {
+                        type: 'xpath',
+                        version: 'xpath-30',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      components: {
+        successActions: {
+          ReusableSuccess: {
+            name: 'reusable-success',
+            type: 'end',
+            criteria: [{ condition: '$statusCode == 201' }],
+          },
+        },
+        failureActions: {
+          ReusableFailure: {
+            name: 'reusable-failure',
+            type: 'end',
+            criteria: [{ condition: '$statusCode == 500', type: 'regex' }],
+          },
+        },
+      },
+    } as Partial<ArazzoDefinition>;
+
+    collectCriterionObjectTypes(arazzoDocument, respectCriterionObjectTypes);
+
+    expect([...respectCriterionObjectTypes]).toEqual(['jsonpath', 'regex', 'simple', 'xpath']);
+  });
+
+  it('should handle documents with no criterion objects', () => {
+    const respectCriterionObjectTypes = new Set<string>();
+    const arazzoDocument = {} as Partial<ArazzoDefinition>;
+    collectCriterionObjectTypes(arazzoDocument, respectCriterionObjectTypes);
+    expect([...respectCriterionObjectTypes]).toEqual([]);
   });
 });
 

--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -57,6 +57,8 @@ describe('commandWrapper', () => {
         spec_keyword: 'openapi',
         spec_full_version: '3.1.0',
         respect_x_security_auth_types: [],
+        respect_source_description_types: [],
+        respect_criterion_object_types: [],
       })
     );
   });
@@ -88,6 +90,8 @@ describe('commandWrapper', () => {
         spec_keyword: undefined,
         spec_full_version: undefined,
         respect_x_security_auth_types: [],
+        respect_source_description_types: [],
+        respect_criterion_object_types: [],
       })
     );
   });

--- a/packages/cli/src/utils/__tests__/telemetry.test.ts
+++ b/packages/cli/src/utils/__tests__/telemetry.test.ts
@@ -27,6 +27,8 @@ it('sendTelemetry calls all telemetry functions', async () => {
     spec_keyword: 'openapi',
     spec_full_version: '3.1.0',
     respect_x_security_auth_types: undefined,
+    respect_source_description_types: undefined,
+    respect_criterion_object_types: undefined,
   });
 
   expect(respondWithinMs).toHaveBeenCalled();

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -25,7 +25,6 @@ import { respondWithinMs } from './network-check.js';
 import { version } from './package.js';
 
 type ArazzoWorkflow = NonNullable<ArazzoDefinition['workflows']>[number];
-type ArazzoStep = ArazzoWorkflow['steps'][number];
 type ArazzoSuccessAction = NonNullable<ArazzoWorkflow['successActions']>[number];
 type ArazzoFailureAction = NonNullable<ArazzoWorkflow['failureActions']>[number];
 
@@ -150,43 +149,46 @@ export function collectCriterionObjectTypes(
   document: Partial<ArazzoDefinition>,
   respectCriterionObjectTypes: Set<string>
 ) {
-  for (const criterionObject of getCriterionObjects(document)) {
-    const type = getCriterionObjectType(criterionObject);
-    if (type) {
-      respectCriterionObjectTypes.add(type);
-    }
-  }
-}
-
-function getCriterionObjects(document: Partial<ArazzoDefinition>) {
-  const criterionObjects: CriterionObject[] = [];
-
   for (const workflow of document.workflows ?? []) {
-    collectActionCriteria(workflow.successActions, criterionObjects);
-    collectActionCriteria(workflow.failureActions, criterionObjects);
+    collectActionCriteriaTypes(workflow.successActions, respectCriterionObjectTypes);
+    collectActionCriteriaTypes(workflow.failureActions, respectCriterionObjectTypes);
 
     for (const step of workflow.steps ?? []) {
-      collectStepCriteria(step, criterionObjects);
+      collectCriteriaTypes(step.successCriteria, respectCriterionObjectTypes);
+      collectActionCriteriaTypes(step.onSuccess, respectCriterionObjectTypes);
+      collectActionCriteriaTypes(step.onFailure, respectCriterionObjectTypes);
     }
   }
 
-  collectActionCriteria(Object.values(document.components?.successActions ?? {}), criterionObjects);
-  collectActionCriteria(Object.values(document.components?.failureActions ?? {}), criterionObjects);
-
-  return criterionObjects;
+  collectActionCriteriaTypes(
+    Object.values(document.components?.successActions ?? {}),
+    respectCriterionObjectTypes
+  );
+  collectActionCriteriaTypes(
+    Object.values(document.components?.failureActions ?? {}),
+    respectCriterionObjectTypes
+  );
 }
 
-function collectStepCriteria(step: ArazzoStep, criterionObjects: CriterionObject[]) {
-  criterionObjects.push(...(step.successCriteria ?? []));
-  collectActionCriteria(step.onSuccess, criterionObjects);
-  collectActionCriteria(step.onFailure, criterionObjects);
-}
-
-function collectActionCriteria(
+function collectActionCriteriaTypes(
   actions: readonly (ArazzoSuccessAction | ArazzoFailureAction)[] | undefined,
-  criterionObjects: CriterionObject[]
+  types: Set<string>
 ) {
-  criterionObjects.push(...(actions ?? []).flatMap((action) => action.criteria ?? []));
+  for (const action of actions ?? []) {
+    collectCriteriaTypes(action.criteria, types);
+  }
+}
+
+function collectCriteriaTypes(
+  criteria: readonly CriterionObject[] | undefined,
+  types: Set<string>
+) {
+  for (const criterion of criteria ?? []) {
+    const type = getCriterionObjectType(criterion);
+    if (type) {
+      types.add(type);
+    }
+  }
 }
 
 function getCriterionObjectType(criterionObject: CriterionObject) {

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -16,12 +16,18 @@ import type { ExtendedSecurity } from 'respect-core/src/types.js';
 import { ulid } from 'ulid';
 import type { Arguments } from 'yargs';
 
+import type { CriterionObject } from '../../../core/src/typings/arazzo.js';
 import { getReuniteUrl } from '../reunite/api/index.js';
 import type { CommandArgv } from '../types.js';
 import { ANONYMOUS_ID_CACHE_FILE } from './constants.js';
 import type { ExitCode } from './miscellaneous.js';
 import { respondWithinMs } from './network-check.js';
 import { version } from './package.js';
+
+type ArazzoWorkflow = NonNullable<ArazzoDefinition['workflows']>[number];
+type ArazzoStep = ArazzoWorkflow['steps'][number];
+type ArazzoSuccessAction = NonNullable<ArazzoWorkflow['successActions']>[number];
+type ArazzoFailureAction = NonNullable<ArazzoWorkflow['failureActions']>[number];
 
 const SECRET_REPLACEMENT = '***';
 
@@ -34,6 +40,8 @@ export async function sendTelemetry({
   spec_keyword,
   spec_full_version,
   respect_x_security_auth_types,
+  respect_source_description_types,
+  respect_criterion_object_types,
 }: {
   config: Config | undefined;
   argv: Arguments<CommandArgv> | undefined;
@@ -43,6 +51,8 @@ export async function sendTelemetry({
   spec_keyword: string | undefined;
   spec_full_version: string | undefined;
   respect_x_security_auth_types: string[] | undefined;
+  respect_source_description_types: string[] | undefined;
+  respect_criterion_object_types: string[] | undefined;
 }): Promise<void> {
   try {
     if (!argv) {
@@ -93,6 +103,14 @@ export async function sendTelemetry({
           spec_version === 'arazzo1' && respect_x_security_auth_types?.length
             ? JSON.stringify(respect_x_security_auth_types)
             : undefined,
+        respect_source_description_types:
+          spec_version === 'arazzo1' && respect_source_description_types?.length
+            ? JSON.stringify(respect_source_description_types)
+            : undefined,
+        respect_criterion_object_types:
+          spec_version === 'arazzo1' && respect_criterion_object_types?.length
+            ? JSON.stringify(respect_criterion_object_types)
+            : undefined,
       },
     ];
 
@@ -117,9 +135,70 @@ export async function sendTelemetry({
   }
 }
 
+export function collectSourceDescriptionTypes(
+  document: Partial<ArazzoDefinition>,
+  respectSourceDescriptionTypes: Set<string>
+) {
+  for (const sourceDescription of document.sourceDescriptions ?? []) {
+    if (sourceDescription.type) {
+      respectSourceDescriptionTypes.add(sourceDescription.type);
+    }
+  }
+}
+
+export function collectCriterionObjectTypes(
+  document: Partial<ArazzoDefinition>,
+  respectCriterionObjectTypes: Set<string>
+) {
+  for (const criterionObject of getCriterionObjects(document)) {
+    const type = getCriterionObjectType(criterionObject);
+    if (type) {
+      respectCriterionObjectTypes.add(type);
+    }
+  }
+}
+
+function getCriterionObjects(document: Partial<ArazzoDefinition>) {
+  const criterionObjects: CriterionObject[] = [];
+
+  for (const workflow of document.workflows ?? []) {
+    collectActionCriteria(workflow.successActions, criterionObjects);
+    collectActionCriteria(workflow.failureActions, criterionObjects);
+
+    for (const step of workflow.steps ?? []) {
+      collectStepCriteria(step, criterionObjects);
+    }
+  }
+
+  collectActionCriteria(Object.values(document.components?.successActions ?? {}), criterionObjects);
+  collectActionCriteria(Object.values(document.components?.failureActions ?? {}), criterionObjects);
+
+  return criterionObjects;
+}
+
+function collectStepCriteria(step: ArazzoStep, criterionObjects: CriterionObject[]) {
+  criterionObjects.push(...(step.successCriteria ?? []));
+  collectActionCriteria(step.onSuccess, criterionObjects);
+  collectActionCriteria(step.onFailure, criterionObjects);
+}
+
+function collectActionCriteria(
+  actions: readonly (ArazzoSuccessAction | ArazzoFailureAction)[] | undefined,
+  criterionObjects: CriterionObject[]
+) {
+  criterionObjects.push(...(actions ?? []).flatMap((action) => action.criteria ?? []));
+}
+
+function getCriterionObjectType(criterionObject: CriterionObject) {
+  const type = criterionObject.type;
+  return typeof type === 'string'
+    ? type
+    : type?.type || (criterionObject.condition ? 'simple' : undefined);
+}
+
 export function collectXSecurityAuthTypes(
   document: Partial<ArazzoDefinition>,
-  respectXSecurityAuthTypesAndSchemeName: string[]
+  respectXSecurityAuthTypesAndSchemeName: Set<string>
 ) {
   for (const workflow of document.workflows ?? []) {
     // Collect auth types from workflow-level x-security
@@ -127,8 +206,8 @@ export function collectXSecurityAuthTypes(
       const scheme = (security as ExtendedSecurity).scheme;
       if (scheme?.type) {
         const authType = scheme.type === 'http' ? scheme.scheme : scheme.type;
-        if (authType && !respectXSecurityAuthTypesAndSchemeName.includes(authType)) {
-          respectXSecurityAuthTypesAndSchemeName.push(authType);
+        if (authType) {
+          respectXSecurityAuthTypesAndSchemeName.add(authType);
         }
       }
     }
@@ -140,15 +219,15 @@ export function collectXSecurityAuthTypes(
         const scheme = (security as ExtendedSecurity).scheme;
         if (scheme?.type) {
           const authType = scheme.type === 'http' ? scheme.scheme : scheme.type;
-          if (authType && !respectXSecurityAuthTypesAndSchemeName.includes(authType)) {
-            respectXSecurityAuthTypesAndSchemeName.push(authType);
+          if (authType) {
+            respectXSecurityAuthTypesAndSchemeName.add(authType);
           }
         }
 
         // Handle schemeName case
         const schemeName = (security as ExtendedSecurity).schemeName;
-        if (schemeName && !respectXSecurityAuthTypesAndSchemeName.includes(schemeName)) {
-          respectXSecurityAuthTypesAndSchemeName.push(schemeName);
+        if (schemeName) {
+          respectXSecurityAuthTypesAndSchemeName.add(schemeName);
         }
       }
     }

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -15,7 +15,12 @@ import type { CommandArgv } from './types.js';
 import { AbortFlowError, exitWithError } from './utils/error.js';
 import { loadConfigAndHandleErrors, type ExitCode } from './utils/miscellaneous.js';
 import { version } from './utils/package.js';
-import { sendTelemetry, collectXSecurityAuthTypes } from './utils/telemetry.js';
+import {
+  sendTelemetry,
+  collectXSecurityAuthTypes,
+  collectSourceDescriptionTypes,
+  collectCriterionObjectTypes,
+} from './utils/telemetry.js';
 
 export type CommandArgs<T extends CommandArgv> = {
   argv: T;
@@ -35,7 +40,9 @@ export function commandWrapper<T extends CommandArgv>(
     let specKeyword: string | undefined;
     let specFullVersion: string | undefined;
     let config: Config | undefined;
-    const respectXSecurityAuthTypes: string[] = [];
+    const respectXSecurityAuthTypes = new Set<string>();
+    const respectSourceDescriptionTypes = new Set<string>();
+    const respectCriterionObjectTypes = new Set<string>();
     const collectSpecData: CollectFn = (document) => {
       try {
         specVersion = detectSpec(document);
@@ -62,7 +69,10 @@ export function commandWrapper<T extends CommandArgv>(
       }
 
       if (specVersion === 'arazzo1') {
-        collectXSecurityAuthTypes(document as Partial<ArazzoDefinition>, respectXSecurityAuthTypes);
+        const arazzoDocument = document as Partial<ArazzoDefinition>;
+        collectXSecurityAuthTypes(arazzoDocument, respectXSecurityAuthTypes);
+        collectSourceDescriptionTypes(arazzoDocument, respectSourceDescriptionTypes);
+        collectCriterionObjectTypes(arazzoDocument, respectCriterionObjectTypes);
       }
     };
 
@@ -100,7 +110,9 @@ export function commandWrapper<T extends CommandArgv>(
           spec_version: specVersion,
           spec_keyword: specKeyword,
           spec_full_version: specFullVersion,
-          respect_x_security_auth_types: respectXSecurityAuthTypes,
+          respect_x_security_auth_types: [...respectXSecurityAuthTypes],
+          respect_source_description_types: [...respectSourceDescriptionTypes],
+          respect_criterion_object_types: [...respectCriterionObjectTypes],
         });
       }
       process.once('beforeExit', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.48.1",
+    "@redocly/config": "^0.48.2",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -8329,7 +8329,13 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "dismissible": {
         "type": "boolean",
       },
+      "endAt": {
+        "type": "string",
+      },
       "rbac": "rootRedoclyConfigSchema.banner_items.rbac",
+      "startAt": {
+        "type": "string",
+      },
       "target": {
         "type": "string",
       },
@@ -16843,7 +16849,13 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "dismissible": {
         "type": "boolean",
       },
+      "endAt": {
+        "type": "string",
+      },
       "rbac": "rootRedoclyConfigSchema.env_additionalProperties.banner_items.rbac",
+      "startAt": {
+        "type": "string",
+      },
       "target": {
         "type": "string",
       },


### PR DESCRIPTION
## What/Why/How?

- Updated config package version.
- Extended respect event with additional fields.
- Updated redocly-otel package version.

## Reference

https://github.com/Redocly/redocly/pull/23264

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [x] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands telemetry payload collection for Arazzo specs and upgrades telemetry/config dependencies, which could affect event shape/analytics and needs validation for data/compatibility, but does not change core linting behavior.
> 
> **Overview**
> **Extends CLI telemetry for Arazzo (`spec_version === 'arazzo1'`)** by collecting and sending two new event fields: `respect_source_description_types` (from `sourceDescriptions[].type`) and `respect_criterion_object_types` (derived from all criteria locations, including reusable component actions).
> 
> Refactors `collectXSecurityAuthTypes` to use `Set`-based de-duplication and updates wrapper/tests accordingly, then bumps dependencies (`@redocly/config` to `0.48.2` in core and `@redocly/cli-otel` to `0.3.1` in CLI) with an updated config schema snapshot (adds banner `startAt`/`endAt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af0c350800059759b0ea4ab0919568f7e670118b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->