### PR TITLE
chore: apply consistent formatting to embedded docs

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,7 +2,6 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 100,
   "singleQuote": true,
-  "embeddedLanguageFormatting": "off",
   "experimentalSortPackageJson": false,
   "ignorePatterns": [
     "coverage/",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ When contributing to Redocly CLI, it's important to follow these logging guideli
 1. Use the built-in logger from `@redocly/openapi-core` package:
 
    ```typescript
-   import { logger } from "@redocly/openapi-core";
+   import { logger } from '@redocly/openapi-core';
    ```
 
 2. All informational messages, warnings, and errors should be written to `stderr` using the appropriate logger methods:
@@ -255,8 +255,8 @@ Note that the snapshot does not always match the command output because of the w
 Here's how the output is processed in tests:
 
 ```typescript
-const out = result.stdout ? result.stdout.toString() : "";
-const err = result.stderr ? result.stderr.toString() : "";
+const out = result.stdout ? result.stdout.toString() : '';
+const err = result.stderr ? result.stderr.toString() : '';
 return `${out}\n${err}`;
 ```
 

--- a/docs/@v1/commands/build-docs.md
+++ b/docs/@v1/commands/build-docs.md
@@ -101,7 +101,10 @@ Sample custom Handlebars template:
     <meta description='{{{templateOptions.metaDescription}}}' />
     <meta name='viewport' content='width=device-width, initial-scale=1' />
     <style>
-      body { padding: 0; margin: 0; }
+      body {
+        padding: 0;
+        margin: 0;
+      }
     </style>
     {{{redocHead}}}
     {{#unless disableGoogleFont}}<link

--- a/docs/@v1/configuration/apis.md
+++ b/docs/@v1/configuration/apis.md
@@ -25,7 +25,6 @@ decorators:
     title: All APIs
     extraProperty: This property will be ignored at the per-API level.
 
-
 apis:
   storefront@latest:
     decorators:

--- a/docs/@v1/configuration/reference/extends.md
+++ b/docs/@v1/configuration/reference/extends.md
@@ -28,7 +28,7 @@ To get started, try the following example to configure your project to be based 
 
 ```yaml
 extends:
- - minimal
+  - minimal
 ```
 
 ## Related options

--- a/docs/@v1/configuration/reference/rules.md
+++ b/docs/@v1/configuration/reference/rules.md
@@ -101,7 +101,6 @@ rules:
       property: operationId
     assertions:
       casing: camelCase
-
 ```
 
 The configurable rules have user-defined names that all start with `rule/` and then a meaningful name.

--- a/docs/@v1/custom-plugins/custom-decorators.md
+++ b/docs/@v1/custom-plugins/custom-decorators.md
@@ -35,7 +35,6 @@ module.exports = function myLocalPlugin() {
     },
   };
 };
-
 ```
 
 Each decorator or preprocessor is a function that returns an object. The object's keys are the node types in the document, and each of those can contain any or all of the `enter()`, `leave()` and `skip()` functions for that node type. Find more information and examples on the [visitor pattern page](./visitor.md).
@@ -50,17 +49,17 @@ To help keep the plugin code organized, this example uses one file per decorator
 module.exports = OperationSparkle;
 
 function OperationSparkle() {
-  console.log("adding sparkles ... ");
+  console.log('adding sparkles ... ');
   return {
     Operation: {
       leave(target) {
-        if(target.description) {
-          target.description = "✨ " + String(target.description);
+        if (target.description) {
+          target.description = '✨ ' + String(target.description);
         }
-      }
+      },
     },
-  }
-};
+  };
+}
 ```
 
 Decorators use the [visitor pattern](./visitor.md) to run an operation on every node in the document. In this example, when the code executes the `leave()` function on the `Operation` node, it checks if the node (passed as `target` in this example) has a description, and updates it if it does.
@@ -70,16 +69,16 @@ To use this decorator, add it to a plugin. In this example the main decorator fi
 ```js
 const OperationSparkle = require('./decorators/operation-sparkle.js');
 
-module.exports =  function sparklePlugin() {
+module.exports = function sparklePlugin() {
   return {
-    id: "sparkle",
+    id: 'sparkle',
     decorators: {
       oas3: {
-        "operation-sparkle": OperationSparkle,
+        'operation-sparkle': OperationSparkle,
       },
     },
   };
-}
+};
 ```
 
 The plugin is good to go. For a user to include it in their Redocly configuration, edit the configuration file to look something like this:
@@ -101,18 +100,18 @@ Here's the decorator code, in a file named `plugins/decorations/add-suffix.js` a
 ```js
 module.exports = OpIdSuffix;
 
-function OpIdSuffix({suffix}) {
-  console.log("updating OperationIds ... ");
+function OpIdSuffix({ suffix }) {
+  console.log('updating OperationIds ... ');
   return {
     Operation: {
       leave(target) {
-        if(target.operationId) {
+        if (target.operationId) {
           target.operationId = target.operationId + suffix;
         }
-      }
+      },
     },
-  }
-};
+  };
+}
 ```
 
 The `suffix` configuration option is automatically passed in, and it can be used in the function.
@@ -125,15 +124,15 @@ const OpIdSuffix = require('./decorators/add-suffix.js');
 
 module.exports = function sparklePlugin() {
   return {
-    id: "sparkle",
+    id: 'sparkle',
     decorators: {
       oas3: {
-        "operation-sparkle": OperationSparkle,
-        "add-opid-suffix": OpIdSuffix,
+        'operation-sparkle': OperationSparkle,
+        'add-opid-suffix': OpIdSuffix,
       },
     },
   };
-}
+};
 ```
 
 All that remains is for a user to configure this decorator in their `redocly.yaml` configuration file to take advantage of the new decorator functionality. Here's an example of the configuration file:

--- a/docs/@v1/custom-plugins/custom-rules.md
+++ b/docs/@v1/custom-plugins/custom-rules.md
@@ -28,7 +28,7 @@ function OperationIdNotTest() {
           });
         }
       },
-    }
+    },
   };
 }
 ```
@@ -96,7 +96,7 @@ You may use the message alone:
 
 ```js
 context.report({
-  message: "Unexpected identifier"
+  message: 'Unexpected identifier',
 });
 ```
 

--- a/docs/@v1/custom-plugins/extended-types.md
+++ b/docs/@v1/custom-plugins/extended-types.md
@@ -26,10 +26,10 @@ Define the type extension for the new `x-metadata` section, in this example, we 
 ```js
 const XMetaData = {
   properties: {
-    lifecycle: { type: 'string', enum: ['development', 'staging', 'production']},
-    'owner-team': { type: 'string'},
+    lifecycle: { type: 'string', enum: ['development', 'staging', 'production'] },
+    'owner-team': { type: 'string' },
   },
-  required: ['lifecycle']
+  required: ['lifecycle'],
 };
 ```
 
@@ -66,7 +66,7 @@ You can use the new type immediately to check the validity of your API document.
 extends: []
 
 plugins:
- - 'plugins/example-type-extension.js'
+  - 'plugins/example-type-extension.js'
 
 rules:
   spec: warn

--- a/docs/@v1/custom-plugins/visitor.md
+++ b/docs/@v1/custom-plugins/visitor.md
@@ -55,10 +55,10 @@ function ExampleRule() {
     Operation: {
       Schema: {
         enter(schema, ctx, parents) {
-          console.log(`type ${schema.type} from ${parents.Operation.operationId}`)
-        }
-      }
-    }
+          console.log(`type ${schema.type} from ${parents.Operation.operationId}`);
+        },
+      },
+    },
   };
 }
 ```

--- a/docs/@v1/decorators/media-type-examples-override.md
+++ b/docs/@v1/decorators/media-type-examples-override.md
@@ -95,12 +95,12 @@ components:
     GetMuseumHoursResponseExample:
       summary: Get hours response
       value:
-        - date: "2024-06-18"
-          timeOpen: "09:00"
-          timeClose: "18:00"
-        - date: "2024-06-19"
-          timeOpen: "09:00"
-          timeClose: "18:00"
+        - date: '2024-06-18'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2024-06-19'
+          timeOpen: '09:00'
+          timeClose: '18:00'
 ```
 
 Given the file `./opening-hours-examples.yaml` with content:
@@ -109,16 +109,15 @@ Given the file `./opening-hours-examples.yaml` with content:
 GetMuseumHoursResponseExampleShort:
   summary: Short-term opening hours
   value:
-    - date: "2023-09-11"
-      timeOpen: "09:00"
-      timeClose: "18:00"
-    - date: "2023-09-12"
-      timeOpen: "09:00"
-      timeClose: "18:00"
+    - date: '2023-09-11'
+      timeOpen: '09:00'
+      timeClose: '18:00'
+    - date: '2023-09-12'
+      timeOpen: '09:00'
+      timeClose: '18:00'
 GetMuseumHoursResponseExampleClosed:
   summary: The museum is closed
   value: []
-
 ```
 
 Given this configuration:

--- a/docs/@v1/guides/configure-rules.md
+++ b/docs/@v1/guides/configure-rules.md
@@ -101,7 +101,6 @@ rules:
     assertions:
       pattern: /1\.[0-9]\.[0-9]/
     message: API version must be in SemVer format, no major version release
-
 ```
 
 The `subject` is the `version` property of the `info` object; Info is a [recognized node type](https://redocly.com/docs/openapi-visual-reference/openapi-node-types/). Using the `pattern` assertion, describe what's allowed with [regular expression syntax](https://en.wikipedia.org/wiki/Regular_expression). Finally, adding the `message` ensures clear information is conveyed if the rule isn't satisfied.

--- a/docs/@v1/guides/hide-specification-extensions.md
+++ b/docs/@v1/guides/hide-specification-extensions.md
@@ -71,18 +71,18 @@ You can name the plugins directory and the file anything you want. Make sure you
    function hideOpenapiExtensions({ pattern }) {
      return {
        any: {
-         enter: node => {
-           pattern.forEach(item => {
-             Object.keys(node).forEach(key => {
+         enter: (node) => {
+           pattern.forEach((item) => {
+             Object.keys(node).forEach((key) => {
                const regex = new RegExp(item, 'i');
                if (regex.test(key)) {
                  delete node[key];
                }
              });
            });
-         }
-       }
-     }
+         },
+       },
+     };
    }
    ```
 
@@ -107,7 +107,7 @@ apis:
         pattern:
           - x-amazon-apigateway
 plugins:
-  - "./plugins/plugin.js"
+  - './plugins/plugin.js'
 extends:
   - recommended
 ```

--- a/docs/@v1/guides/lint-arazzo.md
+++ b/docs/@v1/guides/lint-arazzo.md
@@ -78,7 +78,7 @@ The following example shows configuration for the minimal ruleset with some addi
 
 ```yaml
 extends:
- - minimal
+  - minimal
 
 arazzo1Rules:
   sourceDescription-name-unique: warn

--- a/docs/@v1/guides/migrate-from-spectral.md
+++ b/docs/@v1/guides/migrate-from-spectral.md
@@ -54,7 +54,7 @@ rules:
       property: summary
     assertions:
       notPattern: /test/
-    message: "Operation summary must not include the word test"
+    message: 'Operation summary must not include the word test'
 ```
 
 It is also possible to configure additional rules for specific APIs using the [APIs object](../configuration/index.md#apis-object) to set per-API rules (or exceptions!).

--- a/docs/@v1/quickstart.md
+++ b/docs/@v1/quickstart.md
@@ -98,7 +98,7 @@ For example, let's build a lightweight ruleset using the [minimal ruleset](./rul
 
 ```yaml
 extends:
- - minimal
+  - minimal
 
 rules:
   path-parameters-defined: error

--- a/docs/@v1/rules/arazzo/step-onFailure-unique.md
+++ b/docs/@v1/rules/arazzo/step-onFailure-unique.md
@@ -37,22 +37,22 @@ Example of a **correct** `onFailure` list:
 
 ```yaml Correct example
 workflows:
-- workflowId: get-museum-hours
-  description: This workflow demonstrates how to get the museum opening hours and buy tickets.
-  steps:
-    - stepId: get-museum-hours
-      operationId: museum-api.getMuseumHours
-      successCriteria:
-        - condition: $statusCode == 200
-      onFailure:
-        - name: call-crud-events
-          workflowId: events-crud
-          type: goto
-        - name: second-call-crud-events
-          workflowId: events-crud
-          type: goto
-        - reference: $components.failureActions.notify
-        - reference: $components.failureActions.report
+  - workflowId: get-museum-hours
+    description: This workflow demonstrates how to get the museum opening hours and buy tickets.
+    steps:
+      - stepId: get-museum-hours
+        operationId: museum-api.getMuseumHours
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: call-crud-events
+            workflowId: events-crud
+            type: goto
+          - name: second-call-crud-events
+            workflowId: events-crud
+            type: goto
+          - reference: $components.failureActions.notify
+          - reference: $components.failureActions.report
 ```
 
 ## Related rules

--- a/docs/@v1/rules/arazzo/step-onSuccess-unique.md
+++ b/docs/@v1/rules/arazzo/step-onSuccess-unique.md
@@ -37,22 +37,22 @@ Example of a **correct** `onSuccess` list:
 
 ```yaml Correct example
 workflows:
-- workflowId: get-museum-hours
-  description: This workflow demonstrates how to get the museum opening hours and buy tickets.
-  steps:
-    - stepId: get-museum-hours
-      operationId: museum-api.getMuseumHours
-      successCriteria:
-        - condition: $statusCode == 200
-      onSuccess:
-        - name: call-crud-events
-          workflowId: events-crud
-          type: goto
-        - name: second-call-crud-events
-          workflowId: events-crud
-          type: goto
-        - reference: $components.successActions.notify
-        - reference: $components.successActions.report
+  - workflowId: get-museum-hours
+    description: This workflow demonstrates how to get the museum opening hours and buy tickets.
+    steps:
+      - stepId: get-museum-hours
+        operationId: museum-api.getMuseumHours
+        successCriteria:
+          - condition: $statusCode == 200
+        onSuccess:
+          - name: call-crud-events
+            workflowId: events-crud
+            type: goto
+          - name: second-call-crud-events
+            workflowId: events-crud
+            type: goto
+          - reference: $components.successActions.notify
+          - reference: $components.successActions.report
 ```
 
 ## Related rules

--- a/docs/@v1/rules/arazzo/workflow-dependsOn.md
+++ b/docs/@v1/rules/arazzo/workflow-dependsOn.md
@@ -36,11 +36,11 @@ Example of a **correct** `dependsOn` list:
 
 ```yaml Correct example
 workflows:
-    - workflowId: get-museum-hours
-      description: This workflow demonstrates how to get the museum opening hours and buy tickets.
-      dependsOn:
-        - get-museum-hours-2
-        - get-museum-hours-3
+  - workflowId: get-museum-hours
+    description: This workflow demonstrates how to get the museum opening hours and buy tickets.
+    dependsOn:
+      - get-museum-hours-2
+      - get-museum-hours-3
 ```
 
 ## Resources

--- a/docs/@v1/rules/async/no-channel-trailing-slash.md
+++ b/docs/@v1/rules/async/no-channel-trailing-slash.md
@@ -23,7 +23,6 @@ An example configuration:
 ```yaml
 rules:
   no-channel-trailing-slash: error
-
 ```
 
 ## Examples

--- a/docs/@v1/rules/configure-rules.md
+++ b/docs/@v1/rules/configure-rules.md
@@ -15,7 +15,6 @@ The following example shows rules configured in `redocly.yaml` with short syntax
 ```yaml
 rules:
   operation-operationId: warn
-
 ```
 
 Some rules support additional configuration options. The following example shows the more verbose format where the `severity` setting is added alongside other settings:

--- a/docs/@v1/rules/oas/boolean-parameter-prefixes.md
+++ b/docs/@v1/rules/oas/boolean-parameter-prefixes.md
@@ -65,7 +65,7 @@ The following example configures prefixes:
 rules:
   boolean-parameter-prefixes:
     severity: error
-    prefixes: ["can", "is", "has"]
+    prefixes: ['can', 'is', 'has']
 ```
 
 ## Examples

--- a/docs/@v1/rules/oas/no-example-value-and-externalValue.md
+++ b/docs/@v1/rules/oas/no-example-value-and-externalValue.md
@@ -68,11 +68,11 @@ requestBody:
       examples:
         foo:
           summary: A foo example
-          value: {"foo": "bar"}
+          value: { 'foo': 'bar' }
           externalValue: 'https://example.org/examples/foo-example.xml'
         bar:
           summary: A bar example
-          value: {"bar": "baz"}
+          value: { 'bar': 'baz' }
           externalValue: 'https://example.org/examples/bar-example.xml'
 ```
 
@@ -87,7 +87,7 @@ requestBody:
       examples:
         foo:
           summary: A foo example
-          value: {"foo": "bar"}
+          value: { 'foo': 'bar' }
         bar:
           summary: A bar example
           externalValue: 'https://example.org/examples/address-example.xml'

--- a/docs/@v1/rules/oas/required-string-property-missing-min-length.md
+++ b/docs/@v1/rules/oas/required-string-property-missing-min-length.md
@@ -54,12 +54,11 @@ schemas:
   User:
     type: object
     required:
-        - name
+      - name
     properties:
       name:
         description: User name
         type: string
-
 ```
 
 Example of a **correct** schema:
@@ -69,7 +68,7 @@ schemas:
   User:
     type: object
     required:
-        - name
+      - name
     properties:
       name:
         description: User name

--- a/docs/@v1/rules/oas/tag-description.md
+++ b/docs/@v1/rules/oas/tag-description.md
@@ -25,7 +25,6 @@ tags:
     description: Endpoints used for integrations with partners and external collaborators.
   - name: Customer APIs
     description: Endpoints used for integrations with customers.
-
 ```
 
 The default setting for this rule (in the built-in `recommended` configuration) is `warn`.

--- a/docs/@v2/commands/build-docs.md
+++ b/docs/@v2/commands/build-docs.md
@@ -108,7 +108,10 @@ Sample custom Handlebars template:
     <meta description='{{{templateOptions.metaDescription}}}' />
     <meta name='viewport' content='width=device-width, initial-scale=1' />
     <style>
-      body { padding: 0; margin: 0; }
+      body {
+        padding: 0;
+        margin: 0;
+      }
     </style>
     {{{redocHead}}}
     {{#unless disableGoogleFont}}<link

--- a/docs/@v2/configuration/apis.md
+++ b/docs/@v2/configuration/apis.md
@@ -23,7 +23,6 @@ decorators:
     title: All APIs
     extraProperty: This property will be ignored at the per-API level.
 
-
 apis:
   storefront:
     decorators:

--- a/docs/@v2/configuration/reference/extends.md
+++ b/docs/@v2/configuration/reference/extends.md
@@ -28,7 +28,7 @@ To get started, try the following example to configure your project to be based 
 
 ```yaml
 extends:
- - minimal
+  - minimal
 ```
 
 ## Related options

--- a/docs/@v2/configuration/reference/rules.md
+++ b/docs/@v2/configuration/reference/rules.md
@@ -101,7 +101,6 @@ rules:
       property: operationId
     assertions:
       casing: camelCase
-
 ```
 
 The configurable rules have user-defined names that all start with `rule/` and then a meaningful name.

--- a/docs/@v2/custom-plugins/custom-decorators.md
+++ b/docs/@v2/custom-plugins/custom-decorators.md
@@ -47,14 +47,14 @@ To help keep the plugin code organized, this example uses one file per decorator
 
 ```js
 export default function OperationSparkle() {
-  console.log("adding sparkles ... ");
+  console.log('adding sparkles ... ');
   return {
     Operation: {
       leave(target) {
-        if(target.description) {
-          target.description = "✨ " + String(target.description);
+        if (target.description) {
+          target.description = '✨ ' + String(target.description);
         }
-      }
+      },
     },
   };
 }
@@ -69,10 +69,10 @@ import OperationSparkle from './decorators/operation-sparkle.js';
 
 export default function sparklePlugin() {
   return {
-    id: "sparkle",
+    id: 'sparkle',
     decorators: {
       oas3: {
-        "operation-sparkle": OperationSparkle,
+        'operation-sparkle': OperationSparkle,
       },
     },
   };
@@ -96,15 +96,15 @@ A common use case is a decorator that can accept input values to be used during 
 Here's the decorator code, in a file named `plugins/decorations/add-suffix.js` and it expects a configuration option named `suffix`:
 
 ```js
-export default function OpIdSuffix({suffix}) {
-  console.log("updating OperationIds ... ");
+export default function OpIdSuffix({ suffix }) {
+  console.log('updating OperationIds ... ');
   return {
     Operation: {
       leave(target) {
-        if(target.operationId) {
+        if (target.operationId) {
           target.operationId = target.operationId + suffix;
         }
-      }
+      },
     },
   };
 }
@@ -120,11 +120,11 @@ import OpIdSuffix from './decorators/add-suffix.js';
 
 export default function sparklePlugin() {
   return {
-    id: "sparkle",
+    id: 'sparkle',
     decorators: {
       oas3: {
-        "operation-sparkle": OperationSparkle,
-        "add-opid-suffix": OpIdSuffix,
+        'operation-sparkle': OperationSparkle,
+        'add-opid-suffix': OpIdSuffix,
       },
     },
   };

--- a/docs/@v2/custom-plugins/custom-rules.md
+++ b/docs/@v2/custom-plugins/custom-rules.md
@@ -26,7 +26,7 @@ export default function OperationIdNotTest() {
           });
         }
       },
-    }
+    },
   };
 }
 ```
@@ -94,7 +94,7 @@ You may use the message alone:
 
 ```js
 context.report({
-  message: "Unexpected identifier"
+  message: 'Unexpected identifier',
 });
 ```
 

--- a/docs/@v2/custom-plugins/extended-types.md
+++ b/docs/@v2/custom-plugins/extended-types.md
@@ -26,10 +26,10 @@ Define the type extension for the new `x-metadata` section, in this example, we 
 ```js
 const XMetaData = {
   properties: {
-    lifecycle: { type: 'string', enum: ['development', 'staging', 'production']},
-    'owner-team': { type: 'string'},
+    lifecycle: { type: 'string', enum: ['development', 'staging', 'production'] },
+    'owner-team': { type: 'string' },
   },
-  required: ['lifecycle']
+  required: ['lifecycle'],
 };
 ```
 
@@ -66,7 +66,7 @@ You can use the new type immediately to check the validity of your API document.
 extends: []
 
 plugins:
- - 'plugins/example-type-extension.js'
+  - plugins/example-type-extension.js
 
 rules:
   struct: warn

--- a/docs/@v2/custom-plugins/visitor.md
+++ b/docs/@v2/custom-plugins/visitor.md
@@ -55,10 +55,10 @@ function ExampleRule() {
     Operation: {
       Schema: {
         enter(schema, ctx, parents) {
-          console.log(`type ${schema.type} from ${parents.Operation.operationId}`)
-        }
-      }
-    }
+          console.log(`type ${schema.type} from ${parents.Operation.operationId}`);
+        },
+      },
+    },
   };
 }
 ```

--- a/docs/@v2/decorators/media-type-examples-override.md
+++ b/docs/@v2/decorators/media-type-examples-override.md
@@ -95,12 +95,12 @@ components:
     GetMuseumHoursResponseExample:
       summary: Get hours response
       value:
-        - date: "2024-06-18"
-          timeOpen: "09:00"
-          timeClose: "18:00"
-        - date: "2024-06-19"
-          timeOpen: "09:00"
-          timeClose: "18:00"
+        - date: '2024-06-18'
+          timeOpen: '09:00'
+          timeClose: '18:00'
+        - date: '2024-06-19'
+          timeOpen: '09:00'
+          timeClose: '18:00'
 ```
 
 Given the file `./opening-hours-examples.yaml` with content:
@@ -109,16 +109,15 @@ Given the file `./opening-hours-examples.yaml` with content:
 GetMuseumHoursResponseExampleShort:
   summary: Short-term opening hours
   value:
-    - date: "2023-09-11"
-      timeOpen: "09:00"
-      timeClose: "18:00"
-    - date: "2023-09-12"
-      timeOpen: "09:00"
-      timeClose: "18:00"
+    - date: '2023-09-11'
+      timeOpen: '09:00'
+      timeClose: '18:00'
+    - date: '2023-09-12'
+      timeOpen: '09:00'
+      timeClose: '18:00'
 GetMuseumHoursResponseExampleClosed:
   summary: The museum is closed
   value: []
-
 ```
 
 Given this configuration:

--- a/docs/@v2/guides/hide-specification-extensions.md
+++ b/docs/@v2/guides/hide-specification-extensions.md
@@ -67,17 +67,17 @@ You can name the plugins directory and the file anything you want. Make sure you
    export default function hideOpenapiExtensions({ pattern }) {
      return {
        any: {
-         enter: node => {
-           pattern.forEach(item => {
-             Object.keys(node).forEach(key => {
+         enter: (node) => {
+           pattern.forEach((item) => {
+             Object.keys(node).forEach((key) => {
                const regex = new RegExp(item, 'i');
                if (regex.test(key)) {
                  delete node[key];
                }
              });
            });
-         }
-       }
+         },
+       },
      };
    }
    ```
@@ -103,7 +103,7 @@ apis:
         pattern:
           - x-amazon-apigateway
 plugins:
-  - "./plugins/plugin.js"
+  - ./plugins/plugin.js
 extends:
   - recommended
 ```

--- a/docs/@v2/guides/lint-arazzo.md
+++ b/docs/@v2/guides/lint-arazzo.md
@@ -78,7 +78,7 @@ The following example shows configuration for the minimal ruleset with some addi
 
 ```yaml
 extends:
- - minimal
+  - minimal
 
 arazzo1Rules:
   sourceDescription-name-unique: warn

--- a/docs/@v2/guides/migrate-from-spectral.md
+++ b/docs/@v2/guides/migrate-from-spectral.md
@@ -54,7 +54,7 @@ rules:
       property: summary
     assertions:
       notPattern: /test/
-    message: "Operation summary must not include the word test"
+    message: Operation summary must not include the word test
 ```
 
 It is also possible to configure additional rules for specific APIs using the [APIs object](../configuration/index.md#apis-object) to set per-API rules (or exceptions!).

--- a/docs/@v2/guides/replace-servers-url.md
+++ b/docs/@v2/guides/replace-servers-url.md
@@ -88,17 +88,15 @@ It accepts a `serverUrl` parameter from the Redocly configuration file and overw
 
 ```js
 /** @type {import('@redocly/cli').OasDecorator} */
-export default function ReplaceServersURL({serverUrl}) {
+export default function ReplaceServersURL({ serverUrl }) {
   return {
     Server: {
       leave(Server) {
-
         if (serverUrl) {
           Server.url = serverUrl;
         }
-
-      }
-    }
+      },
+    },
   };
 }
 ```

--- a/docs/@v2/quickstart.md
+++ b/docs/@v2/quickstart.md
@@ -73,7 +73,7 @@ For example, let's build a lightweight ruleset using the [spec ruleset](./rules/
 
 ```yaml
 extends:
- - spec
+  - spec
 
 rules:
   path-parameters-defined: error

--- a/docs/@v2/rules/arazzo/step-onFailure-unique.md
+++ b/docs/@v2/rules/arazzo/step-onFailure-unique.md
@@ -37,22 +37,22 @@ Example of a **correct** `onFailure` list:
 
 ```yaml Correct example
 workflows:
-- workflowId: get-museum-hours
-  description: This workflow demonstrates how to get the museum opening hours and buy tickets.
-  steps:
-    - stepId: get-museum-hours
-      operationId: museum-api.getMuseumHours
-      successCriteria:
-        - condition: $statusCode == 200
-      onFailure:
-        - name: call-crud-events
-          workflowId: events-crud
-          type: goto
-        - name: second-call-crud-events
-          workflowId: events-crud
-          type: goto
-        - reference: $components.failureActions.notify
-        - reference: $components.failureActions.report
+  - workflowId: get-museum-hours
+    description: This workflow demonstrates how to get the museum opening hours and buy tickets.
+    steps:
+      - stepId: get-museum-hours
+        operationId: museum-api.getMuseumHours
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: call-crud-events
+            workflowId: events-crud
+            type: goto
+          - name: second-call-crud-events
+            workflowId: events-crud
+            type: goto
+          - reference: $components.failureActions.notify
+          - reference: $components.failureActions.report
 ```
 
 ## Related rules

--- a/docs/@v2/rules/arazzo/step-onSuccess-unique.md
+++ b/docs/@v2/rules/arazzo/step-onSuccess-unique.md
@@ -37,22 +37,22 @@ Example of a **correct** `onSuccess` list:
 
 ```yaml Correct example
 workflows:
-- workflowId: get-museum-hours
-  description: This workflow demonstrates how to get the museum opening hours and buy tickets.
-  steps:
-    - stepId: get-museum-hours
-      operationId: museum-api.getMuseumHours
-      successCriteria:
-        - condition: $statusCode == 200
-      onSuccess:
-        - name: call-crud-events
-          workflowId: events-crud
-          type: goto
-        - name: second-call-crud-events
-          workflowId: events-crud
-          type: goto
-        - reference: $components.successActions.notify
-        - reference: $components.successActions.report
+  - workflowId: get-museum-hours
+    description: This workflow demonstrates how to get the museum opening hours and buy tickets.
+    steps:
+      - stepId: get-museum-hours
+        operationId: museum-api.getMuseumHours
+        successCriteria:
+          - condition: $statusCode == 200
+        onSuccess:
+          - name: call-crud-events
+            workflowId: events-crud
+            type: goto
+          - name: second-call-crud-events
+            workflowId: events-crud
+            type: goto
+          - reference: $components.successActions.notify
+          - reference: $components.successActions.report
 ```
 
 ## Related rules

--- a/docs/@v2/rules/arazzo/workflow-dependsOn.md
+++ b/docs/@v2/rules/arazzo/workflow-dependsOn.md
@@ -36,11 +36,11 @@ Example of a **correct** `dependsOn` list:
 
 ```yaml Correct example
 workflows:
-    - workflowId: get-museum-hours
-      description: This workflow demonstrates how to get the museum opening hours and buy tickets.
-      dependsOn:
-        - get-museum-hours-2
-        - get-museum-hours-3
+  - workflowId: get-museum-hours
+    description: This workflow demonstrates how to get the museum opening hours and buy tickets.
+    dependsOn:
+      - get-museum-hours-2
+      - get-museum-hours-3
 ```
 
 ## Resources

--- a/docs/@v2/rules/async/no-channel-trailing-slash.md
+++ b/docs/@v2/rules/async/no-channel-trailing-slash.md
@@ -23,7 +23,6 @@ An example configuration:
 ```yaml
 rules:
   no-channel-trailing-slash: error
-
 ```
 
 ## Examples

--- a/docs/@v2/rules/common/no-required-schema-properties-undefined.md
+++ b/docs/@v2/rules/common/no-required-schema-properties-undefined.md
@@ -116,9 +116,9 @@ schemas:
     type: object
     anyOf:
       - required:
-        - id
+          - id
       - required:
-        - name
+          - name
     properties:
       id:
         type: integer

--- a/docs/@v2/rules/configure-rules.md
+++ b/docs/@v2/rules/configure-rules.md
@@ -15,7 +15,6 @@ The following example shows rules configured in `redocly.yaml` with short syntax
 ```yaml
 rules:
   operation-operationId: warn
-
 ```
 
 Some rules support additional configuration options. The following example shows the more verbose format where the `severity` setting is added alongside other settings:

--- a/docs/@v2/rules/oas/boolean-parameter-prefixes.md
+++ b/docs/@v2/rules/oas/boolean-parameter-prefixes.md
@@ -66,7 +66,7 @@ The following example configures prefixes:
 rules:
   boolean-parameter-prefixes:
     severity: error
-    prefixes: ["can", "is", "has"]
+    prefixes: [can, is, has]
 ```
 
 ## Examples

--- a/docs/@v2/rules/oas/no-example-value-and-externalValue.md
+++ b/docs/@v2/rules/oas/no-example-value-and-externalValue.md
@@ -67,17 +67,17 @@ Example of an **incorrect** example object:
 ```yaml Bad example
 requestBody:
   content:
-    'application/json':
+    application/json:
       schema:
         $ref: '#/components/schemas/Address'
       examples:
         foo:
           summary: A foo example
-          value: {"foo": "bar"}
+          value: { foo: bar }
           externalValue: https://example.org/examples/foo-example.xml
         bar:
           summary: A bar example
-          value: {"bar": "baz"}
+          value: { bar: baz }
           externalValue: https://example.org/examples/bar-example.xml
 ```
 
@@ -86,13 +86,13 @@ Example of a **correct** example object:
 ```yaml Good example
 requestBody:
   content:
-    'application/json':
+    application/json:
       schema:
         $ref: '#/components/schemas/Address'
       examples:
         foo:
           summary: A foo example
-          value: {"foo": "bar"}
+          value: { foo: bar }
         bar:
           summary: A bar example
           externalValue: https://example.org/examples/address-example.xml

--- a/docs/@v2/rules/oas/nullable-type-sibling.md
+++ b/docs/@v2/rules/oas/nullable-type-sibling.md
@@ -49,7 +49,6 @@ components:
         - $ref: '#/components/schemas/SomeType'
     SomeType:
       type: string
-
 ```
 
 Example of a **correct** usage:

--- a/docs/@v2/rules/oas/required-string-property-missing-min-length.md
+++ b/docs/@v2/rules/oas/required-string-property-missing-min-length.md
@@ -55,12 +55,11 @@ schemas:
   User:
     type: object
     required:
-        - name
+      - name
     properties:
       name:
         description: User name
         type: string
-
 ```
 
 Example of a **correct** schema:
@@ -70,7 +69,7 @@ schemas:
   User:
     type: object
     required:
-        - name
+      - name
     properties:
       name:
         description: User name

--- a/docs/@v2/rules/oas/tag-description.md
+++ b/docs/@v2/rules/oas/tag-description.md
@@ -26,7 +26,6 @@ tags:
     description: Endpoints used for integrations with partners and external collaborators.
   - name: Customer APIs
     description: Endpoints used for integrations with customers.
-
 ```
 
 The default setting for this rule (in the built-in `recommended` configuration) is `warn`.

--- a/docs/@v2/rules/respect/x-security-scheme-name-reference.md
+++ b/docs/@v2/rules/respect/x-security-scheme-name-reference.md
@@ -46,7 +46,7 @@ sourceDescriptions:
 workflows:
   - workflowId: list-users
     x-security:
-      - schemeName: BasicAuth   # <- must be a reference when multiple sources exist
+      - schemeName: BasicAuth # <- must be a reference when multiple sources exist
         values:
           username: test@example.com
           password: 123456

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -253,15 +253,15 @@ async function bundle(options: {
   // optional base path for resolution
   base?: string | null;
 }): Promise<{
-    bundle: {
-      parsed: object; // OpenAPI document object as js object
-    };
-    problems: NormalizedProblem[]
-    fileDependencies
-    rootType
-    refTypes
-    visitorsData
-  }>;
+  bundle: {
+    parsed: object; // OpenAPI document object as js object
+  };
+  problems: NormalizedProblem[];
+  fileDependencies;
+  rootType;
+  refTypes;
+  visitorsData;
+}>;
 ```
 
 ### `bundleFromString`
@@ -286,15 +286,15 @@ async function bundleFromString(options: {
   // optional external reference resolver
   externalRefResolver?: BaseResolver;
 }): Promise<{
-    bundle: {
-      parsed: object; // OpenAPI document object as js object
-    };
-    problems: NormalizedProblem[]
-    fileDependencies
-    rootType
-    refTypes
-    visitorsData
-  }>;
+  bundle: {
+    parsed: object; // OpenAPI document object as js object
+  };
+  problems: NormalizedProblem[];
+  fileDependencies;
+  rootType;
+  refTypes;
+  visitorsData;
+}>;
 ```
 
 ### `stringifyYaml`


### PR DESCRIPTION
## What/Why/How?

Applied the same formatting to embedded docs as to the standalone ones.
No actual changes to the docs themselves.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily reformatting of Markdown/YAML/JS snippets and formatter config, with no functional runtime code changes; low risk aside from potential doc-rendering or example-copy/paste accuracy issues.
> 
> **Overview**
> Applies consistent formatting across embedded documentation snippets in `docs/@v1` and `docs/@v2` (quote style, indentation, spacing, and YAML list formatting) to match the repo’s standard formatting.
> 
> Updates `.oxfmtrc.json` by removing `embeddedLanguageFormatting` configuration, and makes a small formatting-only cleanup to the `packages/core/README.md` TypeScript API return type examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4e6bfbdf70c56044afd48893a0923a21e8197a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->