### PR TITLE
fix: externalResolver cache issue

### DIFF
--- a/.changeset/respect-multi-file-resolver-cache.md
+++ b/.changeset/respect-multi-file-resolver-cache.md
@@ -1,0 +1,5 @@
+---
+'@redocly/respect-core': patch
+---
+
+Fixed an issue where running `respect` on multiple Arazzo files in a single invocation could surface false-positive `struct` lint errors.

--- a/packages/respect-core/src/__tests__/run.test.ts
+++ b/packages/respect-core/src/__tests__/run.test.ts
@@ -1,0 +1,73 @@
+import { BaseResolver, createConfig, logger } from '@redocly/openapi-core';
+
+import * as flowRunner from '../modules/flow-runner/index.js';
+import type * as loggerOutput from '../modules/logger-output/index.js';
+import { run } from '../run.js';
+
+vi.mock('../modules/flow-runner/index.js', () => ({
+  runTestFile: vi.fn(),
+}));
+
+vi.mock('../modules/logger-output/index.js', async () => {
+  const actual = await vi.importActual<typeof loggerOutput>('../modules/logger-output/index.js');
+  return {
+    ...actual,
+    displayErrors: vi.fn(),
+    displaySummary: vi.fn(),
+  };
+});
+
+describe('run', () => {
+  const defaultRunResult = {
+    executedWorkflows: [],
+    ctx: { noSecretsMasking: false, secretsSet: new Set() },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(flowRunner.runTestFile).mockResolvedValue(defaultRunResult as any);
+  });
+
+  it('clears the externalRefResolver cache between file runs so mutated parsed docs do not leak into the next file', async () => {
+    const config = await createConfig({});
+    const externalRefResolver = new BaseResolver(config.resolve);
+
+    externalRefResolver.cache.set('/seeded/before/run.yaml', Promise.resolve({} as any));
+
+    const seenCacheSizes: number[] = [];
+    vi.mocked(flowRunner.runTestFile).mockImplementation(async ({ options }) => {
+      seenCacheSizes.push(options.externalRefResolver?.cache.size ?? -1);
+      options.externalRefResolver?.cache.set(`/leaked/${options.file}`, Promise.resolve({} as any));
+      return defaultRunResult as any;
+    });
+
+    await run({
+      files: ['a.arazzo.yaml', 'b.arazzo.yaml', 'c.arazzo.yaml'],
+      config,
+      maxSteps: 2000,
+      maxFetchTimeout: 40_000,
+      requestFileLoader: { getFileBody: async () => new Blob() },
+      logger,
+      fetch,
+      externalRefResolver,
+    });
+
+    expect(seenCacheSizes).toEqual([0, 0, 0]);
+  });
+
+  it('does not throw when externalRefResolver is not provided', async () => {
+    const config = await createConfig({});
+
+    await expect(
+      run({
+        files: ['a.arazzo.yaml'],
+        config,
+        maxSteps: 2000,
+        maxFetchTimeout: 40_000,
+        requestFileLoader: { getFileBody: async () => new Blob() },
+        logger,
+        fetch,
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/respect-core/src/run.ts
+++ b/packages/respect-core/src/run.ts
@@ -47,6 +47,15 @@ export async function run(options: RespectOptions): Promise<RunFileResult[]> {
   const runAllFilesResult = [];
 
   for (const path of files) {
+    // The runner mutates the parsed Arazzo document in place (adds `workflow.time`
+    // and `step.checks`). When `externalRefResolver` is shared across files, its
+    // cache would return those mutated documents to the lint pass of subsequent
+    // files (e.g. ones previously executed via `$sourceDescriptions.*` workflow
+    // references), producing false "property is not expected here" struct errors.
+    // Clear the cache between files so each file starts from freshly parsed
+    // documents while preserving the resolver's transport config (proxy, mTLS, etc).
+    options.externalRefResolver?.cache.clear();
+
     const result = await runFile({
       options: { ...options, file: path },
       startedAt: performance.now(),


### PR DESCRIPTION
## What/Why/How?

Fixed the issue with externalResolver cache when multiple Arazzo files executed.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [x] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes multi-file execution behavior by invalidating resolver cache between files, which could impact performance or any implicit reliance on cached refs.
> 
> **Overview**
> Fixes a multi-file `respect` invocation issue where a shared `externalRefResolver` could return *mutated* parsed Arazzo documents to subsequent file linting, producing false-positive `struct` errors.
> 
> The runner now clears `options.externalRefResolver.cache` before each file run, and adds unit tests covering cache isolation across files and the no-resolver case. A patch changeset is included for `@redocly/respect-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20e73cae68fac11fffc9c4b60f9755b93ad70ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->