### PR TITLE
chore: update config version 0.49.0

### DIFF
--- a/.changeset/real-hotels-bathe.md
+++ b/.changeset/real-hotels-bathe.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.49.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,9 +2557,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.48.2",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.2.tgz",
-      "integrity": "sha512-DUHthTRdj+caAQWCtJae4yzvxaUDuwQkFsZFVaAEyORd8Bt8K2wYso61jYZuR/kQZaDejfUREtQTVVZ5VYTqgw==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.0.tgz",
+      "integrity": "sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -12544,7 +12544,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.48.2",
+        "@redocly/config": "^0.49.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.48.2",
+    "@redocly/config": "^0.49.0",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -19776,6 +19776,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         },
         "type": "array",
       },
+      "template": "rootRedoclyConfigSchema.env_additionalProperties.markdown.template",
       "toc": "rootRedoclyConfigSchema.env_additionalProperties.markdown.toc",
     },
     "required": undefined,
@@ -19817,6 +19818,16 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.markdown.template": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.markdown.toc": {
@@ -28104,6 +28115,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         },
         "type": "array",
       },
+      "template": "rootRedoclyConfigSchema.env_additionalProperties.theme.markdown.template",
       "toc": "rootRedoclyConfigSchema.env_additionalProperties.theme.markdown.toc",
     },
     "required": undefined,
@@ -28145,6 +28157,16 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.theme.markdown.template": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.theme.markdown.toc": {
@@ -33470,6 +33492,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         },
         "type": "array",
       },
+      "template": "rootRedoclyConfigSchema.markdown.template",
       "toc": "rootRedoclyConfigSchema.markdown.toc",
     },
     "required": undefined,
@@ -33511,6 +33534,16 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.markdown.template": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.markdown.toc": {


### PR DESCRIPTION
## What/Why/How?

Updated config version to 0.49.0.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump; functional impact is limited to any behavioral/schema changes introduced by `@redocly/config@0.49.0`, reflected in updated snapshots.
> 
> **Overview**
> Updates `@redocly/openapi-core` to depend on `@redocly/config@0.49.0` (from `0.48.2`), including corresponding `package-lock.json` updates.
> 
> Refreshes the `redocly-yaml` config schema snapshot to match the new config schema, notably adding the new `markdown.template` entries in the generated types, and adds a changeset documenting the patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a211fcbc5834a51c4e7c996e7a98ff114b44f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->