### PR TITLE
fix: pin specific nodejs version in dockerfile

### DIFF
--- a/.changeset/six-flowers-draw.md
+++ b/.changeset/six-flowers-draw.md
@@ -2,4 +2,4 @@
 '@redocly/cli': patch
 ---
 
-Pinned the official Docker image base to `node:24-alpine`. The previous floating `node:alpine` tag started pulling Node.js 26+, whose internal `undici` is incompatible with the `undici@6.x` dispatcher we ship and caused `redocly push` to fail.
+Pinned the official Docker image base to `node:24-alpine`.

--- a/.changeset/six-flowers-draw.md
+++ b/.changeset/six-flowers-draw.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': patch
+---
+
+Pinned the official Docker image base to `node:24-alpine`. The previous floating `node:alpine` tag started pulling Node.js 26+, whose internal `undici` is incompatible with the `undici@6.x` dispatcher we ship and caused `redocly push` to fail.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM node:alpine
+# Pin to a specific Node.js major so the image doesn't drift onto a Node
+# release whose internal `undici` is incompatible with the `undici@6.x`
+# dispatcher we ship. Node 26+ uses the new Dispatcher.Handler interface,
+# which causes `redocly push` to fail with
+# `UND_ERR_INVALID_ARG: invalid onError method`. Node 24's internal undici
+# v7 still keeps the legacy handler methods, so the bundled v6 dispatcher
+# and the runtime's `fetch` stay compatible.
+FROM node:24-alpine
 
 WORKDIR /build
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-# Pin to a specific Node.js major so the image doesn't drift onto a Node
-# release whose internal `undici` is incompatible with the `undici@6.x`
-# dispatcher we ship. Node 26+ uses the new Dispatcher.Handler interface,
-# which causes `redocly push` to fail with
-# `UND_ERR_INVALID_ARG: invalid onError method`. Node 24's internal undici
-# v7 still keeps the legacy handler methods, so the bundled v6 dispatcher
-# and the runtime's `fetch` stay compatible.
 FROM node:24-alpine
 
 WORKDIR /build


### PR DESCRIPTION
## What/Why/How?

Due to recent changes in the base image used by the official Docker image:

```
FROM node:alpine
```

node:alpine is a floating tag. The 2.30.3 Docker image got built with whatever Node was current at that time (Node 22/24 line, internal undici still legacy-compatible). The 2.30.4 image was rebuilt later, picked up a newer Node (now Node 26+ on node:alpine), and started shipping an internal undici whose handler interface no longer satisfies the v6 dispatcher's onError validation — so the very first authenticated request the push command makes (getDefaultBranch) fails before it even hits the wire.

That's why bumping the published version "broke" push without any push-related code change: it's a transitive break from node:alpine floating to Node 26.

## Reference

https://github.com/Redocly/redocly-cli/issues/2835

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Dockerfile base-image pin with no application logic changes; reduces risk of future floating-tag runtime regressions.
> 
> **Overview**
> The official Docker image no longer uses the floating **`node:alpine`** tag. The **`Dockerfile`** now pins the base image to **`node:24-alpine`** so rebuilds pick up a consistent Node major line instead of whatever is current on `alpine` (e.g. Node 26+), which had caused **`push`** to fail on authenticated requests due to an internal **undici** / dispatcher mismatch without any CLI code changes.
> 
> A **patch** changeset documents the Docker base pin for **`@redocly/cli`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f93a5b2687161f2a2bf350cb2cb351e531e8be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->