### PR TITLE
chore: update tsconfig, vitest, pr template, etc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,11 @@
 
 ## Check yourself
 
-- [ ] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
+- [ ] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
 - [ ] All new/updated code is covered by tests
 - [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
 - [ ] New package installed? - Tested in different environments (browser/node)
-- [ ] Documentation update has been considered <!-- TODO: make it required -->
+- [ ] Documentation update has been considered <!-- required 🔒 -->
 
 ## Security
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -223,10 +223,6 @@ jobs:
           Install with NPM:
           \`\`\`bash
           npm install @redocly/cli@$VERSION
-          # or
-          npm install @redocly/openapi-core@$VERSION
-          # or
-          npm install @redocly/respect-core@$VERSION
           \`\`\`
 
           ⚠️ Note: This is a development build and may contain unstable features."

--- a/.mlc.toml
+++ b/.mlc.toml
@@ -6,4 +6,3 @@ ignore-links=["../../*", "/docs/*", "/learn/*",
 # Path to the root folder used to resolve all relative paths
 root-dir="./docs"
 offline = true
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ Before submitting a pull request, please make sure the following is done:
    If you think it makes sense to keep several commit descriptions, please rebase your PR instead of squashing it to preserve the commits.
    Please use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
+Please do not modify the PR template.
+
 ## Development setup
 
 [Node.js](http://nodejs.org) at v22.12.0+ and NPM v11+ are required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Before submitting a pull request, please make sure the following is done:
    If you think it makes sense to keep several commit descriptions, please rebase your PR instead of squashing it to preserve the commits.
    Please use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
-Please do not modify the PR template.
+**Please do not modify the PR template.**
 
 ## Development setup
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "lint-staged": {
     "**/*.{ts,js,yaml,yml,json,md}": [
       "npm run lint",
-      "npm run format"
+      "oxfmt --write"
     ],
     "packages/**/*.ts": [
       "npm run lint:fix"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": false,
-    "lib": ["ES2023", "DOM", "dom.iterable"],
+    "lib": ["ESNext", "DOM", "dom.iterable"],
     "paths": { "*": ["./packages/*"] },
     "skipLibCheck": true,
     "moduleResolution": "nodenext",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,8 +20,8 @@ const configExtension: { [key: string]: ViteUserConfig } = {
           'packages/cli/src/utils/assert-node-version.ts',
         ],
         thresholds: {
-          lines: 80,
-          functions: 83,
+          lines: 81,
+          functions: 84,
           statements: 80,
           branches: 72,
         },


### PR DESCRIPTION
## What/Why/How?

Updated tsconfig, vitest, pr template, etc..
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling, docs, and workflow comment tweaks only; no auth, security, or core CLI logic changes.
> 
> **Overview**
> This PR tightens **contributor and CI housekeeping** without changing product runtime behavior.
> 
> The **PR template** marks the contributing-guide and documentation checklist items as **required** (replacing TODO comments with `required 🔒`).
> 
> **CONTRIBUTING.md** adds an explicit rule: **do not modify the PR template.**
> 
> **Snapshot release** PR comments now only show `npm install @redocly/cli@$VERSION` (removed optional `openapi-core` / `respect-core` install lines).
> 
> **lint-staged** runs **`oxfmt --write`** directly instead of **`npm run format`**.
> 
> **TypeScript** `lib` moves from **`ES2023`** to **`ESNext`**. **Vitest** coverage thresholds bump slightly (**lines** 80→81, **functions** 83→84).
> 
> **`.mlc.toml`** drops a trailing blank line after `offline = true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a37b201a771c329df2b57544b4648ae13a1c6f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->