### PR TITLE
chore: update x-security snapshots as mock-server start consider auth scheme

### DIFF
--- a/tests/e2e/respect/x-security-bearer-auth/__snapshots__/x-security-bearer-auth.test.ts.snap
+++ b/tests/e2e/respect/x-security-bearer-auth/__snapshots__/x-security-bearer-auth.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`should make request with Authorization header \`Bearer ...\` 1`] = `
+exports[`should make request with Authorization header \`Bearer ...\`, actual response is not relevant 1`] = `
 "──────────────────────────────────────────────────────────────────────────────── 
  
   Running workflow x-security-bearer-auth.arazzo.yaml / bearer-auth-workflow 
@@ -13,63 +13,15 @@ exports[`should make request with Authorization header \`Bearer ...\` 1`] = `
       authorization: Bearer ******** 
  
 
-    Response status code: 200
+    Response status code: 400
     Response time: <test> ms
     Response Headers: <response headers test>
     Response Size: <test> bytes
     Response Body:
-      [
-        {
-          "date": "2023-09-11",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-12",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-13",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-14",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-15",
-          "timeOpen": "10:00",
-          "timeClose": "16:00"
-        },
-        {
-          "date": "2023-09-18",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-19",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-20",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-21",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-22",
-          "timeOpen": "10:00",
-          "timeClose": "16:00"
-        }
-      ] 
+      {
+        "type": "object",
+        "title": "Not authenticated. Supported authentication types: MuseumPlaceholderAuth."
+      } 
  
     ✓ status code check - $statusCode in [200, 400, 404]
     ✓ content-type check

--- a/tests/e2e/respect/x-security-bearer-auth/x-security-bearer-auth.test.ts
+++ b/tests/e2e/respect/x-security-bearer-auth/x-security-bearer-auth.test.ts
@@ -5,7 +5,7 @@ import { getCommandOutput, getParams } from '../../helpers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('should make request with Authorization header `Bearer ...`', () => {
+test('should make request with Authorization header `Bearer ...`, actual response is not relevant', () => {
   const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
   const fixturesPath = join(__dirname, 'x-security-bearer-auth.arazzo.yaml');
   const args = getParams(indexEntryPoint, [

--- a/tests/e2e/respect/x-security-oauth2-auth/__snapshots__/x-security-oauth2-auth.test.ts.snap
+++ b/tests/e2e/respect/x-security-oauth2-auth/__snapshots__/x-security-oauth2-auth.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`should make request with Authorization header \`Bearer ...\` using OAuth2 accessToken 1`] = `
+exports[`should make request with Authorization header \`Bearer ...\` using OAuth2 accessToken, actual response is not relevant 1`] = `
 "──────────────────────────────────────────────────────────────────────────────── 
  
   Running workflow x-security-oauth2-auth.arazzo.yaml / oauth2-auth-workflow 
@@ -13,63 +13,15 @@ exports[`should make request with Authorization header \`Bearer ...\` using OAut
       authorization: Bearer ******** 
  
 
-    Response status code: 200
+    Response status code: 400
     Response time: <test> ms
     Response Headers: <response headers test>
     Response Size: <test> bytes
     Response Body:
-      [
-        {
-          "date": "2023-09-11",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-12",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-13",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-14",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-15",
-          "timeOpen": "10:00",
-          "timeClose": "16:00"
-        },
-        {
-          "date": "2023-09-18",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-19",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-20",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-21",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-22",
-          "timeOpen": "10:00",
-          "timeClose": "16:00"
-        }
-      ] 
+      {
+        "type": "object",
+        "title": "Not authenticated. Supported authentication types: MuseumPlaceholderAuth."
+      } 
  
     ✓ status code check - $statusCode in [200, 400, 404]
     ✓ content-type check

--- a/tests/e2e/respect/x-security-oauth2-auth/x-security-oauth2-auth.test.ts
+++ b/tests/e2e/respect/x-security-oauth2-auth/x-security-oauth2-auth.test.ts
@@ -5,7 +5,7 @@ import { getCommandOutput, getParams } from '../../helpers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('should make request with Authorization header `Bearer ...` using OAuth2 accessToken', () => {
+test('should make request with Authorization header `Bearer ...` using OAuth2 accessToken, actual response is not relevant', () => {
   const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
   const fixturesPath = join(__dirname, 'x-security-oauth2-auth.arazzo.yaml');
   const args = getParams(indexEntryPoint, ['respect', fixturesPath, '--verbose']);

--- a/tests/e2e/respect/x-security-open-id-connect-auth/__snapshots__/x-security-open-id-connect-auth.test.ts.snap
+++ b/tests/e2e/respect/x-security-open-id-connect-auth/__snapshots__/x-security-open-id-connect-auth.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`should make request with Authorization header \`Bearer ...\` using OpenID Connect accessToken 1`] = `
+exports[`should make request with Authorization header \`Bearer ...\` using OpenID Connect accessToken, actual response is not relevant 1`] = `
 "──────────────────────────────────────────────────────────────────────────────── 
  
   Running workflow x-security-open-id-connect-auth.arazzo.yaml / open-id-connect-auth-workflow 
@@ -13,63 +13,15 @@ exports[`should make request with Authorization header \`Bearer ...\` using Open
       authorization: Bearer ******** 
  
 
-    Response status code: 200
+    Response status code: 400
     Response time: <test> ms
     Response Headers: <response headers test>
     Response Size: <test> bytes
     Response Body:
-      [
-        {
-          "date": "2023-09-11",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-12",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-13",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-14",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-15",
-          "timeOpen": "10:00",
-          "timeClose": "16:00"
-        },
-        {
-          "date": "2023-09-18",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-19",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-20",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-21",
-          "timeOpen": "09:00",
-          "timeClose": "18:00"
-        },
-        {
-          "date": "2023-09-22",
-          "timeOpen": "10:00",
-          "timeClose": "16:00"
-        }
-      ] 
+      {
+        "type": "object",
+        "title": "Not authenticated. Supported authentication types: MuseumPlaceholderAuth."
+      } 
  
     ✓ status code check - $statusCode in [200, 400, 404]
     ✓ content-type check

--- a/tests/e2e/respect/x-security-open-id-connect-auth/x-security-open-id-connect-auth.test.ts
+++ b/tests/e2e/respect/x-security-open-id-connect-auth/x-security-open-id-connect-auth.test.ts
@@ -5,7 +5,7 @@ import { getCommandOutput, getParams } from '../../helpers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('should make request with Authorization header `Bearer ...` using OpenID Connect accessToken', () => {
+test('should make request with Authorization header `Bearer ...` using OpenID Connect accessToken, actual response is not relevant', () => {
   const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
   const fixturesPath = join(__dirname, 'x-security-open-id-connect-auth.arazzo.yaml');
   const args = getParams(indexEntryPoint, ['respect', fixturesPath, '--verbose']);


### PR DESCRIPTION
## What/Why/How?

Update x-security snapshots as mock-server start consider auth scheme.
Snapshots only verify the proper auth headers, not the mock server response, so it can be actually unauthorized.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only snapshot and title updates; no runtime CLI or auth implementation changes.
> 
> **Overview**
> Updates **Respect** e2e coverage for `x-security` bearer, OAuth2, and OpenID Connect flows so expectations match the demo mock server now enforcing auth schemes.
> 
> Test titles now state that the **response body/status is not the assertion target**—snapshots still lock in `Authorization: Bearer ********` on the outbound request. Expected verbose output shifts from **200** with museum-hours JSON to **400** with a not-authenticated problem payload; workflows still pass because status checks already allow `[200, 400, 404]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec85197643c190285efdf0b761c885f6e491dbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->