### PR TITLE
feat: add junit output format to the lint

### DIFF
--- a/.changeset/easy-carpets-tan.md
+++ b/.changeset/easy-carpets-tan.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': minor
+'@redocly/cli': minor
+---
+
+Added support for `junit` output in the `lint` command.

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -283,15 +283,29 @@ The `lint` command supports the JUnit XML report format, which is consumed by ma
 Each linted API becomes a `<testsuite>`, and each problem becomes a `<testcase>`.
 Errors are reported as `<error>` elements and warnings as `<failure>` elements, so CI tools that render the two differently keep errors and warnings visually distinct.
 
+Each `<testcase>` body repeats the rule, severity, location, pointer, and message as a readable detail block, matching the [`scorecard-classic`](./scorecard-classic.md) JUnit output.
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="redocly lint" tests="3" errors="2" failures="1" skipped="0">
-<testsuite name="museum-with-errors.yaml" tests="3" errors="2" failures="1">
+<testsuites name="redocly lint" tests="2" errors="1" failures="1" skipped="0">
+<testsuite name="museum-with-errors.yaml" tests="2" errors="1" failures="1">
 <testcase classname="struct" name="struct - 19:7" file="museum-with-errors.yaml" line="19">
-<error message="Property `operationIds` is not expected here." type="struct">at #/paths/~1museum-hours/get</error>
+<error message="Property `operationIds` is not expected here." type="struct">Rule: struct
+Severity: error
+File: museum-with-errors.yaml
+Line: 19
+Column: 7
+Pointer: #/paths/~1museum-hours/get
+Message: Property `operationIds` is not expected here.</error>
 </testcase>
 <testcase classname="operation-operationId" name="operation-operationId - 16:5" file="museum-with-errors.yaml" line="16">
-<failure message="Operation object should contain `operationId` field." type="operation-operationId">at #/paths/~1museum-hours/get</failure>
+<failure message="Operation object should contain `operationId` field." type="operation-operationId">Rule: operation-operationId
+Severity: warn
+File: museum-with-errors.yaml
+Line: 16
+Column: 5
+Pointer: #/paths/~1museum-hours/get
+Message: Operation object should contain `operationId` field.</failure>
 </testcase>
 </testsuite>
 </testsuites>

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -29,7 +29,7 @@ redocly lint --version
 | apis                   | [string] | Array of API or Arazzo description filenames that need to be linted. See [the API section](#specify-api) for more options.                                                                                  |
 | --config               | string   | Specify path to the [configuration file](#use-custom-configuration-file).                                                                                                                                   |
 | --extends              | [string] | [Extend a specific configuration](#extend-configuration) (defaults or config file settings). Build-in rulesets are: `spec`, `minimal`, `recommended`, `recommended-strict`. Default value is `recommended`. |
-| --format               | string   | Format for the output.<br />**Possible values:** `codeframe`, `stylish`, `json`, `checkstyle`, `codeclimate`, `github-actions`, `markdown`, `summary`. Default value is `codeframe`.                        |
+| --format               | string   | Format for the output.<br />**Possible values:** `codeframe`, `stylish`, `json`, `checkstyle`, `codeclimate`, `github-actions`, `markdown`, `summary`, `junit`. Default value is `codeframe`.               |
 | --generate-ignore-file | boolean  | [Generate ignore file](#generate-ignore-file).                                                                                                                                                              |
 | --help                 | boolean  | Show help.                                                                                                                                                                                                  |
 | --lint-config          | string   | Specify the severity level for the configuration file. <br/> **Possible values:** `warn`, `error`, `off`. Default value is `warn`.                                                                          |
@@ -130,7 +130,7 @@ However, if you have a configuration file, but it doesn't include any rules or e
 ### Specify output format
 
 The standard `codeframe` output format works well in most situations, but `redocly` can also produce output to integrate with other tools.
-When multiple APIs are linted in a single command, the `checkstyle` format produces a single combined XML document with one `<file>` element per API.
+When multiple APIs are linted in a single command, the `checkstyle` and `junit` formats each produce a single combined XML document, with one `<file>` (checkstyle) or `<testsuite>` (junit) element per API.
 
 #### Codeframe (default)
 
@@ -272,6 +272,39 @@ Run this command to use the following standard format output with your other too
 
 Due to the limitations of this format, only file name, line, column, severity, and rule ID (in the `source` attribute) are included.
 All other information is omitted.
+
+#### JUnit
+
+```bash
+redocly lint --format=junit
+```
+
+The `lint` command supports the JUnit XML report format, which is consumed by many CI systems (for example, CircleCI's `store_test_results` step).
+Each linted API becomes a `<testsuite>`, and each problem becomes a `<testcase>`.
+Errors are reported as `<error>` elements and warnings as `<failure>` elements, so CI tools that render the two differently keep errors and warnings visually distinct.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="redocly lint" tests="3" errors="2" failures="1" skipped="0">
+<testsuite name="museum-with-errors.yaml" tests="3" errors="2" failures="1">
+<testcase classname="struct" name="struct - 19:7" file="museum-with-errors.yaml" line="19">
+<error message="Property `operationIds` is not expected here." type="struct">at #/paths/~1museum-hours/get</error>
+</testcase>
+<testcase classname="operation-operationId" name="operation-operationId - 16:5" file="museum-with-errors.yaml" line="16">
+<failure message="Operation object should contain `operationId` field." type="operation-operationId">at #/paths/~1museum-hours/get</failure>
+</testcase>
+</testsuite>
+</testsuites>
+```
+
+A valid (empty) report is produced even when no problems are found, so passing runs still populate the CI test results.
+In CircleCI, write the output to a file and upload it:
+
+```yaml
+- run: redocly lint openapi.yaml --format=junit > /tmp/test-results/redocly.xml
+- store_test_results:
+    path: /tmp/test-results
+```
 
 #### GitHub Actions
 

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -279,7 +279,7 @@ All other information is omitted.
 redocly lint --format=junit
 ```
 
-The `lint` command supports the JUnit XML report format, which is consumed by many CI systems (for example, CircleCI's `store_test_results` step).
+The `lint` command supports the JUnit XML report format, which is consumed by many CI systems.
 Each linted API becomes a `<testsuite>`, and each problem becomes a `<testcase>`.
 Errors are reported as `<error>` elements and warnings as `<failure>` elements, so CI tools that render the two differently keep errors and warnings visually distinct.
 
@@ -298,19 +298,14 @@ Errors are reported as `<error>` elements and warnings as `<failure>` elements, 
 ```
 
 A valid (empty) report is produced even when no problems are found, so passing runs still populate the CI test results.
-In CircleCI, write the output to a file and upload it:
 
-```yaml
-- run: redocly lint openapi.yaml --format=junit > /tmp/test-results/redocly.xml
-- store_test_results:
-    path: /tmp/test-results
-```
+````
 
 #### GitHub Actions
 
 ```bash
 redocly lint --format=github-actions
-```
+````
 
 The `lint` command also comes with support for a [GitHub Actions](https://docs.github.com/en/actions) specific formatting.
 Specify this output format to have any encountered problem annotated on the affected files.

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -283,13 +283,13 @@ The `lint` command supports the JUnit XML report format, which is consumed by ma
 Each linted API becomes a `<testsuite>`, and each problem becomes a `<testcase>`.
 Errors are reported as `<error>` elements and warnings as `<failure>` elements, so CI tools that render the two differently keep errors and warnings visually distinct.
 
-Each `<testcase>` body repeats the rule, severity, location, pointer, and message as a readable detail block, matching the [`scorecard-classic`](./scorecard-classic.md) JUnit output.
+Each `<testcase>` body repeats the rule, severity, location, pointer, and message as a readable detail block.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="redocly lint" tests="2" errors="1" failures="1" skipped="0">
 <testsuite name="museum-with-errors.yaml" tests="2" errors="1" failures="1">
-<testcase classname="struct" name="struct - 19:7" file="museum-with-errors.yaml" line="19">
+<testcase classname="struct" name="struct" file="museum-with-errors.yaml" line="19">
 <error message="Property `operationIds` is not expected here." type="struct">Rule: struct
 Severity: error
 File: museum-with-errors.yaml
@@ -298,7 +298,7 @@ Column: 7
 Pointer: #/paths/~1museum-hours/get
 Message: Property `operationIds` is not expected here.</error>
 </testcase>
-<testcase classname="operation-operationId" name="operation-operationId - 16:5" file="museum-with-errors.yaml" line="16">
+<testcase classname="operation-operationId" name="operation-operationId" file="museum-with-errors.yaml" line="16">
 <failure message="Operation object should contain `operationId` field." type="operation-operationId">Rule: operation-operationId
 Severity: warn
 File: museum-with-errors.yaml

--- a/docs/@v2/commands/lint.md
+++ b/docs/@v2/commands/lint.md
@@ -313,13 +313,11 @@ Message: Operation object should contain `operationId` field.</failure>
 
 A valid (empty) report is produced even when no problems are found, so passing runs still populate the CI test results.
 
-````
-
 #### GitHub Actions
 
 ```bash
 redocly lint --format=github-actions
-````
+```
 
 The `lint` command also comes with support for a [GitHub Actions](https://docs.github.com/en/actions) specific formatting.
 Specify this output format to have any encountered problem annotated on the affected files.

--- a/packages/cli/src/__tests__/commands/lint.test.ts
+++ b/packages/cli/src/__tests__/commands/lint.test.ts
@@ -1,5 +1,6 @@
 import {
   lint,
+  lintConfig,
   getTotals,
   formatProblems,
   logger,
@@ -13,7 +14,7 @@ import { performance } from 'perf_hooks';
 import { type MockInstance } from 'vitest';
 import { type Arguments } from 'yargs';
 
-import { handleLint, type LintArgv } from '../../commands/lint.js';
+import { handleLint, handleLintConfig, type LintArgv } from '../../commands/lint.js';
 import { exitWithError } from '../../utils/error.js';
 import {
   getFallbackApisOrExit,
@@ -52,6 +53,7 @@ describe('handleLint', () => {
       return {
         ...actual,
         lint: vi.fn(async (): Promise<NormalizedProblem[]> => []),
+        lintConfig: vi.fn(async (): Promise<NormalizedProblem[]> => []),
         getTotals: vi.fn(() => ({ errors: 0, warnings: 0, ignored: 0 }) as Totals),
         doesYamlFileExist: vi.fn((path) => path === 'redocly.yaml'),
         logger: {
@@ -234,6 +236,22 @@ describe('handleLint', () => {
       );
     });
 
+    it('should aggregate problems from multiple APIs into a single formatProblems call for junit', async () => {
+      vi.mocked(lint)
+        .mockResolvedValueOnce(['problem-a'] as any)
+        .mockResolvedValueOnce(['problem-b'] as any);
+      await commandWrapper(handleLint)({
+        ...argvMock,
+        apis: ['a.yaml', 'b.yaml'],
+        format: 'junit',
+      });
+      expect(formatProblems).toHaveBeenCalledTimes(1);
+      expect(formatProblems).toHaveBeenCalledWith(
+        ['problem-a', 'problem-b'],
+        expect.objectContaining({ format: 'junit' })
+      );
+    });
+
     it('should catch error in handleError if something fails', async () => {
       vi.mocked(lint).mockRejectedValueOnce('error');
       await commandWrapper(handleLint)(argvMock);
@@ -286,5 +304,38 @@ describe('handleLint', () => {
         )} configuration by default.\n\n`
       );
     });
+  });
+});
+
+describe('handleLintConfig', () => {
+  const configWithDocument = { ...configFixture, document: { parsed: {} } } as any;
+
+  it.each(['json', 'junit', 'checkstyle'] as const)(
+    'should not print config lint results for the single-document %s format',
+    async (format) => {
+      vi.mocked(lintConfig).mockResolvedValue(['config-problem'] as any);
+      vi.mocked(formatProblems).mockClear();
+
+      await handleLintConfig(
+        { ...argvMock, 'lint-config': 'warn', format } as any,
+        '2.0.0',
+        configWithDocument
+      );
+
+      expect(formatProblems).not.toHaveBeenCalled();
+    }
+  );
+
+  it('should print config lint results for text formats', async () => {
+    vi.mocked(lintConfig).mockResolvedValue([] as any);
+    vi.mocked(formatProblems).mockClear();
+
+    await handleLintConfig(
+      { ...argvMock, 'lint-config': 'warn', format: 'stylish' } as any,
+      '2.0.0',
+      configWithDocument
+    );
+
+    expect(formatProblems).toHaveBeenCalledWith([], expect.objectContaining({ format: 'stylish' }));
   });
 });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -49,8 +49,8 @@ export async function handleLint({
 
   const totals: Totals = { errors: 0, warnings: 0, ignored: 0 };
   let totalIgnored = 0;
-  const isCheckstyle = argv.format === 'checkstyle';
-  const checkstyleResults: Awaited<ReturnType<typeof lint>> = [];
+  const isAggregatedXmlFormat = argv.format === 'checkstyle' || argv.format === 'junit';
+  const aggregatedResults: Awaited<ReturnType<typeof lint>> = [];
 
   // TODO: use shared externalRef resolver, blocked by preprocessors now as they can mutate documents
   for (const { path, alias } of apis) {
@@ -95,8 +95,8 @@ export async function handleLint({
           config.addIgnore(m);
           totalIgnored++;
         }
-      } else if (isCheckstyle) {
-        checkstyleResults.push(...results);
+      } else if (isAggregatedXmlFormat) {
+        aggregatedResults.push(...results);
       } else {
         formatProblems(results, {
           format: argv.format,
@@ -114,8 +114,8 @@ export async function handleLint({
     }
   }
 
-  if (isCheckstyle && !argv['generate-ignore-file']) {
-    formatProblems(checkstyleResults, {
+  if (isAggregatedXmlFormat && !argv['generate-ignore-file']) {
+    formatProblems(aggregatedResults, {
       format: argv.format,
       maxProblems: argv['max-problems'],
       totals,
@@ -143,8 +143,8 @@ export async function handleLintConfig(argv: Exact<CommandArgv>, version: string
     return;
   }
 
-  if (argv.format === 'json') {
-    // we can't print config lint results as it will break json output
+  if (argv.format === 'json' || argv.format === 'junit' || argv.format === 'checkstyle') {
+    // these are single-document formats, so a separate config-lint document would break the output
     return;
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -374,6 +374,7 @@ yargs(hideBin(process.argv))
               'summary',
               'markdown',
               'github-actions',
+              'junit',
             ] as ReadonlyArray<OutputFormat>,
             default: 'codeframe' as OutputFormat,
           },

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -370,6 +370,70 @@ describe('format', () => {
     `);
   });
 
+  it('should group problems from different files into separate testsuites in junit format', () => {
+    const problems: NormalizedProblem[] = [
+      {
+        ruleId: 'struct',
+        message: 'error in first file',
+        severity: 'error',
+        location: [
+          {
+            source: { absoluteRef: 'first.yaml' } as Source,
+            start: { line: 1, col: 2 },
+            end: { line: 3, col: 4 },
+          } as LocationObject,
+        ],
+        suggest: [],
+      },
+      {
+        ruleId: 'struct',
+        message: 'error in second file',
+        severity: 'error',
+        location: [
+          {
+            source: { absoluteRef: 'second.yaml' } as Source,
+            start: { line: 7, col: 5 },
+            end: { line: 7, col: 9 },
+          } as LocationObject,
+        ],
+        suggest: [],
+      },
+    ];
+
+    formatProblems(problems, {
+      format: 'junit',
+      version: '1.0.0',
+      totals: getTotals(problems),
+    });
+
+    expect(output).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="redocly lint" tests="2" errors="2" failures="0" skipped="0">
+      <testsuite name="first.yaml" tests="1" errors="1" failures="0">
+      <testcase classname="struct" name="struct" file="first.yaml" line="1">
+      <error message="error in first file" type="struct">Rule: struct
+      Severity: error
+      File: first.yaml
+      Line: 1
+      Column: 2
+      Message: error in first file</error>
+      </testcase>
+      </testsuite>
+      <testsuite name="second.yaml" tests="1" errors="1" failures="0">
+      <testcase classname="struct" name="struct" file="second.yaml" line="7">
+      <error message="error in second file" type="struct">Rule: struct
+      Severity: error
+      File: second.yaml
+      Line: 7
+      Column: 5
+      Message: error in second file</error>
+      </testcase>
+      </testsuite>
+      </testsuites>
+      "
+    `);
+  });
+
   it('should emit a valid empty report in junit format when there are no problems', () => {
     formatProblems([], {
       format: 'junit',

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -348,7 +348,7 @@ describe('format', () => {
       "<?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="redocly lint" tests="2" errors="1" failures="1" skipped="0">
       <testsuite name="openapi.yaml" tests="2" errors="1" failures="1">
-      <testcase classname="struct" name="struct - 1:2" file="openapi.yaml" line="1">
+      <testcase classname="struct" name="struct" file="openapi.yaml" line="1">
       <error message="message" type="struct">Rule: struct
       Severity: error
       File: openapi.yaml
@@ -356,7 +356,7 @@ describe('format', () => {
       Column: 2
       Message: message</error>
       </testcase>
-      <testcase classname="other-rule" name="other-rule - 5:1" file="openapi.yaml" line="5">
+      <testcase classname="other-rule" name="other-rule" file="openapi.yaml" line="5">
       <failure message="a warning" type="other-rule">Rule: other-rule
       Severity: warn
       File: openapi.yaml

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -307,4 +307,71 @@ describe('format', () => {
       "
     `);
   });
+
+  it('should map errors to <error> and warnings to <failure> in junit format', () => {
+    const problems: NormalizedProblem[] = [
+      {
+        ruleId: 'struct',
+        message: 'message',
+        severity: 'error',
+        location: [
+          {
+            source: { absoluteRef: 'openapi.yaml' } as Source,
+            start: { line: 1, col: 2 },
+            end: { line: 3, col: 4 },
+          } as LocationObject,
+        ],
+        suggest: [],
+      },
+      {
+        ruleId: 'other-rule',
+        message: 'a warning',
+        severity: 'warn',
+        location: [
+          {
+            source: { absoluteRef: 'openapi.yaml' } as Source,
+            start: { line: 5, col: 1 },
+            end: { line: 5, col: 9 },
+          } as LocationObject,
+        ],
+        suggest: [],
+      },
+    ];
+
+    formatProblems(problems, {
+      format: 'junit',
+      version: '1.0.0',
+      totals: getTotals(problems),
+    });
+
+    expect(output).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="redocly lint" tests="2" errors="1" failures="1" skipped="0">
+      <testsuite name="openapi.yaml" tests="2" errors="1" failures="1">
+      <testcase classname="struct" name="struct - 1:2" file="openapi.yaml" line="1">
+      <error message="message" type="struct"></error>
+      </testcase>
+      <testcase classname="other-rule" name="other-rule - 5:1" file="openapi.yaml" line="5">
+      <failure message="a warning" type="other-rule"></failure>
+      </testcase>
+      </testsuite>
+      </testsuites>
+      "
+    `);
+  });
+
+  it('should emit a valid empty report in junit format when there are no problems', () => {
+    formatProblems([], {
+      format: 'junit',
+      version: '1.0.0',
+      totals: getTotals([]),
+    });
+
+    expect(output).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="redocly lint" tests="0" errors="0" failures="0" skipped="0">
+      </testsuites>
+      "
+    `);
+  });
 });

--- a/packages/core/src/__tests__/format.test.ts
+++ b/packages/core/src/__tests__/format.test.ts
@@ -349,10 +349,20 @@ describe('format', () => {
       <testsuites name="redocly lint" tests="2" errors="1" failures="1" skipped="0">
       <testsuite name="openapi.yaml" tests="2" errors="1" failures="1">
       <testcase classname="struct" name="struct - 1:2" file="openapi.yaml" line="1">
-      <error message="message" type="struct"></error>
+      <error message="message" type="struct">Rule: struct
+      Severity: error
+      File: openapi.yaml
+      Line: 1
+      Column: 2
+      Message: message</error>
       </testcase>
       <testcase classname="other-rule" name="other-rule - 5:1" file="openapi.yaml" line="5">
-      <failure message="a warning" type="other-rule"></failure>
+      <failure message="a warning" type="other-rule">Rule: other-rule
+      Severity: warn
+      File: openapi.yaml
+      Line: 5
+      Column: 1
+      Message: a warning</failure>
       </testcase>
       </testsuite>
       </testsuites>

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -188,8 +188,8 @@ export function formatProblems(
       break;
     }
     case 'junit': {
-      const emittedErrors = problems.filter((p) => p.severity === 'error').length;
-      const emittedFailures = problems.filter((p) => p.severity === 'warn').length;
+      const totalErrors = problems.filter((p) => p.severity === 'error').length;
+      const totalWarnings = problems.filter((p) => p.severity === 'warn').length;
 
       const groupedByFile: Record<string, NormalizedProblem[]> = {};
       for (const problem of problems) {
@@ -202,17 +202,17 @@ export function formatProblems(
 
       logger.output('<?xml version="1.0" encoding="UTF-8"?>\n');
       logger.output(
-        `<testsuites name="redocly lint" tests="${problems.length}" errors="${emittedErrors}" failures="${emittedFailures}" skipped="0">\n`
+        `<testsuites name="redocly lint" tests="${problems.length}" errors="${totalErrors}" failures="${totalWarnings}" skipped="0">\n`
       );
 
       for (const [file, fileProblems] of Object.entries(groupedByFile)) {
         const relativePath = isAbsoluteUrl(file) ? file : path.relative(cwd, file);
         const fileErrors = fileProblems.filter((p) => p.severity === 'error').length;
-        const fileFailures = fileProblems.filter((p) => p.severity === 'warn').length;
+        const fileWarnings = fileProblems.filter((p) => p.severity === 'warn').length;
         logger.output(
           `<testsuite name="${xmlEscape(relativePath)}" tests="${
             fileProblems.length
-          }" errors="${fileErrors}" failures="${fileFailures}">\n`
+          }" errors="${fileErrors}" failures="${fileWarnings}">\n`
         );
         fileProblems.forEach((problem) => formatJunit(problem, relativePath));
         logger.output(`</testsuite>\n`);

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -368,13 +368,27 @@ export function formatProblems(
     const element = problem.severity === 'error' ? 'error' : 'failure';
     const ruleId = xmlEscape(problem.ruleId);
     const message = xmlEscape(problem.message);
-    const body = location.pointer ? `at ${xmlEscape(location.pointer)}` : '';
+
+    const details = [
+      `Rule: ${ruleId}`,
+      `Severity: ${xmlEscape(problem.severity)}`,
+      `File: ${xmlEscape(relativePath)}`,
+      `Line: ${start.line}`,
+      `Column: ${start.col}`,
+    ];
+    if (location.pointer) {
+      details.push(`Pointer: ${xmlEscape(location.pointer)}`);
+    }
+    details.push(`Message: ${message}`);
+
     logger.output(
       `<testcase classname="${ruleId}" name="${xmlEscape(
         `${problem.ruleId} - ${start.line}:${start.col}`
       )}" file="${xmlEscape(relativePath)}" line="${start.line}">\n`
     );
-    logger.output(`<${element} message="${message}" type="${ruleId}">${body}</${element}>\n`);
+    logger.output(
+      `<${element} message="${message}" type="${ruleId}">${details.join('\n')}</${element}>\n`
+    );
     logger.output(`</testcase>\n`);
   }
 }

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -55,7 +55,8 @@ export type OutputFormat =
   | 'codeclimate'
   | 'summary'
   | 'github-actions'
-  | 'markdown';
+  | 'markdown'
+  | 'junit';
 
 export function getTotals(problems: (NormalizedProblem & { ignored?: boolean })[]): Totals {
   let errors = 0;
@@ -110,7 +111,7 @@ export function formatProblems(
     .sort((a, b) => severityToNumber(a.severity) - severityToNumber(b.severity))
     .slice(0, maxProblems);
 
-  if (!totalProblems && format !== 'json') return;
+  if (!totalProblems && format !== 'json' && format !== 'junit') return;
 
   switch (format) {
     case 'json':
@@ -184,6 +185,37 @@ export function formatProblems(
       }
 
       logger.output(`</checkstyle>\n`);
+      break;
+    }
+    case 'junit': {
+      const emittedErrors = problems.filter((p) => p.severity === 'error').length;
+      const emittedFailures = problems.length - emittedErrors;
+
+      const groupedByFile: Record<string, NormalizedProblem[]> = {};
+      for (const problem of problems) {
+        const absoluteRef = problem.location[0].source.absoluteRef;
+        (groupedByFile[absoluteRef] ||= []).push(problem);
+      }
+
+      logger.output('<?xml version="1.0" encoding="UTF-8"?>\n');
+      logger.output(
+        `<testsuites name="redocly lint" tests="${problems.length}" errors="${emittedErrors}" failures="${emittedFailures}" skipped="0">\n`
+      );
+
+      for (const [file, fileProblems] of Object.entries(groupedByFile)) {
+        const relativePath = isAbsoluteUrl(file) ? file : path.relative(cwd, file);
+        const fileErrors = fileProblems.filter((p) => p.severity === 'error').length;
+        const fileFailures = fileProblems.length - fileErrors;
+        logger.output(
+          `<testsuite name="${xmlEscape(relativePath)}" tests="${
+            fileProblems.length
+          }" errors="${fileErrors}" failures="${fileFailures}">\n`
+        );
+        fileProblems.forEach((problem) => formatJunit(problem, relativePath));
+        logger.output(`</testsuite>\n`);
+      }
+
+      logger.output(`</testsuites>\n`);
       break;
     }
     case 'codeclimate':
@@ -328,6 +360,22 @@ export function formatProblems(
     logger.output(
       `<error line="${line}" column="${col}" severity="${severity}" message="${message}" source="${source}" />\n`
     );
+  }
+
+  function formatJunit(problem: NormalizedProblem, relativePath: string) {
+    const location = problem.location[0];
+    const { start } = getLineColLocation(location);
+    const element = problem.severity === 'error' ? 'error' : 'failure';
+    const ruleId = xmlEscape(problem.ruleId);
+    const message = xmlEscape(problem.message);
+    const body = location.pointer ? `at ${xmlEscape(location.pointer)}` : '';
+    logger.output(
+      `<testcase classname="${ruleId}" name="${xmlEscape(
+        `${problem.ruleId} - ${start.line}:${start.col}`
+      )}" file="${xmlEscape(relativePath)}" line="${start.line}">\n`
+    );
+    logger.output(`<${element} message="${message}" type="${ruleId}">${body}</${element}>\n`);
+    logger.output(`</testcase>\n`);
   }
 }
 

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -189,12 +189,15 @@ export function formatProblems(
     }
     case 'junit': {
       const emittedErrors = problems.filter((p) => p.severity === 'error').length;
-      const emittedFailures = problems.length - emittedErrors;
+      const emittedFailures = problems.filter((p) => p.severity === 'warn').length;
 
       const groupedByFile: Record<string, NormalizedProblem[]> = {};
       for (const problem of problems) {
         const absoluteRef = problem.location[0].source.absoluteRef;
-        (groupedByFile[absoluteRef] ||= []).push(problem);
+        if (!groupedByFile[absoluteRef]) {
+          groupedByFile[absoluteRef] = [];
+        }
+        groupedByFile[absoluteRef].push(problem);
       }
 
       logger.output('<?xml version="1.0" encoding="UTF-8"?>\n');
@@ -205,7 +208,7 @@ export function formatProblems(
       for (const [file, fileProblems] of Object.entries(groupedByFile)) {
         const relativePath = isAbsoluteUrl(file) ? file : path.relative(cwd, file);
         const fileErrors = fileProblems.filter((p) => p.severity === 'error').length;
-        const fileFailures = fileProblems.length - fileErrors;
+        const fileFailures = fileProblems.filter((p) => p.severity === 'warn').length;
         logger.output(
           `<testsuite name="${xmlEscape(relativePath)}" tests="${
             fileProblems.length
@@ -382,9 +385,9 @@ export function formatProblems(
     details.push(`Message: ${message}`);
 
     logger.output(
-      `<testcase classname="${ruleId}" name="${xmlEscape(
-        `${problem.ruleId} - ${start.line}:${start.col}`
-      )}" file="${xmlEscape(relativePath)}" line="${start.line}">\n`
+      `<testcase classname="${ruleId}" name="${ruleId}" file="${xmlEscape(
+        relativePath
+      )}" line="${start.line}">\n`
     );
     logger.output(
       `<${element} message="${message}" type="${ruleId}">${details.join('\n')}</${element}>\n`

--- a/tests/e2e/lint-config/invalid-lint-config-severity/snapshot.txt
+++ b/tests/e2e/lint-config/invalid-lint-config-severity/snapshot.txt
@@ -11,7 +11,7 @@ Options:
   --help                  Show help.                                   [boolean]
   --format                Use a specific output format.
   [choices: "stylish", "codeframe", "json", "checkstyle", "codeclimate", "summar
-                        y", "markdown", "github-actions"] [default: "codeframe"]
+               y", "markdown", "github-actions", "junit"] [default: "codeframe"]
   --max-problems          Reduce output to a maximum of N problems.
                                                          [number] [default: 100]
   --generate-ignore-file  Generate an ignore file.                     [boolean]


### PR DESCRIPTION
## What/Why/How?
Added `junit` output format to the `lint` command.

## Reference
Resolves #1989

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive reporting and CLI wiring with tests; no changes to lint rules or API validation behavior.
> 
> **Overview**
> Adds **`junit`** as a `--format` option for `redocly lint`, aimed at CI systems that ingest JUnit XML.
> 
> **Core (`formatProblems`)** emits a single `<testsuites>` document: one `<testsuite>` per linted file, each problem as a `<testcase>` with errors as `<error>` and warnings as `<failure>`, plus a detail block (rule, severity, location, pointer, message). **Empty successful runs** still output valid XML (same idea as `json`).
> 
> **CLI** treats `junit` like `checkstyle`: problems from multiple APIs are **aggregated** into one `formatProblems` call. **Config lint** output is **skipped** for `junit` (with `json` and `checkstyle`) so a second report does not break the single XML document.
> 
> Docs, changeset, CLI yargs choices, unit tests, and an e2e help snapshot are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de99eb56027f7861c5404fb6bdb8f5cce28dc848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->