### PR TITLE
fix(core): enforce external ref path casing

### DIFF
--- a/.changeset/case-sensitive-refs.md
+++ b/.changeset/case-sensitive-refs.md
@@ -1,0 +1,6 @@
+---
+'@redocly/cli': patch
+'@redocly/openapi-core': patch
+---
+
+Reject local external refs when the referenced file path casing does not match the filesystem entry.

--- a/packages/core/src/__tests__/resolve.test.ts
+++ b/packages/core/src/__tests__/resolve.test.ts
@@ -411,6 +411,34 @@ describe('collect refs', () => {
     expect(Array.from(resolvedRefs.values()).pop()!.node).toEqual({ type: 'string' });
   });
 
+  it('should reject external refs with mismatched file path casing', async () => {
+    const { root } = path.parse(process.cwd());
+    const wrongCasePath = path.join(root, 'tmp', 'externalInfo.yaml');
+    const tmpPath = path.join(root, 'tmp');
+
+    const readdirMock = vi.spyOn(fs, 'readdirSync').mockImplementation((dirPath) => {
+      if (dirPath === root) return ['tmp'] as any;
+      if (dirPath === tmpPath) return ['externalinfo.yaml'] as any;
+      return [] as any;
+    });
+    const lstatMock = vi
+      .spyOn(fs, 'lstatSync')
+      .mockImplementation(() => ({ isDirectory: () => false }) as any);
+    const readFileMock = vi
+      .spyOn(fs.promises, 'readFile')
+      .mockResolvedValue('openapi: 3.0.0' as any);
+
+    try {
+      await expect(new BaseResolver().loadExternalRef(wrongCasePath)).rejects.toThrow(
+        `ENOENT: no such file or directory '${wrongCasePath}'`
+      );
+    } finally {
+      readdirMock.mockRestore();
+      lstatMock.mockRestore();
+      readFileMock.mockRestore();
+    }
+  });
+
   it('should throw error if ref is folder', async () => {
     const cwd = path.join(__dirname, 'fixtures/resolve');
     const rootDocument = parseYamlToDocument(

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -116,6 +116,7 @@ export class BaseResolver {
         const { body, mimeType } = await readFileFromUrl(absoluteRef, this.config.http);
         return new Source(absoluteRef, body, mimeType);
       } else {
+        assertPathCasing(absoluteRef);
         if (fs.lstatSync(absoluteRef).isDirectory()) {
           throw new Error(`Expected a file but received a folder at ${absoluteRef}.`);
         }
@@ -168,6 +169,20 @@ export class BaseResolver {
     this.cache.set(absoluteRef, doc);
 
     return doc;
+  }
+}
+
+function assertPathCasing(filePath: string): void {
+  const resolvedPath = path.resolve(filePath);
+  const { root } = path.parse(resolvedPath);
+  const parts = path.relative(root, resolvedPath).split(path.sep).filter(Boolean);
+  let currentPath = root;
+
+  for (const part of parts) {
+    if (!fs.readdirSync(currentPath).includes(part)) {
+      throw new Error(`ENOENT: no such file or directory '${filePath}'`);
+    }
+    currentPath = path.join(currentPath, part);
   }
 }
 


### PR DESCRIPTION
## What/Why/How?

### Summary

Fixes #1326 by making local external ref resolution reject file paths whose casing does not match the filesystem entry.

### Reproduction

On case-insensitive filesystems, a ref such as `./externalInfo.yaml` can resolve successfully even when the real file is named `externalinfo.yaml`. That means rules such as `no-unresolved-refs` may accept refs that fail on case-sensitive environments.

The added regression test simulates this by making the filesystem report `externalinfo.yaml` while the resolver tries to load `externalInfo.yaml`.

### Root cause

`BaseResolver.loadExternalRef` resolved local paths with `path.resolve`, then called `lstatSync` and `readFile`. On a case-insensitive filesystem those calls still succeed for a mismatched filename, so the resolver never observed the casing mismatch.

### Changes

- Add a local path casing check before reading non-URL external refs.
- Keep URL refs unchanged.
- Add a regression test for mismatched file path casing.
- Add a patch changeset for `@redocly/openapi-core` and `@redocly/cli`.

## Reference

Fixes #1326

## Testing

- `git diff --check`
- `VITEST_SUITE=unit ./node_modules/.bin/vitest run packages/core/src/__tests__/resolve.test.ts --coverage.enabled=false`
- `npm run compile`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run format:check`

## Screenshots (optional)

N/A

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines
