### PR TITLE
feat(cli): mention shell completion after install

### DIFF
--- a/.changeset/calm-apples-complete.md
+++ b/.changeset/calm-apples-complete.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Display a post-install tip for the `redocly completion` command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,6 +8780,7 @@
       "name": "@redocly/cli",
       "version": "2.32.0",
       "license": "MIT",
+      "hasInstallScript": true,
       "dependencies": {
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
         "@opentelemetry/resources": "2.6.1",

--- a/packages/cli/bin/postinstall.js
+++ b/packages/cli/bin/postinstall.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const shouldSkip =
+  process.env.CI ||
+  process.env.REDOCLY_CLI_SKIP_POSTINSTALL ||
+  ['silent', 'error'].includes(process.env.npm_config_loglevel || '');
+
+if (!shouldSkip) {
+  console.error(
+    'Redocly CLI tip: enable shell autocompletion with `redocly completion`.\n' +
+      'Learn more: https://redocly.com/docs/cli/commands/completion/'
+  );
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "compile": "tsc",
     "copy-assets": "cp src/commands/build-docs/template.hbs lib/commands/build-docs/template.hbs ",
+    "postinstall": "node ./bin/postinstall.js",
     "prepack": "npm run copy-assets",
     "prepublishOnly": "npm run copy-assets && cp ../../README.md ."
   },


### PR DESCRIPTION
## Summary
- Adds a small post-install tip for the existing `redocly completion` command.
- Keeps the hint out of CI, silent installs, and environments that set `REDOCLY_CLI_SKIP_POSTINSTALL`.
- Closes #1160.

## Reproduction
The `redocly completion` command is documented, but installing `@redocly/cli` does not currently surface it to users after installation.

## Root cause
`packages/cli/package.json` has no install lifecycle hook or other package-level message that points users to shell completion.

## Changes
- Added `packages/cli/bin/postinstall.js` to print a concise completion tip.
- Added a `postinstall` script to `packages/cli/package.json`.
- Updated `package-lock.json` install-script metadata.
- Added a patch changeset for `@redocly/cli`.

## Tests
- `node packages/cli/bin/postinstall.js`
- `CI=true node packages/cli/bin/postinstall.js`
- `npm_config_loglevel=silent node packages/cli/bin/postinstall.js`
- `node --check packages/cli/bin/postinstall.js`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --workspace @redocly/cli`

## Screenshots/Logs
Normal local postinstall output:

```text
Redocly CLI tip: enable shell autocompletion with `redocly completion`.
Learn more: https://redocly.com/docs/cli/commands/completion/
```

AI assistance disclosure: I used OpenAI Codex to help inspect the issue, make the small patch, and run the verification commands.