### PR TITLE
chore: mask server values in respect command

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -752,6 +752,43 @@ describe('cleanArgs', () => {
     );
   });
 
+  it('should remove server values from parsed args and raw CLI input', () => {
+    const serverValue =
+      'cafe-api=https://example.com/api-endpoint,another-api=https://example.com/another-api';
+    const rawInput = [
+      'redocly',
+      'respect',
+      './fixtures/openapi.yaml',
+      '--server',
+      serverValue,
+      '-S',
+      serverValue,
+    ];
+    const parsedArgs = {
+      files: ['./fixtures/openapi.yaml'],
+      server: serverValue,
+      S: serverValue,
+      'max-steps': 100,
+      'max-fetch-timeout': 100,
+      'execution-timeout': 100,
+      'no-secrets-masking': false,
+    };
+    const result = cleanArgs(parsedArgs, rawInput);
+
+    expect(result.raw_input).toEqual('redocly respect file-yaml --server *** -S ***');
+    expect(result.arguments).toEqual(
+      JSON.stringify({
+        files: ['file-yaml'],
+        server: '***',
+        S: '***',
+        'max-steps': 100,
+        'max-fetch-timeout': 100,
+        'execution-timeout': 100,
+        'no-secrets-masking': false,
+      })
+    );
+  });
+
   it('should preserve safe data from raw CLI input', () => {
     const rawInput = [
       'redocly',

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -313,7 +313,17 @@ function collectSensitiveValues(
 }
 
 export function cleanArgs(parsedArgs: CommandArgv, rawArgv: string[]) {
-  const KEYS_TO_CLEAN = ['organization', 'o', 'input', 'i', 'clientCert', 'clientKey', 'caCert'];
+  const KEYS_TO_CLEAN = [
+    'organization',
+    'o',
+    'input',
+    'i',
+    'clientCert',
+    'clientKey',
+    'caCert',
+    'server',
+    'S',
+  ];
   let commandInput = rawArgv.join(' ');
   const commandArguments: Record<string, string | string[] | object> = {};
 


### PR DESCRIPTION
## What/Why/How?

Masked server values in respect command.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only redaction with test coverage; no runtime behavior change for respect execution.
> 
> **Overview**
> Extends CLI telemetry sanitization so **`respect`** `--server` / `-S` values (including alias→URL maps) are redacted as `***` in both serialized arguments and reconstructed `raw_input`, matching existing masking for certs, org, and input secrets.
> 
> Adds a **`cleanArgs`** unit test covering `redocly respect` with long and short server flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95609cf8d3ca4b6fbea88d9794f25392c439fde1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->