### PR TITLE
chore: add v2.32.1 to performance benchmark

### DIFF
--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -20,6 +20,7 @@
     "cli-2.27.0": "npm:@redocly/cli@2.27.0",
     "cli-2.30.2": "npm:@redocly/cli@2.30.2",
     "cli-2.31.0": "npm:@redocly/cli@2.31.0",
+    "cli-2.31.2": "npm:@redocly/cli@2.32.1",
     "cli-latest": "npm:@redocly/cli@latest",
     "cli-next": "file:../../redocly-cli.tgz"
   },

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -20,7 +20,7 @@
     "cli-2.27.0": "npm:@redocly/cli@2.27.0",
     "cli-2.30.2": "npm:@redocly/cli@2.30.2",
     "cli-2.31.0": "npm:@redocly/cli@2.31.0",
-    "cli-2.31.2": "npm:@redocly/cli@2.32.1",
+    "cli-2.32.1": "npm:@redocly/cli@2.32.1",
     "cli-latest": "npm:@redocly/cli@latest",
     "cli-next": "file:../../redocly-cli.tgz"
   },


### PR DESCRIPTION
## What/Why/How?
Added `v2.32.1` to performance benchmark as this release contains changes to instantiating of AJV.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/benchmark configuration only; no production CLI or runtime behavior changes.
> 
> **Overview**
> Registers **Redocly CLI `2.32.1`** in `tests/performance/package.json` under `_enhancedDependencies`, extending the historical version matrix used for opt-in performance benchmarks (not the default `cli-latest` vs `cli-next` PR runs).
> 
> This follows the usual post-release step so release workflows can compare bundle/lint/check-config timing against prior versions, including around the **AJV instantiation** changes shipped in 2.32.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc42b36f8e974f412b0664d3f772a7ee57f06107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->