### PR TITLE
chore: test comment by perf benchmark

### DIFF
--- a/.github/workflows/performance-comment.yaml
+++ b/.github/workflows/performance-comment.yaml
@@ -1,0 +1,38 @@
+name: Performance Benchmark Comment
+
+# Posts the benchmark result on the PR. Runs via workflow_run so it has a write token even for
+# fork PRs, without granting one to the untrusted benchmark job.
+
+on:
+  workflow_run:
+    workflows: ['Performance Benchmark']
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark result
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: performance-benchmark
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          file-path: benchmark_chart.md
+          pr-number: ${{ steps.pr.outputs.number }}
+          comment-tag: historical-versions-comparison

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -2,7 +2,6 @@ name: Performance Benchmark
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request:
@@ -55,9 +54,15 @@ jobs:
           cat benchmark_bundle.md benchmark_lint.md benchmark_check-config.md
           npm run chart # Creates benchmark_chart.md with the performance bar chart.
 
-      - name: Comment PR
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      # This job runs untrusted PR code, so it has no write token to comment. It uploads the
+      # result and performance-comment.yaml posts it (which also works for fork PRs).
+      - name: Save PR number
+        run: echo "${{ github.event.number }}" > tests/performance/pr-number.txt
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          file-path: tests/performance/benchmark_chart.md
-          comment-tag: historical-versions-comparison
+          name: performance-benchmark
+          path: |
+            tests/performance/benchmark_chart.md
+            tests/performance/pr-number.txt

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -179,6 +179,8 @@ export function walkDocument<T extends BaseVisitor>(opts: {
     const { node: resolvedNode, location: resolvedLocation, error } = resolve(node);
     const enteredContexts: Set<VisitorLevelContext> = new Set();
 
+    setTimeout(() => {}, 10000); // Testing performance of walk function with large documents, can be removed later
+
     if (nodeIsRef) {
       const refEnterVisitors = normalizedVisitors.ref.enter;
       for (const { visit: visitor, ruleId, severity, message, context } of refEnterVisitors) {

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -179,8 +179,6 @@ export function walkDocument<T extends BaseVisitor>(opts: {
     const { node: resolvedNode, location: resolvedLocation, error } = resolve(node);
     const enteredContexts: Set<VisitorLevelContext> = new Set();
 
-    setTimeout(() => {}, 10000); // Testing performance of walk function with large documents, can be removed later
-
     if (nodeIsRef) {
       const refEnterVisitors = normalizedVisitors.ref.enter;
       for (const { visit: visitor, ruleId, severity, message, context } of refEnterVisitors) {

--- a/tests/performance/chart.js
+++ b/tests/performance/chart.js
@@ -62,12 +62,33 @@ const renderRow = (version) =>
     })
     .join(' | ')} |`;
 
+const regressions = columns.flatMap(({ name, data }) => {
+  const next = data.get('cli-next');
+  const latest = data.get('cli-latest');
+  if (!next || !latest) return [];
+
+  const slowdown = next.median / latest.median - 1;
+  const noise = Math.sqrt((next.mad / next.median) ** 2 + (latest.mad / latest.median) ** 2);
+  if (slowdown <= 0.05 || slowdown <= noise) return [];
+
+  return [`> - **${name}**: ${(slowdown * 100).toFixed(1)}% slower`];
+});
+
 const output = [
   '## Performance Benchmark (Lower is Faster)',
   '',
   `| CLI Version | ${columns.map((c) => c.name).join(' | ')} |`,
   `|---|${columns.map(() => '---').join('|')}|`,
   ...versions.map(renderRow),
-].join('\n');
+];
 
-process.stdout.write(output);
+if (regressions.length) {
+  output.push(
+    '',
+    '> [!WARNING]',
+    '> This PR may introduce a performance regression vs the latest released version:',
+    ...regressions
+  );
+}
+
+process.stdout.write(output.join('\n'));


### PR DESCRIPTION
## What/Why/How?
Testing comment by performance benchmark.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes with tighter permissions on the benchmark job; no runtime product or auth/data paths affected.
> 
> **Overview**
> **Benchmark PR comments** no longer run inside the pull-request workflow that executes untrusted code. That job drops `pull-requests: write`, writes the PR number and `benchmark_chart.md` as a `performance-benchmark` artifact, and a new **Performance Benchmark Comment** workflow (`workflow_run` after a successful benchmark) downloads the artifact and posts the chart—including on fork PRs.
> 
> **Benchmark markdown** now compares `cli-next` to `cli-latest` per operation (Bundle, Lint, Check Config). When slowdown exceeds ~5% and is larger than combined MAD noise, the chart appends a GitHub `WARNING` callout listing affected operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc78c6966c8aca0cacb4caf1ecd4842d5f8b55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->