### PR TITLE
chore: refactor specVersion binding for config and entities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,6 +242,7 @@ Unit tests in the **cli** package are sensitive to top-level configuration file 
 To run tests from a single file, run: `npm run unit -- <path/to/your/file.test.ts>`
 To run a specific test, use this command: `npm run unit -- -t 'Test name'`.
 To update snapshots, run `npm run unit -- -u`.
+To skip coverage, run it with `--coverage=false`.
 
 ### E2E tests
 

--- a/packages/core/src/bundle/bundle-visitor.ts
+++ b/packages/core/src/bundle/bundle-visitor.ts
@@ -113,6 +113,8 @@ export function mapTypeToComponent(typeName: string, version: SpecMajorVersion) 
         default:
           return null;
       }
+    default:
+      return null;
   }
 }
 

--- a/packages/core/src/bundle/bundle.ts
+++ b/packages/core/src/bundle/bundle.ts
@@ -28,7 +28,7 @@ export function collectConfigPlugins(
   const visitorsData: PluginsCollectorVisitorData = { plugins: [], rootConfigDir };
   const ctx: BundleContext = {
     problems: [],
-    specVersion: 'oas3_0', // TODO: change it to a config-specific type
+    specVersion: 'config',
     refTypes: new Map<string, NormalizedNodeType>(),
     visitorsData: {
       [PLUGINS_COLLECTOR_VISITOR_ID]: visitorsData,
@@ -54,7 +54,7 @@ export function bundleConfig(
   const visitorsData: ConfigBundlerVisitorData = { plugins };
   const ctx: BundleContext = {
     problems: [],
-    specVersion: 'oas3_0', // TODO: change it to a config-specific type
+    specVersion: 'config',
     refTypes: new Map<string, NormalizedNodeType>(),
     visitorsData: {
       [CONFIG_BUNDLER_VISITOR_ID]: visitorsData,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,18 +1,18 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { specVersions } from '../detect-spec.js';
 import { stringifyYaml } from '../js-yaml/index.js';
-import type {
-  Oas2RuleSet,
-  Oas3RuleSet,
-  Async2RuleSet,
-  Async3RuleSet,
-  Arazzo1RuleSet,
-  Overlay1RuleSet,
-  OpenRpc1RuleSet,
-  SpecVersion,
-  SpecMajorVersion,
+import {
+  type Oas2RuleSet,
+  type Oas3RuleSet,
+  type Async2RuleSet,
+  type Async3RuleSet,
+  type Arazzo1RuleSet,
+  type Overlay1RuleSet,
+  type OpenRpc1RuleSet,
+  type SpecVersion,
+  type SpecMajorVersion,
+  specVersions,
 } from '../oas-types.js';
 import { isAbsoluteUrl } from '../ref-utils.js';
 import type { Document, ResolvedRefMap } from '../resolve.js';
@@ -322,7 +322,7 @@ export class Config {
     };
   }
 
-  // TODO: add default case for redocly.yaml
+  // TODO: add rules for redocly.yaml / entities?
   getRulesForSpecVersion(version: SpecMajorVersion) {
     switch (version) {
       case 'oas3':

--- a/packages/core/src/config/rules.ts
+++ b/packages/core/src/config/rules.ts
@@ -30,7 +30,7 @@ export function initRules(
   )[],
   config: Config,
   type: 'rules' | 'preprocessors' | 'decorators',
-  oasVersion: SpecVersion
+  specVersion: SpecVersion
 ): InitializedRule[] {
   return rules
     .flatMap((ruleset) =>
@@ -39,10 +39,10 @@ export function initRules(
 
         const ruleSettings =
           type === 'rules'
-            ? config.getRuleSettings(ruleId, oasVersion)
+            ? config.getRuleSettings(ruleId, specVersion)
             : type === 'preprocessors'
-              ? config.getPreprocessorSettings(ruleId, oasVersion)
-              : config.getDecoratorSettings(ruleId, oasVersion);
+              ? config.getPreprocessorSettings(ruleId, specVersion)
+              : config.getDecoratorSettings(ruleId, specVersion);
 
         if (ruleSettings.severity === 'off') {
           return undefined;

--- a/packages/core/src/detect-spec.ts
+++ b/packages/core/src/detect-spec.ts
@@ -2,25 +2,15 @@ import type { SpecMajorVersion, SpecVersion } from './oas-types.js';
 import { VERSION_PATTERN } from './typings/arazzo.js';
 import { isPlainObject } from './utils/is-plain-object.js';
 
-export const specVersions = [
-  'oas2',
-  'oas3_0',
-  'oas3_1',
-  'oas3_2',
-  'async2',
-  'async3',
-  'arazzo1',
-  'overlay1',
-  'openrpc1',
-] as const;
-
 export function getMajorSpecVersion(version: SpecVersion): SpecMajorVersion {
-  if (version === 'oas2') {
+  if (version.startsWith('oas3')) {
+    return 'oas3';
+  } else if (version === 'oas2') {
     return 'oas2';
-  } else if (version === 'async2') {
-    return 'async2';
   } else if (version === 'async3') {
     return 'async3';
+  } else if (version === 'async2') {
+    return 'async2';
   } else if (version === 'arazzo1') {
     return 'arazzo1';
   } else if (version === 'overlay1') {

--- a/packages/core/src/lint-entity.ts
+++ b/packages/core/src/lint-entity.ts
@@ -4,7 +4,6 @@ import type { JSONSchema } from 'json-schema-to-ts';
 
 import { createConfig, type Config } from './config/index.js';
 import { lintDocument } from './lint.js';
-import { type SpecVersion } from './oas-types.js';
 import { BaseResolver, resolveDocument, makeDocumentFromString, type Document } from './resolve.js';
 import { EntityKeyValid } from './rules/catalog-entity/entity-key-valid.js';
 import { Assertions, type Assertion } from './rules/common/assertions/index.js';
@@ -54,7 +53,7 @@ export async function lintEntityFile(opts: {
   } = opts;
   const ctx: WalkContext = {
     problems: [],
-    specVersion: 'entity' as SpecVersion, // FIXME: this should be proper SpecVersion
+    specVersion: 'entity',
     visitorsData: {},
   };
 

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -136,7 +136,7 @@ export async function lintConfig(opts: {
 
   const ctx: WalkContext = {
     problems: [],
-    specVersion: 'oas3_0', // TODO: use config-specific version
+    specVersion: 'config',
     config,
     visitorsData: {},
   };

--- a/packages/core/src/rules/ajv.ts
+++ b/packages/core/src/rules/ajv.ts
@@ -7,10 +7,9 @@ import Ajv2020, {
 import AjvDraft4 from '@redocly/ajv/dist/draft4.js';
 import addFormats from 'ajv-formats';
 
-import type { SpecVersion } from '../oas-types.js';
 import { escapePointerFragment, type Location } from '../ref-utils.js';
 import type { Oas3Schema, Oas3_1Schema } from '../typings/openapi.js';
-import type { ResolveFn } from '../walk.js';
+import type { ResolveFn, UserContext } from '../walk.js';
 
 type AjvDialect = '2020' | 'draft4';
 
@@ -18,7 +17,7 @@ function getSchemaIdKey(dialect: AjvDialect) {
   return dialect === 'draft4' ? 'id' : '$id';
 }
 
-function getDialectBySpecVersion(specVersion: SpecVersion): AjvDialect {
+function getDialectBySpecVersion(specVersion: UserContext['specVersion']): AjvDialect {
   if (specVersion === 'oas2' || specVersion === 'oas3_0') return 'draft4';
   return '2020';
 }
@@ -35,7 +34,7 @@ export class AjvValidator {
       resolve: ResolveFn;
       allowAdditionalProperties: boolean;
       ajvContext?: AjvContext;
-      specVersion: SpecVersion;
+      specVersion: UserContext['specVersion'];
     }
   ): { valid: boolean; errors: (ErrorObject & { suggest?: string[] })[] } {
     const { schemaLoc, instancePath, resolve, allowAdditionalProperties, ajvContext, specVersion } =

--- a/packages/core/src/rules/catalog-entity/__tests__/entity-key-valid.test.ts
+++ b/packages/core/src/rules/catalog-entity/__tests__/entity-key-valid.test.ts
@@ -2,7 +2,6 @@ import { entityFileSchema, entityFileDefaultSchema } from '@redocly/config';
 import { outdent } from 'outdent';
 import { describe, it, expect } from 'vitest';
 
-import { type SpecVersion } from '../../../oas-types.js';
 import { makeDocumentFromString } from '../../../resolve.js';
 import { createEntityTypes } from '../../../types/entity.js';
 import { normalizeTypes } from '../../../types/index.js';
@@ -17,7 +16,7 @@ function lintEntityKey(source: string): WalkContext['problems'] {
 
   const ctx: WalkContext = {
     problems: [],
-    specVersion: 'entity' as SpecVersion, // FIXME: this should be proper SpecVersion
+    specVersion: 'entity',
     visitorsData: {},
   };
 

--- a/packages/core/src/rules/common/struct.ts
+++ b/packages/core/src/rules/common/struct.ts
@@ -10,11 +10,13 @@ import type {
   Arazzo1Rule,
   Overlay1Rule,
   OpenRpc1Rule,
+  ConfigRule,
 } from '../../visitors.js';
 import type { UserContext } from '../../walk.js';
 import { oasTypeOf, matchesJsonSchemaType, getSuggest, validateSchemaEnumType } from '../utils.js';
 
 export const Struct:
+  | ConfigRule
   | Oas3Rule
   | Oas2Rule
   | Async2Rule

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -1,7 +1,6 @@
 import type { Context as AjvContext } from '@redocly/ajv/dist/2020.js';
 import { default as levenshtein } from 'js-levenshtein';
 
-import { type SpecVersion } from '../oas-types.js';
 import { isRef, Location } from '../ref-utils.js';
 import type {
   Oas3Schema,
@@ -193,7 +192,7 @@ export function validateExample({
       resolve,
       allowAdditionalProperties,
       ajvContext,
-      specVersion: specVersion as SpecVersion,
+      specVersion,
     });
     if (!valid) {
       for (const error of errors) {

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -1,6 +1,7 @@
 import type { Context as AjvContext } from '@redocly/ajv/dist/2020.js';
 import { default as levenshtein } from 'js-levenshtein';
 
+import { type SpecVersion } from '../oas-types.js';
 import { isRef, Location } from '../ref-utils.js';
 import type {
   Oas3Schema,
@@ -192,7 +193,7 @@ export function validateExample({
       resolve,
       allowAdditionalProperties,
       ajvContext,
-      specVersion,
+      specVersion: specVersion as SpecVersion,
     });
     if (!valid) {
       for (const error of errors) {

--- a/packages/core/src/visitors.ts
+++ b/packages/core/src/visitors.ts
@@ -411,6 +411,9 @@ export type OpenRpc1Visitor = BaseVisitor &
 
 export type CatalogEntityVisitor = BaseVisitor & Record<string, VisitFunction<any>>;
 
+export type ConfigVisitor = BaseVisitor &
+  Record<string, VisitFunction<any> | NestedVisitObject<any, BaseVisitor>>;
+
 export type NestedVisitor<T> = Exclude<T, 'any' | 'ref' | 'Root'>;
 
 export type NormalizedOasVisitors<T extends BaseVisitor> = {
@@ -440,6 +443,7 @@ export type OpenRpc1Rule = (options: Record<string, any>) => OpenRpc1Visitor | O
 export type CatalogEntityRule = (
   options: Record<string, any>
 ) => CatalogEntityVisitor | CatalogEntityVisitor[];
+export type ConfigRule = (options: Record<string, any>) => ConfigVisitor | ConfigVisitor[];
 export type Oas3Preprocessor = Oas3Decorator;
 export type Oas2Preprocessor = Oas2Decorator;
 export type Async2Preprocessor = Async2Decorator;

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -18,6 +18,8 @@ import type {
   VisitorNode,
 } from './visitors.js';
 
+type ExtendedSpecVersion = SpecVersion | 'config' | 'entity';
+
 export type NonUndefined =
   | string
   | number
@@ -46,7 +48,7 @@ export type UserContext = {
   type: NormalizedNodeType;
   key: string | number;
   parent: any;
-  specVersion: SpecVersion;
+  specVersion: ExtendedSpecVersion;
   config?: Config;
   getVisitorData: () => Record<string, unknown>;
 };
@@ -95,7 +97,7 @@ export type NormalizedProblem = {
 
 export type WalkContext = {
   problems: NormalizedProblem[];
-  specVersion: SpecVersion;
+  specVersion: ExtendedSpecVersion;
   config?: Config;
   visitorsData: Record<string, Record<string, unknown>>; // custom data store that visitors can use for various purposes
   refTypes?: Map<string, NormalizedNodeType>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,7 @@ const configExtension: { [key: string]: ViteUserConfig } = {
           lines: 81,
           functions: 84,
           statements: 80,
-          branches: 72,
+          branches: 73,
         },
       },
     },


### PR DESCRIPTION
## What/Why/How?

-  Refactored `specVersion` for config and entitites (mostly types).
- Updated the test's config


## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly typing and walk-context labeling for config/entity flows; OpenAPI lint still uses detected spec versions, with a small chance of AJV dialect edge cases for config/entity validation.
> 
> **Overview**
> Walk/lint/bundle paths for **redocly.yaml** and catalog entities no longer pretend to be OpenAPI 3.0: `WalkContext` / `UserContext` use an **`ExtendedSpecVersion`** (`SpecVersion | 'config' | 'entity'`), and config bundling plus `lintConfig` / `lintEntityFile` set **`specVersion: 'config'`** or **`'entity'`** instead of **`oas3_0`** or cast hacks.
> 
> Supporting type work adds **`ConfigVisitor`** / **`ConfigRule`**, wires **`Struct`** as a config rule, and types AJV dialect selection off **`UserContext['specVersion']`** (config/entity follow the non–draft-4 path). **`getMajorSpecVersion`** now maps any **`oas3_*`** via **`startsWith('oas3')`**; **`specVersions`** is imported from **`oas-types`** (removed from **`detect-spec`**). **`mapTypeToComponent`** gets an outer **`default: return null`**. **`initRules`** renames its version parameter to **`specVersion`**.
> 
> Docs/tooling: **`CONTRIBUTING.md`** documents **`npm run unit -- --coverage=false`**; unit coverage **branch** threshold **73%** in **`vitest.config.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad01e163b6f910822a453c1d848cdfc48d6d6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->