### PR TITLE
chore: refactor async3 types

### DIFF
--- a/.changeset/cool-poets-smell.md
+++ b/.changeset/cool-poets-smell.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Improved AsyncAPI 3 types.

--- a/packages/core/src/typings/asyncapi3.ts
+++ b/packages/core/src/typings/asyncapi3.ts
@@ -1,16 +1,18 @@
+import type { Referenced } from './openapi.js';
+
 export type Async3Definition = {
   asyncapi: string;
   servers?: Record<string, any>;
   info: Async3Info;
-  channels?: Record<string, Channel>;
+  channels?: Record<string, Referenced<Channel>>;
   components?: Record<string, any>;
-  operations?: Record<string, Async3Operation>;
+  operations?: Record<string, Referenced<Async3Operation>>;
   defaultContentType?: string;
 };
 
 export type Async3Operation = {
   action: 'send' | 'receive';
-  channel: Channel;
+  channel: Referenced<Channel>;
   title?: string;
   summary?: string;
   description?: string;
@@ -21,7 +23,7 @@ export type Async3Operation = {
   traits?: Record<string, any>[];
   messages?: Record<string, any>[];
   reply?: Record<string, any>;
-  'x-send-operations'?: string[]; //
+  'x-send-operations'?: string[];
 };
 
 export interface Async3Info {

--- a/packages/core/src/typings/asyncapi3.ts
+++ b/packages/core/src/typings/asyncapi3.ts
@@ -1,18 +1,16 @@
-import type { Referenced } from './openapi.js';
-
 export type Async3Definition = {
   asyncapi: string;
   servers?: Record<string, any>;
   info: Async3Info;
-  channels?: Record<string, Referenced<Channel>>;
+  channels?: Record<string, Channel>;
   components?: Record<string, any>;
-  operations?: Record<string, Referenced<Async3Operation>>;
+  operations?: Record<string, Async3Operation>;
   defaultContentType?: string;
 };
 
 export type Async3Operation = {
   action: 'send' | 'receive';
-  channel: Referenced<Channel>;
+  channel: Channel;
   title?: string;
   summary?: string;
   description?: string;
@@ -23,7 +21,8 @@ export type Async3Operation = {
   traits?: Record<string, any>[];
   messages?: Record<string, any>[];
   reply?: Record<string, any>;
-  'x-send-operations'?: string[];
+
+  'x-send-operations'?: string[]; // internal type
 };
 
 export interface Async3Info {
@@ -36,6 +35,8 @@ export interface Async3Info {
   license?: Async3License;
   tags?: Tag[];
   externalDocs?: ExternalDoc;
+
+  'x-deprecated-payload-format'?: boolean; // internal type
 }
 
 export interface Async3Contact {

--- a/packages/core/src/typings/asyncapi3.ts
+++ b/packages/core/src/typings/asyncapi3.ts
@@ -1,12 +1,28 @@
-export interface Async3Definition {
+export type Async3Definition = {
   asyncapi: string;
   servers?: Record<string, any>;
   info: Async3Info;
   channels?: Record<string, Channel>;
   components?: Record<string, any>;
-  operations?: Record<string, any>;
+  operations?: Record<string, Async3Operation>;
   defaultContentType?: string;
-}
+};
+
+export type Async3Operation = {
+  action: 'send' | 'receive';
+  channel: Channel;
+  title?: string;
+  summary?: string;
+  description?: string;
+  security?: Record<string, any>[];
+  tags?: Tag[];
+  externalDocs?: ExternalDocumentation;
+  bindings?: Record<string, any>;
+  traits?: Record<string, any>[];
+  messages?: Record<string, any>[];
+  reply?: Record<string, any>;
+  'x-send-operations'?: string[]; //
+};
 
 export interface Async3Info {
   title: string;
@@ -42,7 +58,7 @@ export interface ExternalDoc {
   description?: string;
 }
 
-export interface Channel {
+export type Channel = {
   address?: string | null;
   messages?: Record<string, any>;
   title?: string;
@@ -52,10 +68,37 @@ export interface Channel {
   parameters?: Record<string, any>;
   tags?: Record<string, any>;
   externalDocs?: ExternalDocumentation;
-  bindings?: Record<string, any>;
-}
+  bindings?: ChannelBindings;
+};
 
 export interface ExternalDocumentation {
   url: string;
   description?: string;
 }
+
+export type ChannelBindings = {
+  amqp?: AmqpChannelBinding;
+} & Record<string, Record<string, any> | undefined>;
+
+export type AmqpChannelBinding = {
+  is?: 'queue' | 'routingKey';
+  exchange?: AmqpChannelBindingExchange;
+  queue?: AmqpChannelBindingQueue;
+  bindingVersion?: string;
+};
+
+export type AmqpChannelBindingQueue = {
+  name?: string;
+  durable?: boolean;
+  exclusive?: boolean;
+  autoDelete?: boolean;
+  vhost?: string;
+};
+
+export type AmqpChannelBindingExchange = {
+  name?: string;
+  type?: 'topic' | 'direct' | 'fanout' | 'default' | 'headers';
+  durable?: boolean;
+  autoDelete?: boolean;
+  vhost?: string;
+};


### PR DESCRIPTION
## What/Why/How?

Improved AsyncAPI 3 types (mostly by copying from the monorepo).
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes in typings with a patch changeset; no runtime, auth, or validation logic is modified.
> 
> **Overview**
> **Tightens `@redocly/openapi-core` AsyncAPI 3 typings** in `asyncapi3.ts` by replacing loose `Record<string, any>` shapes with explicit types, aligned with the monorepo.
> 
> `operations` is now `Record<string, Async3Operation>` with a full operation shape (`action`, `channel`, metadata, bindings, traits, messages, reply). **Channel** `bindings` use a new `ChannelBindings` type with structured **AMQP** queue/exchange fields. **Internal extension fields** are typed on `Async3Info` (`x-deprecated-payload-format`) and `Async3Operation` (`x-send-operations`). Several definitions move from `interface` to `type` aliases for consistency.
> 
> A patch **changeset** documents the improvement for consumers of the package types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac756f9ebd778ab3ee874c3c57d3a0ce86498af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->