### PR TITLE
fix: respect arbitrary code execution via $faker runtime expression

### DIFF
--- a/.changeset/slimy-beers-fry.md
+++ b/.changeset/slimy-beers-fry.md
@@ -2,6 +2,5 @@
 '@redocly/respect-core': patch
 ---
 
-Fixed a remote code execution vulnerability where a crafted $faker expression in
-an Arazzo description could execute arbitrary JavaScript during respect runs.
-Thanks to Hamza Haroon (GitHub: @thegr1ffyn) for the report.
+Fixed a remote code execution vulnerability where a crafted `$faker` expression in an Arazzo description could execute arbitrary JavaScript during Redocly Respect runs.
+Reported by Hamza Haroon (GitHub: @thegr1ffyn).

--- a/.changeset/slimy-beers-fry.md
+++ b/.changeset/slimy-beers-fry.md
@@ -1,0 +1,7 @@
+---
+'@redocly/respect-core': patch
+---
+
+Fixed a remote code execution vulnerability where a crafted $faker expression in
+an Arazzo description could execute arbitrary JavaScript during respect runs.
+Thanks to Hamza Haroon (GitHub: @thegr1ffyn) for the report.

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -311,17 +311,6 @@ describe('getFakeData argument parsing', () => {
     ).toEqual(5);
   });
 
-  it('strips prototype-polluting keys from parsed argument objects', () => {
-    expect(
-      getValueFromContext({
-        value: '$faker.number.integer({ __proto__: { polluted: 1 }, min: 5, max: 5 })',
-        ctx,
-        logger,
-      })
-    ).toEqual(5);
-    expect(({} as any).polluted).toBeUndefined();
-  });
-
   it('supports calls with no arguments', () => {
     expect(getValueFromContext({ value: '$faker.string.uuid()', ctx, logger })).toEqual(
       expect.any(String)

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -12,14 +12,14 @@ describe('getValueFromContext', () => {
   it('should return value from context', () => {
     const ctx = {
       $some: 'test',
-    } as unknown as TestContext;
+    } as any;
     expect(getValueFromContext({ value: '$some', ctx, logger })).toEqual('test');
   });
 
   it('should return custom list of objects value', () => {
     const ctx = {
       $some: 'John Wick',
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({ value: [{ name: '$some' }, { name: 'Jonny Mnemonic' }], ctx, logger })
     ).toEqual([{ name: 'John Wick' }, { name: 'Jonny Mnemonic' }]);
@@ -28,7 +28,7 @@ describe('getValueFromContext', () => {
   it('should return custom list value', () => {
     const ctx = {
       $some: 'John Wick',
-    } as unknown as TestContext;
+    } as any;
     expect(getValueFromContext({ value: ['Jonny Mnemonic', 'John Wick'], ctx, logger })).toEqual([
       'Jonny Mnemonic',
       'John Wick',
@@ -38,7 +38,7 @@ describe('getValueFromContext', () => {
   it('should return custom object value', () => {
     const ctx = {
       $some: 'John',
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({ value: { name: '$some', lastname: 'Mnemonic' }, ctx, logger })
     ).toEqual({
@@ -52,7 +52,7 @@ describe('getValueFromContext', () => {
       $env: {
         token: 'test',
       },
-    } as unknown as TestContext;
+    } as any;
     expect(getValueFromContext({ value: 'bearer {$env.token}', ctx, logger })).toEqual(
       'bearer test'
     );
@@ -64,7 +64,7 @@ describe('getValueFromContext', () => {
         token: 'test',
       },
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({
         value: 'bearer {$env.token} {$faker.number.integer({min:5,max:5})}',
@@ -80,7 +80,7 @@ describe('getValueFromContext', () => {
         token: 'test',
       },
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({
         value:
@@ -96,7 +96,7 @@ describe('getValueFromContext', () => {
       secret: {
         token: 'test',
       },
-    } as unknown as TestContext;
+    } as any;
     expect(getValueFromContext({ value: 'custom.domain.com', ctx, logger })).toEqual(
       'custom.domain.com'
     );
@@ -105,7 +105,7 @@ describe('getValueFromContext', () => {
   it('should return faker generated data', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({ value: '$faker.number.integer({ min: 5, max: 5 })', ctx, logger })
     ).toEqual(5);
@@ -114,7 +114,7 @@ describe('getValueFromContext', () => {
   it('should return faker generated data with additional text', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({
         value: 'number is {$faker.number.integer({min:5,max:5})}',
@@ -127,7 +127,7 @@ describe('getValueFromContext', () => {
   it('should return faker generated data', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({ value: 'city is {$faker.address.city}', ctx, logger })
     ).not.toMatch('{$faker.address.city}');
@@ -136,7 +136,7 @@ describe('getValueFromContext', () => {
   it('should remove `$file` identifier from the value', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     expect(getValueFromContext({ value: "$file('./test.yaml')", ctx, logger })).toEqual(
       './test.yaml'
     );
@@ -155,7 +155,7 @@ describe('getValueFromContext', () => {
           ],
         },
       },
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({
         value: '$sourceDescriptions.test.workflows.workflowTestId',
@@ -180,7 +180,7 @@ describe('getValueFromContext', () => {
           ],
         },
       },
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({
         value: '$sourceDescriptions.notExistingName.workflows.workflowTestId',
@@ -202,7 +202,7 @@ describe('getValueFromContext', () => {
           ],
         },
       },
-    } as unknown as TestContext;
+    } as any;
     expect(
       getValueFromContext({ value: '$sourceDescriptions.notExistingName.workflows.', ctx, logger })
     ).toEqual(undefined);
@@ -220,14 +220,14 @@ describe('getValueFromContext', () => {
           ],
         },
       },
-    } as unknown as TestContext;
+    } as any;
     expect(getValueFromContext({ value: '{$faker.city}', ctx, logger })).toEqual('undefined');
   });
 
   it('should not execute arbitrary code via the $faker constructor escape', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     (globalThis as any).__respectPwned = false;
     const payload =
       '$faker.constructor.constructor(\'globalThis["__respectPwned"]=true;return 1\')()';
@@ -242,7 +242,7 @@ describe('getValueFromContext', () => {
   it('should not execute arbitrary code via bracket-notation $faker payloads', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
     (globalThis as any).__respectPwned2 = false;
     const payload =
       '$faker.string["constructor"]["constructor"](\'globalThis["__respectPwned2"]=true\')()';
@@ -257,7 +257,7 @@ describe('getValueFromContext', () => {
   it('should not resolve prototype-chain properties via $faker', () => {
     const ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
 
     expect(
       getValueFromContext({ value: '$faker.__proto__.polluted', ctx, logger })
@@ -272,7 +272,7 @@ describe('getFakeData argument parsing', () => {
   beforeEach(() => {
     ctx = {
       $faker: createFaker(),
-    } as unknown as TestContext;
+    } as any;
   });
 
   it('parses float arguments without being mangled by dots in the pointer', () => {

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -223,6 +223,98 @@ describe('getValueFromContext', () => {
     } as unknown as TestContext;
     expect(getValueFromContext({ value: '{$faker.city}', ctx, logger })).toEqual('undefined');
   });
+
+  it('should not execute arbitrary code via the $faker constructor escape', () => {
+    const ctx = {
+      $faker: createFaker(),
+    } as unknown as TestContext;
+    (globalThis as any).__respectPwned = false;
+    const payload =
+      '$faker.constructor.constructor(\'globalThis["__respectPwned"]=true;return 1\')()';
+
+    const result = getValueFromContext({ value: payload, ctx, logger });
+
+    expect((globalThis as any).__respectPwned).toBe(false);
+    expect(result).toBeUndefined();
+    delete (globalThis as any).__respectPwned;
+  });
+
+  it('should not execute arbitrary code via bracket-notation $faker payloads', () => {
+    const ctx = {
+      $faker: createFaker(),
+    } as unknown as TestContext;
+    (globalThis as any).__respectPwned2 = false;
+    const payload =
+      '$faker.string["constructor"]["constructor"](\'globalThis["__respectPwned2"]=true\')()';
+
+    const result = getValueFromContext({ value: payload, ctx, logger });
+
+    expect((globalThis as any).__respectPwned2).toBe(false);
+    expect(result).toBeUndefined();
+    delete (globalThis as any).__respectPwned2;
+  });
+
+  it('should not resolve prototype-chain properties via $faker', () => {
+    const ctx = {
+      $faker: createFaker(),
+    } as unknown as TestContext;
+
+    expect(
+      getValueFromContext({ value: '$faker.__proto__.polluted', ctx, logger })
+    ).toBeUndefined();
+    expect(getValueFromContext({ value: '$faker.constructor', ctx, logger })).toBeUndefined();
+  });
+});
+
+describe('getFakeData argument parsing', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => {
+    ctx = {
+      $faker: createFaker(),
+    } as unknown as TestContext;
+  });
+
+  const call = (value: string) => getValueFromContext({ value, ctx, logger });
+
+  it('parses float arguments without being mangled by dots in the pointer', () => {
+    const result = call('$faker.number.float({ min: 0.5, max: 1.5 })') as number;
+    expect(result).toBeGreaterThanOrEqual(0.5);
+    expect(result).toBeLessThanOrEqual(1.5);
+  });
+
+  it('parses negative numbers', () => {
+    const result = call('$faker.number.integer({ min: -5, max: -1 })') as number;
+    expect(result).toBeGreaterThanOrEqual(-5);
+    expect(result).toBeLessThanOrEqual(-1);
+  });
+
+  it('parses string arguments and dotted values', () => {
+    expect(call("$faker.string.email({ provider: 'example', domain: 'org' })")).toContain(
+      'example.org'
+    );
+  });
+
+  it('tolerates trailing commas', () => {
+    expect(call('$faker.number.integer({ min: 5, max: 5, })')).toEqual(5);
+  });
+
+  it('strips prototype-polluting keys from parsed argument objects', () => {
+    expect(call('$faker.number.integer({ __proto__: { polluted: 1 }, min: 5, max: 5 })')).toEqual(
+      5
+    );
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('supports calls with no arguments', () => {
+    expect(call('$faker.string.uuid()')).toEqual(expect.any(String));
+  });
+
+  it('returns undefined for malformed argument lists', () => {
+    expect(call('$faker.number.integer({ min: })')).toBeUndefined();
+    expect(call("$faker.string.email('unterminated)")).toBeUndefined();
+    expect(call('$faker.number.integer(@)')).toBeUndefined();
+  });
 });
 
 describe('parsePath', () => {

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -275,45 +275,67 @@ describe('getFakeData argument parsing', () => {
     } as unknown as TestContext;
   });
 
-  const call = (value: string) => getValueFromContext({ value, ctx, logger });
-
   it('parses float arguments without being mangled by dots in the pointer', () => {
-    const result = call('$faker.number.float({ min: 0.5, max: 1.5 })') as number;
+    const result = getValueFromContext({
+      value: '$faker.number.float({ min: 0.5, max: 1.5 })',
+      ctx,
+      logger,
+    }) as number;
     expect(result).toBeGreaterThanOrEqual(0.5);
     expect(result).toBeLessThanOrEqual(1.5);
   });
 
   it('parses negative numbers', () => {
-    const result = call('$faker.number.integer({ min: -5, max: -1 })') as number;
+    const result = getValueFromContext({
+      value: '$faker.number.integer({ min: -5, max: -1 })',
+      ctx,
+      logger,
+    }) as number;
     expect(result).toBeGreaterThanOrEqual(-5);
     expect(result).toBeLessThanOrEqual(-1);
   });
 
   it('parses string arguments and dotted values', () => {
-    expect(call("$faker.string.email({ provider: 'example', domain: 'org' })")).toContain(
-      'example.org'
-    );
+    expect(
+      getValueFromContext({
+        value: "$faker.string.email({ provider: 'example', domain: 'org' })",
+        ctx,
+        logger,
+      })
+    ).toContain('example.org');
   });
 
   it('tolerates trailing commas', () => {
-    expect(call('$faker.number.integer({ min: 5, max: 5, })')).toEqual(5);
+    expect(
+      getValueFromContext({ value: '$faker.number.integer({ min: 5, max: 5, })', ctx, logger })
+    ).toEqual(5);
   });
 
   it('strips prototype-polluting keys from parsed argument objects', () => {
-    expect(call('$faker.number.integer({ __proto__: { polluted: 1 }, min: 5, max: 5 })')).toEqual(
-      5
-    );
+    expect(
+      getValueFromContext({
+        value: '$faker.number.integer({ __proto__: { polluted: 1 }, min: 5, max: 5 })',
+        ctx,
+        logger,
+      })
+    ).toEqual(5);
     expect(({} as any).polluted).toBeUndefined();
   });
 
   it('supports calls with no arguments', () => {
-    expect(call('$faker.string.uuid()')).toEqual(expect.any(String));
+    expect(getValueFromContext({ value: '$faker.string.uuid()', ctx, logger })).toEqual(
+      expect.any(String)
+    );
   });
 
   it('returns undefined for malformed argument lists', () => {
-    expect(call('$faker.number.integer({ min: })')).toBeUndefined();
-    expect(call("$faker.string.email('unterminated)")).toBeUndefined();
-    expect(call('$faker.number.integer(@)')).toBeUndefined();
+    expect(
+      getValueFromContext({ value: '$faker.number.integer({ min: })', ctx, logger })
+    ).toBeUndefined();
+    expect(
+      getValueFromContext({ value: "$faker.string.email('unterminated)", ctx, logger })
+    ).toBeUndefined();
+    expect(getValueFromContext({ value: '$faker.number.integer(@)', ctx, logger })).toBeUndefined();
   });
 });
 

--- a/packages/respect-core/src/modules/context-parser/get-value-from-context.ts
+++ b/packages/respect-core/src/modules/context-parser/get-value-from-context.ts
@@ -69,11 +69,201 @@ export function replaceFakerVariablesInString(
   }
 }
 
-function runInContext(code: string, context: any) {
-  const contextKeys = Object.keys(context);
-  const contextValues = Object.values(context);
+// Property names that would allow escaping the faker object and reaching the
+// prototype chain (and therefore `Function`/`constructor`-based code execution).
+const FORBIDDEN_FAKER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const SAFE_FAKER_KEY = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
 
-  return new Function(...contextKeys, `return ${code}`)(...contextValues);
+// Safely parses the single options object of a faker function call (e.g. the
+// `{ min: 5, max: 5 }` in `faker.number.integer({ min: 5, max: 5 })`) WITHOUT
+// evaluating it as JavaScript. Faker functions take at most one options object
+// whose values are strings or numbers.
+class FakerArgumentParser {
+  private pos = 0;
+
+  constructor(private readonly src: string) {}
+
+  parseArguments(): unknown[] {
+    this.skipWhitespace();
+    if (this.pos >= this.src.length) return [];
+
+    const value = this.parseValue();
+    this.skipWhitespace();
+    if (this.pos < this.src.length) {
+      throw new Error(`Unexpected token "${this.src[this.pos]}" in faker arguments`);
+    }
+    return [value];
+  }
+
+  private parseValue(): unknown {
+    this.skipWhitespace();
+    const char = this.src[this.pos];
+
+    if (char === '{') return this.parseObject();
+    if (char === '"' || char === "'") return this.parseString(char);
+    if (char === '-' || (char >= '0' && char <= '9')) return this.parseNumber();
+    throw new Error(`Unexpected token "${char}" in faker arguments`);
+  }
+
+  private parseObject(): Record<string, unknown> {
+    this.pos++; // consume '{'
+    const obj: Record<string, unknown> = {};
+    this.skipWhitespace();
+
+    if (this.src[this.pos] === '}') {
+      this.pos++;
+      return obj;
+    }
+
+    while (true) {
+      this.skipWhitespace();
+      const key = this.parseKey();
+      this.skipWhitespace();
+      if (this.src[this.pos] !== ':') {
+        throw new Error('Expected ":" in faker arguments object');
+      }
+      this.pos++; // consume ':'
+      const value = this.parseValue();
+      // Reject keys that could pollute the prototype of the options object.
+      if (!FORBIDDEN_FAKER_KEYS.has(key)) {
+        obj[key] = value;
+      }
+      this.skipWhitespace();
+
+      const next = this.src[this.pos];
+      if (next === ',') {
+        this.pos++;
+        this.skipWhitespace();
+      } else if (next === '}') {
+        this.pos++;
+        return obj;
+      } else {
+        throw new Error('Expected "," or "}" in faker arguments object');
+      }
+
+      if (this.src[this.pos] === '}') {
+        this.pos++; // allow a trailing comma
+        return obj;
+      }
+    }
+  }
+
+  private parseKey(): string {
+    const char = this.src[this.pos];
+    if (char === '"' || char === "'") return this.parseString(char);
+
+    const start = this.pos;
+    while (this.pos < this.src.length && /[a-zA-Z0-9_$]/.test(this.src[this.pos])) {
+      this.pos++;
+    }
+    if (this.pos === start) {
+      throw new Error('Expected property name in faker arguments object');
+    }
+    return this.src.slice(start, this.pos);
+  }
+
+  private parseString(quote: string): string {
+    this.pos++; // consume opening quote
+    let result = '';
+    while (this.pos < this.src.length) {
+      const char = this.src[this.pos++];
+      if (char === '\\') {
+        result += this.src[this.pos++] ?? '';
+      } else if (char === quote) {
+        return result;
+      } else {
+        result += char;
+      }
+    }
+    throw new Error('Unterminated string in faker arguments');
+  }
+
+  private parseNumber(): number {
+    const start = this.pos;
+    if (this.src[this.pos] === '-') this.pos++;
+    while (this.pos < this.src.length && /[0-9.]/.test(this.src[this.pos])) {
+      this.pos++;
+    }
+    const raw = this.src.slice(start, this.pos);
+    const value = Number(raw);
+    if (Number.isNaN(value)) {
+      throw new Error(`Invalid number "${raw}" in faker arguments`);
+    }
+    return value;
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.src.length && /\s/.test(this.src[this.pos])) {
+      this.pos++;
+    }
+  }
+}
+
+// Splits a faker pointer on `.`, ignoring dots inside a function call's
+// arguments (parentheses) or string literals, e.g. `faker.number.float({ min: 0.5 })`.
+function splitFakerPointer(pointer: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+  let depth = 0;
+
+  for (let i = 0; i < pointer.length; i++) {
+    const char = pointer[i];
+
+    if (quote) {
+      current += char;
+      if (char === '\\') {
+        current += pointer[++i] ?? '';
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+    } else if (char === '.' && depth === 0) {
+      segments.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  segments.push(current.trim());
+  return segments;
+}
+
+// Only own properties of the faker object are allowed,
+// which prevents reaching `constructor`/`__proto__` and the `Function` escape.
+function resolveFakerSegment(target: unknown, segment: string): unknown {
+  const callMatch = segment.match(/^([^()]+)\((.*)\)$/s);
+  const name = (callMatch ? callMatch[1] : segment).trim();
+
+  if (!SAFE_FAKER_KEY.test(name) || FORBIDDEN_FAKER_KEYS.has(name)) {
+    throw new Error(`Unsupported faker reference: "${name}"`);
+  }
+
+  if (target == null || !Object.prototype.hasOwnProperty.call(target, name)) {
+    throw new Error(`Unknown faker reference: "${name}"`);
+  }
+
+  const member = (target as Record<string, unknown>)[name];
+
+  if (callMatch) {
+    if (typeof member !== 'function') {
+      throw new Error(`Faker reference "${name}" is not callable`);
+    }
+    const args = new FakerArgumentParser(callMatch[2]).parseArguments();
+    return (member as (...args: unknown[]) => unknown).apply(target, args);
+  }
+
+  return member;
 }
 
 function replaceVariablesInString(
@@ -201,20 +391,17 @@ export function getFakeData({
   ctx: TestContext | RuntimeExpressionContext;
   logger: LoggerInterface;
 }): any {
-  const segments = pointer.split('.');
-  const fakerContext = { ctx: { faker: ctx.$faker } };
+  const segments = splitFakerPointer(pointer);
 
   try {
-    const escapedSegments = segments
-      .map((segment) => segment.trim())
-      .map((segment, idx) =>
-        // Dumb function check (if ends by ')'), if function goes first dont need to put '.',
-        // if goes second and so on - must be prepended by '.', like ["escaped-field"].func()
-        segment.endsWith(')') ? `${idx == 0 ? '' : '.'}${segment}` : `["${segment}"]`
-      )
-      .join('');
+    // The pointer always starts with `faker` (e.g. `faker.number.integer(...)`).
+    if (segments[0] !== 'faker') {
+      throw new Error(`Unsupported faker reference: "${segments[0]}"`);
+    }
 
-    return runInContext(`ctx${escapedSegments}`, fakerContext);
+    return segments
+      .slice(1)
+      .reduce<unknown>((target, segment) => resolveFakerSegment(target, segment), ctx.$faker);
   } catch (err: any) {
     logger.error(red(err.toString()));
 


### PR DESCRIPTION
## What/Why/How?

Fixed a remote code execution vulnerability where a crafted $faker expression in
an Arazzo description could execute arbitrary JavaScript during respect runs.
$faker expressions are now resolved against the known faker object with literal-only
argument parsing, blocking prototype-chain escapes.


Thanks to Hamza Haroon (GitHub: @thegr1ffyn) for the report.

## Reference

## Testing

Internally => https://github.com/Redocly/redocly/pull/23998

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This closes a remote code execution path in Respect’s expression resolver; the change is security-critical but narrows behavior to safe faker access rather than broadening attack surface.
> 
> **Overview**
> **Security fix:** `$faker` runtime expressions in Arazzo descriptions no longer run through dynamic `new Function` evaluation, which allowed arbitrary JavaScript execution (e.g. via `constructor` / bracket-notation escapes).
> 
> **`getFakeData` now** walks only **own properties** on the real faker instance: pointers are split with `splitFakerPointer` (dots inside calls/strings preserved), each segment is resolved with `resolveFakerSegment`, and names like `constructor`, `__proto__`, and `prototype` are blocked. Function arguments are parsed by a **literal-only** `FakerArgumentParser` (numbers, strings, simple option objects)—not executed as JS.
> 
> Tests add exploit regression cases and cover argument parsing edge cases (floats, negatives, malformed input). A patch changeset documents the fix for `@redocly/respect-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a2e988111e863af4b542dd08f11a519bf6e5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->