### PR TITLE
fix: isSubdir regex should match literal ".." not any chars

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -24,6 +24,21 @@ describe('isSubdir', () => {
     });
   });
 
+  it('allows two-character subdir names and still blocks traversal', () => {
+    (
+      [
+        ['/a/b', '/a/b/c.png', true], // direct child
+        ['/a/b', '/a/b/ab/logo.png', true], // regression: two-char subdir was wrongly rejected
+        ['/a/b', '/a/b/xy', true], // two-char name, no traversal
+        ['/a/b', '/a/c', false], // sibling (../c)
+        ['/a/b', '/etc/passwd', false], // escapes upward
+        ['/a/b', '/a/b', false], // same dir (relative is '')
+      ] as [string, string, boolean][]
+    ).forEach(([parent, child, expectRes]) => {
+      expect(isSubdir(parent, child)).toBe(expectRes);
+    });
+  });
+
   it('can correctly determine if subdir for windows-based paths', () => {
     const os = require('os');
     os.platform.mockImplementation(() => 'win32');

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -321,5 +321,5 @@ export function exitWithError(message: string) {
  */
 export function isSubdir(parent: string, dir: string): boolean {
   const relative = path.relative(parent, dir);
-  return !!relative && !/^..($|\/)/.test(relative) && !path.isAbsolute(relative);
+  return !!relative && !/^\.\.($|[\\/])/.test(relative) && !path.isAbsolute(relative);
 }


### PR DESCRIPTION
## What/Why/How?

**What:** Fix the `isSubdir(parent, dir)` guard regex used by the preview-docs static file server.

**Why:** The regex `/^..($|\/)/` used **unescaped** dots, so each `.` matched *any* character instead of a literal dot. It therefore wrongly rejected legitimate paths whose relative form is two characters then end-or-slash — e.g. any file inside a two-character-named subdirectory (`ab/logo.png` → relative `ab/logo.png` → matched `ab/`), producing false 404s in preview-docs. This is **not** a security loosening: the old regex was *stricter*, not looser — it still rejected real `../` traversal.

**How:** Replace it with `/^\.\.($|[\\/])/` — a literal `..` at the start, followed by end-of-string, `/`, or `\` (also tolerates the Windows path separator). Traversal protection is unchanged.

## Reference

Implements internal advisor plan `plans/005-fix-issubdir-regex.md` (P2, bug).

## Testing

Added a regression block to `packages/cli/src/__tests__/utils.test.ts`:

- direct child → `true`
- **two-char subdir** `ab/logo.png` → `true` (the regression this fixes; failed on the old regex)
- two-char name `xy` → `true`
- sibling `../c` → `false`
- `/etc/passwd` → `false` (traversal still blocked)
- same dir → `false`

`npx jest packages/cli/src/__tests__/utils.test.ts` → **8 passed**.

> Note: repo-wide `npm run typecheck` / full `npm run jest` currently show pre-existing failures unrelated to this change (older TypeScript can't parse modern `.d.ts` build artifacts; one flaky `core/lint.test.ts` timeout that passes in isolation). Verified identical with and without this change — covered separately by plans 004/012.

## Screenshots (optional)

N/A — logic-only change.

## Check yourself

- [x] Code is linted — `eslint` on the changed files reports 0 errors
- [ ] Tested with redoc/reference-docs/workflows — not applicable; unit-tested only
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered — the fix does not weaken `../` traversal protection (the old regex was stricter); it only removes false negatives
- [x] Code follows company security practices and guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)