### PR TITLE
perf: compute parentLocations lazily in walk

### DIFF
--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -434,6 +434,12 @@ export function walkDocument<T extends BaseVisitor>(opts: {
       customMessage: string | undefined
     ) {
       const report = (opts: Problem) => reportFn(ruleId, severity, customMessage, opts);
+      // `parentLocations` is read by only a minority of rules, yet eagerly
+      // collecting it walks the full parent chain and allocates a record on every
+      // visitor invocation (the hot path). Defer it to a lazy getter and cache the
+      // result within this single visit — safe because the `activatedOn` stack the
+      // chain walk reads is stable for the duration of the call.
+      let cachedParentLocations: Record<string, Location> | undefined;
       visit(
         resolvedNode,
         {
@@ -445,7 +451,12 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           type,
           parent,
           key,
-          parentLocations: collectParentsLocations(context),
+          get parentLocations() {
+            if (cachedParentLocations === undefined) {
+              cachedParentLocations = collectParentsLocations(context);
+            }
+            return cachedParentLocations;
+          },
           specVersion: ctx.specVersion,
           config: ctx.config,
           ignoreNextVisitorsOnNode: () => {


### PR DESCRIPTION
## What/Why/How?

Makes `parentLocations` **lazy** in the `walk.ts` lint hot loop.

**Why:** `walkDocument`'s `visitWithContext` runs on every visitor invocation — every node × every activated rule, the hottest path in the linter. It eagerly built `parentLocations` by walking the full parent-context chain and allocating a fresh record on *every* call. Only two rules actually read it (`boolean-parameter-prefixes`, `operation-parameters-unique`), so for everything else this was pure wasted allocation and chain-walking.

**How:** Replaced the eager `parentLocations: collectParentsLocations(context)` property with a native object-literal getter that computes on first access and caches the result for the duration of the single `visit` call. Caching within the call is safe because the `activatedOn` stack the chain-walk reads is stable while a visit is in flight (it's pushed/popped only as traversal descends/ascends). `collectParents` (the 3rd positional arg) is intentionally left eager — making a bare positional value lazy would require touching visitor signatures, which is out of scope.

Behavior-preserving: no rule semantics change, just *when* `parentLocations` is computed.

## Reference

Implements internal improvement-plan item **009** ("Lazy parent collection in walk hot loop", P3/perf) from the `improve` audit. No linked public issue.

## Testing

- `npm run typecheck` → exit 0
- `npm run unit` → 242 files pass; coverage thresholds met (statements 80.67%, branches 72.92%, functions 84.47%, lines 81.31%)
- `npm run e2e` → 47 files / 323 tests pass
- Ran the two `parentLocations`-consuming rule suites explicitly (`boolean-parameter-prefixes` oas2/oas3, `operation-parameters-unique`) — green. These assert `location: parentLocations.X.child(...)`, so green confirms the getter returns values identical to the previous eager computation.

> [!WARNING]
> **The perf win is unverified.** The plan specified a mandatory before/after benchmark gate, but the benchmark harness has migrated to Vitest and is mid-rework off `main` — there is no `npm run benchmark` on `main` today. This change is correctness-verified but its speedup is **not** measured on a real workload. Recommend running the benchmark once the harness lands before relying on the perf claim; the change is low-risk and behavior-preserving regardless.

## Screenshots (optional)

N/A

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests — the changed path is exercised by the existing `parentLocations` rule tests; behavior-preserving, so no new test added
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only) — ⚠️ core (`walk.ts`) **did** change but I have **not** verified against other Redocly products; a maintainer should confirm
- [ ] New package installed? - N/A, no new package
- [x] Documentation update has been considered <!-- required 🔒 --> — no docs change needed (internal perf refactor, no API/behavior change)

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 --> — none; this only defers/caches an existing computation, introduces no new inputs, outputs, or trust boundaries
- [x] Code follows company security practices and guidelines
