### PR TITLE
chore: bump js-yaml to v4.2.0

### DIFF
--- a/.changeset/ready-donuts-press.md
+++ b/.changeset/ready-donuts-press.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Bump js-yaml from `4.1.1` to `4.2.0`.

--- a/.changeset/ready-donuts-press.md
+++ b/.changeset/ready-donuts-press.md
@@ -2,4 +2,4 @@
 '@redocly/openapi-core': patch
 ---
 
-Bump js-yaml from `4.1.1` to `4.2.0`.
+Updated js-yaml from `4.1.1` to `4.2.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9019,7 +9019,7 @@
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -9052,6 +9052,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/core/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "packages/core/node_modules/picomatch": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",
     "js-levenshtein": "^1.1.6",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.2.0",
     "picomatch": "^4.0.4",
     "pluralize": "^8.0.0",
     "yaml-ast-parser": "0.0.43"


### PR DESCRIPTION
## What/Why/How?

Bump js yaml to v4.2.0

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch bump with no code changes; YAML parse/stringify behavior may shift slightly with the upstream release.
> 
> **Overview**
> Bumps the **`js-yaml`** dependency in **`@redocly/openapi-core`** from **`^4.1.0`** to **`^4.2.0`**, with **`package-lock.json`** updated to resolve **`4.2.0`** under **`packages/core`**.
> 
> A **patch** changeset records the update for **`@redocly/openapi-core`**. No application or wrapper code in the repo is modified—only the dependency version and lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2560180111886efd46ebeb0e008b590ef9ec4d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->