### PR TITLE
chore: change cafe api domain

### DIFF
--- a/resources/cafe-split/cafe.yaml
+++ b/resources/cafe-split/cafe.yaml
@@ -13,7 +13,7 @@ info:
     url: https://opensource.org/licenses/MIT
   termsOfService: https://redocly.com/subscription-agreement
 servers:
-  - url: https://cafe.cloud.redocly.com
+  - url: https://api.cafe.redocly.com
     description: Live server.
 tags:
   - name: Authorization
@@ -51,8 +51,8 @@ components:
       description: OAuth2 authorization for API access.
       flows:
         authorizationCode:
-          authorizationUrl: https://cafe.cloud.redocly.com/oauth2/authorize
-          tokenUrl: https://cafe.cloud.redocly.com/oauth2/token
+          authorizationUrl: https://api.cafe.redocly.com/oauth2/authorize
+          tokenUrl: https://api.cafe.redocly.com/oauth2/token
           scopes:
             menu:read: Read access to menu items and images
             menu:write: Write access to menu items (create, delete)
@@ -60,7 +60,7 @@ components:
             orders:write: Write access to orders (create, update, delete)
             revenue:read: Read access to revenue statistics
         clientCredentials:
-          tokenUrl: https://cafe.cloud.redocly.com/oauth2/token
+          tokenUrl: https://api.cafe.redocly.com/oauth2/token
           scopes:
             menu:read: Read access to menu items and images
             menu:write: Write access to menu items (create, delete)

--- a/resources/cafe-split/paths/oauth2_register.yaml
+++ b/resources/cafe-split/paths/oauth2_register.yaml
@@ -33,7 +33,7 @@ post:
             dataValue:
               name: auth
               redirectUris:
-                - https://cafe.cloud.redocly.com/callback
+                - https://api.cafe.redocly.com/callback
               scopes:
                 - menu:read
                 - menu:write

--- a/resources/cafe.yaml
+++ b/resources/cafe.yaml
@@ -15,7 +15,7 @@ info:
     url: https://opensource.org/licenses/MIT
   termsOfService: https://redocly.com/subscription-agreement
 servers:
-  - url: https://cafe.cloud.redocly.com
+  - url: https://api.cafe.redocly.com
     description: Live server.
 tags:
   - name: Authorization
@@ -520,7 +520,7 @@ paths:
                 dataValue:
                   name: auth
                   redirectUris:
-                    - https://cafe.cloud.redocly.com/callback
+                    - https://api.cafe.redocly.com/callback
                   scopes:
                     - menu:read
                     - menu:write
@@ -571,8 +571,8 @@ components:
       description: OAuth2 authorization for API access.
       flows:
         authorizationCode:
-          authorizationUrl: https://cafe.cloud.redocly.com/oauth2/authorize
-          tokenUrl: https://cafe.cloud.redocly.com/oauth2/token
+          authorizationUrl: https://api.cafe.redocly.com/oauth2/authorize
+          tokenUrl: https://api.cafe.redocly.com/oauth2/token
           scopes:
             menu:read: Read access to menu items and images
             menu:write: Write access to menu items (create, delete)
@@ -580,7 +580,7 @@ components:
             orders:write: Write access to orders (create, update, delete)
             revenue:read: Read access to revenue statistics
         clientCredentials:
-          tokenUrl: https://cafe.cloud.redocly.com/oauth2/token
+          tokenUrl: https://api.cafe.redocly.com/oauth2/token
           scopes:
             menu:read: Read access to menu items and images
             menu:write: Write access to menu items (create, delete)


### PR DESCRIPTION
## What/Why/How?

Change cafe api domain in resources.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates in demo OpenAPI resources; no runtime or auth logic changes in this repo.
> 
> **Overview**
> Updates the Redocly Cafe demo OpenAPI specs so the live base URL and OAuth endpoints use **`https://api.cafe.redocly.com`** instead of **`https://cafe.cloud.redocly.com`**.
> 
> The same host swap is applied in **`resources/cafe.yaml`** and **`resources/cafe-split/cafe.yaml`** for the `servers` entry and OAuth2 `authorizationUrl` / `tokenUrl` (authorization code and client credentials). OAuth client registration examples now use **`https://api.cafe.redocly.com/callback`** in the monolith spec and in **`resources/cafe-split/paths/oauth2_register.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ebcad83fe21c5b5240c4912a45b71a16fa3e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->