### PR TITLE
fix: credentials leaking to cross-origin redirect targets

### DIFF
--- a/.changeset/nasty-pots-attend.md
+++ b/.changeset/nasty-pots-attend.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed `resolve.http.headers` credentials leaking to cross-origin redirect targets.

--- a/packages/core/src/__tests__/bundle-oas.test.ts
+++ b/packages/core/src/__tests__/bundle-oas.test.ts
@@ -102,6 +102,7 @@ describe('bundle-oas', () => {
     expect(problems).toHaveLength(0);
     expect(fetchMock).toHaveBeenCalledWith('https://someexternal.schema', {
       headers: {},
+      redirect: 'manual',
     });
     expect(res.parsed).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -386,6 +386,7 @@ describe('bundle', () => {
     expect(problems).toHaveLength(0);
     expect(fetchMock).toHaveBeenCalledWith('https://someexternal.schema', {
       headers: {},
+      redirect: 'manual',
     });
     expect(res.parsed).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/resolve-http.test.ts
+++ b/packages/core/src/__tests__/resolve-http.test.ts
@@ -4,6 +4,66 @@ import { parseYamlToDocument } from '../../__tests__/utils.js';
 import { resolveDocument, BaseResolver } from '../resolve.js';
 import { normalizeTypes } from '../types/index.js';
 import { Oas3Types } from '../types/oas3.js';
+import { readFileFromUrl } from '../utils/read-file-from-url.js';
+
+function makeFetchMock(hops: Array<{ status: number; location?: string }>) {
+  let callIndex = 0;
+  return vi.fn(() => {
+    const { status, location } = hops[callIndex++];
+    return Promise.resolve({
+      status,
+      ok: status >= 200 && status < 300,
+      headers: { get: (name: string) => (name === 'location' ? (location ?? null) : null) },
+      text: () => Promise.resolve(''),
+    });
+  });
+}
+
+describe('resolve http-headers security: redirect header leak', () => {
+  it('should not send credentials to a cross-origin redirect target', async () => {
+    const fetchMock = makeFetchMock([
+      { status: 302, location: 'https://evil.com/stolen' },
+      { status: 200 },
+    ]);
+
+    await readFileFromUrl('https://trusted.com/spec.yaml', {
+      customFetch: fetchMock,
+      headers: [{ name: 'X-Secret-Token', matches: 'trusted.com/**', value: 'secret' }],
+    });
+
+    expect(fetchMock).toBeCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://trusted.com/spec.yaml', {
+      headers: { 'X-Secret-Token': 'secret' },
+      redirect: 'manual',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://evil.com/stolen', {
+      headers: {},
+      redirect: 'manual',
+    });
+  });
+
+  it('should keep credentials on a same-glob redirect', async () => {
+    const fetchMock = makeFetchMock([
+      { status: 302, location: 'https://trusted.com/spec-v2.yaml' },
+      { status: 200 },
+    ]);
+
+    await readFileFromUrl('https://trusted.com/spec.yaml', {
+      customFetch: fetchMock,
+      headers: [{ name: 'X-Secret-Token', matches: 'trusted.com/**', value: 'secret' }],
+    });
+
+    expect(fetchMock).toBeCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://trusted.com/spec.yaml', {
+      headers: { 'X-Secret-Token': 'secret' },
+      redirect: 'manual',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://trusted.com/spec-v2.yaml', {
+      headers: { 'X-Secret-Token': 'secret' },
+      redirect: 'manual',
+    });
+  });
+});
 
 describe('Resolve http-headers', () => {
   it('should use matching http-headers', async () => {
@@ -55,12 +115,14 @@ describe('Resolve http-headers', () => {
             "headers": {
               "X_TEST": "123",
             },
+            "redirect": "manual",
           },
         ],
         [
           "https://sample.com/test.yaml",
           {
             "headers": {},
+            "redirect": "manual",
           },
         ],
         [
@@ -69,6 +131,7 @@ describe('Resolve http-headers', () => {
             "headers": {
               "X_TEST": "321",
             },
+            "redirect": "manual",
           },
         ],
       ]

--- a/packages/core/src/utils/read-file-from-url.ts
+++ b/packages/core/src/utils/read-file-from-url.ts
@@ -1,26 +1,49 @@
 import picomatch from 'picomatch';
 
-import type { HttpResolveConfig } from '../config/index.js';
+import type { HttpResolveConfig, ResolveHeader } from '../config/index.js';
 import { env } from '../env.js';
 
+const MAX_REDIRECTS = 20;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
 export async function readFileFromUrl(url: string, config: HttpResolveConfig) {
-  const headers: Record<string, string> = {};
-  for (const header of config.headers) {
+  const fetchFn = config.customFetch || fetch;
+  let currentUrl = url;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    const response = await fetchFn(currentUrl, {
+      headers: getMatchingHeaders(currentUrl, config.headers),
+      redirect: 'manual',
+    });
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      if (!response.ok) {
+        throw new Error(`Failed to load ${currentUrl}: ${response.status} ${response.statusText}`);
+      }
+      return { body: await response.text(), mimeType: response.headers.get('content-type') };
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new Error(
+        `Failed to load ${currentUrl}: redirect response is missing a Location header`
+      );
+    }
+    currentUrl = new URL(location, currentUrl).href;
+  }
+
+  throw new Error(`Failed to load ${url}: too many redirects`);
+}
+
+function getMatchingHeaders(url: string, headers: ResolveHeader[]) {
+  const result: Record<string, string> = {};
+  for (const header of headers) {
     if (match(url, header.matches)) {
-      headers[header.name] =
+      result[header.name] =
         header.envVariable !== undefined ? env[header.envVariable] || '' : header.value;
     }
   }
-
-  const req = await (config.customFetch || fetch)(url, {
-    headers: headers,
-  });
-
-  if (!req.ok) {
-    throw new Error(`Failed to load ${url}: ${req.status} ${req.statusText}`);
-  }
-
-  return { body: await req.text(), mimeType: req.headers.get('content-type') };
+  return result;
 }
 
 function match(url: string, pattern: string) {


### PR DESCRIPTION
## What/Why/How?
User can configure in redocly.yaml `resolve.http.headers` property with the custom header, which contains credentials. The hacker can find the endpoint, which accepts redirects and pass to it redirect URL to the malware website. Fetch automatically redirects to the malware website and strips only `Authorization`, `Cookie`, `Host`, and `Proxy Authorization` header, so a custom token header such as `X-Api-Key` is re-sent to the redirect target. I implemented manual redirecting to check on every step if the url matches.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix in HTTP ref resolution affects all URL fetches during bundle/resolve; behavior change for redirect chains but intended and covered by new tests.
> 
> **Overview**
> Fixes a **credential leak** when resolving external OpenAPI refs over HTTP: custom headers from `resolve.http.headers` (e.g. `X-Api-Key`) could be sent to an attacker-controlled host if the initial URL returned a redirect, because fetch only strips a few standard auth headers on redirect—not user-defined ones.
> 
> `readFileFromUrl` now uses **`redirect: 'manual'`** and follows redirects itself (up to 20 hops). On each hop it rebuilds headers with **`getMatchingHeaders` for the current URL**, so secrets are only attached when the request URL still matches the configured `matches` glob—cross-origin redirect targets get **no** configured credentials; same-host redirects that still match keep them.
> 
> Adds focused security tests in `resolve-http.test.ts` and updates bundle/http resolve expectations to include `redirect: 'manual'`. Patch changeset for `@redocly/openapi-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f8fc68a7bf1a6fb616dad7bc4120b91ad12166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->