### PR TITLE
fix: resolve numbers with underscore with js-yaml@v4.2.0

### DIFF
--- a/.changeset/quiet-pets-grin.md
+++ b/.changeset/quiet-pets-grin.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed bundling of strings that look like numbers with underscores (e.g. `'12_34'`). Since js-yaml `4.2.0` such strings were emitted unquoted and could be read back as numbers by YAML 1.1 parsers; they are now kept quoted in the output.

--- a/.changeset/quiet-pets-grin.md
+++ b/.changeset/quiet-pets-grin.md
@@ -2,4 +2,5 @@
 '@redocly/openapi-core': patch
 ---
 
-Fixed bundling of strings that look like numbers with underscores (e.g. `'12_34'`). Since js-yaml `4.2.0` such strings were emitted unquoted and could be read back as numbers by YAML 1.1 parsers; they are now kept quoted in the output.
+Fixed an issue in bundling where strings with numeric characters and underscores (e.g. `'12_34'`) were emitted unquoted.
+These strings could then be read back as numbers by YAML 1.1 parsers.

--- a/packages/core/src/__tests__/js-yaml.test.ts
+++ b/packages/core/src/__tests__/js-yaml.test.ts
@@ -66,6 +66,30 @@ describe('js-yaml', () => {
     expect(parseYaml(stringifyYaml(jsObject))).toEqual(jsObject);
   });
 
+  it('should keep quotes around strings that look like numbers with underscores', () => {
+    // Regression test for: js-yaml >=4.2.0
+    // no longer quotes such strings on its own, so they must stay quoted here to avoid being
+    // read back as numbers by YAML 1.1 parsers. Actual numbers must remain unquoted.
+    expect(
+      stringifyYaml({
+        underscoreNumber: 1234,
+        underscoreInt: '12_34',
+        underscoreThousands: '1_000',
+        underscoreHex: '0x1_2',
+        underscoreFloat: '1_2.3',
+        plain: 'hello',
+      })
+    ).toMatchInlineSnapshot(`
+    "underscoreNumber: 1234
+    underscoreInt: '12_34'
+    underscoreThousands: '1_000'
+    underscoreHex: '0x1_2'
+    underscoreFloat: '1_2.3'
+    plain: hello
+    "
+    `);
+  });
+
   it('should throw an error for unsupported types', () => {
     expect(() => stringifyYaml({ foo: () => {} })).toThrow(
       'unacceptable kind of an object to dump [object Function]'

--- a/packages/core/src/__tests__/js-yaml.test.ts
+++ b/packages/core/src/__tests__/js-yaml.test.ts
@@ -68,8 +68,7 @@ describe('js-yaml', () => {
 
   it('should keep quotes around strings that look like numbers with underscores', () => {
     // Regression test for: js-yaml >=4.2.0
-    // no longer quotes such strings on its own, so they must stay quoted here to avoid being
-    // read back as numbers by YAML 1.1 parsers. Actual numbers must remain unquoted.
+    // Actual numbers must remain unquoted.
     expect(
       stringifyYaml({
         underscoreNumber: 1234,

--- a/packages/core/src/js-yaml/index.ts
+++ b/packages/core/src/js-yaml/index.ts
@@ -17,6 +17,7 @@ const DEFAULT_SCHEMA_WITHOUT_TIMESTAMP = JSON_SCHEMA.extend({
   explicit: [types.binary, types.omap, types.pairs, types.set],
 });
 
+// TODO: remove this after js-yaml update.
 // js-yaml >=4.2.0 stopped resolving numbers with underscores (e.g. `12_34`, `1_000`, `0x1_2`,
 // `1_2.3`) as numeric scalars (https://github.com/nodeca/js-yaml/issues/627). As a side effect
 // the dumper no longer quotes strings that look like such numbers, so YAML 1.1 parsers read

--- a/packages/core/src/js-yaml/index.ts
+++ b/packages/core/src/js-yaml/index.ts
@@ -1,14 +1,45 @@
+import jsYaml, {
+  DEFAULT_SCHEMA,
+  JSON_SCHEMA,
+  Type,
+  load,
+  dump,
+  type LoadOptions,
+  type DumpOptions,
+} from 'js-yaml';
+
+// `types` (the built-in tag instances) is not declared in @types/js-yaml.
 // TODO: add a type for "types" https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/js-yaml/index.d.ts
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { JSON_SCHEMA, types, load, dump, type LoadOptions, type DumpOptions } from 'js-yaml';
+const types = (jsYaml as unknown as { types: Record<string, Type> }).types;
 
 const DEFAULT_SCHEMA_WITHOUT_TIMESTAMP = JSON_SCHEMA.extend({
   implicit: [types.merge],
   explicit: [types.binary, types.omap, types.pairs, types.set],
 });
 
+// js-yaml >=4.2.0 stopped resolving numbers with underscores (e.g. `12_34`, `1_000`, `0x1_2`,
+// `1_2.3`) as numeric scalars (https://github.com/nodeca/js-yaml/issues/627). As a side effect
+// the dumper no longer quotes strings that look like such numbers, so YAML 1.1 parsers read
+// them back as numbers, losing type information.
+// This implicit type matches those underscore-number-like strings so the dumper quotes them; it
+// is only used to influence quoting and never constructs or represents a value.
+const underscoreNumberLike = new Type('tag:redocly.com,2026:underscore-number', {
+  kind: 'scalar',
+  resolve: (data: unknown): boolean => {
+    if (typeof data !== 'string' || !data.includes('_')) return false;
+    const stripped = data.replace(/_/g, '');
+    return types.int.resolve(stripped) || types.float.resolve(stripped);
+  },
+  predicate: (): boolean => false,
+});
+
+// Extend js-yaml's default dump schema (the one `dump` uses when no schema is given) so the
+// only added behavior is quoting underscore-number-like strings; everything else, including
+// quoting of date-like strings via the timestamp type, is preserved.
+const DUMP_SCHEMA = DEFAULT_SCHEMA.extend({ implicit: [underscoreNumberLike] });
+
 export const parseYaml = (str: string, opts?: LoadOptions): unknown =>
   load(str, { schema: DEFAULT_SCHEMA_WITHOUT_TIMESTAMP, ...opts });
 
-export const stringifyYaml = (obj: any, opts?: DumpOptions): string => dump(obj, opts);
+export const stringifyYaml = (obj: any, opts?: DumpOptions): string =>
+  dump(obj, { schema: DUMP_SCHEMA, ...opts });


### PR DESCRIPTION
## What/Why/How?

Fixed bundling of strings that look like numbers with underscores (e.g. `'12_34'`). Since js-yaml `4.2.0` such strings were emitted unquoted and could be read back as numbers by YAML 1.1 parsers; they are now kept quoted in the output.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2906

## Alternative

Migration to v5 contains some breaking change, related to indentation:
https://github.com/Redocly/redocly-cli/pull/2908

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to YAML serialization quoting in openapi-core; parse behavior unchanged and covered by tests.
> 
> **Overview**
> Fixes **bundling/YAML output** for string values that look like numbers with underscores (e.g. `'12_34'`, `'1_000'`), which **js-yaml ≥4.2.0** could emit **unquoted** so YAML 1.1 parsers read them as numbers.
> 
> `stringifyYaml` now dumps with a **custom schema** (`DUMP_SCHEMA`) that adds an implicit scalar type matching underscore-number-like **strings** so the dumper **quotes** them; real numeric values stay unquoted. **Parsing** (`parseYaml`) is unchanged. A **regression test** and **changeset** patch note are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc94a324adf9a8f22bef35f5de5037fd9be6953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->