### PR TITLE
chore: update the formatting config and improve the contributing guide

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,18 +7,17 @@
     "coverage/",
     "lib/",
     "output/",
-    "packages/core/src/rules/common/__tests__/fixtures/invalid-yaml.yaml",
     "packages/respect-core/src/modules/runtime-expressions/abnf-parser.js",
+    "packages/core/src/rules/common/__tests__/fixtures/invalid-yaml.yaml",
     "tests/performance/api-definitions/",
-    "LICENSE.md",
-    "snapshot*.txt",
-    ".changeset/pre.json",
-    "*.html",
-    "tests/e2e/**/*.yaml",
     "tests/smoke/**/*.yaml",
+    "snapshot*.txt",
+    "*.html",
     "*.hbs",
     "*.toml",
-    "CHANGELOG.md"
+    "LICENSE.md",
+    "CHANGELOG.md",
+    ".changeset/pre.json"
   ],
   "experimentalSortImports": {
     "groups": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,11 @@ When contributing to Redocly CLI, it's important to follow these logging guideli
    - `logger.warn()` for warnings
    - `logger.error()` for errors
 
-3. Only write to `stdout` when the output is meant to be consumed by other applications or tools (like when piping to `jq` or other CLI tools). This includes:
-   - Command output that needs to be parsed
-   - Interactive outputs (like login/logout responses)
-   - Data that needs to be piped to other commands
+3. Only write to `stdout` when the output is meant to be consumed by other applications or tools (like when piping to `jq` or other CLI tools).
+   This includes:
+   - command output that needs to be parsed
+   - interactive outputs (like login/logout responses)
+   - data that needs to be piped to other commands
 
    ```typescript
    logger.output(JSON.stringify(stats, null, 2));
@@ -109,7 +110,8 @@ There are two options for testing local changes in other local applications: NPM
 
 ### NPM linking
 
-To test the local source code of the packages in other local applications, you can use npm linking. See the [docs](https://docs.npmjs.com/cli/v9/commands/npm-link).
+To test the local source code of the packages in other local applications, you can use npm linking.
+See the [docs](https://docs.npmjs.com/cli/v9/commands/npm-link).
 
 ### Local packing and installing
 
@@ -130,7 +132,8 @@ You can find the documentation in the `docs/` folder, and this is published to h
 
 To preview your documentation changes locally:
 
-1. Make sure `redocly` is already installed on your local computer. See [installation](https://redocly.com/docs/cli/installation/).
+1. Make sure `redocly` is already installed on your local computer.
+   See [installation](https://redocly.com/docs/cli/installation/).
 
 2. Run this command from the `docs/` folder:
 
@@ -164,7 +167,10 @@ The checks run on pull requests; locally, from the repository root:
 npx markdownlint-cli2 "docs/**/*.md"
 ```
 
-> Note that formatter also runs and reformats Markdown files. Use `npm run format` from the root of the project.
+> Note that formatter also runs and reformats Markdown files.
+> Use `npm run format` from the root of the project.
+
+> Please use semantic line breaks in markdown files (preferably splitting sentences into separate lines).
 
 ### Markdown link checking
 
@@ -304,7 +310,8 @@ There are also other commands available for your convenience to test specific co
 
 What should be verified when changes are applied to the `respect-core` package:
 
-- `mTLS` is working. Can be done by calling API endpoint with mTLS authentication `npm run cli respect {YOUR}.arazzo.yaml -- --verbose --mtls=='{"domain":{"caCert":"ca-cert.pem", "clientKey":"client-key.pem","clientCert":"client-cert.pem"}}'`. [Learn more about mTLS usage in Respect](https://redocly.com/docs/respect/guides/mtls-cli#use-mtls-with-respect-in-redocly-cli).
+- `mTLS` is working. Can be done by calling API endpoint with mTLS authentication `npm run cli respect {YOUR}.arazzo.yaml -- --verbose --mtls=='{"domain":{"caCert":"ca-cert.pem", "clientKey":"client-key.pem","clientCert":"client-cert.pem"}}'`.
+  [Learn more about mTLS usage in Respect](https://redocly.com/docs/respect/guides/mtls-cli#use-mtls-with-respect-in-redocly-cli).
 - File upload is working for both `multipart/form-data` and `application/octet-stream`.
 
 ## Project structure

--- a/tests/e2e/bundle/bundle-remove-unused-components-from-config/oas3-parameter-ref-to-schema-with-unused-schema-opposite-ref/openapi.yaml
+++ b/tests/e2e/bundle/bundle-remove-unused-components-from-config/oas3-parameter-ref-to-schema-with-unused-schema-opposite-ref/openapi.yaml
@@ -15,7 +15,7 @@ paths:
           content:
             application/json:
               schema: {}
-components: 
-  schemas: 
+components:
+  schemas:
     User:
       $ref: schemas.yaml#/User

--- a/tests/e2e/bundle/bundle-remove-unused-components-from-config/oas3-recursive-ref/openapi.yaml
+++ b/tests/e2e/bundle/bundle-remove-unused-components-from-config/oas3-recursive-ref/openapi.yaml
@@ -10,15 +10,15 @@ paths:
           content:
             application/json:
               schema: {}
-components: 
-  schemas: 
+components:
+  schemas:
     RecursiveRef:
       type: object
-      properties: 
+      properties:
         prop:
           type: array
-          items: 
-            anyOf: 
+          items:
+            anyOf:
               - $ref: '#/components/schemas/RecursiveRef'
     UnusedComponent:
       type: string

--- a/tests/e2e/join/root-security-in-both-specs/bar.yaml
+++ b/tests/e2e/join/root-security-in-both-specs/bar.yaml
@@ -20,4 +20,3 @@ paths:
           description: OK
         400:
           description: Bad request
-          

--- a/tests/e2e/join/root-security-without-paths/bar.yaml
+++ b/tests/e2e/join/root-security-without-paths/bar.yaml
@@ -12,4 +12,3 @@ paths:
           description: OK
         400:
           description: Bad request
-          

--- a/tests/e2e/lint/no-invalid-parameter-examples-with-exclusive-minimum/openapi-oas30-draft4.yaml
+++ b/tests/e2e/lint/no-invalid-parameter-examples-with-exclusive-minimum/openapi-oas30-draft4.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: getTest
       parameters:
         - name: validExclusiveMinimum
-          description: "OAS 3.0 draft4: exclusiveMinimum is boolean, used with minimum"
+          description: 'OAS 3.0 draft4: exclusiveMinimum is boolean, used with minimum'
           in: query
           schema:
             type: integer
@@ -18,7 +18,7 @@ paths:
           example: 11
 
         - name: invalidExclusiveMinimumBoundary
-          description: "exclusiveMinimum boundary (value equals threshold)"
+          description: 'exclusiveMinimum boundary (value equals threshold)'
           in: query
           schema:
             type: integer
@@ -27,7 +27,7 @@ paths:
           example: 10
 
         - name: validExclusiveMaximum
-          description: "OAS3.0 draft4: exclusiveMaximum is boolean, used with maximum"  
+          description: 'OAS3.0 draft4: exclusiveMaximum is boolean, used with maximum'
           in: query
           schema:
             type: integer
@@ -41,7 +41,7 @@ components:
   parameters:
     RefInvalidExclusiveMinimumBoundary:
       name: refInvalidExclusiveMinimumBoundary
-      description: "Reference-based invalid boundary case"
+      description: Reference-based invalid boundary case
       in: query
       schema:
         type: integer

--- a/tests/e2e/lint/no-invalid-parameter-examples-with-exclusive-minimum/openapi-oas32-2020.yaml
+++ b/tests/e2e/lint/no-invalid-parameter-examples-with-exclusive-minimum/openapi-oas32-2020.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: getTest
       parameters:
         - name: validExclusiveMinimum
-          description: "draft2020: exclusiveMinimum is numeric threshold"
+          description: 'draft2020: exclusiveMinimum is numeric threshold'
           in: query
           schema:
             type: integer
@@ -17,7 +17,7 @@ paths:
           example: 11
 
         - name: invalidExclusiveMinimumBoundary
-          description: "Invalid exclusiveMinimum boundary (value equals threshold)"
+          description: 'Invalid exclusiveMinimum boundary (value equals threshold)'
           in: query
           schema:
             type: integer
@@ -25,7 +25,7 @@ paths:
           example: 10
 
         - name: validExclusiveMaximum
-          description: "Valid exclusiveMaximum (value < threshold)"
+          description: 'Valid exclusiveMaximum (value < threshold)'
           in: query
           schema:
             type: integer
@@ -33,7 +33,7 @@ paths:
           example: 19
 
         - name: invalidExclusiveMaximumBoundary
-          description: "Invalid exclusiveMaximum boundary (value equals threshold)"
+          description: 'Invalid exclusiveMaximum boundary (value equals threshold)'
           in: query
           schema:
             type: integer
@@ -46,7 +46,7 @@ components:
   parameters:
     RefInvalidExclusiveMinimumBoundary:
       name: refInvalidExclusiveMinimumBoundary
-      description: "Reference-based invalid boundary case"
+      description: Reference-based invalid boundary case
       in: query
       schema:
         type: integer

--- a/tests/e2e/respect/x-allow-reserved-query-param/x-allow-reserved-query-param.arazzo.yaml
+++ b/tests/e2e/respect/x-allow-reserved-query-param/x-allow-reserved-query-param.arazzo.yaml
@@ -14,8 +14,8 @@ workflows:
         parameters:
           - in: query
             name: startDate
-            value: "2023-02-23"
+            value: 2023-02-23
           - in: query
             name: filter
-            value: "https://example.com/path/to;x,y(z)a*b.c[1]@v"
+            value: 'https://example.com/path/to;x,y(z)a*b.c[1]@v'
             x-allowReserved: true


### PR DESCRIPTION
## What/Why/How?

- Updated the formatting config
- Improved the contribution guide
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and formatter-config changes plus cosmetic YAML/Markdown edits in tests; no runtime or product logic touched.
> 
> **Overview**
> Updates **`.oxfmtrc.json`** by reordering `ignorePatterns` and **stopping the formatter from skipping `tests/e2e/**/*.yaml`**, so e2e OpenAPI/Arazzo fixtures are now subject to oxfmt like other tracked YAML.
> 
> **`CONTRIBUTING.md`** is reflowed for semantic line breaks (shorter lines, split blockquotes) and adds explicit guidance to prefer **semantic line breaks** in Markdown alongside the existing `npm run format` note.
> 
> Several **e2e test fixtures** pick up mechanical formatter changes only: YAML key spacing, single-quoted strings where required, removal of trailing whitespace/newlines, and minor quote style on parameter descriptions—no semantic API or test behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4014c353adf9b6d64153886b699f25df31000a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->