### PR TITLE
feat: add sri integrity hash for redoc

### DIFF
--- a/.changeset/build-docs-sri.md
+++ b/.changeset/build-docs-sri.md
@@ -1,5 +1,5 @@
 ---
-'@redocly/cli': patch
+'@redocly/cli': minor
 ---
 
-Added Subresource Integrity to `build-docs` output: the generated HTML now loads `redoc.standalone.js` from the CDN with an `integrity` hash and `crossorigin="anonymous"`, so the browser verifies the script before running it. The hash is tied to the Redoc version bundled with the CLI.
+Added Subresource Integrity to `build-docs` output.

--- a/.changeset/build-docs-sri.md
+++ b/.changeset/build-docs-sri.md
@@ -2,4 +2,4 @@
 '@redocly/cli': minor
 ---
 
-Added Subresource Integrity to `build-docs` output.
+Added a [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash to the Redoc standalone script tag in the HTML produced by `build-docs`, ensuring the script's integrity.

--- a/.changeset/build-docs-sri.md
+++ b/.changeset/build-docs-sri.md
@@ -2,4 +2,4 @@
 '@redocly/cli': minor
 ---
 
-Added a [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash to the Redoc standalone script tag in the HTML produced by `build-docs`, ensuring the script's integrity.
+Added a Subresource Integrity (SRI) hash to the Redoc standalone script tag in the HTML produced by `build-docs`, ensuring the script's integrity.

--- a/.changeset/build-docs-sri.md
+++ b/.changeset/build-docs-sri.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': patch
+---
+
+Added Subresource Integrity to `build-docs` output: the generated HTML now loads `redoc.standalone.js` from the CDN with an `integrity` hash and `crossorigin="anonymous"`, so the browser verifies the script before running it. The hash is tied to the Redoc version bundled with the CLI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ When updating Redoc, recompute the subresource integrity [SRI](https://developer
 openssl dgst -sha384 -binary node_modules/redoc/bundles/redoc.standalone.js | openssl base64 -A
 ```
 
-Also needs to be updated in test snapshots.
+Also needs to be updated in [test snapshots](#e2e-tests).
 
 ## Arguments usage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,16 @@ To make changes to documentation:
 2. Add the link to the rule page to the [built-in rules list](docs/@v2/rules/built-in-rules.md) and the [sidebar](docs/@v2/v2.sidebars.yaml).
 3. Update the rulesets pages and [ruleset templates](docs/@v2/rules/ruleset-templates.md).
 
+## Updating Redoc
+
+When updating Redoc, recompute the subresource integrity (`redocStandaloneSri` in [package.ts](./packages/cli/src/utils/package.ts)):
+
+```bash
+openssl dgst -sha384 -binary node_modules/redoc/bundles/redoc.standalone.js | openssl base64 -A
+```
+
+Also needs to be updated in test snapshots.
+
 ## Arguments usage
 
 There are three ways of providing arguments to the CLI: environment variables, command line arguments, and a Redocly configuration file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,9 +200,9 @@ To make changes to documentation:
 2. Add the link to the rule page to the [built-in rules list](docs/@v2/rules/built-in-rules.md) and the [sidebar](docs/@v2/v2.sidebars.yaml).
 3. Update the rulesets pages and [ruleset templates](docs/@v2/rules/ruleset-templates.md).
 
-## Updating Redoc
+## Update Redoc
 
-When updating Redoc, recompute the subresource integrity (`redocStandaloneSri` in [package.ts](./packages/cli/src/utils/package.ts)):
+When updating Redoc, recompute the subresource integrity [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (`redocStandaloneSri` in [package.ts](./packages/cli/src/utils/package.ts)):
 
 ```bash
 openssl dgst -sha384 -binary node_modules/redoc/bundles/redoc.standalone.js | openssl base64 -A

--- a/packages/cli/src/__tests__/commands/build-docs.test.ts
+++ b/packages/cli/src/__tests__/commands/build-docs.test.ts
@@ -9,6 +9,19 @@ import { type BuildDocsArgv } from '../../commands/build-docs/types.js';
 import { getPageHTML } from '../../commands/build-docs/utils.js';
 import { getFallbackApisOrExit } from '../../utils/miscellaneous.js';
 
+vi.mock('redoc');
+vi.mock('node:fs');
+vi.mock('../../utils/miscellaneous.js');
+vi.mock('react-dom/server', () => ({
+  renderToString: vi.fn(),
+}));
+vi.mock('handlebars', () => ({
+  compile: vi.fn(() => vi.fn(() => '<html></html>')),
+  default: {
+    compile: vi.fn(() => vi.fn(() => '<html></html>')),
+  },
+}));
+
 const config = {
   output: '',
   title: 'Test',
@@ -20,25 +33,10 @@ const config = {
 
 describe('build-docs', () => {
   beforeEach(() => {
-    vi.mock('redoc');
     vi.mocked(loadAndBundleSpec).mockResolvedValue({ openapi: '3.0.0' } as OpenAPISpec);
     vi.mocked(createStore).mockResolvedValue({ toJS: vi.fn(async () => '{}' as any) } as any);
 
-    vi.mock('node:fs');
     vi.mocked(fs.readFileSync).mockImplementation(() => '');
-
-    vi.mock('../../utils/miscellaneous.js');
-
-    vi.mock('react-dom/server', () => ({
-      renderToString: vi.fn(),
-    }));
-
-    vi.mock('handlebars', () => ({
-      compile: vi.fn(() => vi.fn(() => '<html></html>')),
-      default: {
-        compile: vi.fn(() => vi.fn(() => '<html></html>')),
-      },
-    }));
 
     vi.mocked(getFallbackApisOrExit).mockImplementation(
       async (entrypoints) => entrypoints?.map((path: string) => ({ path })) ?? []
@@ -48,10 +46,10 @@ describe('build-docs', () => {
   it('should return correct html and call function for ssr', async () => {
     const result = await getPageHTML({}, '../some-path/openapi.yaml', {
       ...config,
-      redocCurrentVersion: '2.0.0',
+      redocVersion: '2.0.0',
     });
-    expect(renderToString).toBeCalledTimes(1);
-    expect(createStore).toBeCalledTimes(1);
+    expect(renderToString).toHaveBeenCalledTimes(1);
+    expect(createStore).toHaveBeenCalledTimes(1);
     expect(result).toBe('<html></html>');
   });
 

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -6,7 +6,7 @@ import { default as redoc } from 'redoc';
 
 import { exitWithError } from '../../utils/error.js';
 import { getExecutionTime, getFallbackApisOrExit } from '../../utils/miscellaneous.js';
-import { redocVersion as redocCurrentVersion } from '../../utils/package.js';
+import { redocVersion } from '../../utils/package.js';
 import type { CommandArgs } from '../../wrapper.js';
 import type { BuildDocsArgv } from './types.js';
 import { getObjectOrJSON, getPageHTML } from './utils.js';
@@ -36,12 +36,7 @@ export const handlerBuildCommand = async ({
       isAbsoluteUrl(pathToApi) ? pathToApi : resolve(pathToApi)
     );
     collectSpecData?.(api);
-    const pageHTML = await getPageHTML(
-      api,
-      pathToApi,
-      { ...options, redocCurrentVersion },
-      argv.config
-    );
+    const pageHTML = await getPageHTML(api, pathToApi, { ...options, redocVersion }, argv.config);
 
     mkdirSync(dirname(options.output), { recursive: true });
     writeFileSync(options.output, pageHTML);

--- a/packages/cli/src/commands/build-docs/types.ts
+++ b/packages/cli/src/commands/build-docs/types.ts
@@ -9,7 +9,7 @@ export type BuildDocsOptions = {
   templateFileName?: string;
   templateOptions?: any;
   redocOptions?: any;
-  redocCurrentVersion: string;
+  redocVersion: string;
 };
 
 export type BuildDocsArgv = {

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -76,7 +76,7 @@ export async function getPageHTML(
     templateFileName,
     templateOptions,
     redocOptions = {},
-    redocCurrentVersion,
+    redocVersion,
   }: BuildDocsOptions,
   configPath?: string
 ) {
@@ -111,7 +111,7 @@ export async function getPageHTML(
 
       </script>`,
     redocHead:
-      `<script src="https://cdn.redocly.com/redoc/v${redocCurrentVersion}/bundles/redoc.standalone.js"></script>` +
+      `<script src="https://cdn.redocly.com/redoc/v${redocVersion}/bundles/redoc.standalone.js"></script>` +
       css,
     title: title || api.info.title || 'ReDoc documentation',
     disableGoogleFont,

--- a/packages/cli/src/commands/build-docs/utils.ts
+++ b/packages/cli/src/commands/build-docs/utils.ts
@@ -8,6 +8,7 @@ import { default as redoc } from 'redoc';
 import { ServerStyleSheet } from 'styled-components';
 
 import { exitWithError } from '../../utils/error.js';
+import { redocStandaloneSri } from '../../utils/package.js';
 import type { BuildDocsOptions } from './types.js';
 
 const DEFAULT_TEMPLATE_SOURCE = `<!DOCTYPE html>
@@ -111,7 +112,7 @@ export async function getPageHTML(
 
       </script>`,
     redocHead:
-      `<script src="https://cdn.redocly.com/redoc/v${redocVersion}/bundles/redoc.standalone.js"></script>` +
+      `<script src="https://cdn.redocly.com/redoc/v${redocVersion}/bundles/redoc.standalone.js" integrity="${redocStandaloneSri}" crossorigin="anonymous"></script>` +
       css,
     title: title || api.info.title || 'ReDoc documentation',
     disableGoogleFont,

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -2,3 +2,12 @@ import packageJson from '../../package.json' with { type: 'json' };
 
 export const { version, name, engines } = packageJson;
 export const redocVersion = packageJson.devDependencies.redoc;
+
+/**
+ * Subresource Integrity hash for the redoc.standalone.js bundle loaded from the CDN.
+ * Must match `redocVersion`. When bumping redoc, recompute with:
+ *   openssl dgst -sha384 -binary node_modules/redoc/bundles/redoc.standalone.js | openssl base64 -A
+ * The smoke-test snapshot (tests/smoke/basic/pre-built/redoc.html) flags the resulting output change.
+ */
+export const redocStandaloneSri =
+  'sha384-xiEssMQFSpSfLbzRZCGfxxIM5QDb2DTrU6vyoZdp2sV1L6pmOMy6MpTtUoLbpC96';

--- a/tests/e2e/build-docs/build-docs-with-config-option/snapshot.txt
+++ b/tests/e2e/build-docs/build-docs-with-config-option/snapshot.txt
@@ -12,7 +12,7 @@
             margin: 0;
         }
     </style>
-    <script src="https://cdn.redocly.com/redoc/v2.5.3/bundles/redoc.standalone.js"></script><style data-styled="true" data-styled-version="6.4.2">.kktglN{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
+    <script src="https://cdn.redocly.com/redoc/v2.5.3/bundles/redoc.standalone.js" integrity="sha384-xiEssMQFSpSfLbzRZCGfxxIM5QDb2DTrU6vyoZdp2sV1L6pmOMy6MpTtUoLbpC96" crossorigin="anonymous"></script><style data-styled="true" data-styled-version="6.4.2">.kktglN{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
 @media print,screen and (max-width: 75rem){.kktglN{width:100%;padding:40px 40px;}}/*!sc*/
 data-styled.g5[id="sc-hKVpXn"]{content:"kktglN,"}/*!sc*/
 .jleRXN{padding:40px 0;}/*!sc*/

--- a/tests/e2e/build-docs/build-docs-with-disabled-search/snapshot.txt
+++ b/tests/e2e/build-docs/build-docs-with-disabled-search/snapshot.txt
@@ -12,7 +12,7 @@
       margin: 0;
     }
   </style>
-  <script src="https://cdn.redocly.com/redoc/v2.5.3/bundles/redoc.standalone.js"></script><style data-styled="true" data-styled-version="6.4.2">.kktglN{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
+  <script src="https://cdn.redocly.com/redoc/v2.5.3/bundles/redoc.standalone.js" integrity="sha384-xiEssMQFSpSfLbzRZCGfxxIM5QDb2DTrU6vyoZdp2sV1L6pmOMy6MpTtUoLbpC96" crossorigin="anonymous"></script><style data-styled="true" data-styled-version="6.4.2">.kktglN{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
 @media print,screen and (max-width: 75rem){.kktglN{width:100%;padding:40px 40px;}}/*!sc*/
 data-styled.g5[id="sc-hKVpXn"]{content:"kktglN,"}/*!sc*/
 .jleRXN{padding:40px 0;}/*!sc*/

--- a/tests/e2e/build-docs/build-docs.test.ts
+++ b/tests/e2e/build-docs/build-docs.test.ts
@@ -38,7 +38,7 @@ describe('build-docs', () => {
     `);
 
     expect(existsSync(join(testPath, 'nested/redoc-static.html'))).toEqual(true);
-    expect(statSync(join(testPath, 'nested/redoc-static.html')).size).toEqual(36375);
+    expect(statSync(join(testPath, 'nested/redoc-static.html')).size).toEqual(36483);
     const output = readFileSync(join(testPath, 'nested/redoc-static.html'), 'utf8');
     await expect(output).toMatchFileSnapshot(join(testPath, 'snapshot.txt'));
   });

--- a/tests/e2e/build-docs/redoc-sri/openapi.yaml
+++ b/tests/e2e/build-docs/redoc-sri/openapi.yaml
@@ -1,0 +1,227 @@
+openapi: 3.2.0
+info:
+  title: Redocly Cafe
+tags:
+  - name: Products
+    description: Operations related to products.
+paths:
+  /menu:
+    get:
+      tags:
+        - Products
+      summary: List all menu items
+      description: Retrieve a collection of menu items with optional filtering and pagination.
+      operationId: listMenuItems
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MenuItemList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+components:
+  schemas:
+    Page:
+      type: object
+      properties:
+        endCursor:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Use with the `after` query parameter to load the next page of data.
+            When `null`, there is no data.
+            The cursor is opaque and internal structure is subject to change.
+        startCursor:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Use with the `before` query parameter to load the previous page of data.
+            When `null`, there is no data.
+            The cursor is opaque and internal structure is subject to change.
+        hasNextPage:
+          type: boolean
+          description: Indicates if there is a next page with items.
+        hasPrevPage:
+          type: boolean
+          description: Indicates if there is a previous page with items.
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+          description: Value showing how many items are in the page limit.
+        total:
+          type: integer
+          description: Count of items across all pages.
+          minimum: 0
+      required:
+        - endCursor
+        - startCursor
+        - hasNextPage
+        - hasPrevPage
+        - limit
+        - total
+    MenuBaseItem:
+      type: object
+      properties:
+        createdAt:
+          description: Created date.
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          description: Updated date.
+          type: string
+          format: date-time
+          readOnly: true
+        id:
+          description: Menu item ID. Unique identifier prefixed with `prd_`.
+          type: string
+          readOnly: true
+          pattern: ^prd_[0-9abcdefghjkmnpqrstvwxyz]{26}$
+          example: prd_01h1s5z6vf2mm1mz3hevnn9va7
+        object:
+          description: Entity name.
+          type: string
+          const: menuItem
+          readOnly: true
+        name:
+          description: Menu item name.
+          type: string
+          minLength: 1
+          maxLength: 50
+        price:
+          description: Price in cents.
+          type: integer
+          minimum: 0
+        photo:
+          writeOnly: true
+          type:
+            - string
+            - 'null'
+          format: binary
+          description: Photo of the menu item. Must be a PNG image and less than 1MB.
+        photoUrl:
+          readOnly: true
+          type: string
+          format: uri
+          description: Photo URL of the menu item.
+        photoTextDescription:
+          type:
+            - string
+            - 'null'
+      required:
+        - id
+        - name
+        - price
+        - createdAt
+        - updatedAt
+        - object
+    Beverage:
+      allOf:
+        - type: object
+          properties:
+            category:
+              description: Menu item category.
+              type: string
+              const: beverage
+            volume:
+              type: number
+              description: Size of the beverage in milliliters.
+              exclusiveMinimum: 0
+            containsCaffeine:
+              type: boolean
+              description: Indicates if the beverage contains caffeine.
+          required:
+            - category
+            - volume
+            - containsCaffeine
+        - $ref: '#/components/schemas/MenuBaseItem'
+    Dessert:
+      allOf:
+        - type: object
+          properties:
+            category:
+              description: Menu item category.
+              type: string
+              const: dessert
+            calories:
+              type: number
+              exclusiveMinimum: 0
+              description: Amount of calories.
+          required:
+            - category
+            - calories
+        - $ref: '#/components/schemas/MenuBaseItem'
+    MenuItem:
+      discriminator:
+        propertyName: category
+        mapping:
+          beverage: '#/components/schemas/Beverage'
+          dessert: '#/components/schemas/Dessert'
+      oneOf:
+        - $ref: '#/components/schemas/Beverage'
+        - $ref: '#/components/schemas/Dessert'
+      required:
+        - category
+    MenuItemList:
+      type: object
+      properties:
+        object:
+          type: string
+          const: list
+          description: Entity name.
+        page:
+          $ref: '#/components/schemas/Page'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MenuItem'
+      required:
+        - object
+        - page
+        - items
+    Error:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri-reference
+          description: URI reference that identifies the problem type.
+          default: about:blank
+        title:
+          type: string
+          description: Short summary of the problem type.
+        status:
+          type: integer
+          format: int32
+          description: |
+            HTTP status code generated by the origin server for this occurrence of the problem.
+          minimum: 100
+          exclusiveMaximum: 600
+        instance:
+          type: string
+          format: uri-reference
+          description: |
+            URI reference that identifies the specific occurrence of the problem, e.g. by adding a fragment identifier or sub-path to the problem type.
+            May be used to locate the root of this problem in the source code.
+          example: /some/uri-reference#specific-occurrence-context
+        details:
+          description: Additional error details.
+          type: object
+          additionalProperties: true
+      required:
+        - type
+        - title
+        - status
+  responses:
+    BadRequest:
+      description: Bad request - invalid input parameters.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/tests/e2e/build-docs/redoc-sri/openapi.yaml
+++ b/tests/e2e/build-docs/redoc-sri/openapi.yaml
@@ -1,16 +1,10 @@
 openapi: 3.2.0
 info:
   title: Redocly Cafe
-tags:
-  - name: Products
-    description: Operations related to products.
 paths:
   /menu:
     get:
-      tags:
-        - Products
       summary: List all menu items
-      description: Retrieve a collection of menu items with optional filtering and pagination.
       operationId: listMenuItems
       responses:
         '200':
@@ -18,210 +12,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MenuItemList'
+                type: array
+                items:
+                  type: object
         '400':
           $ref: '#/components/responses/BadRequest'
 components:
-  schemas:
-    Page:
-      type: object
-      properties:
-        endCursor:
-          type:
-            - string
-            - 'null'
-          description: |-
-            Use with the `after` query parameter to load the next page of data.
-            When `null`, there is no data.
-            The cursor is opaque and internal structure is subject to change.
-        startCursor:
-          type:
-            - string
-            - 'null'
-          description: |-
-            Use with the `before` query parameter to load the previous page of data.
-            When `null`, there is no data.
-            The cursor is opaque and internal structure is subject to change.
-        hasNextPage:
-          type: boolean
-          description: Indicates if there is a next page with items.
-        hasPrevPage:
-          type: boolean
-          description: Indicates if there is a previous page with items.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          default: 10
-          description: Value showing how many items are in the page limit.
-        total:
-          type: integer
-          description: Count of items across all pages.
-          minimum: 0
-      required:
-        - endCursor
-        - startCursor
-        - hasNextPage
-        - hasPrevPage
-        - limit
-        - total
-    MenuBaseItem:
-      type: object
-      properties:
-        createdAt:
-          description: Created date.
-          type: string
-          format: date-time
-          readOnly: true
-        updatedAt:
-          description: Updated date.
-          type: string
-          format: date-time
-          readOnly: true
-        id:
-          description: Menu item ID. Unique identifier prefixed with `prd_`.
-          type: string
-          readOnly: true
-          pattern: ^prd_[0-9abcdefghjkmnpqrstvwxyz]{26}$
-          example: prd_01h1s5z6vf2mm1mz3hevnn9va7
-        object:
-          description: Entity name.
-          type: string
-          const: menuItem
-          readOnly: true
-        name:
-          description: Menu item name.
-          type: string
-          minLength: 1
-          maxLength: 50
-        price:
-          description: Price in cents.
-          type: integer
-          minimum: 0
-        photo:
-          writeOnly: true
-          type:
-            - string
-            - 'null'
-          format: binary
-          description: Photo of the menu item. Must be a PNG image and less than 1MB.
-        photoUrl:
-          readOnly: true
-          type: string
-          format: uri
-          description: Photo URL of the menu item.
-        photoTextDescription:
-          type:
-            - string
-            - 'null'
-      required:
-        - id
-        - name
-        - price
-        - createdAt
-        - updatedAt
-        - object
-    Beverage:
-      allOf:
-        - type: object
-          properties:
-            category:
-              description: Menu item category.
-              type: string
-              const: beverage
-            volume:
-              type: number
-              description: Size of the beverage in milliliters.
-              exclusiveMinimum: 0
-            containsCaffeine:
-              type: boolean
-              description: Indicates if the beverage contains caffeine.
-          required:
-            - category
-            - volume
-            - containsCaffeine
-        - $ref: '#/components/schemas/MenuBaseItem'
-    Dessert:
-      allOf:
-        - type: object
-          properties:
-            category:
-              description: Menu item category.
-              type: string
-              const: dessert
-            calories:
-              type: number
-              exclusiveMinimum: 0
-              description: Amount of calories.
-          required:
-            - category
-            - calories
-        - $ref: '#/components/schemas/MenuBaseItem'
-    MenuItem:
-      discriminator:
-        propertyName: category
-        mapping:
-          beverage: '#/components/schemas/Beverage'
-          dessert: '#/components/schemas/Dessert'
-      oneOf:
-        - $ref: '#/components/schemas/Beverage'
-        - $ref: '#/components/schemas/Dessert'
-      required:
-        - category
-    MenuItemList:
-      type: object
-      properties:
-        object:
-          type: string
-          const: list
-          description: Entity name.
-        page:
-          $ref: '#/components/schemas/Page'
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/MenuItem'
-      required:
-        - object
-        - page
-        - items
-    Error:
-      type: object
-      properties:
-        type:
-          type: string
-          format: uri-reference
-          description: URI reference that identifies the problem type.
-          default: about:blank
-        title:
-          type: string
-          description: Short summary of the problem type.
-        status:
-          type: integer
-          format: int32
-          description: |
-            HTTP status code generated by the origin server for this occurrence of the problem.
-          minimum: 100
-          exclusiveMaximum: 600
-        instance:
-          type: string
-          format: uri-reference
-          description: |
-            URI reference that identifies the specific occurrence of the problem, e.g. by adding a fragment identifier or sub-path to the problem type.
-            May be used to locate the root of this problem in the source code.
-          example: /some/uri-reference#specific-occurrence-context
-        details:
-          description: Additional error details.
-          type: object
-          additionalProperties: true
-      required:
-        - type
-        - title
-        - status
   responses:
     BadRequest:
       description: Bad request - invalid input parameters.
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/Error'
+            type: object

--- a/tests/e2e/build-docs/redoc-sri/redoc-sri.test.ts
+++ b/tests/e2e/build-docs/redoc-sri/redoc-sri.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getCommandOutput, getParams } from '../../helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
+
+test('build-docs embeds an integrity hash matching the redoc bundle on the CDN', async () => {
+  rmSync(join(__dirname, 'redoc-static.html'), { force: true });
+
+  // run build-docs to generate redoc-static.html, which should contain a <script> tag with an integrity attribute
+  getCommandOutput(getParams(indexEntryPoint, ['build-docs', 'openapi.yaml']), {
+    testPath: __dirname,
+  });
+
+  const html = readFileSync(join(__dirname, 'redoc-static.html'), 'utf8');
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const script = doc.querySelector('script[src$="redoc.standalone.js"]');
+  expect(script, 'build-docs did not emit an integrity-protected redoc <script>').not.toBeNull();
+
+  const src = script!.getAttribute('src')!;
+  const integrity = script!.getAttribute('integrity')!;
+
+  const response = await fetch(src);
+  expect(response.ok, `Could not fetch ${src} (HTTP ${response.status})`).toBe(true);
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const fetchedHash = `sha384-${createHash('sha384').update(bytes).digest('base64')}`;
+
+  expect(
+    fetchedHash,
+    `The redoc bundle at ${src} hashes to ${fetchedHash}, but build-docs embedded ${integrity}. ` +
+      `If you bumped redoc, recompute redocStandaloneSri in packages/cli/src/utils/package.ts.`
+  ).toBe(integrity);
+}, 100_000);

--- a/tests/smoke/basic/pre-built/redoc.html
+++ b/tests/smoke/basic/pre-built/redoc.html
@@ -12,7 +12,7 @@
       margin: 0;
     }
   </style>
-  <script src="https://cdn.redocly.com/redoc/v2.5.3/bundles/redoc.standalone.js"></script><style data-styled="true" data-styled-version="6.4.2">.kktglN{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
+  <script src="https://cdn.redocly.com/redoc/v2.5.3/bundles/redoc.standalone.js" integrity="sha384-xiEssMQFSpSfLbzRZCGfxxIM5QDb2DTrU6vyoZdp2sV1L6pmOMy6MpTtUoLbpC96" crossorigin="anonymous"></script><style data-styled="true" data-styled-version="6.4.2">.kktglN{width:calc(100% - 40%);padding:0 40px;}/*!sc*/
 @media print,screen and (max-width: 75rem){.kktglN{width:100%;padding:40px 40px;}}/*!sc*/
 data-styled.g5[id="sc-hKVpXn"]{content:"kktglN,"}/*!sc*/
 .jleRXN{padding:40px 0;}/*!sc*/


### PR DESCRIPTION
## What/Why/How?

Added the integrity attribute for Redoc standalone:

```
<script src="https://cdn.redocly.com/.../redoc.standalone.js" integrity="sha384-..." crossorigin="anonymous"></script>
```

## Reference

Closes https://github.com/Redocly/redocly-cli/issues/2875
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Generated docs depend on a manually maintained SRI hash matching the CDN bundle; a Redoc bump without updating the hash will break pages or fail CI, but the change hardens against CDN tampering.
> 
> **Overview**
> **`build-docs`** now emits the CDN `redoc.standalone.js` `<script>` with **`integrity`** (sha384) and **`crossorigin="anonymous"`**, using a new **`redocStandaloneSri`** constant in `package.ts` that must stay in sync with the pinned Redoc version.
> 
> The build-docs option field is renamed from **`redocCurrentVersion`** to **`redocVersion`**. **CONTRIBUTING** documents how to recompute the hash when bumping Redoc.
> 
> Coverage includes an e2e test that fetches the live CDN bundle and asserts the embedded hash matches, plus updated HTML snapshots and smoke pre-built output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cebfd4048e6a8065e9894edfc1930c955ad600f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->