### PR TITLE
docs: add yaml parsing changes to the v2 migration guide

### DIFF
--- a/docs/@v2/guides/migrate-to-v2.md
+++ b/docs/@v2/guides/migrate-to-v2.md
@@ -155,11 +155,11 @@ redocly bundle tmp.yaml -o joined.yaml
 ### Changes in YAML parsing behavior
 
 Since v2.0, Redocly CLI uses the latest specification when parsing YAML files (v1.2 at this time).
-This changes how some YAML features are interpreted compared to v1.x:
+This update changes how some YAML features are interpreted compared to v1.x:
 
 - Numbers with underscores are treated as strings (e.g. `3_14` is treated literally as a string instead of `314`).
-- Stricter indentation requirements for mixed YAML and JSON content.
-  Now everything related to a property must be indented, including the closing brace:
+- Indentation requirements are stricter for mixed YAML and JSON content.
+  Everything related to a property must be indented, including the closing brace:
 
   ```yaml
   foo: {

--- a/docs/@v2/guides/migrate-to-v2.md
+++ b/docs/@v2/guides/migrate-to-v2.md
@@ -152,6 +152,23 @@ redocly join foo.yaml bar.yaml -o tmp.yaml
 redocly bundle tmp.yaml -o joined.yaml
 ```
 
+### Changes in YAML parsing behavior
+
+Since v2.0, Redocly CLI uses the latest specification when parsing YAML files (v1.2 at this time).
+This changes how some YAML features are interpreted compared to v1.x:
+
+- Numbers with underscores are treated as strings (e.g. `3_14` is treated literally as a string instead of `314`).
+- Stricter indentation requirements for mixed YAML and JSON content.
+  Now everything related to a property must be indented, including the closing brace:
+
+  ```yaml
+  foo: {
+    bar: something
+  } # [!code --]
+    } # [!code ++]
+  baz: something else
+  ```
+
 ### Platform changes
 
 - **Legacy Registry**: Support for the legacy Redocly API Registry has been removed in favor of [Reunite](https://app.cloud.redocly.com/).
@@ -209,6 +226,7 @@ paths:
 1. **Update configurable rules** to use `rule/` prefix instead of `assert/`.
 1. **Replace `undefined` assertions** with `defined: true`.
 1. **Revise `join` command usage** if your workflow relies on root-level `servers` in joined output.
+1. **Revise your YAML files** to comply with the latest YAML specification (v1.2).
 1. **Update configuration structure**:
    - Replace `apiDefinitions` with `apis`
    - Move `features.openapi.*` to `openapi.*`


### PR DESCRIPTION
## What/Why/How?

Clarified the YAML files parsing behaviour changes in the v2 migration guide.

## Reference

Originated from this discussion: https://github.com/Redocly/redocly-cli/issues/2906#issuecomment-4778086682.

 

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **Changes in YAML parsing behavior** section to the v2 migration guide, explaining that Redocly CLI v2 parses YAML with the v1.2 spec and how that differs from v1.x (underscores in numeric-looking values stay strings, stricter indentation for inline JSON-style blocks).
> 
> Also adds a migration checklist step to **revise YAML files** for YAML 1.2 compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c719bc4cda5cbeedffc2a73f9847f50f53e386a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->