### PR TITLE
chore: update js-yaml to 4.2

### DIFF
--- a/.changeset/common-clubs-attend.md
+++ b/.changeset/common-clubs-attend.md
@@ -1,0 +1,7 @@
+---
+"@redocly/respect-core": patch
+"@redocly/openapi-core": patch
+"@redocly/cli": patch
+---
+
+Updated `js-yaml` to the `4.2.0` version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8260,9 +8260,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13536,7 +13546,7 @@
         "get-port-please": "3.0.1",
         "glob": "7.2.3",
         "handlebars": "4.7.9",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "mobx": "6.12.3",
         "pluralize": "8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
@@ -13612,7 +13622,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -13668,7 +13678,7 @@
         "form-data": "4.0.4",
         "jest-diff": "29.7.0",
         "jest-matcher-utils": "29.7.0",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "json-pointer": "0.6.2",
         "jsonpath-plus": "10.3.0",
         "open": "10.1.0",
@@ -15394,7 +15404,7 @@
         "get-port-please": "3.0.1",
         "glob": "7.2.3",
         "handlebars": "4.7.9",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "mobx": "6.12.3",
         "pluralize": "8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
@@ -15437,7 +15447,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "json-schema-to-ts": "^3.1.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
@@ -15481,7 +15491,7 @@
         "form-data": "4.0.4",
         "jest-diff": "29.7.0",
         "jest-matcher-utils": "29.7.0",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "json-pointer": "0.6.2",
         "json-schema-to-ts": "^3.0.1",
         "jsonpath-plus": "10.3.0",
@@ -19900,9 +19910,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "get-port-please": "3.0.1",
     "glob": "7.2.3",
     "handlebars": "4.7.9",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "mobx": "6.12.3",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.53.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "colorette": "1.4.0",
     "https-proxy-agent": "7.0.6",
     "js-levenshtein": "1.1.6",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "minimatch": "5.1.9",
     "pluralize": "8.0.0",
     "yaml-ast-parser": "0.0.43"

--- a/packages/respect-core/package.json
+++ b/packages/respect-core/package.json
@@ -52,7 +52,7 @@
     "form-data": "4.0.4",
     "jest-diff": "29.7.0",
     "jest-matcher-utils": "29.7.0",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "json-pointer": "0.6.2",
     "jsonpath-plus": "10.3.0",
     "open": "10.1.0",


### PR DESCRIPTION
## What/Why/How?

Update `js-yaml` to `4.2.0`

It will fix the `redoc` vulnerability and `v2` accordingly.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no logic changes; YAML parse/dump behavior could differ slightly but scope is limited to version pins.
> 
> **Overview**
> Bumps the shared **`js-yaml`** dependency from **4.1.1** to **4.2.0** in `@redocly/cli`, `@redocly/openapi-core`, and `@redocly/respect-core`, with matching **`package-lock.json`** updates and a patch **changeset** for those packages.
> 
> There are **no application code changes**—only version pins and the lockfile. The intent is to address a **`redoc`-related vulnerability** by pulling in the newer `js-yaml` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022fcdaf257b7defcd7756c64fec07f405d08791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->