### PR TITLE
chore: update config to version 0.49.1

### DIFF
--- a/.changeset/huge-colts-hope.md
+++ b/.changeset/huge-colts-hope.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.49.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.0.tgz",
-      "integrity": "sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
+      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -3990,9 +3990,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -4863,10 +4863,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7270,9 +7279,9 @@
       "license": "MIT"
     },
     "node_modules/redoc/node_modules/@redocly/openapi-core": {
-      "version": "1.34.15",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.15.tgz",
-      "integrity": "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==",
+      "version": "1.34.16",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.16.tgz",
+      "integrity": "sha512-zIgmQTT2TV/U/SJ3N4jlIw36erH6X8ga1UNIoyrlbr0yLEbsiII/16LZ0kMxWu2A8pw0xd56rwTz5sMudy2OAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7281,7 +7290,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -8898,7 +8907,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.0",
+        "@redocly/config": "^0.49.1",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -8936,28 +8945,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/core/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "packages/core/node_modules/picomatch": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.49.0",
+    "@redocly/config": "^0.49.1",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -996,6 +996,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {},
     "required": undefined,
   },
+  "ScorecardClassicLevel.arazzo1_1Rules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
   "ScorecardClassicLevel.async2Rules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
@@ -1415,6 +1423,13 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "object",
       },
       "arazzo1Rules": "rootRedoclyConfigSchema.arazzo1Rules",
+      "arazzo1_1Decorators": {
+        "type": "object",
+      },
+      "arazzo1_1Preprocessors": {
+        "type": "object",
+      },
+      "arazzo1_1Rules": "rootRedoclyConfigSchema.arazzo1_1Rules",
       "async2Decorators": {
         "type": "object",
       },
@@ -2381,6 +2396,13 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "object",
       },
       "arazzo1Rules": "rootRedoclyConfigSchema.apis_additionalProperties.arazzo1Rules",
+      "arazzo1_1Decorators": {
+        "type": "object",
+      },
+      "arazzo1_1Preprocessors": {
+        "type": "object",
+      },
+      "arazzo1_1Rules": "rootRedoclyConfigSchema.apis_additionalProperties.arazzo1_1Rules",
       "async2Decorators": {
         "type": "object",
       },
@@ -2476,6 +2498,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     ],
   },
   "rootRedoclyConfigSchema.apis_additionalProperties.arazzo1Rules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.apis_additionalProperties.arazzo1_1Rules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
     "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
@@ -8302,6 +8332,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {},
     "required": undefined,
   },
+  "rootRedoclyConfigSchema.arazzo1_1Rules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
   "rootRedoclyConfigSchema.async2Rules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
@@ -9942,6 +9980,13 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "object",
       },
       "arazzo1Rules": "rootRedoclyConfigSchema.env_additionalProperties.arazzo1Rules",
+      "arazzo1_1Decorators": {
+        "type": "object",
+      },
+      "arazzo1_1Preprocessors": {
+        "type": "object",
+      },
+      "arazzo1_1Rules": "rootRedoclyConfigSchema.env_additionalProperties.arazzo1_1Rules",
       "async2Decorators": {
         "type": "object",
       },
@@ -10901,6 +10946,13 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "object",
       },
       "arazzo1Rules": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.arazzo1Rules",
+      "arazzo1_1Decorators": {
+        "type": "object",
+      },
+      "arazzo1_1Preprocessors": {
+        "type": "object",
+      },
+      "arazzo1_1Rules": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.arazzo1_1Rules",
       "async2Decorators": {
         "type": "object",
       },
@@ -10996,6 +11048,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     ],
   },
   "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.arazzo1Rules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.arazzo1_1Rules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
     "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
@@ -16815,6 +16875,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.arazzo1Rules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.arazzo1_1Rules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
     "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",


### PR DESCRIPTION
## What/Why/How?

- update config to 0.49.1
- npm audit

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch dependency and lockfile-only changes; behavior shifts come from the external config schema (new optional Arazzo 1.1 lint config keys).
> 
> **Overview**
> Bumps **`@redocly/config`** from `^0.49.0` to **`^0.49.1`** in `@redocly/openapi-core`, with a patch **changeset** noting the update.
> 
> The lockfile refresh also pulls in **`npm audit`**-driven transitive bumps (e.g. **`dompurify`**, **`js-yaml`** at the root, and nested **`@redocly/openapi-core`** under `redoc`). **`redocly-yaml.test.ts.snap`** is updated so generated Redocly config schema metadata includes new **Arazzo 1.1** keys (`arazzo1_1Rules`, `arazzo1_1Decorators`, `arazzo1_1Preprocessors`) at root, API, env, and scorecard levels—reflecting schema changes shipped in the new config package, not hand-written core logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e940aafda3dccae15d18be5b4a2f8f0c6233fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->