### PR TITLE
fix: fix $faker expression code execution vulnerablility

### DIFF
--- a/.changeset/slimy-beers-fry.md
+++ b/.changeset/slimy-beers-fry.md
@@ -1,0 +1,5 @@
+---
+'@redocly/respect-core': patch
+---
+
+Fixed a code execution vulnerability where a crafted `$faker` expression in an Arazzo description could execute arbitrary JavaScript during Redocly Respect runs.

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -244,19 +244,13 @@ describe('getFakeData argument parsing', () => {
   });
 
   it('parses float arguments without being mangled by dots in the pointer', () => {
-    const result = getValueFromContext(
-      '$faker.number.float({ min: 0.5, max: 1.5 })',
-      ctx
-    );
+    const result = getValueFromContext('$faker.number.float({ min: 0.5, max: 1.5 })', ctx);
     expect(result).toBeGreaterThanOrEqual(0.5);
     expect(result).toBeLessThanOrEqual(1.5);
   });
 
   it('parses negative numbers', () => {
-    const result = getValueFromContext(
-      '$faker.number.integer({ min: -5, max: -1 })',
-      ctx
-    );
+    const result = getValueFromContext('$faker.number.integer({ min: -5, max: -1 })', ctx);
     expect(result).toBeGreaterThanOrEqual(-5);
     expect(result).toBeLessThanOrEqual(-1);
   });

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -244,13 +244,19 @@ describe('getFakeData argument parsing', () => {
   });
 
   it('parses float arguments without being mangled by dots in the pointer', () => {
-    const result = getValueFromContext('$faker.number.float({ min: 0.5, max: 1.5 })', ctx) as number;
+    const result = getValueFromContext(
+      '$faker.number.float({ min: 0.5, max: 1.5 })',
+      ctx
+    );
     expect(result).toBeGreaterThanOrEqual(0.5);
     expect(result).toBeLessThanOrEqual(1.5);
   });
 
   it('parses negative numbers', () => {
-    const result = getValueFromContext('$faker.number.integer({ min: -5, max: -1 })', ctx) as number;
+    const result = getValueFromContext(
+      '$faker.number.integer({ min: -5, max: -1 })',
+      ctx
+    );
     expect(result).toBeGreaterThanOrEqual(-5);
     expect(result).toBeLessThanOrEqual(-1);
   });

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -193,6 +193,83 @@ describe('getValueFromContext', () => {
     } as unknown as TestContext;
     expect(getValueFromContext('{$faker.city}', ctx)).toEqual('undefined');
   });
+
+  it('should not execute arbitrary code via the $faker constructor escape', () => {
+    const ctx = {
+      $faker: createFaker(),
+    } as any;
+    (globalThis as any).__respectPwned = false;
+    const payload =
+      '$faker.constructor.constructor(\'globalThis["__respectPwned"]=true;return 1\')()';
+
+    const result = getValueFromContext(payload, ctx);
+
+    expect((globalThis as any).__respectPwned).toBe(false);
+    expect(result).toBeUndefined();
+    delete (globalThis as any).__respectPwned;
+  });
+
+  it('should not execute arbitrary code via bracket-notation $faker payloads', () => {
+    const ctx = {
+      $faker: createFaker(),
+    } as any;
+    (globalThis as any).__respectPwned2 = false;
+    const payload =
+      '$faker.string["constructor"]["constructor"](\'globalThis["__respectPwned2"]=true\')()';
+
+    const result = getValueFromContext(payload, ctx);
+
+    expect((globalThis as any).__respectPwned2).toBe(false);
+    expect(result).toBeUndefined();
+    delete (globalThis as any).__respectPwned2;
+  });
+
+  it('should not resolve prototype-chain properties via $faker', () => {
+    const ctx = {
+      $faker: createFaker(),
+    } as any;
+
+    expect(getValueFromContext('$faker.__proto__.polluted', ctx)).toBeUndefined();
+    expect(getValueFromContext('$faker.constructor', ctx)).toBeUndefined();
+  });
+});
+
+describe('getFakeData argument parsing', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => {
+    ctx = {
+      $faker: createFaker(),
+    } as any;
+  });
+
+  it('parses float arguments without being mangled by dots in the pointer', () => {
+    const result = getValueFromContext('$faker.number.float({ min: 0.5, max: 1.5 })', ctx) as number;
+    expect(result).toBeGreaterThanOrEqual(0.5);
+    expect(result).toBeLessThanOrEqual(1.5);
+  });
+
+  it('parses negative numbers', () => {
+    const result = getValueFromContext('$faker.number.integer({ min: -5, max: -1 })', ctx) as number;
+    expect(result).toBeGreaterThanOrEqual(-5);
+    expect(result).toBeLessThanOrEqual(-1);
+  });
+
+  it('parses string arguments and dotted values', () => {
+    expect(
+      getValueFromContext("$faker.string.email({ provider: 'example', domain: 'org' })", ctx)
+    ).toContain('example.org');
+  });
+
+  it('supports calls with no arguments', () => {
+    expect(getValueFromContext('$faker.string.uuid()', ctx)).toEqual(expect.any(String));
+  });
+
+  it('returns undefined for malformed argument lists', () => {
+    expect(getValueFromContext('$faker.number.integer({ min: })', ctx)).toBeUndefined();
+    expect(getValueFromContext("$faker.string.email('unterminated)", ctx)).toBeUndefined();
+    expect(getValueFromContext('$faker.number.integer(@)', ctx)).toBeUndefined();
+  });
 });
 
 describe('parsePath', () => {

--- a/packages/respect-core/src/modules/config-parser/get-value-from-context.ts
+++ b/packages/respect-core/src/modules/config-parser/get-value-from-context.ts
@@ -1,5 +1,4 @@
 import { red } from 'colorette';
-import { createContext, runInContext } from 'node:vm';
 import { DefaultLogger } from '../../utils/logger/logger';
 
 import type { RuntimeExpressionContext, TestContext, Workflow } from '../../types';
@@ -58,6 +57,204 @@ export function replaceFakerVariablesInString(
   } else {
     return input;
   }
+}
+
+// Property names that would allow escaping the faker object and reaching the
+// prototype chain (and therefore `Function`/`constructor`-based code execution).
+const FORBIDDEN_FAKER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const SAFE_FAKER_KEY = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+
+// Safely parses the single options object of a faker function call (e.g. the
+// `{ min: 5, max: 5 }` in `faker.number.integer({ min: 5, max: 5 })`) WITHOUT
+// evaluating it as JavaScript. Faker functions take at most one options object
+// whose values are strings or numbers.
+class FakerArgumentParser {
+  private pos = 0;
+
+  constructor(private readonly src: string) {}
+
+  parseArguments(): unknown[] {
+    this.skipWhitespace();
+    if (this.pos >= this.src.length) return [];
+
+    const value = this.parseValue();
+    this.skipWhitespace();
+    if (this.pos < this.src.length) {
+      throw new Error(`Unexpected token "${this.src[this.pos]}" in faker arguments`);
+    }
+    return [value];
+  }
+
+  private parseValue(): unknown {
+    this.skipWhitespace();
+    const char = this.src[this.pos];
+
+    if (char === '{') return this.parseObject();
+    if (char === '"' || char === "'") return this.parseString(char);
+    if (char === '-' || (char >= '0' && char <= '9')) return this.parseNumber();
+    throw new Error(`Unexpected token "${char}" in faker arguments`);
+  }
+
+  private parseObject(): Record<string, unknown> {
+    this.pos++; // consume '{'
+    const obj: Record<string, unknown> = {};
+    this.skipWhitespace();
+
+    if (this.src[this.pos] === '}') {
+      this.pos++;
+      return obj;
+    }
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      this.skipWhitespace();
+      const key = this.parseKey();
+      this.skipWhitespace();
+      if (this.src[this.pos] !== ':') {
+        throw new Error('Expected ":" in faker arguments object');
+      }
+      this.pos++; // consume ':'
+      const value = this.parseValue();
+      // Reject keys that could pollute the prototype of the options object.
+      if (!FORBIDDEN_FAKER_KEYS.has(key)) {
+        obj[key] = value;
+      }
+      this.skipWhitespace();
+
+      const next = this.src[this.pos];
+      if (next === ',') {
+        this.pos++;
+        this.skipWhitespace();
+      } else if (next === '}') {
+        this.pos++;
+        return obj;
+      } else {
+        throw new Error('Expected "," or "}" in faker arguments object');
+      }
+
+      if (this.src[this.pos] === '}') {
+        this.pos++; // allow a trailing comma
+        return obj;
+      }
+    }
+  }
+
+  private parseKey(): string {
+    const char = this.src[this.pos];
+    if (char === '"' || char === "'") return this.parseString(char);
+
+    const start = this.pos;
+    while (this.pos < this.src.length && /[a-zA-Z0-9_$]/.test(this.src[this.pos])) {
+      this.pos++;
+    }
+    if (this.pos === start) {
+      throw new Error('Expected property name in faker arguments object');
+    }
+    return this.src.slice(start, this.pos);
+  }
+
+  private parseString(quote: string): string {
+    this.pos++; // consume opening quote
+    let result = '';
+    while (this.pos < this.src.length) {
+      const char = this.src[this.pos++];
+      if (char === '\\') {
+        result += this.src[this.pos++] ?? '';
+      } else if (char === quote) {
+        return result;
+      } else {
+        result += char;
+      }
+    }
+    throw new Error('Unterminated string in faker arguments');
+  }
+
+  private parseNumber(): number {
+    const start = this.pos;
+    if (this.src[this.pos] === '-') this.pos++;
+    while (this.pos < this.src.length && /[0-9.]/.test(this.src[this.pos])) {
+      this.pos++;
+    }
+    const raw = this.src.slice(start, this.pos);
+    const value = Number(raw);
+    if (Number.isNaN(value)) {
+      throw new Error(`Invalid number "${raw}" in faker arguments`);
+    }
+    return value;
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.src.length && /\s/.test(this.src[this.pos])) {
+      this.pos++;
+    }
+  }
+}
+
+// Splits a faker pointer on `.`, ignoring dots inside a function call's
+// arguments (parentheses) or string literals, e.g. `faker.number.float({ min: 0.5 })`.
+function splitFakerPointer(pointer: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+  let depth = 0;
+
+  for (let i = 0; i < pointer.length; i++) {
+    const char = pointer[i];
+
+    if (quote) {
+      current += char;
+      if (char === '\\') {
+        current += pointer[++i] ?? '';
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+    } else if (char === '.' && depth === 0) {
+      segments.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  segments.push(current.trim());
+  return segments;
+}
+
+// Only own properties of the faker object are allowed,
+// which prevents reaching `constructor`/`__proto__` and the `Function` escape.
+function resolveFakerSegment(target: unknown, segment: string): unknown {
+  const callMatch = segment.match(/^([^()]+)\((.*)\)$/s);
+  const name = (callMatch ? callMatch[1] : segment).trim();
+
+  if (!SAFE_FAKER_KEY.test(name) || FORBIDDEN_FAKER_KEYS.has(name)) {
+    throw new Error(`Unsupported faker reference: "${name}"`);
+  }
+
+  if (target == null || !Object.prototype.hasOwnProperty.call(target, name)) {
+    throw new Error(`Unknown faker reference: "${name}"`);
+  }
+
+  const member = (target as Record<string, unknown>)[name];
+
+  if (callMatch) {
+    if (typeof member !== 'function') {
+      throw new Error(`Faker reference "${name}" is not callable`);
+    }
+    const args = new FakerArgumentParser(callMatch[2]).parseArguments();
+    return (member as (...args: unknown[]) => unknown).apply(target, args);
+  }
+
+  return member;
 }
 
 function replaceVariablesInString(
@@ -168,21 +365,17 @@ const getFrom =
   };
 
 export function getFakeData(pointer: string, ctx: TestContext | RuntimeExpressionContext): any {
-  const segments = pointer.split('.');
-  const fakerContext = { ctx: { faker: ctx.$faker } };
+  const segments = splitFakerPointer(pointer);
 
   try {
-    createContext(fakerContext);
-    const escapedSegments = segments
-      .map((segment) => segment.trim())
-      .map((segment, idx) =>
-        // Dumb function check (if ends by ')'), if function goes first dont need to put '.',
-        // if goes second and so on - must be prepended by '.', like ["escaped-field"].func()
-        segment.endsWith(')') ? `${idx == 0 ? '' : '.'}${segment}` : `["${segment}"]`
-      )
-      .join('');
+    // The pointer always starts with `faker` (e.g. `faker.number.integer(...)`).
+    if (segments[0] !== 'faker') {
+      throw new Error(`Unsupported faker reference: "${segments[0]}"`);
+    }
 
-    return runInContext(`ctx${escapedSegments}`, fakerContext);
+    return segments
+      .slice(1)
+      .reduce<unknown>((target, segment) => resolveFakerSegment(target, segment), ctx.$faker);
   } catch (err: any) {
     logger.error(red(err.toString()));
 


### PR DESCRIPTION
## What/Why/How?


Fixed a code execution vulnerability where a crafted `$faker` expression in an Arazzo description could execute arbitrary JavaScript during Redocly Respect runs.

## Reference


Backported https://github.com/Redocly/redocly-cli/pull/2881.



## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security fix in expression evaluation used when parsing untrusted Arazzo content; behavior changes for invalid or prototype-chain `$faker` paths but removes critical RCE risk.
> 
> **Overview**
> **Closes a code execution hole** where malicious `$faker` strings in Arazzo descriptions could run arbitrary JavaScript during Respect runs.
> 
> `getFakeData` no longer uses `node:vm` `runInContext` to evaluate faker pointers. It now walks `ctx.$faker` with **own-property-only** lookups, blocks `constructor` / `__proto__` / `prototype`, and parses call arguments with a small lexer instead of executing them as JS. Pointer splitting respects dots inside parentheses and string literals so options like `{ min: 0.5 }` still work.
> 
> Tests add exploit-style cases (constructor escape, bracket notation) and cover argument parsing edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba58a6f406ea30225f0ed07b32db1267515df7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->