### PR TITLE
fix: path traversal in the `split` command

### DIFF
--- a/.changeset/fix-split-path-traversal.md
+++ b/.changeset/fix-split-path-traversal.md
@@ -1,5 +1,0 @@
----
-"@redocly/cli": patch
----
-
-Fixed a path traversal in the `split` command that might have written files outside the chosen `--outDir`.

--- a/.changeset/fix-split-path-traversal.md
+++ b/.changeset/fix-split-path-traversal.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed a path traversal in the `split` command that might have written files outside the chosen `--outDir`.

--- a/.changeset/odd-chefs-teach.md
+++ b/.changeset/odd-chefs-teach.md
@@ -1,0 +1,5 @@
+---
+"@redocly/cli": patch
+---
+
+Fixed a path traversal in the `split` command that might have written files outside the chosen `--outDir`.

--- a/packages/cli/src/commands/split/__tests__/fixtures/path-traversal-paths.json
+++ b/packages/cli/src/commands/split/__tests__/fixtures/path-traversal-paths.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Path name traversal PoC", "version": "1.0.0" },
+  "paths": {
+    "/../../../../../../tmp/redocly_escaped": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}

--- a/packages/cli/src/commands/split/__tests__/fixtures/path-traversal.json
+++ b/packages/cli/src/commands/split/__tests__/fixtures/path-traversal.json
@@ -1,0 +1,10 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Path traversal PoC", "version": "1.0.0" },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "../../../../../../tmp/redocly_escaped": { "type": "object" }
+    }
+  }
+}

--- a/packages/cli/src/commands/split/__tests__/index.test.ts
+++ b/packages/cli/src/commands/split/__tests__/index.test.ts
@@ -47,6 +47,42 @@ describe('#split', () => {
     );
   });
 
+  it('aborts instead of writing a component file outside the output directory', async () => {
+    const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/path-traversal.json';
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await expect(
+      handleSplit({
+        argv: {
+          api: filePath,
+          outDir: openapiDir,
+          separator: '_',
+        },
+        config: loadConfigAndHandleErrors() as any as Config,
+        version: 'cli-version',
+      })
+    ).rejects.toThrow(utils.HandledError);
+
+    expect(utils.writeToFileByExtension).not.toHaveBeenCalled();
+  });
+
+  it('aborts instead of writing a path file outside the output directory', async () => {
+    const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/path-traversal-paths.json';
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await expect(
+      handleSplit({
+        argv: {
+          api: filePath,
+          outDir: openapiDir,
+          separator: '/',
+        },
+        config: loadConfigAndHandleErrors() as any as Config,
+        version: 'cli-version',
+      })
+    ).rejects.toThrow(utils.HandledError);
+  });
+
   it('should use the correct separator', async () => {
     const filePath = 'packages/cli/src/commands/split/__tests__/fixtures/spec.json';
 

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -261,6 +261,14 @@ function getFileNamePath(componentDirPath: string, componentName: string, ext: s
   return path.join(componentDirPath, componentName) + `.${ext}`;
 }
 
+function assertWithinDir(baseDir: string, targetPath: string, subject: string) {
+  const base = path.resolve(baseDir);
+  const target = path.resolve(targetPath);
+  if (target !== base && !target.startsWith(base + path.sep)) {
+    exitWithError(`Refusing to write "${subject}" outside the output directory.`);
+  }
+}
+
 function gatherComponentsFiles(
   components: Oas3Components | Oas3_1Components,
   componentsFiles: ComponentsFiles,
@@ -298,6 +306,8 @@ function iteratePathItems(
 
     if (isRef(pathData)) continue;
 
+    assertWithinDir(openapiDir, pathFile, pathName);
+
     for (const method of OPENAPI3_METHOD_NAMES) {
       const methodData = pathData[method];
       const methodDataXCode = methodData?.['x-code-samples'] || methodData?.['x-codeSamples'];
@@ -313,6 +323,8 @@ function iteratePathItems(
           codeSamplesPathPrefix + pathToFilename(pathName, pathSeparator),
           method + langToExt(sample.lang)
         );
+
+        assertWithinDir(openapiDir, sampleFileName, sample.lang);
 
         fs.mkdirSync(path.dirname(sampleFileName), { recursive: true });
         fs.writeFileSync(sampleFileName, sample.source);
@@ -353,6 +365,7 @@ function iterateComponents(
       const componentDirPath = path.join(componentsDir, componentType);
       for (const componentName of Object.keys(components?.[componentType] || {})) {
         const filename = getFileNamePath(componentDirPath, componentName, ext);
+        assertWithinDir(openapiDir, filename, componentName);
         gatherComponentsFiles(components!, componentsFiles, componentType, componentName, filename);
       }
     }


### PR DESCRIPTION
split built output file paths straight from names in the API description, so a name containing `../` could write a file outside the chosen --outDir. Adds a check before every write that aborts (exit 1) if the resulting path would land outside --outDir.

## What/Why/How?
Fixed vulnerability Arbitrary file write via path traversal in redocly split.

Previously split command built each output file's path straight from names in the API description or other fields, so a name containing ../ could make it write a file outside the --outDir folder (a path traversal).
This adds a check before every write that aborts split with exit code 1 if the resulting path would land outside --outDir.
## Reference
[Issue](https://redoc-ly.slack.com/archives/C02UHE7EL3E/p1781507694397939)
[Related issue](https://github.com/Redocly/redocly-cli/pull/2891)
## Testing
```yaml
# evil.yaml
openapi: 3.0.0
info:
  title: Path traversal in `redocly split`
  version: 1.0.0
paths: {}
components:
  schemas:
    '../../../redocly_escaped':
      type: object
```
<img width="575" height="173" alt="Screenshot 2026-06-30 at 16 26 08" src="https://github.com/user-attachments/assets/7a33f750-eea5-4961-864d-7d4e9a30c81c" />


## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix for arbitrary file write on untrusted specs; behavior change aborts split on malicious names but normal specs should be unaffected.
> 
> **Overview**
> Fixes an **arbitrary file write** in `redocly split` where OpenAPI **component keys**, **path keys**, or **code-sample paths** containing `..` could resolve outside `--outDir`.
> 
> Adds **`assertWithinDir`**, which resolves paths and calls **`exitWithError`** before any split output write when the target is not under the output directory. Checks run for path/webhook files, component schema (and other component) files during gathering, and **`x-code-samples`** files.
> 
> Tests use malicious fixtures and expect **`HandledError`** with no **`writeToFileByExtension`** calls; changeset records a patch for **`@redocly/cli`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309063d136d6ca3a1551996fb0161153edcc4d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->