### PR TITLE
docs: update changelog entry for v1

### DIFF
--- a/docs/@v1/changelog.md
+++ b/docs/@v1/changelog.md
@@ -7,6 +7,20 @@ toc:
 
 <!-- do-not-remove -->
 
+## 1.34.17 (2026-06-30)
+
+### Patch Changes
+
+- Fixed a path traversal in the `split` command that might have written files outside the chosen `--outDir`.
+- Updated @redocly/respect-core to v1.34.17.
+
+## 1.34.16 (2026-06-26)
+
+### Patch Changes
+
+- Updated `js-yaml` to the `4.2.0` version.
+- Updated @redocly/respect-core to v1.34.16.
+
 ## 1.34.15 (2026-05-25)
 
 ### Patch Changes


### PR DESCRIPTION
## What/Why/How?
Updated V1 changelog in accordance to the recent release: https://github.com/Redocly/redocly-cli/pull/2924.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no runtime or code changes in this PR.
> 
> **Overview**
> Adds **v1 changelog** sections for **1.34.17** (2026-06-30) and **1.34.16** (2026-06-26) at the top of `docs/@v1/changelog.md`, ahead of the existing 1.34.15 entry.
> 
> **1.34.17** documents a patch fix for path traversal in the `split` command (files could be written outside `--outDir`) and a bump to `@redocly/respect-core` v1.34.17.
> 
> **1.34.16** documents upgrading `js-yaml` to 4.2.0 and `@redocly/respect-core` v1.34.16.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950f15fe01e5c93b0a959dd3d5c327f5fc218fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->