### PR TITLE
chore: cleanup after refactoring config exports

### DIFF
--- a/packages/core/src/config/visitors.ts
+++ b/packages/core/src/config/visitors.ts
@@ -1,4 +1,4 @@
-import * as redoclyConfig from '@redocly/config';
+import { CONFIG_NODE_TYPE_NAMES } from '@redocly/config';
 
 import { replaceRef } from '../ref-utils.js';
 import { NormalizedConfigTypes } from '../types/redocly-yaml.js';
@@ -48,12 +48,7 @@ export const pluginsCollectorVisitor = normalizeVisitors(
             collectorHandleNode(node, ctx);
           },
         },
-        [redoclyConfig.CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]: {
-          leave(node: unknown, ctx: UserContext) {
-            collectorHandleNode(node, ctx);
-          },
-        },
-        'rootRedoclyConfigSchema.scorecardClassic.levels_items': {
+        [CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]: {
           leave(node: unknown, ctx: UserContext) {
             collectorHandleNode(node, ctx);
           },
@@ -104,12 +99,7 @@ export const configBundlerVisitor = normalizeVisitors(
             bundlerHandleNode(node, ctx);
           },
         },
-        [redoclyConfig.CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]: {
-          leave(node: unknown, ctx: UserContext) {
-            bundlerHandleNode(node, ctx);
-          },
-        },
-        'rootRedoclyConfigSchema.scorecardClassic.levels_items': {
+        [CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]: {
           leave(node: unknown, ctx: UserContext) {
             bundlerHandleNode(node, ctx);
           },

--- a/packages/core/src/lint-entity.ts
+++ b/packages/core/src/lint-entity.ts
@@ -1,5 +1,10 @@
-import * as redoclyConfig from '@redocly/config';
-import type { EntityFileSchema, EntityBaseFileSchema, ScorecardConfig } from '@redocly/config';
+import {
+  entityFileDefaultSchema,
+  entityFileSchema,
+  type EntityFileSchema,
+  type EntityBaseFileSchema,
+  type ScorecardConfig,
+} from '@redocly/config';
 import type { JSONSchema } from 'json-schema-to-ts';
 
 import { createConfig, type Config } from './config/index.js';
@@ -168,8 +173,8 @@ export async function lintEntityWithScorecardLevel(
 
   const entityProblems = await lintEntityFile({
     document: entityDocument,
-    entitySchema: redoclyConfig.entityFileSchema,
-    entityDefaultSchema: redoclyConfig.entityFileDefaultSchema,
+    entitySchema: entityFileSchema,
+    entityDefaultSchema: entityFileDefaultSchema,
     externalRefResolver,
     assertionConfig: entityRules,
   });

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -1,4 +1,4 @@
-import * as redoclyConfig from '@redocly/config';
+import { CONFIG_NODE_TYPE_NAMES, rootRedoclyConfigSchema } from '@redocly/config';
 import type { JSONSchema } from 'json-schema-to-ts';
 import path from 'node:path';
 
@@ -533,9 +533,9 @@ function createAssertionDefinitionSubject(nodeNames: string[]): NodeType {
 
 function createScorecardLevelsItems(nodeTypes: Record<string, NodeType>): NodeType {
   return {
-    ...nodeTypes[redoclyConfig.CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel],
+    ...nodeTypes[CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel],
     properties: {
-      ...nodeTypes[redoclyConfig.CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]?.properties,
+      ...nodeTypes[CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]?.properties,
       ...configGovernanceProperties,
     },
   };
@@ -724,8 +724,7 @@ export function createConfigTypes(extraSchemas: JSONSchema, config?: Config) {
     ConfigApisProperties: createConfigApisProperties(nodeTypes),
     Subject: createAssertionDefinitionSubject(nodeNames),
     ...nodeTypes,
-    [redoclyConfig.CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]:
-      createScorecardLevelsItems(nodeTypes),
+    [CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel]: createScorecardLevelsItems(nodeTypes),
   };
 }
 
@@ -749,9 +748,9 @@ const CoreConfigTypes: Record<string, NodeType> = {
 };
 
 // FIXME: remove this once we remove `theme` from the schema
-const { theme: _, ...propertiesWithoutTheme } = redoclyConfig.rootRedoclyConfigSchema.properties;
+const { theme: _, ...propertiesWithoutTheme } = rootRedoclyConfigSchema.properties;
 const redoclyConfigSchemaWithoutTheme = {
-  ...redoclyConfig.rootRedoclyConfigSchema,
+  ...rootRedoclyConfigSchema,
   properties: propertiesWithoutTheme,
 };
 

--- a/packages/core/src/utils/scorecards.ts
+++ b/packages/core/src/utils/scorecards.ts
@@ -1,4 +1,4 @@
-import * as redoclyConfig from '@redocly/config';
+import { ENTITY_NODE_TYPE_NAMES } from '@redocly/config';
 
 import type { RuleConfig } from '../config/types.js';
 import type { Document } from '../resolve.js';
@@ -21,7 +21,7 @@ function transformEntityTypeName(subjectType: string, entityType: string): strin
 
   const specificType = capitalizedEntityType + subjectType;
 
-  if ((Object.values(redoclyConfig.ENTITY_NODE_TYPE_NAMES) as string[]).includes(specificType)) {
+  if (Object.values<string>(ENTITY_NODE_TYPE_NAMES).includes(specificType)) {
     return specificType;
   }
 
@@ -106,7 +106,7 @@ function isAssertionRule(ruleKey: string, ruleValue: unknown): ruleValue is RawA
 }
 
 function isEntityAssertion(assertion: Assertion): boolean {
-  return Object.values(redoclyConfig.ENTITY_NODE_TYPE_NAMES).some(
+  return Object.values(ENTITY_NODE_TYPE_NAMES).some(
     (entityTypeName) => assertion.subject.type === entityTypeName
   );
 }


### PR DESCRIPTION
## What/Why/How?

Cleaned up the config constants usage after cleaning up the config package.

## Reference

Related: 
- https://github.com/Redocly/redocly/pull/23968 
- https://github.com/Redocly/redocly-cli/pull/2589

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import and visitor-key deduplication with no intended behavior change; risk is limited to a mis-typed export name at compile time.
> 
> **Overview**
> Follow-up to the `@redocly/config` export cleanup: **`packages/core`** now imports **named symbols** (`CONFIG_NODE_TYPE_NAMES`, `ENTITY_NODE_TYPE_NAMES`, `rootRedoclyConfigSchema`, `entityFileSchema`, `entityFileDefaultSchema`, and related types) instead of `import * as redoclyConfig`.
> 
> In **config visitors**, scorecard classic level handling is consolidated to a single visitor keyed by `CONFIG_NODE_TYPE_NAMES.ScorecardClassicLevel`; the redundant string key `'rootRedoclyConfigSchema.scorecardClassic.levels_items'` is removed.
> 
> **`scorecards.ts`** tightens entity type checks with `Object.values<string>(ENTITY_NODE_TYPE_NAMES)` where appropriate. Behavior is intended to stay the same—this is import/style alignment, not new features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a5819e02100397103b2f3e43289c13f1b93704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->