### PR TITLE
docs(cli): add missing required `root` parameter

### DIFF
--- a/docs/@v1/commands/push.md
+++ b/docs/@v1/commands/push.md
@@ -437,7 +437,7 @@ You can also add files and folders by providing them in the `redocly.yaml` confi
 ```yaml
 apis:
   main:
-    root: ./openapi.yam;
+    root: ./openapi.yaml
 files:
   - ./path/to/folder
   - ./path/to/another-folder/file.md

--- a/docs/@v1/configuration/apis.md
+++ b/docs/@v1/configuration/apis.md
@@ -27,6 +27,7 @@ decorators:
 
 apis:
   storefront@latest:
+    root: ./openapi.yaml
     decorators:
       plugin/change-title:
         title: Storefront APIs

--- a/docs/@v2/configuration/apis.md
+++ b/docs/@v2/configuration/apis.md
@@ -25,6 +25,7 @@ decorators:
 
 apis:
   storefront:
+    root: ./openapi/openapi.yaml
     decorators:
       plugin/change-title:
         title: Storefront APIs

--- a/docs/@v2/guides/migrate-to-v2.md
+++ b/docs/@v2/guides/migrate-to-v2.md
@@ -29,7 +29,8 @@ apiDefinitions:
 
 # ✅ Use this instead
 apis:
-  main: openapi.yaml
+  main: 
+    root: ./openapi.yaml
 ```
 
 ```yaml

--- a/docs/@v2/guides/migrate-to-v2.md
+++ b/docs/@v2/guides/migrate-to-v2.md
@@ -29,7 +29,7 @@ apiDefinitions:
 
 # ✅ Use this instead
 apis:
-  main: 
+  main:
     root: ./openapi.yaml
 ```
 


### PR DESCRIPTION
## What/Why/How?

Adds missing required `root` parameter under `apis`.

## Reference

Closes https://github.com/Redocly/redocly/issues/24537


## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only documentation and example YAML change; no runtime or configuration validation code is modified.
> 
> **Overview**
> **Documentation-only** updates so `redocly.yaml` examples match the required per-API **`root`** property.
> 
> In **`push.md`**, the config snippet under “Upload other folders and files” now nests `root: ./openapi.yaml` under `apis.main` and fixes a typo (`openapi.yam;` → `openapi.yaml`).
> 
> In **`@v1/configuration/apis.md`** and **`@v2/configuration/apis.md`**, the inheritance examples for `storefront` / `storefront@latest` add **`root`** so the YAML is valid alongside decorators.
> 
> In **`migrate-to-v2.md`**, the v2 `apis` migration example replaces the shorthand `main: openapi.yaml` with the object form `main: { root: ./openapi.yaml }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b81e8ae0b002661760ada38c8d7064b9b587351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->