### PR TITLE
chore: fix release pipeline crashing when trying to store changesets status

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,8 +46,8 @@ jobs:
           commit: 'chore: 🔖 release new versions'
           title: 'chore: 🔖 release new versions'
           version: |
-            npx changeset status --output output/changesets.json # store the changesets status
-            node scripts/add-cli-dependency-changesets.js # add deps changesets depending on the changesets status
+            # Store the changesets status to a file and add deps changesets depending on it 
+            npx changeset status --output=__changesets__.json && node scripts/add-cli-dependency-changesets.js __changesets__.json
             npx changeset version
             npm i
             node scripts/post-changeset.js

--- a/scripts/add-cli-dependency-changesets.js
+++ b/scripts/add-cli-dependency-changesets.js
@@ -1,7 +1,13 @@
 import fs from 'node:fs';
 import outdent from 'outdent';
 
-const json = JSON.parse(fs.readFileSync('./output/changesets.json', 'utf-8'));
+const filePath = process.argv[2];
+if (!filePath) {
+  console.error('Please provide a path to the changesets JSON file as an argument.');
+  process.exit(1);
+}
+
+const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 
 const versions = {};
 for (const { name, newVersion } of json.releases) {


### PR DESCRIPTION


## What/Why/How?

Fixed the release pipeline crashing when trying to store the changesets status.

## Reference

The pipeline: https://github.com/Redocly/redocly-cli/actions/runs/28612220117/job/84847249114

## Testing

Tested locally. Needs confirmation after merging this.
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release scripting with no runtime product impact; behavior is unchanged aside from avoiding the missing-directory crash.
> 
> **Overview**
> Fixes the **main release** `changesets-action` **version** step failing when persisting `changeset status` output.
> 
> The workflow no longer writes to `output/changesets.json` (which could crash if that directory is missing). It now runs `npx changeset status --output=__changesets__.json` and only continues with `&&` into `scripts/add-cli-dependency-changesets.js __changesets__.json`, then the existing `changeset version` / `npm i` / `post-changeset` steps.
> 
> `add-cli-dependency-changesets.js` takes the JSON path from **argv** instead of a hardcoded file, and exits with a clear error if the argument is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a57b48732b4dec27a936c860501bbbdb362120a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->