### PR TITLE
chore: fix release pipeline crashing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,8 +46,8 @@ jobs:
           commit: 'chore: 🔖 release new versions'
           title: 'chore: 🔖 release new versions'
           version: |
-            # Store the changesets status to a file and add deps changesets depending on it 
-            npx changeset status --output=__changesets__.json && node scripts/add-cli-dependency-changesets.js __changesets__.json
+            npx changeset status --output=__changesets__.json
+            node scripts/add-cli-dependency-changesets.js __changesets__.json
             npx changeset version
             npm i
             node scripts/post-changeset.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ output/
 *.tgz
 redoc-static.html
 .env
+__changesets__.json


### PR DESCRIPTION
## What/Why/How?

Fixed the release pipeline crash

## Reference

The pipeline: https://github.com/Redocly/redocly-cli/actions/runs/28615346952/job/84857683859

Introduced in https://github.com/Redocly/redocly-cli/pull/2930

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and gitignore tweaks with no runtime or security impact.
> 
> **Overview**
> Fixes the **main release workflow** crash by running the changesets status export and the CLI dependency changeset script as **separate steps** in the `version` block instead of chaining them with `&&` on one line.
> 
> Also adds **`__changesets__.json`** to `.gitignore` so the temporary status output from `npx changeset status --output=...` is not tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9467e77ad8d1f63d17f3e9f0829fa6c562c847b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->