### PR TITLE
chore(tests): cover anonymous security alternatives

### DIFF
--- a/packages/core/src/rules/common/__tests__/security-defined.test.ts
+++ b/packages/core/src/rules/common/__tests__/security-defined.test.ts
@@ -62,6 +62,41 @@ describe('Oas3 security-defined', () => {
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should not report if operation security includes an anonymous alternative', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.1.0
+          info:
+            title: Xquik API
+            version: '1.0'
+          paths:
+            /api/v1/x/tweets/search:
+              get:
+                security:
+                  - apiKey: []
+                  - oauthBearer: []
+                  - {}
+          components:
+            securitySchemes:
+              apiKey:
+                type: apiKey
+                in: header
+                name: x-api-key
+              oauthBearer:
+                type: http
+                scheme: bearer`,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'security-defined': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
+
   it('should report if security not defined at all', async () => {
     const document = parseYamlToDocument(
       outdent`


### PR DESCRIPTION
## What/Why/How?

Add a regression test for the `security-defined` rule covering an OpenAPI 3.1 operation with apiKey, bearer, and anonymous security alternatives. This checks that optional authentication expressed with `{}` alongside named schemes does not report a false-positive lint error.

The fixture uses a reduced public Xquik-style search operation so the test stays small while covering the optional-auth shape.

## Reference

This addresses a regression-risk gap for optional-auth OpenAPI operations. There is no linked issue.

## Testing

- `git diff --check`
- Not run: local dependency install and focused unit test were unavailable in the contributor environment.

## Screenshots (optional)

N/A - test-only change.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [ ] Code follows company security practices and guidelines

## Changeset

Not included because this is test-only coverage. A maintainer can add the `no changeset needed` label if that matches project policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production rule or runtime behavior modifications.
> 
> **Overview**
> Adds a **regression test** for the `security-defined` rule so operations that list named schemes plus an **anonymous** `{}` security requirement do not produce lint errors.
> 
> The fixture is a compact OpenAPI 3.1 operation with `apiKey`, `oauthBearer`, and `{}` alternatives (optional-auth shape). The test asserts `lintDocument` returns no findings when the rule is set to `error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20e56695373d7e67cc50919cde8b81a3bb9ecf76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->