### PR TITLE
chore: update config package to v0.50.0 and apply audit fix

### DIFF
--- a/.changeset/giant-points-notice.md
+++ b/.changeset/giant-points-notice.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.50.0.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,10 @@ jobs:
           publish: npm run release
           commit: 'chore: 🔖 release new versions'
           title: 'chore: 🔖 release new versions'
+          # This calculates the changed packages and creates an additional changeset for internal dependency updates.
+          # Then `changeset version` produces all necessary version bumps in package.json files.
+          # After that, `npm i` ensures the lockfile is updated with the new versions.
+          # Finally, the `post-changeset` script and updates the main changelog.
           version: |
             npx changeset status --output=__changesets__.json
             node scripts/add-cli-dependency-changesets.js __changesets__.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
-      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.50.0.tgz",
+      "integrity": "sha512-DuNKw383I/kAMNIeJJBt/EoHruvhG4HM/mDtrz2+5vksTNOnM8bR04TpjFN4do68gSIhUIMH2m5kDiffkcMn9Q==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -7195,9 +7195,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8916,7 +8916,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.1",
+        "@redocly/config": "^0.50.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.49.1",
+    "@redocly/config": "^0.50.0",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -397,6 +397,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "graphql": "rootRedoclyConfigSchema.graphql",
       "graphqlRules": "Rules",
       "i18n": "rootRedoclyConfigSchema.i18n",
+      "idps": [Function],
       "ignore": {
         "items": {
           "type": "string",
@@ -1528,6 +1529,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "footer": "rootRedoclyConfigSchema.footer",
       "graphql": "rootRedoclyConfigSchema.graphql",
       "i18n": "rootRedoclyConfigSchema.i18n",
+      "idps": [Function],
       "ignore": {
         "items": {
           "type": "string",
@@ -1657,10 +1659,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
   },
   "rootRedoclyConfigSchema.access": {
     "additionalProperties": undefined,
-    "description": undefined,
+    "description": "Use either \`access.sso\` (filter by category) or \`access.idps\` (filter by slug), not both.",
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
+      "idps": [Function],
       "logoutReturnUrl": {
         "pattern": "^https?://.*",
         "type": "string",
@@ -10084,6 +10087,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "footer": "rootRedoclyConfigSchema.env_additionalProperties.footer",
       "graphql": "rootRedoclyConfigSchema.env_additionalProperties.graphql",
       "i18n": "rootRedoclyConfigSchema.env_additionalProperties.i18n",
+      "idps": [Function],
       "ignore": {
         "items": {
           "type": "string",
@@ -10208,10 +10212,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
   },
   "rootRedoclyConfigSchema.env_additionalProperties.access": {
     "additionalProperties": undefined,
-    "description": undefined,
+    "description": "Use either \`access.sso\` (filter by category) or \`access.idps\` (filter by slug), not both.",
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
+      "idps": [Function],
       "logoutReturnUrl": {
         "pattern": "^https?://.*",
         "type": "string",

--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -548,6 +548,7 @@ describe('lint', () => {
             "apis",
             "seo",
             "sso",
+            "idps",
             "mcp",
             "env",
           ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,7 @@ const configExtension: { [key: string]: ViteUserConfig } = {
         thresholds: {
           lines: 81,
           functions: 84,
-          statements: 80,
+          statements: 81,
           branches: 73,
         },
       },


### PR DESCRIPTION
## What/Why/How?

- Updated @redocly/config to v0.50.0 (and test snapshots accordringly)
- Applied audit fix
- Added a brief explanation of the `Create Release Pull Request or Publish to npm` step in the release pipeline
- Updated test threshold
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dependency and test/snapshot updates; config validation gains new `idps`/`access` fields from the upstream schema, with limited direct logic changes in this repo.
> 
> **Overview**
> Bumps **`@redocly/config`** from `0.49.1` to **`0.50.0`** in `@redocly/openapi-core`, with a patch changeset and lockfile refresh. The new config schema adds top-level **`idps`** and **`access.idps`**, plus guidance that **`access.sso`** and **`access.idps`** must not be used together; snapshots and a **`lintConfig`** typo suggestion test now include **`idps`**.
> 
> Also bumps transitive **`js-yaml`** (`3.14.2` → `3.15.0`) under `read-yaml-file` (audit fix), documents the release workflow **`version`** step in **`.github/workflows/release.yaml`**, and raises Vitest **statements** coverage threshold from **80** to **81**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684f860d031fde71c4660e3732c6bd463fe9dec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->