### PR TITLE
docs: document --continue-on-deploy-failures option for push and push-status

### DIFF
--- a/docs/@v2/commands/push-status.md
+++ b/docs/@v2/commands/push-status.md
@@ -22,19 +22,20 @@ See the [Manage API keys](https://redocly.com/docs/realm/setup/how-to/api-keys) 
 ## Usage
 
 ```bash
-REDOCLY_AUTHORIZATION=<api-key> redocly push-status <pushId> --organization <orgSlug> --project <projectSlug> [--wait] [--max-execution-time <timeInSeconds>]
+REDOCLY_AUTHORIZATION=<api-key> redocly push-status <pushId> --organization <orgSlug> --project <projectSlug> [--wait] [--continue-on-deploy-failures] [--max-execution-time <timeInSeconds>]
 ```
 
 ## Options
 
-| Option               | Type    | Description                                                                                                                    |
-| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| pushId               | string  | **REQUIRED.** Identifier of the push you are tracking. Returned as result of the [`push`](./push.md) command.                  |
-| --organization, -o   | string  | **REQUIRED.** [Organization slug](#find-org-slug).                                                                             |
-| --project, -p        | string  | **REQUIRED.** [Project slug](#find-org-slug).                                                                                  |
-| --domain, -d         | string  | The domain that the `push` command pushed to. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com). |
-| --wait               | boolean | Waits until the build is completed if it is in progress. Default value is `false`.                                             |
-| --max-execution-time | number  | Maximum wait time for build completion in seconds (used in conjunction with the `--wait` option). Default value is `1200`.     |
+| Option                        | Type    | Description                                                                                                                    |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| pushId                        | string  | **REQUIRED.** Identifier of the push you are tracking. Returned as result of the [`push`](./push.md) command.                  |
+| --organization, -o            | string  | **REQUIRED.** [Organization slug](#find-org-slug).                                                                             |
+| --project, -p                 | string  | **REQUIRED.** [Project slug](#find-org-slug).                                                                                  |
+| --domain, -d                  | string  | The domain that the `push` command pushed to. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com). |
+| --wait                        | boolean | Waits until the build is completed if it is in progress. Default value is `false`.                                             |
+| --max-execution-time          | number  | Maximum wait time for build completion in seconds (used in conjunction with the `--wait` option). Default value is `1200`.     |
+| --continue-on-deploy-failures | boolean | Prevents the command from returning a non-zero exit code when the deployment fails. Default value is `false`.                  |
 
 <details>
 <summary>How to find and copy the Reunite organization or project slugs<a id="find-org-slug"></a></summary>

--- a/docs/@v2/commands/push.md
+++ b/docs/@v2/commands/push.md
@@ -22,33 +22,34 @@ See the [Manage API keys](https://redocly.com/docs/realm/setup/how-to/api-keys) 
 ## Command usage
 
 ```bash
-REDOCLY_AUTHORIZATION=<api-key> redocly push <files> --organization <organizationSlug> --project <projectSlug> --mount-path <mountPath> --branch <branch> --message <message> --author <'Author Name <author-email@example.com>'> [--commit-sha <sha>] [--commit-url <url>] [--created-at <commitCreationDate>] [--repository <repositoryId> ] [--namespace <repositoryOrg>] [--default-branch <repositoryDefaultBranch>] [--domain <domain>] [--wait-for-deployment] [--max-execution-time <timeInSeconds>] [--lint-config <warn | error | off>] [--verbose]
+REDOCLY_AUTHORIZATION=<api-key> redocly push <files> --organization <organizationSlug> --project <projectSlug> --mount-path <mountPath> --branch <branch> --message <message> --author <'Author Name <author-email@example.com>'> [--commit-sha <sha>] [--commit-url <url>] [--created-at <commitCreationDate>] [--repository <repositoryId> ] [--namespace <repositoryOrg>] [--default-branch <repositoryDefaultBranch>] [--domain <domain>] [--wait-for-deployment] [--continue-on-deploy-failures] [--max-execution-time <timeInSeconds>] [--lint-config <warn | error | off>] [--verbose]
 
 ```
 
 ## Command options
 
-| Option                |   Type   | Description                                                                                                                                                                            |
-| --------------------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| files                 | [string] | **REQUIRED.** List of folders and/or files to upload.                                                                                                                                  |
-| --organization, -o    |  string  | **REQUIRED.** Organization slug.                                                                                                                                                       |
-| --project, -p         |  string  | **REQUIRED.** Project slug.                                                                                                                                                            |
-| --mount-path, -mp     |  string  | **REQUIRED.** The path where the files are mounted in the project. Cannot be empty or identical to the project path.                                                                   |
-| --branch, -b          |  string  | **REQUIRED.** The branch files are pushed from.                                                                                                                                        |
-| --author, -a          |  string  | **REQUIRED.** The author of the push in the format: `'Author Name <author-email@example.com>'`.                                                                                        |
-| --message, -m         |  string  | **REQUIRED.** The commit message for the push.                                                                                                                                         |
-| --commit-sha, -sha    |  string  | Commit SHA.                                                                                                                                                                            |
-| --commit-url, -url    |  string  | Commit URL.                                                                                                                                                                            |
-| --repository          |  string  | Repository ID. Example: `redocly-cli`.                                                                                                                                                 |
-| --namespace           |  string  | Repository owner/organization/workspace. Example: `Redocly`.                                                                                                                           |
-| --created-at          |  string  | Commit creation date. Format: `yyyy-mm-ddThh:mm:ss+offset value`. Example: `2024-02-20T14:26:26+02:00`                                                                                 |
-| --domain              |  string  | The domain to which the files are pushed. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com).                                                             |
-| --default-branch      |  string  | The default branch of the repository the push originates from. Default value is `main`.                                                                                                |
-| --lint-config         |  string  | Severity level for configuration file linting. <br/> **Possible values:** `warn`, `error`, `off`. Default value is `warn`.                                                             |
-| --max-execution-time  |  number  | Maximum wait time for deployment completion in seconds (used in conjunction with the `--wait-for-deployment` option). Default value is `1200`.                                         |
-| --wait-for-deployment | boolean  | Waits until the build is completed if it is in progress. Behaves the same as `push-status` command when passed. See [push-status](./push-status.md) command. Default value is `false`. |
-| --verbose             | boolean  | Verbose output. Default value is `false`.                                                                                                                                              |
-| --help                | boolean  | Help output for the command.                                                                                                                                                           |
+| Option                        |   Type   | Description                                                                                                                                                                            |
+| ----------------------------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| files                         | [string] | **REQUIRED.** List of folders and/or files to upload.                                                                                                                                  |
+| --organization, -o            |  string  | **REQUIRED.** Organization slug.                                                                                                                                                       |
+| --project, -p                 |  string  | **REQUIRED.** Project slug.                                                                                                                                                            |
+| --mount-path, -mp             |  string  | **REQUIRED.** The path where the files are mounted in the project. Cannot be empty or identical to the project path.                                                                   |
+| --branch, -b                  |  string  | **REQUIRED.** The branch files are pushed from.                                                                                                                                        |
+| --author, -a                  |  string  | **REQUIRED.** The author of the push in the format: `'Author Name <author-email@example.com>'`.                                                                                        |
+| --message, -m                 |  string  | **REQUIRED.** The commit message for the push.                                                                                                                                         |
+| --commit-sha, -sha            |  string  | Commit SHA.                                                                                                                                                                            |
+| --commit-url, -url            |  string  | Commit URL.                                                                                                                                                                            |
+| --repository                  |  string  | Repository ID. Example: `redocly-cli`.                                                                                                                                                 |
+| --namespace                   |  string  | Repository owner/organization/workspace. Example: `Redocly`.                                                                                                                           |
+| --created-at                  |  string  | Commit creation date. Format: `yyyy-mm-ddThh:mm:ss+offset value`. Example: `2024-02-20T14:26:26+02:00`                                                                                 |
+| --domain                      |  string  | The domain to which the files are pushed. Default value is [https://app.cloud.redocly.com](https://app.cloud.redocly.com).                                                             |
+| --default-branch              |  string  | The default branch of the repository the push originates from. Default value is `main`.                                                                                                |
+| --lint-config                 |  string  | Severity level for configuration file linting. <br/> **Possible values:** `warn`, `error`, `off`. Default value is `warn`.                                                             |
+| --max-execution-time          |  number  | Maximum wait time for deployment completion in seconds (used in conjunction with the `--wait-for-deployment` option). Default value is `1200`.                                         |
+| --wait-for-deployment         | boolean  | Waits until the build is completed if it is in progress. Behaves the same as `push-status` command when passed. See [push-status](./push-status.md) command. Default value is `false`. |
+| --continue-on-deploy-failures | boolean  | Prevents the command from returning a non-zero exit code when the deployment fails. Default value is `false`.                                                                          |
+| --verbose                     | boolean  | Verbose output. Default value is `false`.                                                                                                                                              |
+| --help                        | boolean  | Help output for the command.                                                                                                                                                           |
 
 ## Example usage
 


### PR DESCRIPTION
## What/Why/How?

The `--continue-on-deploy-failures` flag ships on both the `push` and `push-status` commands (`packages/cli/src/index.ts`) but was undocumented. This adds it to the options table and usage synopsis of both `@v2` command references.

Note on the flag name: issue #7920 requested docs for `ignore-deployment-failures`. That flag name never existed — the shipped flag (introduced in #1481) is `--continue-on-deploy-failures`. This PR documents it under its real name.

Why every table row shows as changed: the option name is wider than the existing Option column, so satisfying markdownlint's `MD060` "aligned" table style required re-padding every row of both tables. The only content change is the single new row per table; the rest is whitespace re-alignment.

## Reference
Closes #7920 


## Testing

Ran the repo's markdownlint config (`markdownlint-cli2 --config .markdownlint.yaml`) against both files: 0 errors. Verified the rendered docs preview build.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- TODO: make it required -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- TODO: make it required -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or behavioral changes.
> 
> **Overview**
> Documents the existing **`--continue-on-deploy-failures`** flag on the Reunite **`push`** and **`push-status`** commands (already implemented in the CLI but previously missing from the `@v2` references).
> 
> Each page adds the flag to the usage synopsis and options table, describing it as a boolean that **avoids a non-zero exit code when deployment fails** (default `false`). The wider option name required re-aligning both markdown option tables for `MD060`; aside from the new row, changes are formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35faeacbba1076a063a2c07d249f8b6162e22c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->