### PR TITLE
chore: update redocly config version to 0.50.1

### DIFF
--- a/.changeset/some-camels-sniff.md
+++ b/.changeset/some-camels-sniff.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.50.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.50.0.tgz",
-      "integrity": "sha512-DuNKw383I/kAMNIeJJBt/EoHruvhG4HM/mDtrz2+5vksTNOnM8bR04TpjFN4do68gSIhUIMH2m5kDiffkcMn9Q==",
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.50.1.tgz",
+      "integrity": "sha512-TrdZUK50baxIjJB/y2ROOqfg35ex+GbkHPoJ40kXQXKMOjrfxfYQ9IliiaLqT5H/Y8qbajPrYQN2DLfvcMaHSw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -8916,7 +8916,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.50.0",
+        "@redocly/config": "^0.50.1",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.50.0",
+    "@redocly/config": "^0.50.1",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -1025,6 +1025,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {},
     "required": undefined,
   },
+  "ScorecardClassicLevel.graphqlRules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
   "ScorecardClassicLevel.oas2Rules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
@@ -1528,6 +1536,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "feedback": "rootRedoclyConfigSchema.feedback",
       "footer": "rootRedoclyConfigSchema.footer",
       "graphql": "rootRedoclyConfigSchema.graphql",
+      "graphqlRules": "rootRedoclyConfigSchema.graphqlRules",
       "i18n": "rootRedoclyConfigSchema.i18n",
       "idps": [Function],
       "ignore": {
@@ -2487,6 +2496,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "array",
       },
       "graphql": "rootRedoclyConfigSchema.apis_additionalProperties.graphql",
+      "graphqlRules": "rootRedoclyConfigSchema.apis_additionalProperties.graphqlRules",
       "metadata": {
         "type": "object",
       },
@@ -3213,6 +3223,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.apis_additionalProperties.graphqlRules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.apis_additionalProperties.oas2Rules": {
@@ -10086,6 +10104,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "feedback": "rootRedoclyConfigSchema.env_additionalProperties.feedback",
       "footer": "rootRedoclyConfigSchema.env_additionalProperties.footer",
       "graphql": "rootRedoclyConfigSchema.env_additionalProperties.graphql",
+      "graphqlRules": "rootRedoclyConfigSchema.env_additionalProperties.graphqlRules",
       "i18n": "rootRedoclyConfigSchema.env_additionalProperties.i18n",
       "idps": [Function],
       "ignore": {
@@ -11039,6 +11058,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "array",
       },
       "graphql": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphql",
+      "graphqlRules": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphqlRules",
       "metadata": {
         "type": "object",
       },
@@ -11765,6 +11785,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphqlRules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.oas2Rules": {
@@ -19731,6 +19759,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.graphqlRules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.i18n": {
@@ -33440,6 +33476,14 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
     },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.graphqlRules": {
+    "additionalProperties": [Function],
+    "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
+    "documentationLink": "https://redocly.com/docs/cli/configuration/reference/rules#rules",
+    "items": undefined,
+    "properties": {},
     "required": undefined,
   },
   "rootRedoclyConfigSchema.i18n": {


### PR DESCRIPTION
## What/Why/How?

Updated redocly/config version to 0.50.1

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch with snapshot-only test updates; no core logic changes beyond consuming the updated config schema.
> 
> **Overview**
> Bumps **`@redocly/openapi-core`**’s dependency on **`@redocly/config`** from `^0.50.0` to **`^0.50.1`**, with matching **`package-lock.json`** updates and a **changeset** marking a patch release for `@redocly/openapi-core`.
> 
> The only other diff is refreshed **`redocly-yaml.test.ts.snap`** output: the newer config schema adds **`graphqlRules`** in the same places as other rules blocks (root config, per-API, env overrides, scorecard classic level), so Redocly YAML schema introspection tests stay aligned with the package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d72ee6f7560d02162357bae54051e521cfc912d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->