### PR TITLE
chore: adjust codeowners for drift and proxy commands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@ README.md @Redocly/technical-writers
 docs/ @Redocly/technical-writers
 packages/cli/src/utils/otel.ts @Redocly/hot-dogs
 packages/cli/src/utils/telemetry.ts @Redocly/hot-dogs
+packages/cli/src/commands/drift/ @Redocly/cyberpunks
+packages/cli/src/commands/proxy/ @Redocly/cyberpunks


### PR DESCRIPTION
## What/Why/How?

Adjusting CODEOWNERS for `drift` and `proxy` commands.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [ ] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change to review ownership; no runtime or application code is modified.
> 
> **Overview**
> Updates **`.github/CODEOWNERS`** so **`@Redocly/cyberpunks`** is required on reviews for **`packages/cli/src/commands/drift/`** and **`packages/cli/src/commands/proxy/`**.
> 
> Also keeps **`packages/cli/src/utils/telemetry.ts`** owned by **`@Redocly/hot-dogs`** (with a trailing newline fix on the file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab6959ddc2ed3dbe0c71fcaafcc5e71ef1e3aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->