### PR TITLE
chore: update analytics data format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,9 +2400,9 @@
       "link": true
     },
     "node_modules/@redocly/cli-otel": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.1.tgz",
-      "integrity": "sha512-TbC4bK2zLtU/O9I2pszHPP0rtJOvFhQmEwQ/FHxERPu71fgKG8POUDP2jSiGmsXE7NdGSHBKqnf+y9Acn2jq5g==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.4.tgz",
+      "integrity": "sha512-INh/9ngnXQNYh4MPpSjJiDhDZStyJiruTRFoS6T0bLNLUAlK1QcN5Ft00/Kqp9BJi9eaKu6k1vrIp893L6xjvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8877,7 +8877,7 @@
         "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/sdk-trace-node": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.41.1",
-        "@redocly/cli-otel": "0.3.1",
+        "@redocly/cli-otel": "0.3.4",
         "@redocly/openapi-core": "2.38.0",
         "@redocly/respect-core": "2.38.0",
         "@types/cookie": "0.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-trace-node": "2.8.0",
     "@opentelemetry/semantic-conventions": "1.41.1",
-    "@redocly/cli-otel": "0.3.1",
+    "@redocly/cli-otel": "0.3.4",
     "@redocly/openapi-core": "2.38.0",
     "@redocly/respect-core": "2.38.0",
     "@types/cookie": "0.6.0",

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -83,9 +83,9 @@ export async function sendTelemetry({
     const majorSpecVersion = getMajorSpecVersion(spec_version as SpecVersion);
     const eventData: EventPayload<EventType> = [
       {
-        id: 'cli-command-run',
+        id: `${command}`,
         object: 'command',
-        uri: 'urn:redocly:cli',
+        uri: `urn:redocly:cli:command:${command}`,
         logged_in: logged_in ? 'yes' : 'no',
         command: `${command}`,
         ...cleanArgs(args, process.argv.slice(2)),
@@ -118,7 +118,7 @@ export async function sendTelemetry({
 
     const cloudEvent = CloudEvents.mapToCloudEvent({
       type: 'com.redocly.command.ran',
-      source: 'com.redocly.cli',
+      source: 'urn:redocly:cli',
       origin: 'redocly-cli',
       osPlatform: os.platform(),
       actor: {

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -87,7 +87,7 @@ export async function sendTelemetry({
         object: 'command',
         uri: `urn:redocly:cli:command:${command}`,
         logged_in: logged_in ? 'yes' : 'no',
-        command: command,
+        command,
         ...cleanArgs(args, process.argv.slice(2)),
         node_version: process.version,
         npm_version: execSync('npm -v').toString().replace('\n', ''),

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -83,11 +83,11 @@ export async function sendTelemetry({
     const majorSpecVersion = getMajorSpecVersion(spec_version as SpecVersion);
     const eventData: EventPayload<EventType> = [
       {
-        id: `${command}`,
+        id: command,
         object: 'command',
         uri: `urn:redocly:cli:command:${command}`,
         logged_in: logged_in ? 'yes' : 'no',
-        command: `${command}`,
+        command: command,
         ...cleanArgs(args, process.argv.slice(2)),
         node_version: process.version,
         npm_version: execSync('npm -v').toString().replace('\n', ''),


### PR DESCRIPTION
## What/Why/How?
This PR updates usage analytics to align with the new data format that fixes warnings.

| Attribute (data) | Change |
|---|---|
| `cloudevents.event_source` | `com.redocly.cli` → `urn:redocly:cli` |
| `cloudevents.event_data.command.uri` | `urn:redocly:cli` → `urn:redocly:cli:command:<command>` |
| `cloudevents.event_data.command.id` | `cli-command-run` → `<command>` |
| `cloudevents.event_subject` | `cli-command-run` → `<command>` |

Changes include:
- [x]  update dashboards (checked, no need updates)
 

## Reference
[Related issue](https://github.com/Redocly/redocly/issues/22148)
[VSCE part](https://github.com/Redocly/redocly/pull/22866)
## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [x] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect optional product telemetry payload shape, not CLI behavior, auth, or data handling.
> 
> **Overview**
> CLI **usage telemetry** now emits CloudEvents in the updated Redocly analytics shape so downstream ingestion stops raising format warnings.
> 
> For each command run, the event **subject/id** is the actual command name instead of the generic `cli-command-run`, the command object **uri** is `urn:redocly:cli:command:<command>`, and the CloudEvent **source** is `urn:redocly:cli` instead of `com.redocly.cli`. The **`@redocly/cli-otel`** dev dependency is bumped **0.3.1 → 0.3.4** (lockfile included) to match the mapping helpers used for these fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c014b43726b10d99cff63e20072e8379e05a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->