### PR TITLE
chore: update redocly-config to v0.51.0

### DIFF
--- a/.changeset/plenty-kids-return.md
+++ b/.changeset/plenty-kids-return.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.51.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.50.1.tgz",
-      "integrity": "sha512-TrdZUK50baxIjJB/y2ROOqfg35ex+GbkHPoJ40kXQXKMOjrfxfYQ9IliiaLqT5H/Y8qbajPrYQN2DLfvcMaHSw==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.51.0.tgz",
+      "integrity": "sha512-XoSkEN28ojqvF1fP8mhOlzHPowpr1/jkvbo3qXKIKXG8RqTiQkLCGTvYdMBjcagEheFFXAsaJKM/GMdoczd4Zg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -8916,7 +8916,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.50.1",
+        "@redocly/config": "^0.51.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.50.1",
+    "@redocly/config": "^0.51.0",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -686,7 +686,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "clientSecret": {
-        "minLength": 0,
         "type": "string",
       },
       "configuration": "OIDC.configuration",
@@ -2137,7 +2136,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "suggestions": {
-        "default": [],
         "items": {
           "type": "string",
         },
@@ -2360,7 +2358,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "dataLayerName": {
         "type": "string",
       },
-      "defaultDataLayer": {},
+      "defaultDataLayer": {
+        "type": "object",
+      },
       "enableWebVitalsTracking": {
         "type": "boolean",
       },
@@ -3467,7 +3467,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -3482,6 +3481,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -3650,21 +3650,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.apis_additionalProperties.openapi.codeSamples.languages_items.options",
@@ -4059,6 +4044,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -6371,7 +6357,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -6386,6 +6371,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -6554,21 +6540,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.apis_additionalProperties.theme.openapi.codeSamples.languages_items.options",
@@ -6963,6 +6934,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -8654,10 +8626,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "modes": {
-        "default": [
-          "light",
-          "dark",
-        ],
         "items": {
           "type": "string",
         },
@@ -10922,7 +10890,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "dataLayerName": {
         "type": "string",
       },
-      "defaultDataLayer": {},
+      "defaultDataLayer": {
+        "type": "object",
+      },
       "enableWebVitalsTracking": {
         "type": "boolean",
       },
@@ -12029,7 +11999,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -12044,6 +12013,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -12212,21 +12182,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.openapi.codeSamples.languages_items.options",
@@ -12621,6 +12576,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -14933,7 +14889,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -14948,6 +14903,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -15116,21 +15072,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.theme.openapi.codeSamples.languages_items.options",
@@ -15525,6 +15466,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -20075,6 +20017,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "docs": "rootRedoclyConfigSchema.env_additionalProperties.mcp.docs",
+      "gateway": "rootRedoclyConfigSchema.env_additionalProperties.mcp.gateway",
       "hide": {
         "type": "boolean",
       },
@@ -20098,6 +20041,24 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "name": {
         "type": "string",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.mcp.gateway": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "allowedHosts": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "hide": {
+        "type": "boolean",
       },
     },
     "required": undefined,
@@ -20649,7 +20610,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -20664,6 +20624,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -20832,21 +20793,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.env_additionalProperties.openapi.codeSamples.languages_items.options",
@@ -21241,6 +21187,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -24199,11 +24146,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
-      "const": {},
+      "const": [Function],
       "defined": {
         "type": "boolean",
       },
-      "eq": {},
+      "eq": [Function],
       "gt": {
         "type": "number",
       },
@@ -24274,11 +24221,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
-      "const": {},
+      "const": [Function],
       "defined": {
         "type": "boolean",
       },
-      "eq": {},
+      "eq": [Function],
       "gt": {
         "type": "number",
       },
@@ -25070,7 +25017,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "dataLayerName": {
         "type": "string",
       },
-      "defaultDataLayer": {},
+      "defaultDataLayer": {
+        "type": "object",
+      },
       "enableWebVitalsTracking": {
         "type": "boolean",
       },
@@ -28882,7 +28831,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -28897,6 +28845,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -29065,21 +29014,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.env_additionalProperties.theme.openapi.codeSamples.languages_items.options",
@@ -29474,6 +29408,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -31791,11 +31726,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
-      "const": {},
+      "const": [Function],
       "defined": {
         "type": "boolean",
       },
-      "eq": {},
+      "eq": [Function],
       "gt": {
         "type": "number",
       },
@@ -31866,11 +31801,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
-      "const": {},
+      "const": [Function],
       "defined": {
         "type": "boolean",
       },
-      "eq": {},
+      "eq": [Function],
       "gt": {
         "type": "number",
       },
@@ -33700,10 +33635,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {
       "editPage": "rootRedoclyConfigSchema.markdown.editPage",
       "frontMatterKeysToResolve": {
-        "default": [
-          "image",
-          "links",
-        ],
         "items": {
           "type": "string",
         },
@@ -33711,9 +33642,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "lastUpdatedBlock": "rootRedoclyConfigSchema.markdown.lastUpdatedBlock",
       "partialsFolders": {
-        "default": [
-          "**/_partials/**",
-        ],
         "items": {
           "type": "string",
         },
@@ -33799,6 +33727,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "docs": "rootRedoclyConfigSchema.mcp.docs",
+      "gateway": "rootRedoclyConfigSchema.mcp.gateway",
       "hide": {
         "type": "boolean",
       },
@@ -33815,7 +33744,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "ignore": {
-        "default": [],
         "items": {
           "type": "string",
         },
@@ -33823,6 +33751,24 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "name": {
         "type": "string",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.mcp.gateway": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "allowedHosts": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "hide": {
+        "type": "boolean",
       },
     },
     "required": undefined,
@@ -34132,14 +34078,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "items": {
-        "default": [
-          "copy",
-          "view",
-          "chatgpt",
-          "claude",
-          "docs-mcp-cursor",
-          "docs-mcp-vscode",
-        ],
         "items": {
           "enum": [
             "copy",
@@ -34382,7 +34320,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "oAuth2RedirectURI": {
-        "nullable": true,
         "type": "string",
       },
       "onDeepLinkClick": {
@@ -34397,6 +34334,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "section",
           "item",
         ],
+        "type": "string",
       },
       "pathInMiddlePanel": {
         "type": "boolean",
@@ -34565,21 +34503,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "lang": {
-        "examples": [
-          "curl",
-          "JavaScript",
-          "Node.js",
-          "Python",
-          "Java8+Apache",
-          "Java",
-          "C#",
-          "C#+Newtonsoft",
-          "PHP",
-          "Go",
-          "Ruby",
-          "R",
-          "Payload",
-        ],
         "type": "string",
       },
       "options": "rootRedoclyConfigSchema.openapi.codeSamples.languages_items.options",
@@ -34974,6 +34897,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "R",
           "Ruby",
         ],
+        "type": "string",
       },
     },
     "required": [
@@ -37932,11 +37856,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
-      "const": {},
+      "const": [Function],
       "defined": {
         "type": "boolean",
       },
-      "eq": {},
+      "eq": [Function],
       "gt": {
         "type": "number",
       },
@@ -38007,11 +37931,11 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {
-      "const": {},
+      "const": [Function],
       "defined": {
         "type": "boolean",
       },
-      "eq": {},
+      "eq": [Function],
       "gt": {
         "type": "number",
       },
@@ -38235,9 +38159,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "shortcuts": {
-        "default": [
-          "⌘+K,ctrl+K",
-        ],
         "items": {
           "type": "string",
         },
@@ -38260,7 +38181,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "suggestions": {
-        "default": [],
         "items": {
           "type": "string",
         },
@@ -38389,7 +38309,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "details": "rootRedoclyConfigSchema.seo.llmstxt.details",
       "excludeFiles": {
-        "default": [],
         "items": {
           "type": "string",
         },
@@ -38438,14 +38357,12 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "excludeFiles": {
-        "default": [],
         "items": {
           "type": "string",
         },
         "type": "array",
       },
       "includeFiles": {
-        "default": [],
         "items": {
           "type": "string",
         },


### PR DESCRIPTION
## What/Why/How?

Update redocly-config to v0.51.0.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency upgrade with snapshot-only test updates; no application logic changes in this repo.
> 
> **Overview**
> Bumps **`@redocly/config`** from **0.50.1** to **0.51.0** in `@redocly/openapi-core` (with lockfile and a patch changeset).
> 
> The updated package schema is reflected in the **`redocly-yaml`** test snapshot: notably **`mcp.gateway`** is now a first-class config section with **`allowedHosts`** (string array) and **`hide`**. Other snapshot deltas are mostly schema-shape housekeeping from upstream (e.g. explicit **`type`** on some enum fields, **`defaultDataLayer`** typed as object, removal of some **`nullable`**, **`minLength`**, **`default`**, and **`examples`** metadata on various properties).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97821ffd195d37145707df778fa94756259cd3d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->