### PR TITLE
fix: do not collapse internal $ref chains when bundling

### DIFF
--- a/.changeset/moody-radios-serve.md
+++ b/.changeset/moody-radios-serve.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed an issue where the `bundle` command rewrote internal `$ref`s pointing to other `$ref`s, which made AsyncAPI 3 operation `messages` refs point to `components` instead of channel messages.

--- a/.changeset/moody-radios-serve.md
+++ b/.changeset/moody-radios-serve.md
@@ -3,4 +3,5 @@
 '@redocly/cli': patch
 ---
 
-Fixed an issue where the `bundle` command rewrote internal `$ref`s pointing to other `$ref`s, which made AsyncAPI 3 operation `messages` refs point to `components` instead of channel messages.
+Fixed an issue where the `bundle` command rewrote internal `$ref`s pointing to other `$ref`s.
+The issue caused AsyncAPI 3 operation `messages` references to point to `components` instead of channel messages.

--- a/packages/core/src/__tests__/bundle.test.ts
+++ b/packages/core/src/__tests__/bundle.test.ts
@@ -836,6 +836,84 @@ describe('bundle async', () => {
     expect(problems).toHaveLength(0);
     expect(res.parsed).toMatchSnapshot();
   });
+
+  it('should keep operation message refs pointing to channel messages in asyncapi 3', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        asyncapi: 3.0.0
+        info:
+          title: Ping service
+          version: 1.0.0
+        channels:
+          ping:
+            address: /ping
+            messages:
+              ping:
+                $ref: '#/components/messages/ping'
+        operations:
+          sendPing:
+            action: send
+            channel:
+              $ref: '#/channels/ping'
+            messages:
+              - $ref: '#/channels/ping/messages/ping'
+        components:
+          messages:
+            ping:
+              payload:
+                type: string
+      `,
+      ''
+    );
+
+    const { bundle: res, problems } = await bundleDocument({
+      document,
+      externalRefResolver: new BaseResolver(),
+      config: await createConfig({}),
+      types: AsyncApi3Types,
+    });
+
+    expect(problems).toHaveLength(0);
+    expect((res.parsed as any).operations.sendPing.messages).toEqual([
+      { $ref: '#/channels/ping/messages/ping' },
+    ]);
+  });
+
+  it('should keep operation channel refs pointing to root channels in asyncapi 3', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        asyncapi: 3.0.0
+        info:
+          title: Ping service
+          version: 1.0.0
+        channels:
+          ping:
+            $ref: '#/components/channels/ping'
+        operations:
+          sendPing:
+            action: send
+            channel:
+              $ref: '#/channels/ping'
+        components:
+          channels:
+            ping:
+              address: /ping
+      `,
+      ''
+    );
+
+    const { bundle: res, problems } = await bundleDocument({
+      document,
+      externalRefResolver: new BaseResolver(),
+      config: await createConfig({}),
+      types: AsyncApi3Types,
+    });
+
+    expect(problems).toHaveLength(0);
+    expect((res.parsed as any).operations.sendPing.channel).toEqual({
+      $ref: '#/channels/ping',
+    });
+  });
 });
 
 describe('sibling $ref resolution by spec', () => {

--- a/packages/core/src/bundle/bundle-visitor.ts
+++ b/packages/core/src/bundle/bundle-visitor.ts
@@ -5,6 +5,7 @@ import {
   replaceRef,
   isExternalValue,
   isRef,
+  parseRef,
   pointerBaseName,
   refBaseName,
   type Location,
@@ -156,8 +157,10 @@ export function makeBundleVisitor({
           ctx.type.name !== 'scalar' &&
           !dereference
         ) {
-          // Normalize explicit self-file refs to internal pointer
-          if (node.$ref !== resolved.location.pointer) {
+          // Normalize explicit self-file refs (api.yaml#/x -> #/x). Already-internal refs
+          // stay as authored: rewriting them would collapse $ref chains, and AsyncAPI 3
+          // operation messages must point to channel messages, not to components.
+          if (parseRef(node.$ref).uri !== null && node.$ref !== resolved.location.pointer) {
             node.$ref = resolved.location.pointer;
           }
 

--- a/tests/e2e/bundle/async3-internal-ref-chains/asyncapi.yaml
+++ b/tests/e2e/bundle/async3-internal-ref-chains/asyncapi.yaml
@@ -1,0 +1,49 @@
+asyncapi: 3.0.0
+info:
+  title: Ping/pong service
+  version: 1.0.0
+servers:
+  production:
+    $ref: '#/components/servers/production'
+channels:
+  ping:
+    $ref: '#/components/channels/ping'
+  pong:
+    $ref: '#/components/channels/pong'
+operations:
+  sendPing:
+    action: send
+    channel:
+      $ref: '#/channels/ping'
+    messages:
+      - $ref: '#/channels/ping/messages/ping'
+    reply:
+      channel:
+        $ref: '#/channels/pong'
+      messages:
+        - $ref: '#/channels/pong/messages/pong'
+components:
+  servers:
+    production:
+      host: example.com
+      protocol: ws
+  channels:
+    ping:
+      address: /ping
+      servers:
+        - $ref: '#/servers/production'
+      messages:
+        ping:
+          $ref: '#/components/messages/ping'
+    pong:
+      address: /pong
+      messages:
+        pong:
+          $ref: '#/components/messages/pong'
+  messages:
+    ping:
+      payload:
+        $ref: 'schemas.yaml#/components/schemas/ping'
+    pong:
+      payload:
+        $ref: 'schemas.yaml#/components/schemas/pong'

--- a/tests/e2e/bundle/async3-internal-ref-chains/redocly.yaml
+++ b/tests/e2e/bundle/async3-internal-ref-chains/redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./asyncapi.yaml

--- a/tests/e2e/bundle/async3-internal-ref-chains/schemas.yaml
+++ b/tests/e2e/bundle/async3-internal-ref-chains/schemas.yaml
@@ -1,0 +1,12 @@
+components:
+  schemas:
+    ping:
+      type: object
+      properties:
+        event:
+          type: string
+    pong:
+      type: object
+      properties:
+        replyTo:
+          type: string

--- a/tests/e2e/bundle/async3-internal-ref-chains/snapshot.txt
+++ b/tests/e2e/bundle/async3-internal-ref-chains/snapshot.txt
@@ -1,0 +1,63 @@
+asyncapi: 3.0.0
+info:
+  title: Ping/pong service
+  version: 1.0.0
+servers:
+  production:
+    $ref: '#/components/servers/production'
+channels:
+  ping:
+    $ref: '#/components/channels/ping'
+  pong:
+    $ref: '#/components/channels/pong'
+operations:
+  sendPing:
+    action: send
+    channel:
+      $ref: '#/channels/ping'
+    messages:
+      - $ref: '#/channels/ping/messages/ping'
+    reply:
+      channel:
+        $ref: '#/channels/pong'
+      messages:
+        - $ref: '#/channels/pong/messages/pong'
+components:
+  servers:
+    production:
+      host: example.com
+      protocol: ws
+  channels:
+    ping:
+      address: /ping
+      servers:
+        - $ref: '#/servers/production'
+      messages:
+        ping:
+          $ref: '#/components/messages/ping'
+    pong:
+      address: /pong
+      messages:
+        pong:
+          $ref: '#/components/messages/pong'
+  messages:
+    ping:
+      payload:
+        $ref: '#/components/schemas/ping'
+    pong:
+      payload:
+        $ref: '#/components/schemas/pong'
+  schemas:
+    ping:
+      type: object
+      properties:
+        event:
+          type: string
+    pong:
+      type: object
+      properties:
+        replyTo:
+          type: string
+
+bundling asyncapi.yaml using configuration for api 'main'...
+📦 Created a bundle for asyncapi.yaml at stdout <test>ms.

--- a/tests/e2e/stats/stats-async3-stylish/snapshot.txt
+++ b/tests/e2e/stats/stats-async3-stylish/snapshot.txt
@@ -1,4 +1,4 @@
-🚗 References: 3 
+🚗 References: 4 
 📦 External Documents: 0 
 📈 Schemas: 1 
 👉 Parameters: 0 


### PR DESCRIPTION
## What/Why/How?

The `bundle` command rewrote internal `$ref`s (already in the `#/...` form) to the pointer of their fully resolved target.
When a ref pointed to a node that is itself a `$ref`, the chain was collapsed to its final target.

AsyncAPI 3 forbids this for several refs whose location is semantically significant: operation `channel` and `messages`, 
reply `channel` and `messages`, and channel `servers` MUST point to root `channels`, channel messages, and root 
`servers` — never to `components`.

> [!IMPORTANT]
> A list of $ref pointers pointing to the supported [Message Objects](https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageObject) that can be processed by this operation. It MUST contain a subset of the messages defined in the [channel referenced in this operation](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObjectChannel), and MUST NOT point to a subset of message definitions located in the [Messages Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#componentsMessages) in the [Components Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#componentsObject) or anywhere else.

## Reference

- https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject
- https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject
- https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject

## Testing

- added tests

## Screenshots (optional)

```yaml
# source (and bundle output after the fix)
messages:
  - $ref: '#/channels/ping/messages/ping'

# bundle output before the fix — invalid per the AsyncAPI 3 spec
messages:
  - $ref: '#/components/messages/ping'
```

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to same-document ref normalization during bundle (non-dereference path); behavior for explicit file refs is preserved and covered by new tests.
> 
> **Overview**
> **Fixes bundling** so internal `#/...` references are no longer rewritten to the resolved target pointer when that target is another `$ref`.
> 
> The bundle visitor still normalizes **explicit self-file** refs (e.g. `api.yaml#/channels/ping` → `#/channels/ping`) by checking `parseRef(node.$ref).uri !== null`. Pure internal refs stay as written, which keeps AsyncAPI 3 documents valid: operation `channel` / `messages` (and similar) must keep pointing at root `channels` and channel messages, not at collapsed `components` paths.
> 
> Adds unit tests for AsyncAPI 3 operation message and channel refs, an e2e bundle fixture for internal ref chains (including external schema inlining), and a small stats snapshot update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af733b5be36c2442293a764921c408a47538b256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->