### PR TITLE
fix(respect): referenced workflow execution flow inconsistency

### DIFF
--- a/.changeset/child-workflow-failure-stops-parent.md
+++ b/.changeset/child-workflow-failure-stops-parent.md
@@ -1,0 +1,6 @@
+---
+'@redocly/respect-core': patch
+'@redocly/cli': patch
+---
+
+Fixed `respect` to stop parent workflow execution when a step that references another workflow fails. Previously, the next steps of the parent workflow were still executed after the referenced workflow failed.

--- a/.changeset/child-workflow-failure-stops-parent.md
+++ b/.changeset/child-workflow-failure-stops-parent.md
@@ -3,4 +3,4 @@
 '@redocly/cli': patch
 ---
 
-Fixed `respect` to stop parent workflow execution when a step that references another workflow fails. Previously, the next steps of the parent workflow were still executed after the referenced workflow failed.
+Fixed an issue in `respect` where the execution of parent workflow's steps didn't halt after a step that referenced another workflow had failed.

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -2613,6 +2613,11 @@ describe('runStep', () => {
     } as unknown as TestContext;
 
     vi.mocked(resolveWorkflowContext).mockResolvedValueOnce(localCTX);
+    vi.mocked(runWorkflow).mockResolvedValueOnce({
+      type: 'workflow',
+      workflowId: 'reusable-workflow',
+      executedSteps: [],
+    } as unknown as WorkflowExecutionResult);
 
     await runStep({
       step,
@@ -2623,6 +2628,72 @@ describe('runStep', () => {
 
     expect(runWorkflow).toHaveBeenCalled();
     expect(localCTX.$steps['get-bird'].outputs).toEqual({ stepOutput: 'Hello, world!' });
+  });
+
+  it('should end parent workflow when child workflow step has failed steps', async () => {
+    const step: Step = {
+      stepId: 'call-child-workflow',
+      workflowId: 'child-workflow',
+      checks: [],
+      response: {} as any,
+    };
+    const localCTX = {
+      executedSteps: [],
+      $steps: {},
+      workflows: [
+        {
+          workflowId: 'parent-workflow',
+          steps: [step],
+        },
+        {
+          workflowId: 'child-workflow',
+          steps: [
+            {
+              stepId: 'child-step',
+              'x-operation': {
+                url: 'http://localhost:3000/delete-mock',
+                method: 'delete',
+              },
+              successCriteria: [{ condition: '$statusCode == 204' }],
+              checks: [],
+            },
+          ],
+        },
+      ],
+      options: {
+        filePath: 'runStepTest.yml',
+        logger: logger,
+      },
+      severity: DEFAULT_SEVERITY_CONFIGURATION,
+    } as unknown as TestContext;
+
+    vi.mocked(resolveWorkflowContext).mockResolvedValueOnce(localCTX);
+    vi.mocked(runWorkflow).mockResolvedValueOnce({
+      type: 'workflow',
+      workflowId: 'child-workflow',
+      executedSteps: [
+        {
+          stepId: 'child-step',
+          checks: [
+            {
+              name: CHECKS.SUCCESS_CRITERIA_CHECK,
+              message: 'Checking simple criteria: {"condition":"$statusCode == 204"}',
+              passed: false,
+              severity: 'error',
+            },
+          ],
+        },
+      ],
+    } as unknown as WorkflowExecutionResult);
+
+    const result = await runStep({
+      step,
+      ctx: localCTX,
+      workflowId: 'parent-workflow',
+      executedStepsCount: { value: 0 },
+    });
+
+    expect(result).toEqual({ shouldEnd: true });
   });
 
   it('should run step with workflowId from external workflowSpec', async () => {
@@ -3015,6 +3086,12 @@ describe('runStep', () => {
       arazzo: '1.0.1',
       $outputs: {},
     } as unknown as TestContext;
+
+    vi.mocked(runWorkflow).mockResolvedValueOnce({
+      type: 'workflow',
+      workflowId: 'reusable-external-workflow',
+      executedSteps: [],
+    } as unknown as WorkflowExecutionResult);
 
     await runStep({
       step,
@@ -3462,6 +3539,11 @@ describe('runStep', () => {
     vi.mocked(resolveWorkflowContext).mockImplementation((): any => {
       return { ...localCTX };
     });
+    vi.mocked(runWorkflow).mockResolvedValueOnce({
+      type: 'workflow',
+      workflowId: 'reusable-external-workflow',
+      executedSteps: [],
+    } as unknown as WorkflowExecutionResult);
 
     await runStep({
       step,

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -26,6 +26,7 @@ import {
   printActionsSeparator,
   printUnknownStep,
 } from '../logger-output/helpers.js';
+import { calculateTotals } from '../logger-output/index.js';
 import { evaluateRuntimeExpressionPayload } from '../runtime-expressions/index.js';
 import { Timer } from '../timeout-timer/timer.js';
 import { callAPIAndAnalyzeResults } from './call-api-and-analyze-results.js';
@@ -163,6 +164,25 @@ export async function runStep({
           request: undefined,
           response: undefined,
         };
+      }
+    }
+
+    const childWorkflowFailed = calculateTotals([stepWorkflowResult]).steps.failed > 0;
+
+    if (childWorkflowFailed) {
+      const result = await runActions(failureActionsToRun, 'failure', executedStepsCount);
+      if (result?.retriesLeft && result.retriesLeft > 0) {
+        return result.stepResult;
+      }
+      if (result?.shouldEnd) {
+        return { shouldEnd: true };
+      }
+    }
+
+    if (successActionsToRun.length && !childWorkflowFailed) {
+      const result = await runActions(successActionsToRun, 'success', executedStepsCount);
+      if (result?.shouldEnd) {
+        return { shouldEnd: true };
       }
     }
 

--- a/tests/e2e/respect/max-steps/__snapshots__/max-steps.test.ts.snap
+++ b/tests/e2e/respect/max-steps/__snapshots__/max-steps.test.ts.snap
@@ -32,13 +32,7 @@ exports[`should quit an infinite loop on REDOCLY_CLI_RESPECT_MAX_STEPS 1`] = `
  
  
  
-  ✗ GET /ping - step ping 
-
-    Request URL: https://bad-api-url.com/api/ping 
- 
-    ✗ failed network request
- 
-  Running failure action infinite-loop for the step ping 
+  Running failure action continue for the step with-nested 
  
   ✗ GET /ping - step ping 
 
@@ -87,6 +81,15 @@ exports[`should quit an infinite loop on REDOCLY_CLI_RESPECT_MAX_STEPS 1`] = `
     ✗ failed network request
  
   Running failure action infinite-loop for the step ping 
+ 
+  ✗ GET /ping - step ping 
+
+    Request URL: https://bad-api-url.com/api/ping 
+ 
+    ✗ failed network request
+ 
+  Running failure action infinite-loop for the step ping 
+ 
  
  
  

--- a/tests/e2e/respect/max-steps/arazzo.yaml
+++ b/tests/e2e/respect/max-steps/arazzo.yaml
@@ -21,6 +21,10 @@ workflows:
       - stepId: with-nested
         description: With nested workflow
         workflowId: nested-workflow
+        onFailure:
+          - name: continue
+            type: goto
+            stepId: ping
 
       - stepId: ping
         description: Ping the API


### PR DESCRIPTION
## What/Why/How?

Fixed `respect` to stop parent workflow execution when a step that references another workflow fails. Previously, the next steps of the parent workflow were still executed after the referenced workflow failed.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2963

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workflow control flow for nested Arazzo runs; workflows that relied on continuing after a failed child may behave differently unless they define `onFailure` goto/retry.
> 
> **Overview**
> **respect** now treats a failed **child workflow** (a step with `workflowId`) like a failed API step: after `runWorkflow` finishes, it uses `calculateTotals` on the child result and, when any step failed, runs **`onFailure`** actions (and skips **`onSuccess`**).
> 
> If failure handling ends the flow (default when no matching `goto`/`retry`, or an explicit `end`/`goto`), `runStep` returns **`{ shouldEnd: true }`** so later parent steps no longer run. Previously the nested-workflow path always continued with `{ shouldEnd: false }`.
> 
> Coverage adds a unit test for this behavior, mocks `runWorkflow` in a few workflow-step tests, extends the max-steps e2e Arazzo with `onFailure` on the nested step, and documents the fix in a changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c88bfb01162a6e084e37b867fd88a0072626ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->