### PR TITLE
fix(respect): workflow references format

### DIFF
--- a/.changeset/spec-form-workflow-references.md
+++ b/.changeset/spec-form-workflow-references.md
@@ -3,4 +3,6 @@
 '@redocly/cli': patch
 ---
 
-Added support for the Arazzo spec-compliant workflow reference form `$sourceDescriptions.<name>.<workflowId>` in `dependsOn`, step `workflowId`, and success/failure action `workflowId`. Unresolvable workflow references now fail the affected workflow with a clear error message instead of aborting the whole run or being silently ignored.
+Added support for the Arazzo spec-compliant workflow reference form `$sourceDescriptions.<name>.<workflowId>` in `dependsOn`, step `workflowId`, and success/failure action `workflowId`.
+
+Unresolvable workflow references fail only the affected workflow with a clear error message, and no longer abort the whole run or pass unnoticed.

--- a/.changeset/spec-form-workflow-references.md
+++ b/.changeset/spec-form-workflow-references.md
@@ -1,0 +1,6 @@
+---
+'@redocly/respect-core': patch
+'@redocly/cli': patch
+---
+
+Added support for the Arazzo spec-compliant workflow reference form `$sourceDescriptions.<name>.<workflowId>` in `dependsOn`, step `workflowId`, and success/failure action `workflowId`. Unresolvable workflow references now fail the affected workflow with a clear error message instead of aborting the whole run or being silently ignored.

--- a/packages/cli/src/commands/respect/__tests__/json-logs.test.ts
+++ b/packages/cli/src/commands/respect/__tests__/json-logs.test.ts
@@ -1,0 +1,60 @@
+import { type Step, type TestContext, type WorkflowExecutionResult } from '@redocly/respect-core';
+import { describe, it, expect } from 'vitest';
+
+import { composeJsonLogsFiles } from '../json-logs.js';
+
+describe('composeJsonLogsFiles', () => {
+  it('should serialize a synthetic step that has no declared counterpart in the workflow', () => {
+    // a failed dependsOn resolution produces a step that exists only in the
+    // execution results, not in the workflow definition
+    const syntheticStep = {
+      stepId: 'dependsOn',
+      checks: [
+        {
+          name: 'UNEXPECTED_ERROR',
+          message: 'Workflow some-workflow is not found.',
+          passed: false,
+          severity: 'error',
+        },
+      ],
+    } as unknown as Step;
+
+    const ctx = {
+      $workflows: {
+        'broken-workflow': { steps: {} },
+      },
+      noSecretsMasking: true,
+      secretsSet: new Set<string>(),
+    } as unknown as TestContext;
+
+    const executedWorkflow = {
+      type: 'workflow',
+      workflowId: 'broken-workflow',
+      startTime: 0,
+      endTime: 1,
+      totalTimeMs: 1,
+      executedSteps: [syntheticStep],
+      ctx,
+      globalTimeoutError: false,
+    } as unknown as WorkflowExecutionResult;
+
+    const files = composeJsonLogsFiles([
+      {
+        file: 'test.arazzo.yaml',
+        totalRequests: 0,
+        totalTimeMs: 1,
+        executedWorkflows: [executedWorkflow],
+        ctx,
+        globalTimeoutError: false,
+      },
+    ]);
+
+    const workflowJson = files['test.arazzo.yaml'].executedWorkflows[0];
+    expect(workflowJson.status).toEqual('error');
+    expect(workflowJson.executedSteps[0]).toMatchObject({
+      type: 'step',
+      stepId: 'dependsOn',
+      status: 'error',
+    });
+  });
+});

--- a/packages/cli/src/commands/respect/json-logs.ts
+++ b/packages/cli/src/commands/respect/json-logs.ts
@@ -8,6 +8,7 @@ import {
   type Step,
   type StepExecutionResult,
   type Check,
+  type PublicWorkflowStep,
 } from '@redocly/respect-core';
 
 export function composeJsonLogsFiles(
@@ -73,20 +74,24 @@ function mapJsonStep(
     return mapJsonWorkflow(step as WorkflowExecutionResult);
   }
 
-  const publicStep = ctx.$workflows[workflowId].steps[step.stepId];
+  // synthetic steps (e.g. a failed dependsOn resolution) have no declared
+  // counterpart in the workflow, so there is no public step to read from
+  const publicStep = ctx.$workflows[workflowId].steps[step.stepId] as
+    | PublicWorkflowStep
+    | undefined;
   return {
     type: 'step',
     stepId: step.stepId,
     workflowId,
     request: {
-      method: publicStep.request?.method || '',
+      method: publicStep?.request?.method || '',
       url: step.response?.requestUrl || '',
-      headers: publicStep.request?.header || {},
-      body: publicStep.request?.body,
+      headers: publicStep?.request?.header || {},
+      body: publicStep?.request?.body,
     },
     response: {
       statusCode: step.response?.statusCode || 0,
-      body: publicStep.response?.body,
+      body: publicStep?.response?.body,
       headers: step.response?.header || {},
       time: step.response?.time || 0,
       size: step.response?.responseSize,
@@ -95,7 +100,7 @@ function mapJsonStep(
       ...check,
       status: calculateCheckStatus(check),
     })),
-    totalTimeMs: publicStep.response?.time || 0,
+    totalTimeMs: publicStep?.response?.time || 0,
     retriesLeft: step.retriesLeft,
     status: calculateStepStatus(step.checks),
   };

--- a/packages/core/src/rules/arazzo/__tests__/workflow-dependsOn.test.ts
+++ b/packages/core/src/rules/arazzo/__tests__/workflow-dependsOn.test.ts
@@ -88,7 +88,7 @@ describe('Arazzo workflow-dependsOn', () => {
         dependsOn:
           - events-crud
           - events-crus
-          - $sourceDescriptions.tickets-from-museum-apis.workflows.get-museum-tickets
+          - $sourceDescriptions.tickets-from-museum-apis.get-museum-tickets
         description: >-
           This workflow demonstrates how to get the museum opening hours and buy tickets.
         parameters:
@@ -107,7 +107,7 @@ describe('Arazzo workflow-dependsOn', () => {
           - stepId: buy-ticket
             description: >-
               Buy a ticket for the museum by calling an external workflow from another Arazzo file.
-            workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+            workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
             outputs:
               ticketId: $outputs.ticketId
       - workflowId: events-crud

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -212,6 +212,30 @@ describe('getValueFromContext', () => {
     ).toThrow(/workflow .*notExistingWorkflow.* is not found.*Available workflows: workflowTestId/);
   });
 
+  it('should throw for a legacy form reference with extra segments after the workflowId', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          workflows: [
+            {
+              workflowId: 'workflowTestId',
+              steps: [],
+            },
+          ],
+        },
+      },
+    } as any;
+    expect(() =>
+      getValueFromContext({
+        value: '$sourceDescriptions.test.workflows.workflowTestId.steps.stepA',
+        ctx,
+        logger,
+      })
+    ).toThrow(
+      /invalid workflow reference format.*\$sourceDescriptions\.<name>\.<workflowId>.*\$sourceDescriptions\.<name>\.workflows\.<workflowId>/
+    );
+  });
+
   it('should throw for the legacy form when there is no workflowId provided', () => {
     const ctx = {
       $sourceDescriptions: {

--- a/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/get-value-from-context.test.ts
@@ -143,7 +143,7 @@ describe('getValueFromContext', () => {
   });
 
   // $sourceDescriptions.<name>.workflows.<workflowId>
-  it('should return workflow from $sourceDescriptions', () => {
+  it('should resolve the legacy `$sourceDescriptions.<name>.workflows.<workflowId>` form for backward compatibility', () => {
     const ctx = {
       $sourceDescriptions: {
         test: {
@@ -168,7 +168,7 @@ describe('getValueFromContext', () => {
     });
   });
 
-  it('should return undefined from $sourceDescriptions if there is no such sourceDescription', () => {
+  it('should throw for the legacy form when there is no such sourceDescription', () => {
     const ctx = {
       $sourceDescriptions: {
         test: {
@@ -181,16 +181,16 @@ describe('getValueFromContext', () => {
         },
       },
     } as any;
-    expect(
+    expect(() =>
       getValueFromContext({
         value: '$sourceDescriptions.notExistingName.workflows.workflowTestId',
         ctx,
         logger,
       })
-    ).toEqual(undefined);
+    ).toThrow(/source description .*notExistingName.* is not found/);
   });
 
-  it('should return undefined from $sourceDescriptions if there is no workflowId provided', () => {
+  it('should throw for the legacy form when the workflow is not found in the sourceDescription', () => {
     const ctx = {
       $sourceDescriptions: {
         test: {
@@ -203,9 +203,158 @@ describe('getValueFromContext', () => {
         },
       },
     } as any;
-    expect(
+    expect(() =>
+      getValueFromContext({
+        value: '$sourceDescriptions.test.workflows.notExistingWorkflow',
+        ctx,
+        logger,
+      })
+    ).toThrow(/workflow .*notExistingWorkflow.* is not found.*Available workflows: workflowTestId/);
+  });
+
+  it('should throw for the legacy form when there is no workflowId provided', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          workflows: [
+            {
+              workflowId: 'workflowTestId',
+              steps: [],
+            },
+          ],
+        },
+      },
+    } as any;
+    expect(() =>
       getValueFromContext({ value: '$sourceDescriptions.notExistingName.workflows.', ctx, logger })
-    ).toEqual(undefined);
+    ).toThrow(/notExistingName/);
+  });
+
+  it('should return workflow from $sourceDescriptions using the spec form without `workflows` segment', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          workflows: [
+            {
+              workflowId: 'workflowTestId',
+              steps: [],
+            },
+          ],
+        },
+      },
+    } as unknown as TestContext;
+    expect(
+      getValueFromContext({
+        value: '$sourceDescriptions.test.workflowTestId',
+        ctx,
+        logger,
+      })
+    ).toEqual({
+      workflowId: 'workflowTestId',
+      steps: [],
+    });
+  });
+
+  it('should fall back to field access for the spec form when no workflow matches', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          url: './test.yaml',
+          workflows: [
+            {
+              workflowId: 'workflowTestId',
+              steps: [],
+            },
+          ],
+        },
+      },
+    } as unknown as TestContext;
+    expect(
+      getValueFromContext({
+        value: '$sourceDescriptions.test.url',
+        ctx,
+        logger,
+      })
+    ).toEqual('./test.yaml');
+  });
+
+  it('should resolve Source Description Object fields (url, type, name) for the spec form', () => {
+    const ctx = {
+      sourceDescriptions: [{ name: 'petstore', url: './petstore.yaml', type: 'openapi' }],
+      $sourceDescriptions: {
+        petstore: {
+          paths: {},
+          servers: [{ url: 'https://api.example.com' }],
+        },
+      },
+    } as unknown as TestContext;
+    expect(getValueFromContext({ value: '$sourceDescriptions.petstore.url', ctx, logger })).toEqual(
+      './petstore.yaml'
+    );
+    expect(
+      getValueFromContext({ value: '$sourceDescriptions.petstore.type', ctx, logger })
+    ).toEqual('openapi');
+  });
+
+  it('should throw for the spec form when the source description exists but has no matching workflow or field', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          workflows: [
+            {
+              workflowId: 'workflowTestId',
+              steps: [],
+            },
+          ],
+        },
+      },
+    } as unknown as TestContext;
+    expect(() =>
+      getValueFromContext({
+        value: '$sourceDescriptions.test.notExistingWorkflow',
+        ctx,
+        logger,
+      })
+    ).toThrow(
+      /notExistingWorkflow.* does not match a workflow or a field.*Available workflows: workflowTestId/
+    );
+  });
+
+  it('should throw for the spec form when the source description does not exist', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          workflows: [
+            {
+              workflowId: 'workflowTestId',
+              steps: [],
+            },
+          ],
+        },
+      },
+    } as unknown as TestContext;
+    expect(() =>
+      getValueFromContext({
+        value: '$sourceDescriptions.notExistingName.someWorkflow',
+        ctx,
+        logger,
+      })
+    ).toThrow(
+      /source description .*notExistingName.* is not found.*Available source descriptions: test/
+    );
+  });
+
+  it('should not resolve prototype properties for the spec form', () => {
+    const ctx = {
+      $sourceDescriptions: {
+        test: {
+          workflows: [],
+        },
+      },
+    } as unknown as TestContext;
+    expect(() =>
+      getValueFromContext({ value: '$sourceDescriptions.test.constructor', ctx, logger })
+    ).toThrow(/does not match a workflow or a field/);
   });
 
   it('should return undefined if getFakeData had error resolving value', () => {

--- a/packages/respect-core/src/modules/__tests__/config-parser/resolve-workflow-reference.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/resolve-workflow-reference.test.ts
@@ -1,0 +1,96 @@
+import { type TestContext } from '../../../types.js';
+import { resolveWorkflowReference } from '../../context-parser/index.js';
+
+describe('resolveWorkflowReference', () => {
+  const externalWorkflow = {
+    workflowId: 'externalWorkflow',
+    steps: [],
+  };
+  const localWorkflow = {
+    workflowId: 'localWorkflow',
+    steps: [],
+  };
+  const ctx = {
+    workflows: [localWorkflow],
+    $sourceDescriptions: {
+      externalApi: {
+        info: { title: 'External API' },
+        workflows: [externalWorkflow],
+      },
+      openapiSource: {
+        paths: {},
+        servers: [{ url: 'https://api.example.com' }],
+      },
+    },
+  } as unknown as TestContext;
+
+  it('should resolve a local workflow by its workflowId', () => {
+    expect(resolveWorkflowReference({ ref: 'localWorkflow', ctx })).toEqual(localWorkflow);
+  });
+
+  it('should resolve the `$sourceDescriptions.<name>.<workflowId>` spec form', () => {
+    expect(
+      resolveWorkflowReference({ ref: '$sourceDescriptions.externalApi.externalWorkflow', ctx })
+    ).toEqual(externalWorkflow);
+  });
+
+  it('should resolve the legacy `$sourceDescriptions.<name>.workflows.<workflowId>` form', () => {
+    expect(
+      resolveWorkflowReference({
+        ref: '$sourceDescriptions.externalApi.workflows.externalWorkflow',
+        ctx,
+      })
+    ).toEqual(externalWorkflow);
+  });
+
+  it('should return undefined for an unknown local workflowId', () => {
+    expect(resolveWorkflowReference({ ref: 'unknownWorkflow', ctx })).toBeUndefined();
+  });
+
+  it('should return undefined when the source description does not exist', () => {
+    expect(
+      resolveWorkflowReference({ ref: '$sourceDescriptions.unknownApi.externalWorkflow', ctx })
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when the workflow does not exist in the source description', () => {
+    expect(
+      resolveWorkflowReference({ ref: '$sourceDescriptions.externalApi.unknownWorkflow', ctx })
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when the reference matches a document field instead of a workflow', () => {
+    expect(
+      resolveWorkflowReference({ ref: '$sourceDescriptions.externalApi.info', ctx })
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when the source description has no workflows', () => {
+    expect(
+      resolveWorkflowReference({ ref: '$sourceDescriptions.openapiSource.someWorkflow', ctx })
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for a malformed reference', () => {
+    expect(
+      resolveWorkflowReference({ ref: '$sourceDescriptions.externalApi', ctx })
+    ).toBeUndefined();
+  });
+
+  it('should ignore extra segments after the workflowId in the legacy form for backward compatibility', () => {
+    expect(
+      resolveWorkflowReference({
+        ref: '$sourceDescriptions.externalApi.workflows.externalWorkflow.steps',
+        ctx,
+      })
+    ).toEqual(externalWorkflow);
+  });
+
+  it('should return undefined for other runtime expressions', () => {
+    expect(resolveWorkflowReference({ ref: '$inputs.someInput', ctx })).toBeUndefined();
+  });
+
+  it('should return undefined for an undefined reference', () => {
+    expect(resolveWorkflowReference({ ref: undefined, ctx })).toBeUndefined();
+  });
+});

--- a/packages/respect-core/src/modules/__tests__/config-parser/resolve-workflow-reference.test.ts
+++ b/packages/respect-core/src/modules/__tests__/config-parser/resolve-workflow-reference.test.ts
@@ -77,13 +77,13 @@ describe('resolveWorkflowReference', () => {
     ).toBeUndefined();
   });
 
-  it('should ignore extra segments after the workflowId in the legacy form for backward compatibility', () => {
+  it('should return undefined for a legacy form reference with extra segments after the workflowId', () => {
     expect(
       resolveWorkflowReference({
         ref: '$sourceDescriptions.externalApi.workflows.externalWorkflow.steps',
         ctx,
       })
-    ).toEqual(externalWorkflow);
+    ).toBeUndefined();
   });
 
   it('should return undefined for other runtime expressions', () => {

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -857,6 +857,147 @@ describe('runStep', () => {
     expect(checkCriteria).toHaveBeenCalled();
   });
 
+  it('should throw a clear error when a goto action references a workflow that is not found', async () => {
+    const apiClient = new ApiFetcher({});
+    const stepOne: Step = {
+      stepId: 'get-bird',
+      'x-operation': {
+        url: 'http://localhost:3000/bird',
+        method: 'get',
+      },
+      successCriteria: [{ condition: '$statusCode == 200' }],
+      onSuccess: [
+        {
+          name: 'success-action',
+          workflowId: '$sourceDescriptions.unknown-api.some-workflow',
+          type: 'goto',
+          criteria: [{ condition: '$statusCode == 200' }],
+        },
+      ],
+      checks: [],
+      response: {} as any,
+    };
+
+    vi.mocked(callAPIAndAnalyzeResults).mockImplementationOnce(async ({ step }: { step: Step }) => {
+      step.checks = [
+        {
+          name: CHECKS.STATUS_CODE_CHECK,
+          passed: true,
+          message: '',
+          severity: 'error',
+        },
+      ];
+
+      return {
+        successCriteriaCheck: true,
+        schemaCheck: true,
+        networkCheck: true,
+        unexpectedErrorCheck: true,
+        statusCodeCheck: true,
+      };
+    });
+
+    vi.mocked(checkCriteria).mockImplementation(() => [
+      {
+        name: CHECKS.SUCCESS_CRITERIA_CHECK,
+        passed: true,
+        message: 'Checking simple criteria: {"condition":"$statusCode == 200"}',
+        severity: 'error',
+      },
+    ]);
+
+    const context = {
+      ...basicCTX,
+      apiClient,
+      workflows: [],
+      $sourceDescriptions: {},
+    } as unknown as TestContext;
+
+    await expect(
+      runStep({
+        step: stepOne,
+        ctx: context,
+        workflowId: 'get-bird-workflow',
+        executedStepsCount: { value: 0 },
+      })
+    ).rejects.toThrow(
+      /Workflow .*\$sourceDescriptions\.unknown-api\.some-workflow.* referenced in the goto action of step .*get-bird.* is not found/
+    );
+  });
+
+  it('should throw a clear error when a goto action workflowId matches a document field instead of a workflow', async () => {
+    const apiClient = new ApiFetcher({});
+    const stepOne: Step = {
+      stepId: 'get-bird',
+      'x-operation': {
+        url: 'http://localhost:3000/bird',
+        method: 'get',
+      },
+      successCriteria: [{ condition: '$statusCode == 200' }],
+      onSuccess: [
+        {
+          name: 'success-action',
+          workflowId: '$sourceDescriptions.reusable-api.info',
+          type: 'goto',
+          criteria: [{ condition: '$statusCode == 200' }],
+        },
+      ],
+      checks: [],
+      response: {} as any,
+    };
+
+    vi.mocked(callAPIAndAnalyzeResults).mockImplementationOnce(async ({ step }: { step: Step }) => {
+      step.checks = [
+        {
+          name: CHECKS.STATUS_CODE_CHECK,
+          passed: true,
+          message: '',
+          severity: 'error',
+        },
+      ];
+
+      return {
+        successCriteriaCheck: true,
+        schemaCheck: true,
+        networkCheck: true,
+        unexpectedErrorCheck: true,
+        statusCodeCheck: true,
+      };
+    });
+
+    vi.mocked(checkCriteria).mockImplementation(() => [
+      {
+        name: CHECKS.SUCCESS_CRITERIA_CHECK,
+        passed: true,
+        message: 'Checking simple criteria: {"condition":"$statusCode == 200"}',
+        severity: 'error',
+      },
+    ]);
+
+    const context = {
+      ...basicCTX,
+      apiClient,
+      workflows: [],
+      $sourceDescriptions: {
+        'reusable-api': {
+          info: { title: 'Reusable API', version: '1.0' },
+          workflows: [{ workflowId: 'reusable-external-workflow', steps: [] }],
+        },
+      },
+    } as unknown as TestContext;
+
+    await expect(
+      runStep({
+        step: stepOne,
+        ctx: context,
+        workflowId: 'get-bird-workflow',
+        executedStepsCount: { value: 0 },
+      })
+    ).rejects.toThrow(
+      /Workflow .*\$sourceDescriptions\.reusable-api\.info.* referenced in the goto action of step .*get-bird.* is not found/
+    );
+  });
+
   it('should execute onSuccess step criteria with goto StepId provided by reference', async () => {
     const stepOne: Step = {
       stepId: 'get-bird',
@@ -1075,6 +1216,19 @@ describe('runStep', () => {
                 ],
                 checks: [],
               },
+              {
+                stepId: 'success-action-step',
+                'x-operation': {
+                  url: 'http://localhost:3000/bird',
+                  method: 'get',
+                },
+                checks: [],
+              },
+            ],
+          },
+          {
+            workflowId: 'success-action-workflow',
+            steps: [
               {
                 stepId: 'success-action-step',
                 'x-operation': {
@@ -2699,7 +2853,7 @@ describe('runStep', () => {
   it('should run step with workflowId from external workflowSpec', async () => {
     const step: Step = {
       stepId: 'get-bird',
-      workflowId: '$sourceDescriptions.reusable-api.workflows.reusable-external-workflow',
+      workflowId: '$sourceDescriptions.reusable-api.reusable-external-workflow',
       checks: [],
       response: {} as any,
     };
@@ -3029,7 +3183,7 @@ describe('runStep', () => {
           steps: [
             {
               stepId: 'get-bird',
-              workflowId: '$sourceDescriptions.reusable-api.workflows.reusable-external-workflow',
+              workflowId: '$sourceDescriptions.reusable-api.reusable-external-workflow',
               checks: [],
             },
           ],
@@ -3106,7 +3260,7 @@ describe('runStep', () => {
   it('should run step with workflowId from external workflow and populate inputs from the parameters', async () => {
     const step = {
       stepId: 'get-bird',
-      workflowId: '$sourceDescriptions.reusable-api.workflows.reusable-external-workflow',
+      workflowId: '$sourceDescriptions.reusable-api.reusable-external-workflow',
       parameters: [
         {
           name: 'workflowLevelParam',
@@ -3452,7 +3606,7 @@ describe('runStep', () => {
           steps: [
             {
               stepId: 'get-bird',
-              workflowId: '$sourceDescriptions.reusable-api.workflows.reusable-external-workflow',
+              workflowId: '$sourceDescriptions.reusable-api.reusable-external-workflow',
               parameters: [
                 {
                   name: 'workflowLevelParam',
@@ -3553,7 +3707,7 @@ describe('runStep', () => {
     });
 
     expect(resolveWorkflowContext).toHaveBeenCalledWith(
-      '$sourceDescriptions.reusable-api.workflows.reusable-external-workflow',
+      '$sourceDescriptions.reusable-api.reusable-external-workflow',
       {
         inputs: {
           properties: {
@@ -3600,7 +3754,7 @@ describe('runStep', () => {
   it('should run step with not existing workflowId and populate step.checks with an error', async () => {
     const step: Step = {
       stepId: 'get-bird',
-      workflowId: '$sourceDescriptions.wrong-reusable-api.workflows.reusable-external-workflow',
+      workflowId: '$sourceDescriptions.wrong-reusable-api.reusable-external-workflow',
       outputs: {
         stepOutput: '$outputs.reusableWorkflowOutput.stepOutput',
       },
@@ -4010,8 +4164,99 @@ describe('runStep', () => {
 
     expect(runWorkflow).not.toHaveBeenCalled();
     expect(cleanColors(step?.checks[0]?.message || '')).toEqual(
-      'Workflow $sourceDescriptions.wrong-reusable-api.workflows.reusable-external-workflow not found.'
+      'Workflow $sourceDescriptions.wrong-reusable-api.reusable-external-workflow not found.'
     );
+    // the failed step must be part of the execution results so the run fails
+    expect(localCTX.executedSteps).toHaveLength(1);
+    expect((localCTX.executedSteps[0] as Step).checks[0]?.passed).toBe(false);
+    expect(displayChecks).toHaveBeenCalled();
+  });
+
+  it('should populate step.checks with an error when workflowId matches a document field instead of a workflow', async () => {
+    const step: Step = {
+      stepId: 'get-bird',
+      workflowId: '$sourceDescriptions.reusable-api.info',
+      checks: [],
+      response: {} as any,
+    };
+    const localCTX = {
+      apiClient,
+      executedSteps: [],
+      workflows: [],
+      severity: DEFAULT_SEVERITY_CONFIGURATION,
+      $sourceDescriptions: {
+        'reusable-api': {
+          info: { title: 'Reusable API', version: '1.0' },
+          workflows: [{ workflowId: 'reusable-external-workflow', steps: [] }],
+        },
+      },
+      options: { logger },
+    } as unknown as TestContext;
+
+    await runStep({
+      step,
+      ctx: localCTX,
+      workflowId: 'test-workflow',
+      executedStepsCount: { value: 0 },
+    });
+
+    expect(runWorkflow).not.toHaveBeenCalled();
+    expect(cleanColors(step?.checks[0]?.message || '')).toEqual(
+      'Workflow $sourceDescriptions.reusable-api.info not found.'
+    );
+    // the failed step must be part of the execution results so the run fails
+    expect(localCTX.executedSteps).toHaveLength(1);
+    expect((localCTX.executedSteps[0] as Step).checks[0]?.passed).toBe(false);
+    expect(displayChecks).toHaveBeenCalled();
+  });
+
+  it('should register the step in executed steps when call step outputs fail to resolve', async () => {
+    const step: Step = {
+      stepId: 'buy-ticket',
+      workflowId: '$sourceDescriptions.reusable-api.reusable-external-workflow',
+      outputs: {
+        ticketId: '$outputs.nonExistingOutput.deepField',
+      },
+      checks: [],
+      response: {} as any,
+    };
+    const localCTX = {
+      apiClient,
+      executedSteps: [],
+      workflows: [],
+      severity: DEFAULT_SEVERITY_CONFIGURATION,
+      $sourceDescriptions: {
+        'reusable-api': {
+          workflows: [{ workflowId: 'reusable-external-workflow', steps: [] }],
+        },
+      },
+      $steps: {},
+      $outputs: {},
+      $workflows: {},
+      options: { logger },
+    } as unknown as TestContext;
+
+    vi.mocked(resolveWorkflowContext).mockImplementationOnce(async () => localCTX);
+    vi.mocked(runWorkflow).mockImplementationOnce(async () => {
+      return {
+        type: 'workflow',
+        workflowId: 'reusable-external-workflow',
+        executedSteps: [],
+        ctx: localCTX,
+      } as unknown as WorkflowExecutionResult;
+    });
+
+    await runStep({
+      step,
+      ctx: localCTX,
+      workflowId: 'test-workflow',
+      executedStepsCount: { value: 0 },
+    });
+
+    // the child workflow result and the step itself with its failed check
+    expect(localCTX.executedSteps).toHaveLength(2);
+    const failedStep = localCTX.executedSteps[1] as Step;
+    expect(failedStep.checks[0]?.passed).toBe(false);
   });
 
   it('should report global timeout error and end execution', async () => {

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -1279,7 +1279,7 @@ describe('runStep', () => {
     expect(runWorkflow).toHaveBeenCalled();
   });
 
-  it('should log error when onSuccess step criteria with goto StepId and WorkflowId provided', async () => {
+  it('should fail the step when onSuccess goto action has both StepId and WorkflowId provided', async () => {
     const stepOne: Step = {
       stepId: 'get-bird',
       'x-operation': {
@@ -1389,17 +1389,22 @@ describe('runStep', () => {
       return { ...context };
     });
 
-    await expect(
-      runStep({
-        step: stepOne,
-        ctx: context,
-        workflowId,
-        executedStepsCount: { value: 0 },
-      })
-    ).rejects.toThrowError(
+    context.executedSteps = [];
+    const result = await runStep({
+      step: stepOne,
+      ctx: context,
+      workflowId,
+      executedStepsCount: { value: 0 },
+    });
+
+    expect(result).toEqual({ shouldEnd: true });
+    // the broken action definition fails the step without a duplicate registration
+    expect(context.executedSteps).toHaveLength(1);
+    const executedStep = context.executedSteps[0] as Step;
+    expect(executedStep.checks.at(-1)?.passed).toEqual(false);
+    expect(executedStep.checks.at(-1)?.message).toEqual(
       'Cannot use both workflowId: success-action-workflow and stepId: success-action-step in goto action'
     );
-
     expect(displayChecks).toHaveBeenCalled();
     expect(runWorkflow).not.toHaveBeenCalled();
   });
@@ -1773,7 +1778,7 @@ describe('runStep', () => {
     expect(checkCriteria).toHaveBeenCalledTimes(3);
   });
 
-  it('should result with an error when onFailure step criteria with retry StepId and WorkflowId provided', async () => {
+  it('should fail the step when onFailure retry action has both StepId and WorkflowId provided', async () => {
     const stepOne: Step = {
       stepId: 'get-bird',
       'x-operation': {
@@ -1881,14 +1886,20 @@ describe('runStep', () => {
       },
     } as unknown as TestContext;
 
-    await expect(
-      runStep({
-        step: stepOne,
-        ctx: context,
-        workflowId,
-        executedStepsCount: { value: 0 },
-      })
-    ).rejects.toThrow(
+    context.executedSteps = [];
+    const result = await runStep({
+      step: stepOne,
+      ctx: context,
+      workflowId,
+      executedStepsCount: { value: 0 },
+    });
+
+    expect(result).toEqual({ shouldEnd: true });
+    // the broken action definition fails the step without a duplicate registration
+    expect(context.executedSteps).toHaveLength(1);
+    const executedStep = context.executedSteps[0] as Step;
+    expect(executedStep.checks.at(-1)?.passed).toEqual(false);
+    expect(executedStep.checks.at(-1)?.message).toEqual(
       'Cannot use both workflowId: failure-action-workflow and stepId: failure-action-step in retry action'
     );
   });

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -857,7 +857,7 @@ describe('runStep', () => {
     expect(checkCriteria).toHaveBeenCalled();
   });
 
-  it('should throw a clear error when a goto action references a workflow that is not found', async () => {
+  it('should fail the step with a clear error when a goto action references a workflow that is not found', async () => {
     const apiClient = new ApiFetcher({});
     const stepOne: Step = {
       stepId: 'get-bird',
@@ -911,21 +911,28 @@ describe('runStep', () => {
       apiClient,
       workflows: [],
       $sourceDescriptions: {},
+      executedSteps: [],
     } as unknown as TestContext;
 
-    await expect(
-      runStep({
-        step: stepOne,
-        ctx: context,
-        workflowId: 'get-bird-workflow',
-        executedStepsCount: { value: 0 },
-      })
-    ).rejects.toThrow(
-      /Workflow .*\$sourceDescriptions\.unknown-api\.some-workflow.* referenced in the goto action of step .*get-bird.* is not found/
+    const result = await runStep({
+      step: stepOne,
+      ctx: context,
+      workflowId: 'get-bird-workflow',
+      executedStepsCount: { value: 0 },
+    });
+
+    expect(result).toEqual({ shouldEnd: true });
+    // the step is registered exactly once — the failed action check must not
+    // produce a second entry
+    expect(context.executedSteps).toHaveLength(1);
+    const executedStep = context.executedSteps[0] as Step;
+    expect(cleanColors(executedStep.checks.at(-1)?.message || '')).toEqual(
+      'Workflow $sourceDescriptions.unknown-api.some-workflow referenced in the goto action of step get-bird is not found.'
     );
+    expect(executedStep.checks.at(-1)?.passed).toEqual(false);
   });
 
-  it('should throw a clear error when a goto action workflowId matches a document field instead of a workflow', async () => {
+  it('should fail the step with a clear error when a goto action workflowId matches a document field instead of a workflow', async () => {
     const apiClient = new ApiFetcher({});
     const stepOne: Step = {
       stepId: 'get-bird',
@@ -984,18 +991,23 @@ describe('runStep', () => {
           workflows: [{ workflowId: 'reusable-external-workflow', steps: [] }],
         },
       },
+      executedSteps: [],
     } as unknown as TestContext;
 
-    await expect(
-      runStep({
-        step: stepOne,
-        ctx: context,
-        workflowId: 'get-bird-workflow',
-        executedStepsCount: { value: 0 },
-      })
-    ).rejects.toThrow(
-      /Workflow .*\$sourceDescriptions\.reusable-api\.info.* referenced in the goto action of step .*get-bird.* is not found/
+    const result = await runStep({
+      step: stepOne,
+      ctx: context,
+      workflowId: 'get-bird-workflow',
+      executedStepsCount: { value: 0 },
+    });
+
+    expect(result).toEqual({ shouldEnd: true });
+    expect(context.executedSteps).toHaveLength(1);
+    const executedStep = context.executedSteps[0] as Step;
+    expect(cleanColors(executedStep.checks.at(-1)?.message || '')).toEqual(
+      'Workflow $sourceDescriptions.reusable-api.info referenced in the goto action of step get-bird is not found.'
     );
+    expect(executedStep.checks.at(-1)?.passed).toEqual(false);
   });
 
   it('should execute onSuccess step criteria with goto StepId provided by reference', async () => {

--- a/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/run-step.test.ts
@@ -4178,13 +4178,15 @@ describe('runStep', () => {
       $outputs: {},
     } as unknown as TestContext;
 
-    await runStep({
+    const result = await runStep({
       step,
       ctx: localCTX,
       workflowId,
       executedStepsCount: { value: 0 },
     });
 
+    // a broken workflow reference ends the workflow, same as any other failed step
+    expect(result).toEqual({ shouldEnd: true });
     expect(runWorkflow).not.toHaveBeenCalled();
     expect(cleanColors(step?.checks[0]?.message || '')).toEqual(
       'Workflow $sourceDescriptions.wrong-reusable-api.reusable-external-workflow not found.'
@@ -4216,13 +4218,15 @@ describe('runStep', () => {
       options: { logger },
     } as unknown as TestContext;
 
-    await runStep({
+    const result = await runStep({
       step,
       ctx: localCTX,
       workflowId: 'test-workflow',
       executedStepsCount: { value: 0 },
     });
 
+    // a broken workflow reference ends the workflow, same as any other failed step
+    expect(result).toEqual({ shouldEnd: true });
     expect(runWorkflow).not.toHaveBeenCalled();
     expect(cleanColors(step?.checks[0]?.message || '')).toEqual(
       'Workflow $sourceDescriptions.reusable-api.info not found.'

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/resolve-workflow-context.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../../flow-runner/context/create-test-context.js');
 
 describe('resolveWorkflowContext', async () => {
   const config = await createConfig({});
-  const workflowId = '$sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets';
+  const workflowId = '$sourceDescriptions.tickets-from-museum-api.get-museum-tickets';
   const apiClient = new ApiFetcher({});
   const resolvedWorkflow = {
     workflowId: 'get-museum-tickets',
@@ -379,6 +379,30 @@ describe('resolveWorkflowContext', async () => {
     );
   });
 
+  it('should still resolve the legacy `$sourceDescriptions.<name>.workflows.<workflowId>` form for backward compatibility', async () => {
+    const workflowId = '$sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets';
+    await resolveWorkflowContext(workflowId, resolvedWorkflow, commonCtx, config);
+
+    expect(createTestContext).toHaveBeenCalledWith(
+      commonCtx.$sourceDescriptions['tickets-from-museum-api'],
+      {
+        input: undefined,
+        skip: undefined,
+        workflow: ['get-museum-tickets'],
+        filePath: expect.stringContaining('examples/museum-api/museum-tickets.yaml'),
+        config,
+        executionTimeout: 3_600_000,
+        maxSteps: 2000,
+        maxFetchTimeout: 40_000,
+        server: undefined,
+        severity: undefined,
+        verbose: undefined,
+        metadata: commonCtx.options.metadata,
+      },
+      apiClient
+    );
+  });
+
   it('should call createTestContext with empty filePath when there are no ctx.sourceDescriptions', async () => {
     const ctx = {
       ...commonCtx,
@@ -554,7 +578,7 @@ describe('resolveWorkflowContext', async () => {
         },
       },
     } as any;
-    const workflowId = '$sourceDescriptions.wrong-api.workflows.get-museum-tickets';
+    const workflowId = '$sourceDescriptions.wrong-api.get-museum-tickets';
 
     await expect(
       resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, config)

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
@@ -520,7 +520,7 @@ describe('runTestFile', () => {
     );
   }, 8000);
 
-  it('should throw an error when dependsOn has workflowId with not successful steps expectations', async () => {
+  it('should mark the workflow as failed and continue when a dependsOn workflow has failed steps', async () => {
     const mockDocument = makeDocumentFromString(
       JSON.stringify({
         arazzo: '1.0.1',
@@ -611,12 +611,24 @@ describe('runTestFile', () => {
       }
     );
 
-    await expect(
-      runTestFile({
-        options: { file: 'test.yaml', ...defaultRespectOptions },
-        executedStepsCount: { value: 0 },
-      })
-    ).rejects.toThrowError('Dependent workflows has failed steps');
+    const result = await runTestFile({
+      options: { file: 'test.yaml', ...defaultRespectOptions },
+      executedStepsCount: { value: 0 },
+    });
+
+    // the workflow with the failed dependency is marked as failed, the run continues
+    expect(result.executedWorkflows).toHaveLength(2);
+    const failedWorkflow = result.executedWorkflows.find(
+      (workflow) => workflow.workflowId === 'second-workflow'
+    );
+    const failedStep = failedWorkflow?.executedSteps[0] as Step;
+    expect(failedStep.checks[0]?.passed).toBe(false);
+    expect(cleanColors(failedStep.checks[0]?.message || '')).toEqual(
+      'Dependent workflows of workflow second-workflow have failed steps: get-bird-workflow.'
+    );
+    // the top-level get-bird-workflow run plus its run as a dependency;
+    // the steps of second-workflow itself must not run
+    expect(runStep).toHaveBeenCalledTimes(2);
   }, 8000);
 
   it('should throw an error when sourcedescription OpenAPI file does not exist', async () => {

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
@@ -437,6 +437,7 @@ describe('runTestFile', () => {
     expect(cleanColors(failedStep.checks[0]?.message || '')).toEqual(
       'Workflow not-existing-workflowId from dependsOn of workflow second-workflow is not found.'
     );
+    expect(runStep).toHaveBeenCalledTimes(1);
   }, 8000);
 
   it('should mark the workflow as failed and continue when dependsOn references a workflow that is not found in a source description', async () => {

--- a/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
+++ b/packages/respect-core/src/modules/__tests__/flow-runner/runner/run-test-file.test.ts
@@ -9,6 +9,7 @@ import {
 import * as fs from 'node:fs';
 
 import { type Step, type TestContext } from '../../../../types.js';
+import { cleanColors } from '../../../../utils/clean-colors.js';
 import { runTestFile, runStep } from '../../../flow-runner/index.js';
 
 vi.mock('@redocly/openapi-core', async () => {
@@ -339,7 +340,7 @@ describe('runTestFile', () => {
     expect(runStep).toHaveBeenCalledTimes(3);
   }, 8000);
 
-  it('should throw an error when dependsOn has not existing workflowId', async () => {
+  it('should mark the workflow as failed and continue when dependsOn has not existing workflowId', async () => {
     const mockDocument = makeDocumentFromString(
       JSON.stringify({
         arazzo: '1.0.1',
@@ -421,16 +422,100 @@ describe('runTestFile', () => {
       },
     } as any);
 
-    await expect(
-      runTestFile({
-        options: { file: 'test.yaml', ...defaultRespectOptions },
-        executedStepsCount: { value: 0 },
-      })
-    ).rejects.toThrow(
-      expect.objectContaining({
-        // @ts-expect-error
-        message: expect.stringContaining('Workflow', 'not-existing-workflowId', 'not found'),
-      })
+    const result = await runTestFile({
+      options: { file: 'test.yaml', ...defaultRespectOptions },
+      executedStepsCount: { value: 0 },
+    });
+
+    // the workflow with the broken dependsOn is marked as failed, the run continues
+    expect(result.executedWorkflows).toHaveLength(2);
+    const failedWorkflow = result.executedWorkflows.find(
+      (workflow) => workflow.workflowId === 'second-workflow'
+    );
+    const failedStep = failedWorkflow?.executedSteps[0] as Step;
+    expect(failedStep.checks[0]?.passed).toBe(false);
+    expect(cleanColors(failedStep.checks[0]?.message || '')).toEqual(
+      'Workflow not-existing-workflowId from dependsOn of workflow second-workflow is not found.'
+    );
+  }, 8000);
+
+  it('should mark the workflow as failed and continue when dependsOn references a workflow that is not found in a source description', async () => {
+    const mockDocument = makeDocumentFromString(
+      JSON.stringify({
+        arazzo: '1.0.1',
+        info: {
+          title: 'Cat Facts API',
+          version: '1.0',
+        },
+        sourceDescriptions: [
+          {
+            name: 'cats',
+            type: 'openapi',
+            url: 'api-samples/cats.yaml',
+          },
+        ],
+        workflows: [
+          {
+            workflowId: 'get-bird-workflow',
+            steps: [
+              {
+                stepId: 'delete-step',
+                'x-operation': {
+                  url: 'http://localhost:3000/delete-mock',
+                  method: 'delete',
+                },
+                successCriteria: [
+                  {
+                    condition: '$statusCode == 204',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            workflowId: 'second-workflow',
+            dependsOn: ['$sourceDescriptions.cats.not-existing-workflow'],
+            steps: [
+              {
+                stepId: 'delete-mock',
+                'x-operation': {
+                  url: 'http://localhost:3000/delete-mock',
+                  method: 'delete',
+                },
+                successCriteria: [
+                  {
+                    condition: '$statusCode == 204',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      'api-test-framework/test.yml'
+    );
+
+    vi.mocked(lint).mockResolvedValueOnce([]);
+    vi.mocked(bundle).mockResolvedValueOnce({
+      bundle: {
+        parsed: mockDocument.parsed,
+      },
+    } as any);
+
+    const result = await runTestFile({
+      options: { file: 'test.yaml', ...defaultRespectOptions },
+      executedStepsCount: { value: 0 },
+    });
+
+    // the workflow with the broken dependsOn is marked as failed, the run continues
+    expect(result.executedWorkflows).toHaveLength(2);
+    const failedWorkflow = result.executedWorkflows.find(
+      (workflow) => workflow.workflowId === 'second-workflow'
+    );
+    const failedStep = failedWorkflow?.executedSteps[0] as Step;
+    expect(failedStep.checks[0]?.passed).toBe(false);
+    expect(cleanColors(failedStep.checks[0]?.message || '')).toEqual(
+      'Workflow $sourceDescriptions.cats.not-existing-workflow from dependsOn of workflow second-workflow is not found.'
     );
   }, 8000);
 

--- a/packages/respect-core/src/modules/context-parser/get-value-from-context.ts
+++ b/packages/respect-core/src/modules/context-parser/get-value-from-context.ts
@@ -388,6 +388,16 @@ const resolveValue = (
             )}.${availableWorkflowsHint}`
       );
     }
+
+    // a `workflows` reference with extra segments after the workflowId is not
+    // valid in either supported form
+    if (path.split('.')[2] === 'workflows') {
+      throw new Error(
+        `Can't resolve ${red(
+          path
+        )}: invalid workflow reference format. Use $sourceDescriptions.<name>.<workflowId> or $sourceDescriptions.<name>.workflows.<workflowId>.`
+      );
+    }
   }
 
   if (path && path.trim().startsWith('faker.')) {

--- a/packages/respect-core/src/modules/context-parser/get-value-from-context.ts
+++ b/packages/respect-core/src/modules/context-parser/get-value-from-context.ts
@@ -2,6 +2,10 @@ import { isPlainObject, type LoggerInterface } from '@redocly/openapi-core';
 import { red } from 'colorette';
 
 import { type RuntimeExpressionContext, type TestContext, type Workflow } from '../../types.js';
+import {
+  parseSourceDescriptionWorkflowRef,
+  resolveWorkflowReference,
+} from './resolve-workflow-reference.js';
 
 export interface ParsedParameters {
   queryParams: Record<string, string>;
@@ -316,26 +320,74 @@ const resolveValue = (
     return path.slice(7, -2);
   }
 
-  // $sourceDescriptions.<name>.workflows.<workflowId>
-  if (path.startsWith('$sourceDescriptions.') && path.includes('.workflows.')) {
-    const parts = path.split('.');
+  if (path.startsWith('$sourceDescriptions.')) {
+    const parsedRef = parseSourceDescriptionWorkflowRef(path);
 
-    const sourceDescriptionName = parts[1];
-    const workflowId = parts[3];
+    if (parsedRef) {
+      const { sourceDescriptionName, workflowId: reference, isLegacyForm } = parsedRef;
+      const sourceDescriptions = getFrom(ctx)('$sourceDescriptions');
+      const sourceDescriptionDocument = sourceDescriptions?.[sourceDescriptionName];
 
-    if (!sourceDescriptionName || !workflowId) {
-      return undefined;
+      if (!sourceDescriptionDocument) {
+        throw new Error(
+          `Can't resolve ${red(path)}: source description ${red(
+            sourceDescriptionName
+          )} is not found. Available source descriptions: ${Object.keys(
+            sourceDescriptions ?? {}
+          ).join(', ')}.`
+        );
+      }
+
+      const workflow = resolveWorkflowReference({ ref: path, ctx });
+
+      if (workflow) {
+        return workflow;
+      }
+
+      if (!isLegacyForm) {
+        // Raw Source Description Objects (name, url, type) are only carried by the
+        // test context — they are not exposed on the runtime expression context.
+        const sourceDescriptionObject = (
+          'sourceDescriptions' in ctx ? ctx.sourceDescriptions : undefined
+        )?.find(({ name }) => name === sourceDescriptionName);
+
+        if (
+          sourceDescriptionObject &&
+          Object.prototype.hasOwnProperty.call(sourceDescriptionObject, reference)
+        ) {
+          return (sourceDescriptionObject as Record<string, unknown>)[reference];
+        }
+
+        if (Object.prototype.hasOwnProperty.call(sourceDescriptionDocument, reference)) {
+          return sourceDescriptionDocument[reference];
+        }
+      }
+
+      const availableWorkflows = (
+        Array.isArray(sourceDescriptionDocument.workflows)
+          ? (sourceDescriptionDocument.workflows as Workflow[])
+          : []
+      )
+        .map((workflow) => workflow.workflowId)
+        .join(', ');
+      const availableWorkflowsHint = availableWorkflows
+        ? ` Available workflows: ${availableWorkflows}.`
+        : '';
+
+      throw new Error(
+        isLegacyForm
+          ? `Can't resolve ${red(path)}: workflow ${red(
+              reference
+            )} is not found in source description ${red(
+              sourceDescriptionName
+            )}.${availableWorkflowsHint}`
+          : `Can't resolve ${red(path)}: ${red(
+              reference
+            )} does not match a workflow or a field of source description ${red(
+              sourceDescriptionName
+            )}.${availableWorkflowsHint}`
+      );
     }
-
-    const sourceDescriptions = getFrom(ctx)('$sourceDescriptions');
-
-    if (!sourceDescriptions[sourceDescriptionName]) {
-      return undefined;
-    }
-
-    return sourceDescriptions[sourceDescriptionName].workflows.find(
-      (workflow: Workflow) => workflow.workflowId === workflowId
-    );
   }
 
   if (path && path.trim().startsWith('faker.')) {

--- a/packages/respect-core/src/modules/context-parser/index.ts
+++ b/packages/respect-core/src/modules/context-parser/index.ts
@@ -4,3 +4,4 @@ export * from './parse-request-body.js';
 export * from './handle-request-body-replacements.js';
 export * from './resolve-reusable-object-reference.js';
 export * from './resolve-reusable-component.js';
+export * from './resolve-workflow-reference.js';

--- a/packages/respect-core/src/modules/context-parser/resolve-workflow-reference.ts
+++ b/packages/respect-core/src/modules/context-parser/resolve-workflow-reference.ts
@@ -1,0 +1,54 @@
+import { type RuntimeExpressionContext, type TestContext, type Workflow } from '../../types.js';
+
+// $sourceDescriptions.<name>.<workflowId> (Arazzo spec form)
+// $sourceDescriptions.<name>.workflows.<workflowId> (legacy form)
+export function parseSourceDescriptionWorkflowRef(
+  ref: string
+): { sourceDescriptionName: string; workflowId: string; isLegacyForm: boolean } | undefined {
+  if (!ref.startsWith('$sourceDescriptions.')) {
+    return undefined;
+  }
+
+  const parts = ref.split('.');
+
+  if (parts.length === 3 && parts[1] && parts[2]) {
+    return { sourceDescriptionName: parts[1], workflowId: parts[2], isLegacyForm: false };
+  }
+
+  // Extra segments after the workflowId are tolerated for backward compatibility.
+  if (parts.length >= 4 && parts[2] === 'workflows' && parts[1] && parts[3]) {
+    return { sourceDescriptionName: parts[1], workflowId: parts[3], isLegacyForm: true };
+  }
+
+  return undefined;
+}
+
+export function resolveWorkflowReference({
+  ref,
+  ctx,
+}: {
+  ref: string | undefined;
+  ctx: TestContext | RuntimeExpressionContext;
+}): Workflow | undefined {
+  if (!ref) {
+    return undefined;
+  }
+
+  if (!ref.startsWith('$')) {
+    return 'workflows' in ctx
+      ? ctx.workflows?.find((workflow) => workflow.workflowId === ref)
+      : undefined;
+  }
+
+  const parsedRef = parseSourceDescriptionWorkflowRef(ref);
+
+  if (!parsedRef) {
+    return undefined;
+  }
+
+  const workflows = ctx.$sourceDescriptions?.[parsedRef.sourceDescriptionName]?.workflows;
+
+  return Array.isArray(workflows)
+    ? workflows.find((workflow: Workflow) => workflow.workflowId === parsedRef.workflowId)
+    : undefined;
+}

--- a/packages/respect-core/src/modules/context-parser/resolve-workflow-reference.ts
+++ b/packages/respect-core/src/modules/context-parser/resolve-workflow-reference.ts
@@ -15,8 +15,7 @@ export function parseSourceDescriptionWorkflowRef(
     return { sourceDescriptionName: parts[1], workflowId: parts[2], isLegacyForm: false };
   }
 
-  // Extra segments after the workflowId are tolerated for backward compatibility.
-  if (parts.length >= 4 && parts[2] === 'workflows' && parts[1] && parts[3]) {
+  if (parts.length === 4 && parts[2] === 'workflows' && parts[1] && parts[3]) {
     return { sourceDescriptionName: parts[1], workflowId: parts[3], isLegacyForm: true };
   }
 

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -308,11 +308,30 @@ export async function runStep({
     shouldEnd?: boolean;
     stepResult?: { shouldEnd: boolean } | void;
   } | void> {
+    // reports a broken action definition or reference as a failed check on the
+    // step instead of throwing: an escaped error would make runWorkflow
+    // register the step a second time
+    function failStepWithActionError(message: string): { shouldEnd: true } {
+      step.checks.push({
+        name: CHECKS.UNEXPECTED_ERROR,
+        message,
+        passed: false,
+        severity: ctx.severity['UNEXPECTED_ERROR'],
+      });
+      // the plain step path has already registered the step copy;
+      // the child workflow path has not
+      if (!ctx.executedSteps.includes(step)) {
+        ctx.executedSteps.push(step);
+        printUnknownStep(step, ctx.options.logger);
+      }
+      return { shouldEnd: true };
+    }
+
     for (const action of actions) {
       const { type, criteria } = action;
 
       if (action.workflowId && action.stepId) {
-        throw new Error(
+        return failStepWithActionError(
           `Cannot use both workflowId: ${action.workflowId} and stepId: ${action.stepId} in ${action.type} action`
         );
       }
@@ -330,22 +349,11 @@ export async function runStep({
           : undefined;
 
         if (action.workflowId && !targetWorkflow) {
-          // report the broken reference as a failed check instead of throwing:
-          step.checks.push({
-            name: CHECKS.UNEXPECTED_ERROR,
-            message: `Workflow ${red(action.workflowId)} referenced in the ${type} action of step ${red(
+          return failStepWithActionError(
+            `Workflow ${red(action.workflowId)} referenced in the ${type} action of step ${red(
               stepId
-            )} is not found.`,
-            passed: false,
-            severity: ctx.severity['UNEXPECTED_ERROR'],
-          });
-          // the plain step path has already registered the step copy;
-          // the child workflow path has not
-          if (!ctx.executedSteps.includes(step)) {
-            ctx.executedSteps.push(step);
-            printUnknownStep(step, ctx.options.logger);
-          }
-          return { shouldEnd: true };
+            )} is not found.`
+          );
         }
         const targetCtx =
           action.workflowId && targetWorkflow
@@ -393,7 +401,9 @@ export async function runStep({
           } else if (targetStep) {
             const stepToRun = workflow?.steps.find((s) => s.stepId === targetStep) as Step;
             if (!stepToRun) {
-              throw new Error(`Step ${targetStep} not found in workflow ${workflowId}`);
+              return failStepWithActionError(
+                `Step ${targetStep} not found in workflow ${workflowId}`
+              );
             }
             await runStep({
               step: stepToRun,
@@ -421,7 +431,9 @@ export async function runStep({
           return { shouldEnd: true };
         } else if (type === 'goto') {
           if (!targetWorkflow && !targetStep) {
-            throw new Error('Either workflowId or stepId must be provided in goto action');
+            return failStepWithActionError(
+              'Either workflowId or stepId must be provided in goto action'
+            );
           }
 
           if (targetWorkflow || targetStep) {

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -77,7 +77,8 @@ export async function runStep({
       // register the step so the failed check is displayed and counted in the totals
       ctx.executedSteps.push(step);
       printUnknownStep(step, ctx.options.logger);
-      return;
+      // a broken workflow reference ends the workflow, same as any other failed step
+      return { shouldEnd: true };
     }
 
     const workflowCtx = await resolveWorkflowContext(

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -330,11 +330,22 @@ export async function runStep({
           : undefined;
 
         if (action.workflowId && !targetWorkflow) {
-          throw new Error(
-            `Workflow ${red(action.workflowId)} referenced in the ${type} action of step ${red(
+          // report the broken reference as a failed check instead of throwing:
+          step.checks.push({
+            name: CHECKS.UNEXPECTED_ERROR,
+            message: `Workflow ${red(action.workflowId)} referenced in the ${type} action of step ${red(
               stepId
-            )} is not found.`
-          );
+            )} is not found.`,
+            passed: false,
+            severity: ctx.severity['UNEXPECTED_ERROR'],
+          });
+          // the plain step path has already registered the step copy;
+          // the child workflow path has not
+          if (!ctx.executedSteps.includes(step)) {
+            ctx.executedSteps.push(step);
+            printUnknownStep(step, ctx.options.logger);
+          }
+          return { shouldEnd: true };
         }
         const targetCtx =
           action.workflowId && targetWorkflow

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -313,17 +313,21 @@ export async function runStep({
     // step instead of throwing: an escaped error would make runWorkflow
     // register the step a second time
     function failStepWithActionError(message: string): { shouldEnd: true } {
-      step.checks.push({
+      const failedCheck: Check = {
         name: CHECKS.UNEXPECTED_ERROR,
         message,
         passed: false,
         severity: ctx.severity['UNEXPECTED_ERROR'],
-      });
-      // the plain step path has already registered the step copy;
-      // the child workflow path has not
+      };
+      step.checks.push(failedCheck);
       if (!ctx.executedSteps.includes(step)) {
+        // the child workflow path has not registered nor printed the step yet
         ctx.executedSteps.push(step);
         printUnknownStep(step, ctx.options.logger);
+      } else {
+        // the plain step path printed the step before the actions ran — print
+        // the action failure so the live output doesn't end on a passing step
+        printUnknownStep({ ...step, checks: [failedCheck] }, ctx.options.logger);
       }
       return { shouldEnd: true };
     }

--- a/packages/respect-core/src/modules/flow-runner/run-step.ts
+++ b/packages/respect-core/src/modules/flow-runner/run-step.ts
@@ -10,7 +10,6 @@ import type {
   RuntimeExpressionContext,
   ResolvedParameter,
   ExecutedStepsCount,
-  Workflow,
 } from '../../types.js';
 import { delay } from '../../utils/delay.js';
 import { CHECKS } from '../checks/index.js';
@@ -18,6 +17,7 @@ import {
   getValueFromContext,
   isParameterWithoutIn,
   resolveReusableComponentItem,
+  resolveWorkflowReference,
   type ParameterWithoutIn,
 } from '../context-parser/index.js';
 import {
@@ -64,11 +64,7 @@ export async function runStep({
   );
 
   if (targetWorkflowRef) {
-    const targetWorkflow =
-      ctx.workflows.find((w) => w.workflowId === targetWorkflowRef) ||
-      (getValueFromContext({ value: targetWorkflowRef, ctx, logger: ctx.options.logger }) as
-        | Workflow
-        | undefined);
+    const targetWorkflow = resolveWorkflowReference({ ref: targetWorkflowRef, ctx });
 
     if (!targetWorkflow) {
       const failedCall: Check = {
@@ -78,6 +74,9 @@ export async function runStep({
         severity: ctx.severity['UNEXPECTED_ERROR'],
       };
       step.checks.push(failedCall);
+      // register the step so the failed check is displayed and counted in the totals
+      ctx.executedSteps.push(step);
+      printUnknownStep(step, ctx.options.logger);
       return;
     }
 
@@ -150,6 +149,9 @@ export async function runStep({
           severity: ctx.severity['UNEXPECTED_ERROR'],
         };
         step.checks.push(failedCall);
+        // register the step so the failed check is displayed and counted in the totals
+        ctx.executedSteps.push(step);
+        printUnknownStep(step, ctx.options.logger);
       }
 
       // save local $steps context
@@ -324,12 +326,16 @@ export async function runStep({
 
       if (matchesCriteria) {
         const targetWorkflow = action.workflowId
-          ? (getValueFromContext({
-              value: action.workflowId,
-              ctx,
-              logger: ctx.options.logger,
-            }) as Workflow)
+          ? resolveWorkflowReference({ ref: action.workflowId, ctx })
           : undefined;
+
+        if (action.workflowId && !targetWorkflow) {
+          throw new Error(
+            `Workflow ${red(action.workflowId)} referenced in the ${type} action of step ${red(
+              stepId
+            )} is not found.`
+          );
+        }
         const targetCtx =
           action.workflowId && targetWorkflow
             ? await resolveWorkflowContext(

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -306,18 +306,24 @@ async function handleDependsOn({
 }) {
   if (!workflow.dependsOn?.length) return;
 
+  // resolve every reference before starting any dependency run, so one broken
+  // reference cannot leave sibling dependency workflows running unawaited
+  const resolvedDependencies = workflow.dependsOn.map((workflowId) => {
+    const resolvedWorkflow = resolveWorkflowReference({ ref: workflowId, ctx });
+
+    if (!resolvedWorkflow) {
+      throw new WorkflowDependencyNotFoundError(
+        `Workflow ${red(workflowId)} from dependsOn of workflow ${red(
+          workflow.workflowId
+        )} is not found.`
+      );
+    }
+
+    return { workflowId, resolvedWorkflow };
+  });
+
   const dependenciesWorkflows = await Promise.all(
-    workflow.dependsOn.map(async (workflowId) => {
-      const resolvedWorkflow = resolveWorkflowReference({ ref: workflowId, ctx });
-
-      if (!resolvedWorkflow) {
-        throw new WorkflowDependencyNotFoundError(
-          `Workflow ${red(workflowId)} from dependsOn of workflow ${red(
-            workflow.workflowId
-          )} is not found.`
-        );
-      }
-
+    resolvedDependencies.map(async ({ workflowId, resolvedWorkflow }) => {
       const workflowCtx = await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, config);
 
       printRequiredWorkflowSeparator(workflow.workflowId, ctx.options.logger);

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -102,7 +102,7 @@ async function runWorkflows({
 
         // an unresolvable or failed dependsOn dependency fails this workflow
         // but must not abort the remaining workflows and files
-        const startTime = performance.now();
+        const failureTime = performance.now();
         // a synthetic step to carry the failed check; it has no operation to call
         const failedStep = {
           stepId: 'dependsOn',
@@ -126,9 +126,9 @@ async function runWorkflows({
         executedWorkflows.push({
           type: 'workflow',
           workflowId: workflow.workflowId,
-          startTime,
-          endTime: performance.now(),
-          totalTimeMs: performance.now() - startTime,
+          startTime: failureTime,
+          endTime: failureTime,
+          totalTimeMs: 0,
           executedSteps: [failedStep],
           ctx,
           globalTimeoutError: false,

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -1,5 +1,5 @@
 import type { CollectFn, Config } from '@redocly/openapi-core';
-import { blue } from 'colorette';
+import { blue, red } from 'colorette';
 import { basename, dirname, resolve } from 'node:path';
 
 import type {
@@ -17,10 +17,11 @@ import type {
 } from '../../types.js';
 import { ApiFetcher } from '../../utils/api-fetcher.js';
 import { CHECKS } from '../checks/index.js';
-import { getValueFromContext } from '../context-parser/index.js';
+import { resolveWorkflowReference } from '../context-parser/index.js';
 import {
   printWorkflowSeparator,
   printRequiredWorkflowSeparator,
+  printUnknownStep,
 } from '../logger-output/helpers.js';
 import { calculateTotals } from '../logger-output/index.js';
 import { evaluateRuntimeExpressionPayload } from '../runtime-expressions/index.js';
@@ -92,7 +93,48 @@ async function runWorkflows({
     ctx.executedSteps = [];
     // run dependencies workflows first
     if (workflow.dependsOn?.length) {
-      await handleDependsOn({ workflow, ctx, config: options.config, executedStepsCount });
+      try {
+        await handleDependsOn({ workflow, ctx, config: options.config, executedStepsCount });
+      } catch (error) {
+        if (!(error instanceof WorkflowDependencyNotFoundError)) {
+          throw error;
+        }
+
+        // an unresolvable dependsOn reference fails this workflow but must not
+        // abort the remaining workflows and files
+        const startTime = performance.now();
+        // a synthetic step to carry the failed check; it has no operation to call
+        const failedStep = {
+          stepId: 'dependsOn',
+          checks: [
+            {
+              name: CHECKS.UNEXPECTED_ERROR,
+              message: error.message,
+              passed: false,
+              severity: ctx.severity['UNEXPECTED_ERROR'],
+            },
+          ],
+        } as Step;
+
+        printWorkflowSeparator({
+          fileName: basename(ctx.options.filePath),
+          workflowName: workflow.workflowId,
+          logger: options.logger,
+        });
+        printUnknownStep(failedStep, options.logger);
+
+        executedWorkflows.push({
+          type: 'workflow',
+          workflowId: workflow.workflowId,
+          startTime,
+          endTime: performance.now(),
+          totalTimeMs: performance.now() - startTime,
+          executedSteps: [failedStep],
+          ctx,
+          globalTimeoutError: false,
+        });
+        continue;
+      }
     }
 
     const workflowExecutionResult = await runWorkflow({
@@ -247,6 +289,10 @@ export async function runWorkflow({
   };
 }
 
+// Thrown when a dependsOn entry cannot be resolved to a workflow. Handled per
+// workflow in runWorkflows so one broken reference doesn't abort the rest of the run.
+class WorkflowDependencyNotFoundError extends Error {}
+
 async function handleDependsOn({
   workflow,
   ctx,
@@ -262,11 +308,16 @@ async function handleDependsOn({
 
   const dependenciesWorkflows = await Promise.all(
     workflow.dependsOn.map(async (workflowId) => {
-      const resolvedWorkflow = getValueFromContext({
-        value: workflowId,
-        ctx,
-        logger: ctx.options.logger,
-      }) as Workflow;
+      const resolvedWorkflow = resolveWorkflowReference({ ref: workflowId, ctx });
+
+      if (!resolvedWorkflow) {
+        throw new WorkflowDependencyNotFoundError(
+          `Workflow ${red(workflowId)} from dependsOn of workflow ${red(
+            workflow.workflowId
+          )} is not found.`
+        );
+      }
+
       const workflowCtx = await resolveWorkflowContext(workflowId, resolvedWorkflow, ctx, config);
 
       printRequiredWorkflowSeparator(workflow.workflowId, ctx.options.logger);

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -96,12 +96,12 @@ async function runWorkflows({
       try {
         await handleDependsOn({ workflow, ctx, config: options.config, executedStepsCount });
       } catch (error) {
-        if (!(error instanceof WorkflowDependencyNotFoundError)) {
+        if (!(error instanceof WorkflowDependencyError)) {
           throw error;
         }
 
-        // an unresolvable dependsOn reference fails this workflow but must not
-        // abort the remaining workflows and files
+        // an unresolvable or failed dependsOn dependency fails this workflow
+        // but must not abort the remaining workflows and files
         const startTime = performance.now();
         // a synthetic step to carry the failed check; it has no operation to call
         const failedStep = {
@@ -289,9 +289,10 @@ export async function runWorkflow({
   };
 }
 
-// Thrown when a dependsOn entry cannot be resolved to a workflow. Handled per
-// workflow in runWorkflows so one broken reference doesn't abort the rest of the run.
-class WorkflowDependencyNotFoundError extends Error {}
+// Thrown when a dependsOn entry cannot be resolved to a workflow or a dependency
+// workflow fails. Handled per workflow in runWorkflows so one broken dependency
+// doesn't abort the rest of the run.
+class WorkflowDependencyError extends Error {}
 
 async function handleDependsOn({
   workflow,
@@ -312,7 +313,7 @@ async function handleDependsOn({
     const resolvedWorkflow = resolveWorkflowReference({ ref: workflowId, ctx });
 
     if (!resolvedWorkflow) {
-      throw new WorkflowDependencyNotFoundError(
+      throw new WorkflowDependencyError(
         `Workflow ${red(workflowId)} from dependsOn of workflow ${red(
           workflow.workflowId
         )} is not found.`
@@ -336,11 +337,16 @@ async function handleDependsOn({
     })
   );
 
-  const totals = calculateTotals(dependenciesWorkflows);
-  const hasProblems = totals.steps.failed > 0;
+  const failedDependencies = dependenciesWorkflows
+    .filter((dependencyWorkflow) => calculateTotals([dependencyWorkflow]).steps.failed > 0)
+    .map((dependencyWorkflow) => dependencyWorkflow.workflowId);
 
-  if (hasProblems) {
-    throw new Error('Dependent workflows has failed steps');
+  if (failedDependencies.length) {
+    throw new WorkflowDependencyError(
+      `Dependent workflows of workflow ${red(workflow.workflowId)} have failed steps: ${red(
+        failedDependencies.join(', ')
+      )}.`
+    );
   }
 }
 

--- a/resources/museum-api.arazzo.yaml
+++ b/resources/museum-api.arazzo.yaml
@@ -34,7 +34,7 @@ workflows:
       - stepId: buy-ticket
         description: >-
           Buy a ticket for the museum by calling an external workflow from another Arazzo file.
-        workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+        workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
         outputs:
           ticketId: $outputs.ticketId
   - workflowId: events-crud

--- a/tests/e2e/respect/inputs-passed-to-step-target-workflow-and-remapped/inputs-passed-to-step-target-workflow-and-remapped.arazzo.yaml
+++ b/tests/e2e/respect/inputs-passed-to-step-target-workflow-and-remapped/inputs-passed-to-step-target-workflow-and-remapped.arazzo.yaml
@@ -20,7 +20,7 @@ workflows:
           type: string
     steps:
       - stepId: health-workflow
-        workflowId: $sourceDescriptions.events.workflows.events-crud
+        workflowId: $sourceDescriptions.events.events-crud
         parameters:
           - name: custom_price
             value: 800

--- a/tests/e2e/respect/inputs-passed-to-step-target-workflow/inputs-passed-to-step-target-workflow.arazzo.yaml
+++ b/tests/e2e/respect/inputs-passed-to-step-target-workflow/inputs-passed-to-step-target-workflow.arazzo.yaml
@@ -20,7 +20,7 @@ workflows:
           type: string
     steps:
       - stepId: health-workflow
-        workflowId: $sourceDescriptions.events.workflows.events-crud
+        workflowId: $sourceDescriptions.events.events-crud
         parameters:
           - name: custom_price
             value: 800

--- a/tests/e2e/respect/inputs-with-cli-and-env/inputs-with-cli-and-env.arazzo.yaml
+++ b/tests/e2e/respect/inputs-with-cli-and-env/inputs-with-cli-and-env.arazzo.yaml
@@ -44,7 +44,7 @@ workflows:
       - stepId: buy-ticket
         description: >-
           Buy a ticket for the museum by calling an external workflow from another Arazzo file.
-        workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+        workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
         outputs:
           ticketId: $outputs.ticketId
       - stepId: test-default-input

--- a/tests/e2e/respect/outputs-access-syntax-variations/outputs-access-syntax-variations.arazzo.yaml
+++ b/tests/e2e/respect/outputs-access-syntax-variations/outputs-access-syntax-variations.arazzo.yaml
@@ -29,6 +29,7 @@ workflows:
           schedule: $response.body
           firstEventData: $response.body#/0/date
       - stepId: buy-ticket
+        # the legacy `$sourceDescriptions.<name>.workflows.<workflowId>` form is kept here for backward compatibility coverage
         workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
         outputs:
           ticketId: $outputs.ticketId

--- a/tests/e2e/respect/server-override-with-console-parameters/server-override-with-console-parameters.arazzo.yaml
+++ b/tests/e2e/respect/server-override-with-console-parameters/server-override-with-console-parameters.arazzo.yaml
@@ -26,7 +26,7 @@ workflows:
       - stepId: buy-ticket
         description: >-
           Buy a ticket for the museum by calling an external workflow from another Arazzo file.
-        workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+        workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
         outputs:
           ticketId: $outputs.ticketId
   - workflowId: events-crud

--- a/tests/e2e/respect/workflow-depends-on-failed/__snapshots__/workflow-depends-on-failed.test.ts.snap
+++ b/tests/e2e/respect/workflow-depends-on-failed/__snapshots__/workflow-depends-on-failed.test.ts.snap
@@ -1,0 +1,72 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should fail the workflow whose dependsOn workflow has failed steps and still run the remaining workflows 1`] = `
+"──────────────────────────────────────────────────────────────────────────────── 
+ 
+  Running workflow workflow-depends-on-failed.arazzo.yaml / failing-dependency 
+ 
+  ✗ GET /menu - step list-menu-items 
+    ✗ success criteria check - $statusCode == 500
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+ 
+  Running required workflow for workflow-with-failing-depends-on
+  Running workflow workflow-depends-on-failed.arazzo.yaml / failing-dependency 
+ 
+  ✗ GET /menu - step list-menu-items 
+    ✗ success criteria check - $statusCode == 500
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+──────────────────────────────────────────────────────────────────────────────── 
+ 
+  Running workflow workflow-depends-on-failed.arazzo.yaml / workflow-with-failing-depends-on 
+ 
+  ✗ dependsOn 
+    ✗ unexpected error
+──────────────────────────────────────────────────────────────────────────────── 
+ 
+  Running workflow workflow-depends-on-failed.arazzo.yaml / independent-workflow 
+ 
+  ✓ GET /menu - step list-menu-items-again 
+    ✓ success criteria check - $statusCode == 200
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+
+  Failed tests info:
+
+  Workflow name: failing-dependency
+ 
+    stepId - list-menu-items 
+    ✗ success criteria check 
+      Checking simple criteria: {"condition":"$statusCode == 500"}
+      
+  Workflow name: workflow-with-failing-depends-on
+ 
+    stepId - dependsOn 
+    ✗ unexpected error 
+    Reason: Dependent workflows of workflow workflow-with-failing-depends-on have failed steps: failing-dependency. 
+  Summary for workflow-depends-on-failed.arazzo.yaml
+  
+  Workflows: 1 passed, 2 failed, 3 total
+  Steps: 1 passed, 2 failed, 3 total
+  Checks: 7 passed, 2 failed, 9 total
+  Time: <test>ms 
+ 
+ 
+┌────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────┬─────────┬──────────┐
+│ Filename                                                                       │ Workflows  │ Passed  │ Failed  │ Warnings │
+├────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────┼─────────┼──────────┤
+│ x workflow-depends-on-failed.arazzo.yaml                                       │ 3          │ 1       │ 2       │ -        │
+└────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────┴─────────┴──────────┘
+ 
+
+ Tests exited with error 
+
+"
+`;

--- a/tests/e2e/respect/workflow-depends-on-failed/workflow-depends-on-failed.arazzo.yaml
+++ b/tests/e2e/respect/workflow-depends-on-failed/workflow-depends-on-failed.arazzo.yaml
@@ -1,0 +1,32 @@
+arazzo: 1.0.1
+info:
+  title: Test that the run continues when a `dependsOn` workflow has failed steps
+  description: Testing functionality based on the Redocly Cafe API example
+  version: 1.0.0
+
+sourceDescriptions:
+  - name: cafe-api
+    type: openapi
+    url: ../../../../resources/cafe.yaml
+
+workflows:
+  - workflowId: failing-dependency
+    steps:
+      - stepId: list-menu-items
+        operationId: cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 500
+  - workflowId: workflow-with-failing-depends-on
+    dependsOn:
+      - failing-dependency
+    steps:
+      - stepId: list-menu-items-dependent
+        operationId: cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 200
+  - workflowId: independent-workflow
+    steps:
+      - stepId: list-menu-items-again
+        operationId: cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 200

--- a/tests/e2e/respect/workflow-depends-on-failed/workflow-depends-on-failed.test.ts
+++ b/tests/e2e/respect/workflow-depends-on-failed/workflow-depends-on-failed.test.ts
@@ -1,0 +1,15 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getCommandOutput, getParams } from '../../helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should fail the workflow whose dependsOn workflow has failed steps and still run the remaining workflows', () => {
+  const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
+  const fixturesPath = join(__dirname, 'workflow-depends-on-failed.arazzo.yaml');
+  const args = getParams(indexEntryPoint, ['respect', fixturesPath]);
+
+  const result = getCommandOutput(args);
+  expect(result).toMatchSnapshot();
+}, 60_000);

--- a/tests/e2e/respect/workflow-depends-on-not-found/__snapshots__/workflow-depends-on-not-found.test.ts.snap
+++ b/tests/e2e/respect/workflow-depends-on-not-found/__snapshots__/workflow-depends-on-not-found.test.ts.snap
@@ -1,0 +1,46 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should fail the workflow with an unresolvable dependsOn reference and still run the remaining workflows 1`] = `
+"──────────────────────────────────────────────────────────────────────────────── 
+ 
+  Running workflow workflow-depends-on-not-found.arazzo.yaml / workflow-with-broken-depends-on 
+ 
+  ✗ dependsOn 
+    ✗ unexpected error
+──────────────────────────────────────────────────────────────────────────────── 
+ 
+  Running workflow workflow-depends-on-not-found.arazzo.yaml / independent-workflow 
+ 
+  ✓ GET /menu - step list-menu-items-again 
+    ✓ success criteria check - $statusCode == 200
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+
+  Failed tests info:
+
+  Workflow name: workflow-with-broken-depends-on
+ 
+    stepId - dependsOn 
+    ✗ unexpected error 
+    Reason: Workflow $sourceDescriptions.cafe-api.not-existing-workflow from dependsOn of workflow workflow-with-broken-depends-on is not found. 
+  Summary for workflow-depends-on-not-found.arazzo.yaml
+  
+  Workflows: 1 passed, 1 failed, 2 total
+  Steps: 1 passed, 1 failed, 2 total
+  Checks: 4 passed, 1 failed, 5 total
+  Time: <test>ms 
+ 
+ 
+┌───────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────┬─────────┬──────────┐
+│ Filename                                                                          │ Workflows  │ Passed  │ Failed  │ Warnings │
+├───────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────┼─────────┼──────────┤
+│ x workflow-depends-on-not-found.arazzo.yaml                                       │ 2          │ 1       │ 1       │ -        │
+└───────────────────────────────────────────────────────────────────────────────────┴────────────┴─────────┴─────────┴──────────┘
+ 
+
+ Tests exited with error 
+
+"
+`;

--- a/tests/e2e/respect/workflow-depends-on-not-found/workflow-depends-on-not-found.arazzo.yaml
+++ b/tests/e2e/respect/workflow-depends-on-not-found/workflow-depends-on-not-found.arazzo.yaml
@@ -1,0 +1,26 @@
+arazzo: 1.0.1
+info:
+  title: Test that the run continues when `dependsOn` references an unknown workflow
+  description: Testing functionality based on the Redocly Cafe API example
+  version: 1.0.0
+
+sourceDescriptions:
+  - name: cafe-api
+    type: openapi
+    url: ../../../../resources/cafe.yaml
+
+workflows:
+  - workflowId: workflow-with-broken-depends-on
+    dependsOn:
+      - $sourceDescriptions.cafe-api.not-existing-workflow
+    steps:
+      - stepId: list-menu-items
+        operationId: cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 200
+  - workflowId: independent-workflow
+    steps:
+      - stepId: list-menu-items-again
+        operationId: cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 200

--- a/tests/e2e/respect/workflow-depends-on-not-found/workflow-depends-on-not-found.test.ts
+++ b/tests/e2e/respect/workflow-depends-on-not-found/workflow-depends-on-not-found.test.ts
@@ -1,0 +1,15 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getCommandOutput, getParams } from '../../helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should fail the workflow with an unresolvable dependsOn reference and still run the remaining workflows', () => {
+  const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
+  const fixturesPath = join(__dirname, 'workflow-depends-on-not-found.arazzo.yaml');
+  const args = getParams(indexEntryPoint, ['respect', fixturesPath]);
+
+  const result = getCommandOutput(args);
+  expect(result).toMatchSnapshot();
+}, 60_000);

--- a/tests/e2e/respect/workflow-failure-actions/workflow-failure-actions.arazzo.yaml
+++ b/tests/e2e/respect/workflow-failure-actions/workflow-failure-actions.arazzo.yaml
@@ -18,12 +18,12 @@ workflows:
       - name: repeated-failure-action-1
         type: retry
         retryLimit: 1
-        workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+        workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
         criteria:
           - condition: $statusCode == 200
       - name: repeated-failure-action-2 # this should not be executed as there is another action with the s
         type: goto
-        workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+        workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
         criteria:
           - condition: $statusCode == 200
     description: >-

--- a/tests/e2e/respect/workflow-success-actions/workflow-success-actions.arazzo.yaml
+++ b/tests/e2e/respect/workflow-success-actions/workflow-success-actions.arazzo.yaml
@@ -17,7 +17,7 @@ workflows:
     successActions:
       - name: repeated-success-action-1
         type: goto
-        workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+        workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
         criteria:
           - condition: $statusCode == 200
       - name: repeated-success-action-2 # this should not be executed as there is another action with the same criteria
@@ -57,7 +57,7 @@ workflows:
         onSuccess:
           - type: goto
             name: step-onSuccess-action
-            workflowId: $sourceDescriptions.tickets-from-museum-api.workflows.get-museum-tickets
+            workflowId: $sourceDescriptions.tickets-from-museum-api.get-museum-tickets
             criteria:
               - condition: $statusCode == 200
       - stepId: create-event


### PR DESCRIPTION
## What/Why/How?

Added support for the Arazzo spec-compliant workflow reference form `$sourceDescriptions.<name>.<workflowId>` in `dependsOn`, step `workflowId`, and success/failure action `workflowId`. Unresolvable workflow references now fail the affected workflow with a clear error message instead of aborting the whole run or being silently ignored.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/2826

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Respect workflow resolution and error propagation across dependsOn, nested workflows, and actions; behavior shifts from run-aborting throws to per-workflow failures, which could affect CI expectations but is covered by extensive unit and e2e tests.
> 
> **Overview**
> Adds **Arazzo spec-compliant** workflow references `$sourceDescriptions.<name>.<workflowId>` for `dependsOn`, step `workflowId`, and success/failure action `workflowId`, while keeping the legacy `$sourceDescriptions.<name>.workflows.<workflowId>` form. Resolution is centralized in `resolveWorkflowReference` / `parseSourceDescriptionWorkflowRef`; runtime expression resolution in `getValueFromContext` now throws clear errors (with available workflow hints) instead of returning `undefined` for bad legacy/spec refs, and the spec form can fall back to source-description fields when the segment is not a workflow.
> 
> **Broken references no longer abort the whole Respect run.** Unresolvable `dependsOn` entries or failed dependency workflows mark only that workflow failed (synthetic `dependsOn` step + message) and execution continues. Call steps and goto/retry actions record failed checks on the step (including registering `executedSteps` where needed) rather than throwing, so JSON logs and totals stay consistent—including synthetic steps without a declared workflow definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b300a006f0e904341a6717a8dfe628d3806f1b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->