### PR TITLE
chore: detect graphql specification in collectSpecData

### DIFF
--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -1,4 +1,4 @@
-import { type Config, detectSpec } from '@redocly/openapi-core';
+import { type Config, detectSpec, makeDocumentFromString } from '@redocly/openapi-core';
 import * as process from 'node:process';
 
 import { handleLint } from '../commands/lint.js';
@@ -35,7 +35,7 @@ describe('commandWrapper', () => {
       return 'oas3_1';
     });
     vi.mocked(handleLint).mockImplementation(async ({ collectSpecData }) => {
-      collectSpecData?.({ openapi: '3.1.0' });
+      collectSpecData?.(makeDocumentFromString('openapi: 3.1.0', 'openapi.yaml'));
     });
     process.env.REDOCLY_TELEMETRY = 'on';
 
@@ -63,12 +63,12 @@ describe('commandWrapper', () => {
     );
   });
 
-  it('should not collect spec version if the file is not parsed to json', async () => {
+  it('should not collect spec version if the file is not parsed to json (except for graphql)', async () => {
     vi.mocked(loadConfigAndHandleErrors).mockImplementation(async () => {
       return { resolvedConfig: { telemetry: 'on' } } as Config;
     });
-    vi.mocked(handleLint).mockImplementation(async ({ collectSpecData }: any) => {
-      collectSpecData();
+    vi.mocked(handleLint).mockImplementation(async ({ collectSpecData }) => {
+      collectSpecData?.(makeDocumentFromString('some text file', 'some.txt'));
     });
     process.env.REDOCLY_TELEMETRY = 'on';
 
@@ -92,6 +92,26 @@ describe('commandWrapper', () => {
         respect_x_security_auth_types: [],
         respect_source_description_types: [],
         respect_criterion_object_types: [],
+      })
+    );
+  });
+
+  it('should collect the spec version of a GraphQL document', async () => {
+    vi.mocked(loadConfigAndHandleErrors).mockImplementation(async () => {
+      return { resolvedConfig: { telemetry: 'on' } } as Config;
+    });
+    vi.mocked(handleLint).mockImplementation(async ({ collectSpecData }) => {
+      collectSpecData?.(makeDocumentFromString('type Query { cafe: String }', 'some.graphql'));
+    });
+    process.env.REDOCLY_TELEMETRY = 'on';
+
+    const wrappedHandler = commandWrapper(handleLint);
+    await wrappedHandler({} as any);
+    expect(sendTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec_version: 'graphql',
+        spec_keyword: undefined,
+        spec_full_version: undefined,
       })
     );
   });

--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -116,6 +116,30 @@ describe('commandWrapper', () => {
     );
   });
 
+  it('should not keep the spec keyword of a previously linted document', async () => {
+    vi.mocked(loadConfigAndHandleErrors).mockImplementation(async () => {
+      return { resolvedConfig: { telemetry: 'on' } } as Config;
+    });
+    vi.mocked(detectSpec).mockImplementationOnce(() => {
+      return 'oas3_1';
+    });
+    vi.mocked(handleLint).mockImplementation(async ({ collectSpecData }) => {
+      collectSpecData?.(makeDocumentFromString('openapi: 3.1.0', 'openapi.yaml'));
+      collectSpecData?.(makeDocumentFromString('type Query { cafe: String }', 'some.graphql'));
+    });
+    process.env.REDOCLY_TELEMETRY = 'on';
+
+    const wrappedHandler = commandWrapper(handleLint);
+    await wrappedHandler({} as any);
+    expect(sendTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec_version: 'graphql',
+        spec_keyword: undefined,
+        spec_full_version: undefined,
+      })
+    );
+  });
+
   it('should NOT send telemetry if there is "telemetry: off" in the config', async () => {
     vi.mocked(loadConfigAndHandleErrors).mockImplementation(async () => {
       return { resolvedConfig: { telemetry: 'off' } } as Config;

--- a/packages/cli/src/commands/build-docs/index.ts
+++ b/packages/cli/src/commands/build-docs/index.ts
@@ -35,7 +35,7 @@ export const handlerBuildCommand = async ({
     const api = await redoc.loadAndBundleSpec(
       isAbsoluteUrl(pathToApi) ? pathToApi : resolve(pathToApi)
     );
-    collectSpecData?.(api);
+    collectSpecData?.({ parsed: api });
     const pageHTML = await getPageHTML(api, pathToApi, { ...options, redocVersion }, argv.config);
 
     mkdirSync(dirname(options.output), { recursive: true });

--- a/packages/cli/src/commands/join/index.ts
+++ b/packages/cli/src/commands/join/index.ts
@@ -131,7 +131,7 @@ export async function handleJoin({
   for (const document of documents) {
     try {
       const version = detectSpec(document.parsed);
-      collectSpecData?.(document.parsed);
+      collectSpecData?.(document);
       if (version !== 'oas3_0' && version !== 'oas3_1' && version !== 'oas3_2') {
         return exitWithError(
           `Only OpenAPI 3.0, 3.1, and 3.2 are supported: ${blue(document.source.absoluteRef)}.`

--- a/packages/cli/src/commands/score/__tests__/index.test.ts
+++ b/packages/cli/src/commands/score/__tests__/index.test.ts
@@ -113,17 +113,6 @@ describe('handleScore', () => {
     await expect(handleScore(createArgs())).rejects.toThrow('OpenAPI 3.x');
   });
 
-  it('should call collectSpecData', async () => {
-    const doc = { openapi: '3.0.0' };
-    mockedBundle.mockResolvedValue({ bundle: { parsed: doc } } as any);
-    mockedDetectSpec.mockReturnValue('oas3_1');
-
-    const args = createArgs();
-    await handleScore(args);
-
-    expect(args.collectSpecData).toHaveBeenCalledWith(doc);
-  });
-
   it('should handle document with no operations', async () => {
     mockedCollectMetrics.mockReturnValue({
       metrics: makeDocumentMetrics(),

--- a/packages/cli/src/commands/score/index.ts
+++ b/packages/cli/src/commands/score/index.ts
@@ -40,7 +40,7 @@ export async function handleScore({ argv, config, collectSpecData }: CommandArgs
   const [{ path }] = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
   const externalRefResolver = new BaseResolver(config.resolve);
   const { bundle: document } = await bundle({ config, ref: path });
-  collectSpecData?.(document.parsed);
+  collectSpecData?.(document);
 
   const specVersion = detectSpec(document.parsed);
   if (getMajorSpecVersion(specVersion) !== 'oas3') {

--- a/packages/cli/src/commands/scorecard-classic/index.ts
+++ b/packages/cli/src/commands/scorecard-classic/index.ts
@@ -96,7 +96,7 @@ export async function handleScorecardClassic({
   const externalRefResolver = new BaseResolver(config.resolve);
   const document = (await externalRefResolver.resolveDocument(null, path, true)) as Document;
 
-  collectSpecData?.(document.parsed);
+  collectSpecData?.(document);
 
   const documentInfo = (document as ExtendedDocument).parsed?.info;
   const builtInMetadata = documentInfo?.['x-metadata'] || {};

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -28,7 +28,7 @@ export async function handleSplit({ argv, collectSpecData }: CommandArgs<SplitAr
   if (!fs.existsSync(api)) exitWithError(`File ${blue(api)} does not exist.`);
 
   const definition = readYaml(api) as AnyDefinition;
-  collectSpecData?.(definition);
+  collectSpecData?.({ parsed: definition });
 
   const specVersion = detectSpec(definition);
   switch (specVersion) {

--- a/packages/cli/src/commands/stats/index.ts
+++ b/packages/cli/src/commands/stats/index.ts
@@ -27,7 +27,7 @@ export async function handleStats({ argv, config, collectSpecData }: CommandArgs
   const [{ path }] = await getFallbackApisOrExit(argv.api ? [argv.api] : [], config);
   const externalRefResolver = new BaseResolver(config.resolve);
   const { bundle: document } = await bundle({ config, ref: path });
-  collectSpecData?.(document.parsed);
+  collectSpecData?.(document);
   const specVersion = detectSpec(document.parsed);
   const types = normalizeTypes(config.extendTypes(getTypes(specVersion), specVersion), config);
 

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -4,11 +4,11 @@ import {
   isPlainObject,
   logger,
   HandledError,
+  getMajorSpecVersion,
+  isGraphqlRef,
   type Config,
   type CollectFn,
-  type ArazzoDefinition,
   type Exact,
-  getMajorSpecVersion,
   type SpecVersion,
 } from '@redocly/openapi-core';
 import type { Arguments } from 'yargs';
@@ -45,7 +45,12 @@ export function commandWrapper<T extends CommandArgv>(
     const respectXSecurityAuthTypes = new Set<string>();
     const respectSourceDescriptionTypes = new Set<string>();
     const respectCriterionObjectTypes = new Set<string>();
-    const collectSpecData: CollectFn = (document) => {
+    const collectSpecData: CollectFn = ({ parsed: document, source }) => {
+      if (source?.absoluteRef !== undefined && isGraphqlRef(source?.absoluteRef)) {
+        specVersion = 'graphql';
+        return;
+      }
+
       try {
         specVersion = detectSpec(document);
       } catch (err) {
@@ -72,10 +77,9 @@ export function commandWrapper<T extends CommandArgv>(
       }
 
       if (getMajorSpecVersion(specVersion as SpecVersion) === 'arazzo1') {
-        const arazzoDocument = document as Partial<ArazzoDefinition>;
-        collectXSecurityAuthTypes(arazzoDocument, respectXSecurityAuthTypes);
-        collectSourceDescriptionTypes(arazzoDocument, respectSourceDescriptionTypes);
-        collectCriterionObjectTypes(arazzoDocument, respectCriterionObjectTypes);
+        collectXSecurityAuthTypes(document, respectXSecurityAuthTypes);
+        collectSourceDescriptionTypes(document, respectSourceDescriptionTypes);
+        collectCriterionObjectTypes(document, respectCriterionObjectTypes);
       }
     };
 

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -46,7 +46,11 @@ export function commandWrapper<T extends CommandArgv>(
     const respectSourceDescriptionTypes = new Set<string>();
     const respectCriterionObjectTypes = new Set<string>();
     const collectSpecData: CollectFn = ({ parsed: document, source }) => {
-      if (source?.absoluteRef !== undefined && isGraphqlRef(source?.absoluteRef)) {
+      specVersion = 'unknown';
+      specKeyword = undefined;
+      specFullVersion = undefined;
+
+      if (source?.absoluteRef && isGraphqlRef(source.absoluteRef)) {
         specVersion = 'graphql';
         return;
       }
@@ -54,7 +58,7 @@ export function commandWrapper<T extends CommandArgv>(
       try {
         specVersion = detectSpec(document);
       } catch (err) {
-        specVersion = `unsupported`;
+        specVersion = 'unsupported';
       }
 
       if (!isPlainObject(document)) return;
@@ -71,9 +75,6 @@ export function commandWrapper<T extends CommandArgv>(
                 : undefined;
       if (specKeyword) {
         specFullVersion = document[specKeyword] as string;
-      } else {
-        // Ensure specFullVersion is undefined if specKeyword is not found
-        specFullVersion = undefined;
       }
 
       if (getMajorSpecVersion(specVersion as SpecVersion) === 'arazzo1') {

--- a/packages/core/src/bundle/bundle.ts
+++ b/packages/core/src/bundle/bundle.ts
@@ -95,7 +95,7 @@ export async function bundle(
   if (document instanceof Error) {
     throw document;
   }
-  opts.collectSpecData?.(document.parsed);
+  opts.collectSpecData?.(document);
 
   return bundleDocument({
     document,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,9 +68,9 @@ export {
   escapePointerFragment,
   type Location,
 } from './ref-utils.js';
-export { detectSpec } from './detect-spec.js';
+export { detectSpec, getMajorSpecVersion } from './detect-spec.js';
 export { getTypes, type SpecVersion, type SpecMajorVersion } from './oas-types.js';
-export { getMajorSpecVersion } from './detect-spec.js';
+export { isGraphqlRef } from './graphql/detect-graphql.js';
 export {
   normalizeVisitors,
   type Oas3Visitor,

--- a/packages/core/src/js-yaml/index.ts
+++ b/packages/core/src/js-yaml/index.ts
@@ -31,4 +31,4 @@ export const parseYaml = (str: string, opts?: LoadOptions): unknown => {
   return documents[0];
 };
 
-export const stringifyYaml = (obj: any, opts?: DumpOptions): string => dump(obj, opts);
+export const stringifyYaml = (obj: unknown, opts?: DumpOptions): string => dump(obj, opts);

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -40,7 +40,7 @@ export async function lint(opts: {
 }) {
   const { ref, externalRefResolver = new BaseResolver(opts.config.resolve) } = opts;
   const document = (await externalRefResolver.resolveDocument(null, ref, true)) as Document;
-  opts.collectSpecData?.(document.parsed);
+  opts.collectSpecData?.(document);
 
   return lintDocument({
     document,

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -1,2 +1,5 @@
-export type CollectFn = (value: unknown) => void;
+import type { Document } from '../resolve.js';
+
+export type CollectFn = (document: Partial<Document>) => void;
+
 export type Exact<T extends object> = T & { [key: string]: undefined };

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-arazzo-description.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-arazzo-description.test.ts
@@ -118,7 +118,9 @@ describe('generateArazzoDescription', () => {
       ],
     });
 
-    expect(mockCollectSpecData).toHaveBeenCalledWith(BUNDLED_DESCRIPTION_MOCK);
+    expect(mockCollectSpecData).toHaveBeenCalledWith({
+      parsed: BUNDLED_DESCRIPTION_MOCK,
+    });
   });
 
   it('should generate arazzo description with operationId', async () => {
@@ -189,7 +191,9 @@ describe('generateArazzoDescription', () => {
       ],
     });
 
-    expect(mockCollectSpecData).toHaveBeenCalledWith(BUNDLED_DESCRIPTION_MOCK);
+    expect(mockCollectSpecData).toHaveBeenCalledWith({
+      parsed: BUNDLED_DESCRIPTION_MOCK,
+    });
   });
 
   it('should generate arazzo description with not existing description', async () => {
@@ -219,7 +223,9 @@ describe('generateArazzoDescription', () => {
       workflows: [],
     });
 
-    expect(mockCollectSpecData).toHaveBeenCalledWith({});
+    expect(mockCollectSpecData).toHaveBeenCalledWith({
+      parsed: {},
+    });
   });
 
   it('should generate arazzo description with operationPath', async () => {
@@ -290,6 +296,8 @@ describe('generateArazzoDescription', () => {
       ],
     });
 
-    expect(mockCollectSpecData).toHaveBeenCalledWith(BUNDLED_DESCRIPTION_MOCK_WITHOUT_OPERATION_ID);
+    expect(mockCollectSpecData).toHaveBeenCalledWith({
+      parsed: BUNDLED_DESCRIPTION_MOCK_WITHOUT_OPERATION_ID,
+    });
   });
 });

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
@@ -21,7 +21,7 @@ function resolveDescriptionNameFromPath(descriptionPath: string): string {
 export async function generateArazzoDescription(opts: GenerateArazzoOptions) {
   const { descriptionPath, outputFile, collectSpecData } = opts;
   const document = (await bundleOpenApi(opts)) || {};
-  collectSpecData?.(document);
+  collectSpecData?.({ parsed: document });
 
   const { paths: pathsObject, info, security: rootSecurity, components } = document;
   const sourceDescriptionName = resolveDescriptionNameFromPath(descriptionPath);

--- a/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
@@ -92,7 +92,7 @@ export async function bundleArazzo(options: BundleArazzoOptions) {
     );
   }
 
-  collectSpecData?.(bundledDocument.bundle.parsed || {});
+  collectSpecData?.(bundledDocument.bundle);
 
   const errorLintProblems = lintProblems.filter((problem) => problem.severity === 'error');
   if (errorLintProblems.length) {


### PR DESCRIPTION
## What/Why/How?

- Enabled graphql spec detection
- Refactored the collectSpecData function


## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect internal telemetry plumbing and test expectations; no auth, security, or user-facing command behavior beyond more accurate spec reporting.
> 
> **Overview**
> **`collectSpecData` now receives a partial `Document`** (`parsed` plus optional `source`) instead of raw parsed JSON. CLI commands, core `bundle`/`lint`, and respect-core call sites were updated to pass `{ parsed: … }` or full resolved documents so telemetry can use file paths.
> 
> In **`commandWrapper`**, each `collectSpecData` call **clears** `spec_version`, `spec_keyword`, and `spec_full_version` before updating them. **GraphQL** is recognized when `source.absoluteRef` ends with `.graphql`/`.gql` via newly exported **`isGraphqlRef`**, setting `spec_version` to `graphql` without OpenAPI-style keyword/version fields. OpenAPI/AsyncAPI/Arazzo detection still runs on `parsed` when applicable.
> 
> Tests cover GraphQL telemetry, non-JSON files without GraphQL extensions, and ensuring OpenAPI keyword metadata does not leak after a subsequent GraphQL document in the same command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6b4a34b060c127b97d5c83fb4916cc4e872082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->