### PR TITLE
docs: revise the cookbook catalog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@ packages/cli/src/utils/telemetry.ts @Redocly/hot-dogs
 packages/cli/src/commands/drift/ @Redocly/cyberpunks
 packages/cli/src/commands/generate-spec/ @Redocly/cyberpunks
 packages/cli/src/commands/proxy/ @Redocly/cyberpunks
+cookbook/**/*.md @Redocly/technical-writers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,11 +343,11 @@ mlc docs/
 The tool only checks links within the local docs (it can't check links to other docs sections that are present when we publish all products under https://redocly.com/docs), and doesn't currently check anchors.
 Take care when renaming pages or titles.
 
-## Contribute to the cookbook
+## Contribute to the Cookbook
 
-The [cookbook](./cookbook) is a community collection of rulesets, configuration, custom plugins, and other Redocly CLI additions.
+The [Cookbook](./cookbook) is a community collection of rulesets, configuration, custom plugins, and other Redocly CLI additions.
 Unlike the packages, it is not built or tested as part of the CLI — treat every entry as a shared example that people use at their own risk.
-A cookbook-only change does not affect the published packages, so it does not need a changeset; add the `no changeset needed` label to the pull request instead.
+A Cookbook-only change does not affect the published packages, so it does not need a changeset; add the `no changeset needed` label to the pull request instead.
 
 To add an entry:
 
@@ -365,7 +365,7 @@ To add an entry:
 1. Add a `README.md` to the directory that explains the problem the entry solves and any context a reader needs to reuse it successfully.
    Follow the structure of the existing entries.
 
-1. List your entry in the relevant section of the [cookbook catalog](./cookbook/README.md).
+1. List your entry in the relevant section of the [Cookbook catalog](./cookbook/README.md).
 
 1. Open a pull request.
    Someone from Redocly will review it, suggest changes if needed, and merge it once it is ready.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The `stylish` output is as good as it sounds, but if you need JSON, Markdown, Ch
 
 [Learn more about API standards and configuring Redocly rules](https://redocly.com/docs/cli/api-standards).
 
-Looking for more examples? Check out our [Cookbook](https://github.com/Redocly/redocly-cli-cookbook).
+Looking for more examples? Check out our [Cookbook](./cookbook/README.md).
 
 ### API contract testing with Respect
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,11 +1,15 @@
 # Redocly CLI Cookbook
 
-A community collection of rulesets, configuration, custom plugins and other additions for [Redocly CLI](https://github.com/Redocly/redocly-cli). We know our users have some great tips, examples, and code to share, and this is the place to do just that. We would love to have your [contributions](#contributing) here too!
+A community collection of rulesets, configuration, custom plugins and other additions for [Redocly CLI](https://github.com/Redocly/redocly-cli).
+We know our users have some great tips, examples, and code to share, and this is the place to do just that.
+We would love to have your [contributions](#contributing) here too!
 
 > [!IMPORTANT]
-> Redocly are the repository maintainers, but we can't thoroughly test everything here. Please browse, share, and use what you find at your own risk.
+> Redocly are the repository maintainers, but we can't thoroughly test everything here.
+> Please browse, share, and use what you find at your own risk.
 
-If you're new to Redocly CLI, start with the [documentation](https://redocly.com/docs/cli/) to get up and running, then come back here to pick out any elements you would like to re-use yourself. To keep up with new developments, either subscribe to the project repository, or [sign up for the Redocly product newsletter](https://redocly.com/product-updates/).
+If you're new to Redocly CLI, start with the [documentation](https://redocly.com/docs/cli/) to get up and running, then come back here to pick out any elements you would like to re-use yourself.
+To keep up with new developments, either subscribe to the project repository, or [sign up for the Redocly product newsletter](https://redocly.com/product-updates/).
 
 ## Usage
 
@@ -23,66 +27,74 @@ If you come up with something new, please consider sharing it here by opening a 
 
 ### Rulesets
 
-Combine existing [built-in rules](https://redocly.com/docs/cli/rules/built-in-rules/) in ways that serve a specific purpose, and make a [reusable ruleset](https://redocly.com/docs/cli/guides/configure-rules/#create-a-reusable-ruleset).
+Combine existing [built-in rules](https://redocly.com/docs/cli/rules/built-in-rules/) or configurable rules in ways that serve a specific purpose, and make a [reusable ruleset](https://redocly.com/docs/cli/guides/configure-rules/#create-a-reusable-ruleset).
 
-- [Spec-compliant ruleset](rulesets/spec-compliant/)
-- [Spot common mistakes](rulesets/common-mistakes)
-- [Security ruleset](rulesets/security) adds some defensive rules to your description.
+- [Spec-compliant ruleset](./rulesets/spec-compliant/) - built-in rules that keep a description close to the specification.
+- [Spot common mistakes](./rulesets/common-mistakes/) - extends the spec-compliant ruleset with checks for common oversights.
+- [Security ruleset](./rulesets/security/) - configurable rules that add some defensive checks to your description.
 
 ### Configurable rules
 
-There are some fantastic examples of [configurable rules](https://redocly.com/docs/cli/rules/configurable-rules/) in the wild, we hope the list here inspires you to share more of your own!
+There are some fantastic examples of [configurable rules](https://redocly.com/docs/cli/rules/configurable-rules/) in the wild.
+We hope the list here inspires you to share more of your own!
 
-- [Ban certain words from descriptions](configurable-rules/description-banned-words/)
-- [Require `items` field for schemas of type `array`](configurable-rules/required-items-for-array-schemas/)
-- [Ensure sentence case in operation summaries](configurable-rules/operation-summary-sentence-case)
-- [`POST` SHOULD define `requestBody` schema](configurable-rules/operation-post-should-define-request-body/)
-- [`GET` SHOULD NOT define `requestBody` schema](configurable-rules/operation-get-should-not-define-requestBody/)
-- [`DELETE` SHOULD NOT define `requestBody` schema](configurable-rules/operation-delete-should-not-define-requestBody/)
-- [Info section must have a description](configurable-rules/info-description)
-- [No `<script>` tags in descriptions](configurable-rules/no-script)
-- [Paths should not match a pattern](configurable-rules/path-excludes-pattern/)
-- [API healthcheck rules](configurable-rules/api-health/)
-- [String schemas length defined](configurable-rules/string-schemas-length-defined/)
-- [JSON Schema misconfigurations](configurable-rules/json-schema-misconfigurations/)
-- [Azure APIM unsupported keywords](configurable-rules/azure-apim-unsupported-keyword/)
-- [Operation-deprecated-response-headers](configurable-rules/operation-deprecated-response-headers/)
-- [`operation-operationId` variant that excludes `OPTIONS`](configurable-rules/operation-operationId-exclude-OPTIONS/)
+- [Ban certain words from descriptions](./configurable-rules/description-banned-words/)
+- [Require `items` field for schemas of type `array`](./configurable-rules/required-items-for-array-schemas/)
+- [Ensure sentence case in operation summaries](./configurable-rules/operation-summary-sentence-case/)
+- [`POST` SHOULD define `requestBody` schema](./configurable-rules/operation-post-should-define-request-body/)
+- [`GET` SHOULD NOT define `requestBody` schema](./configurable-rules/operation-get-should-not-define-requestBody/)
+- [`DELETE` SHOULD NOT define `requestBody` schema](./configurable-rules/operation-delete-should-not-define-requestBody/)
+- [Info section must have a description](./configurable-rules/info-description/)
+- [No `<script>` tags in descriptions](./configurable-rules/no-script/)
+- [Paths should not match a pattern](./configurable-rules/path-excludes-pattern/)
+- [API health check rules](./configurable-rules/api-health/) - check the `/health` endpoint, its media type, and its `status` property.
+- [String schemas length defined](./configurable-rules/string-schemas-length-defined/) - require `minLength` and `maxLength` on string schemas.
+- [JSON Schema misconfigurations](./configurable-rules/json-schema-misconfigurations/)
+- [Azure APIM unsupported keywords](./configurable-rules/azure-apim-unsupported-keyword/) - catch OpenAPI usage that Azure APIM doesn't support or silently ignores.
+- [Deprecation strategy response headers](./configurable-rules/operation-deprecated-response-headers/) - require `Deprecation`, `Sunset`, and `Link` headers, plus a `410` response, on deprecated operations.
+- [`operation-operationId` variant that excludes `OPTIONS`](./configurable-rules/operation-operationId-exclude-OPTIONS/)
 
 ### Custom plugins
 
-The [custom plugin](https://redocly.com/docs/cli/custom-plugins/) is the ultimate in extensibility, but it's an advanced feature. Try these plugins for inspiration and to get you started. Rather than including the whole plugin, there are also sections for individual rules and decorators further down.
+The [custom plugin](https://redocly.com/docs/cli/custom-plugins/) is the ultimate in extensibility, but it's an advanced feature.
+Try these plugins for inspiration and to get you started.
+Rather than including the whole plugin, there are also sections for individual rules and decorators further down.
 
-- [Sorting plugin](./custom-plugins/sorting) - rules to check sort order and decorators to transform an API description into the correct order. Includes sorting for tags, methods, properties and enum values.
+- [Sorting plugin](./custom-plugins/sorting/) - rules to check sort order and decorators to transform an API description into the correct order.
+  Includes sorting for tags, methods, properties and enum values.
 
 #### Decorators (for custom plugins)
 
-- [Tag sorting](./custom-plugin-decorators/tag-sorting) - put your tags list in alphabetical order.
-- [Substitute datetime placeholders in an API description](./custom-plugin-decorators/update-example-dates) - update dates in examples to the current date.
-- [OpenAI isConsequential](./custom-plugin-decorators/openai-is-consequential) - add `x-openai-isConsequential: true` specification extension to GET operations.
-- [Remove extensions](./custom-plugin-decorators/remove-extensions) - remove any given [OpenAPI Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions) from an OpenAPI document.
-- [Remove unused tags](./custom-plugin-decorators/remove-unused-tags) - remove tags that are declared but not used by any operations.
-- [Azure APIM](./custom-plugin-decorators/azure-apim) - remove features unsupported by Azure APIM such as examples.
-- [Swap summary and description](./custom-plugin-decorators/swap-summary-description) - swap the contents of summary and description fields if they are the wrong way round.
-- [Apply root-level security](./custom-plugin-decorators/apply-root-security) - re-apply root-level `security` to operations that lose it after `redocly join`.
-- [Set servers URLs](./custom-plugin-decorators/set-servers-urls) - set or overwrite the API `servers` URLs, even when the source description has none.
+- [Tag sorting](./custom-plugin-decorators/tag-sorting/) - put your tags list in alphabetical order.
+- [Substitute datetime placeholders in an API description](./custom-plugin-decorators/update-example-dates/) - update dates in examples to the current date.
+- [OpenAI isConsequential](./custom-plugin-decorators/openai-is-consequential/) - add the `x-openai-isConsequential: true` specification extension to GET operations.
+- [Remove extensions](./custom-plugin-decorators/remove-extensions/) - remove any given [OpenAPI Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions) from an OpenAPI document.
+- [Remove unused tags](./custom-plugin-decorators/remove-unused-tags/) - remove tags that are declared but not used by any operations.
+- [Azure APIM](./custom-plugin-decorators/azure-apim/) - remove features unsupported by Azure APIM, such as examples.
+- [Swap summary and description](./custom-plugin-decorators/swap-summary-description/) - swap the contents of summary and description fields if they are the wrong way round.
+- [Apply root-level security](./custom-plugin-decorators/apply-root-security/) - re-apply root-level `security` to operations that lose it after `redocly join`.
+- [Set servers URLs](./custom-plugin-decorators/set-servers-urls/) - set or overwrite the API `servers` URLs, even when the source description has none.
 
 #### Rules (for custom plugins)
 
-- [Validate Markdown](./custom-plugin-rules/markdown-validator) - check Markdown in description fields is valid.
-- [Check code samples](./custom-plugin-rules/code-sample-checks) - check that an expected list of code samples is present in `x-code-samples` for every operation.
-- [Default is an enum](./custom-plugin-rules/default-enum-match) - check that a schema's `default` is one of its `enum` values.
+- [Validate Markdown](./custom-plugin-rules/markdown-validator/) - check Markdown in description fields is valid.
+- [Check code samples](./custom-plugin-rules/code-sample-checks/) - check that an expected list of code sample languages is present in `x-code-samples` for every operation.
+- [Default is an enum](./custom-plugin-rules/default-enum-match/) - check that a schema's `default` is one of its `enum` values.
 
 ### Miscellaneous (including tips and tricks)
 
 Share anything that didn't fit the existing categories here.
 
-- [Script to re-order an API description](./miscellaneous/reorder-bundled-description-properties/) and put the top-level properties in a particular order.
+- [Script to re-order an API description](./miscellaneous/reorder-bundled-description-properties/) - put the top-level properties of a bundled description in a particular order.
 
 ## Contributing
 
-Please share your best Redocly CLI usage with us! Each item should be shared in its own pull request, following the existing directory structure and including a `README.md` in each folder. Full instructions are in the [contributing guide](../CONTRIBUTING.md#contribute-to-the-cookbook).
+Please share your best Redocly CLI usage with us!
+Each item should be shared in its own pull request, following the existing directory structure and including a `README.md` in each folder.
+Full instructions are in the [contributing guide](../CONTRIBUTING.md#contribute-to-the-cookbook).
 
 ## Requests
 
-If there's something you think should be in the collection and it isn't, let us know! Open an issue, and describe the problem you'd like to see solved with Redocly CLI. We can't make promises, but we are pretty sure someone out there will know the answer.
+If there's something you think should be in the collection and it isn't, let us know!
+Open an issue, and describe the problem you'd like to see solved with Redocly CLI.
+We can't make promises, but we are pretty sure someone out there will know the answer.


### PR DESCRIPTION

- Fixed wrong and inconsistent wording in the Cookbook's content
- Fixed links
- Adjusted codeowners

 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [ ] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and CODEOWNERS only; no runtime, CLI, or package behavior changes.
> 
> **Overview**
> **Documentation-only** refresh of the in-repo **Cookbook**: catalog copy, links, naming, and review ownership.
> 
> The main **`cookbook/README.md`** catalog is reworked so entries use consistent **`./`-relative** paths (with trailing slashes), many items get **one-line descriptions**, and wording is tightened (e.g. rulesets mention configurable rules, “API health check”, “Deprecation strategy response headers”). Long paragraphs are split for readability.
> 
> **`README.md`** now points readers at the **in-repo** Cookbook (`./cookbook/README.md`) instead of the external `redocly-cli-cookbook` GitHub repo.
> 
> **`CONTRIBUTING.md`** standardizes **“Cookbook”** capitalization in the contribution section.
> 
> **`.github/CODEOWNERS`** assigns **`cookbook/**/*.md`** to **`@Redocly/technical-writers`** and restores a proper newline on the proxy command path entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12eafe4a7cb360ed9ab4d6301cd10701e5768852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->