### PR TITLE
chore: fix snapshot release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -218,8 +218,10 @@ jobs:
           jq ".version = \"$VERSION\"" packages/respect-core/package.json > tmp.json && mv tmp.json packages/respect-core/package.json
           jq ".dependencies[\"@redocly/openapi-core\"] = \"$VERSION\"" packages/respect-core/package.json > tmp.json && mv tmp.json packages/respect-core/package.json
 
-          # Update CLI package version
+          # Update CLI package version and dependencies, so npm links the local
+          # workspace packages instead of installing the published versions
           jq ".version = \"$VERSION\"" packages/cli/package.json > tmp.json && mv tmp.json packages/cli/package.json
+          jq ".devDependencies[\"@redocly/openapi-core\"] = \"$VERSION\" | .devDependencies[\"@redocly/respect-core\"] = \"$VERSION\"" packages/cli/package.json > tmp.json && mv tmp.json packages/cli/package.json
 
           # Add comment with installation instructions
           COMMENT="📦 A new experimental 🧪 version **v$VERSION** of Redocly CLI has been published for testing.


### PR DESCRIPTION
## What/Why/How?

Fixed broken snapshot release flow not updating the local dependencies.

## Reference

Failing job: https://github.com/Redocly/redocly-cli/actions/runs/30344987711/job/90229589347?pr=2969

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the labeled PR snapshot job; no runtime product code or auth/data paths affected.
> 
> **Overview**
> **Fixes the PR `snapshot` release workflow** so experimental `@redocly/cli` builds resolve against the same snapshot versions of internal packages.
> 
> When the workflow bumps `packages/core`, `respect-core`, and `cli` to `0.0.0-snapshot.<timestamp>`, it now also sets `packages/cli/package.json` **devDependencies** for `@redocly/openapi-core` and `@redocly/respect-core` to that version (alongside the existing respect-core → openapi-core dependency bump). That keeps `npm install` in the job using the freshly versioned workspace packages instead of published semver ranges, which was breaking the snapshot publish path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2026fae2cc61c86671f841c0f60430d91877f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->