### PR TITLE
chore(cli): add production env to usage data

### DIFF
--- a/docs/@v2/usage-data.md
+++ b/docs/@v2/usage-data.md
@@ -21,7 +21,7 @@ When a command is run, the following data is collected:
 - API specification type and version
 - Arazzo x-security authentication types
 - platform (Linux, macOS, Windows)
-- Anonymous ID (a randomly generated identifier that doesn't contain personal information)
+- anonymous ID (a randomly generated identifier that doesn't contain personal information)
 - command execution time
 - whether the CLI runs from a released build or development build
 

--- a/docs/@v2/usage-data.md
+++ b/docs/@v2/usage-data.md
@@ -20,10 +20,10 @@ When a command is run, the following data is collected:
 - whether the `redocly.yaml` configuration file exists
 - API specification type and version
 - Arazzo x-security authentication types
-- Platform (Linux, macOS, Windows)
+- platform (Linux, macOS, Windows)
 - Anonymous ID (a randomly generated identifier that doesn't contain personal information)
-- Command execution time
-- whether the CLI runs from a released build or from source
+- command execution time
+- whether the CLI runs from a released build or development build
 
 Values such as file names, organization IDs, and URLs are removed, replaced by just "URL" or "file", etc.
 

--- a/docs/@v2/usage-data.md
+++ b/docs/@v2/usage-data.md
@@ -23,6 +23,7 @@ When a command is run, the following data is collected:
 - Platform (Linux, macOS, Windows)
 - Anonymous ID (a randomly generated identifier that doesn't contain personal information)
 - Command execution time
+- whether the CLI runs from a released build or from source
 
 Values such as file names, organization IDs, and URLs are removed, replaced by just "URL" or "file", etc.
 

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -19,7 +19,7 @@ const result = await build({
   target: 'node20.19',
   metafile: true,
   define: {
-    'process.env.REDOCLY_CLI_BUILD_ENV': JSON.stringify('production'),
+    'process.env.REDOCLY_CLI_BUILD_ENV': '"production"',
   },
   // Avoid errors when external dependencies use CJS syntax.
   banner: {

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -18,6 +18,9 @@ const result = await build({
   format: 'esm',
   target: 'node20.19',
   metafile: true,
+  define: {
+    'process.env.REDOCLY_CLI_BUILD_ENV': JSON.stringify('production'),
+  },
   // Avoid errors when external dependencies use CJS syntax.
   banner: {
     js: "import { createRequire as __createRequire } from 'node:module';\nconst require = __createRequire(import.meta.url);",

--- a/packages/cli/src/utils/__tests__/telemetry.test.ts
+++ b/packages/cli/src/utils/__tests__/telemetry.test.ts
@@ -34,6 +34,6 @@ it('sendTelemetry calls all telemetry functions', async () => {
   expect(respondWithinMs).toHaveBeenCalled();
   expect(RedoclyOAuthClient).toHaveBeenCalled();
   expect(getReuniteUrl).toHaveBeenCalled();
-  expect(mockMapToCloudEvent).toHaveBeenCalled();
+  expect(mockMapToCloudEvent).toHaveBeenCalledWith(expect.objectContaining({ env: 'development' }));
   expect(mockOtelSend).toHaveBeenCalled();
 });

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -120,6 +120,7 @@ export async function sendTelemetry({
       type: 'com.redocly.command.ran',
       source: 'urn:redocly:cli',
       origin: 'redocly-cli',
+      // esbuild inlines `production` for released builds; from source it stays `development`.
       env: process.env.REDOCLY_CLI_BUILD_ENV || 'development',
       osPlatform: os.platform(),
       actor: {

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -120,6 +120,7 @@ export async function sendTelemetry({
       type: 'com.redocly.command.ran',
       source: 'urn:redocly:cli',
       origin: 'redocly-cli',
+      env: process.env.REDOCLY_CLI_BUILD_ENV || 'development',
       osPlatform: os.platform(),
       actor: {
         id: anonymous_id,

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -120,8 +120,7 @@ export async function sendTelemetry({
       type: 'com.redocly.command.ran',
       source: 'urn:redocly:cli',
       origin: 'redocly-cli',
-      // esbuild inlines `production` for released builds; from source it stays `development`.
-      env: process.env.REDOCLY_CLI_BUILD_ENV || 'development',
+      env: process.env.REDOCLY_CLI_BUILD_ENV || 'development', // should become "production" ab build time
       osPlatform: os.platform(),
       actor: {
         id: anonymous_id,


### PR DESCRIPTION
## What/Why/How?
Added env field to usage data. Now env will be `production` for the build
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds non-sensitive telemetry metadata only; no changes to auth, data handling, or command behavior.
> 
> **Overview**
> Telemetry cloud events now include an **`env`** field so usage metrics can distinguish **released CLI builds** from **local/development** runs.
> 
> The production bundle sets `REDOCLY_CLI_BUILD_ENV` to `production` at **esbuild** time; otherwise telemetry defaults to `development`. **Usage data** docs list whether the CLI is a released or dev build, and the telemetry test asserts `env: 'development'` when not built for production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514a8dc98f33f44a60395ca96e87633e1fd68df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->