### PR TITLE
chore: pin npm to v11 in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           cache: 'npm'
 
       - name: Update NPM for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Install Dependencies
         run: npm ci
 
@@ -75,7 +75,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update NPM for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Update package versions
         run: |


### PR DESCRIPTION
## What/Why/How?

fix for https://github.com/Redocly/redocly-cli/actions/runs/30457338474/job/90594202370

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or runtime impact.
> 
> **Overview**
> The **Update NPM for trusted publishing** step in `.github/workflows/release.yaml` now installs **`npm@11`** instead of **`npm@latest`**, in both the main **Release** job and the **Release Snapshot** job.
> 
> This pins the CLI version used for npm OIDC/trusted publishing so release CI does not break when a newer npm major ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f3500c7af051545f62433c50b1de68a07bb3b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->