### PR TITLE
chore(deps): bump redocly/config version to v0.53.0

### DIFF
--- a/.changeset/four-games-think.md
+++ b/.changeset/four-games-think.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.53.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2604,9 +2604,9 @@
       "link": true
     },
     "node_modules/@redocly/config": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.52.0.tgz",
-      "integrity": "sha512-e/++L27tRgo35GVCy4ivy+uqHi/ksg4KnhlYzj5FTJ9OokuyX18B0mJm0SUXLBih9VIQMgSk6tXsyYmhg5OsIQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.53.0.tgz",
+      "integrity": "sha512-BH7JXkiqLCZTmH6jJsrJcKOJA0A6iIRkaXpIL2rZcj/Z3IQG1fMoT9vVMixOvZV58PWneMGOPo0Irkjb3Du9lw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -10310,7 +10310,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.52.0",
+        "@redocly/config": "^0.53.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.52.0",
+    "@redocly/config": "^0.53.0",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -2223,10 +2223,21 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "aiSearch": "rootRedoclyConfigSchema.access.rbac.features.aiSearch",
+      "mcp": "rootRedoclyConfigSchema.access.rbac.features.mcp",
     },
     "required": undefined,
   },
   "rootRedoclyConfigSchema.access.rbac.features.aiSearch": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.access.rbac.features.mcp": {
     "additionalProperties": {
       "type": "string",
     },
@@ -10756,10 +10767,21 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "aiSearch": "rootRedoclyConfigSchema.env_additionalProperties.access.rbac.features.aiSearch",
+      "mcp": "rootRedoclyConfigSchema.env_additionalProperties.access.rbac.features.mcp",
     },
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.access.rbac.features.aiSearch": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.access.rbac.features.mcp": {
     "additionalProperties": {
       "type": "string",
     },
@@ -20161,7 +20183,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "docs": "rootRedoclyConfigSchema.env_additionalProperties.mcp.docs",
-      "gateway": "rootRedoclyConfigSchema.env_additionalProperties.mcp.gateway",
       "hide": {
         "type": "boolean",
       },
@@ -20185,24 +20206,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "name": {
         "type": "string",
-      },
-    },
-    "required": undefined,
-  },
-  "rootRedoclyConfigSchema.env_additionalProperties.mcp.gateway": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "allowedHosts": {
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "hide": {
-        "type": "boolean",
       },
     },
     "required": undefined,
@@ -23205,10 +23208,21 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "aiSearch": "rootRedoclyConfigSchema.env_additionalProperties.rbac.features.aiSearch",
+      "mcp": "rootRedoclyConfigSchema.env_additionalProperties.rbac.features.mcp",
     },
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.rbac.features.aiSearch": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.rbac.features.mcp": {
     "additionalProperties": {
       "type": "string",
     },
@@ -33889,7 +33903,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "docs": "rootRedoclyConfigSchema.mcp.docs",
-      "gateway": "rootRedoclyConfigSchema.mcp.gateway",
       "hide": {
         "type": "boolean",
       },
@@ -33913,24 +33926,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "name": {
         "type": "string",
-      },
-    },
-    "required": undefined,
-  },
-  "rootRedoclyConfigSchema.mcp.gateway": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "allowedHosts": {
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "hide": {
-        "type": "boolean",
       },
     },
     "required": undefined,
@@ -36933,10 +36928,21 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "items": undefined,
     "properties": {
       "aiSearch": "rootRedoclyConfigSchema.rbac.features.aiSearch",
+      "mcp": "rootRedoclyConfigSchema.rbac.features.mcp",
     },
     "required": undefined,
   },
   "rootRedoclyConfigSchema.rbac.features.aiSearch": {
+    "additionalProperties": {
+      "type": "string",
+    },
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.rbac.features.mcp": {
     "additionalProperties": {
       "type": "string",
     },


### PR DESCRIPTION
## What/Why/How?
Bump redocly/config to v0.53.0.
## Reference

## Testing
[Tested in Monorepo](https://github.com/Redocly/redocly/pull/25581)
## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch dependency bump with test snapshot updates only; schema changes may affect validation of redocly.yaml using removed mcp.gateway or new rbac.features.mcp.
> 
> **Overview**
> Bumps **`@redocly/config`** from `^0.52.0` to **`^0.53.0`** in `@redocly/openapi-core`, with lockfile and a patch changeset.
> 
> Regenerated Redocly config schema test snapshots to match **v0.53.0**: **`access.rbac.features`** now includes an **`mcp`** feature map (alongside `aiSearch`), and the top-level **`mcp`** block no longer exposes a **`gateway`** sub-schema (`allowedHosts` / `hide`); **`mcp.docs`** and **`mcp.hide`** remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fadb2c8a5c3a1ec29fab83878a92c2ffbef1892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->