### PR TITLE
feat: add skipPluginEval option to loadConfig

### DIFF
--- a/.changeset/skip-plugin-eval.md
+++ b/.changeset/skip-plugin-eval.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': minor
+---
+
+Added a `skipPluginEval` option to `loadConfig` that resolves plugin paths without importing or executing plugin code — the returned plugins contain only their `absolutePath`.

--- a/packages/core/src/config/__tests__/fixtures/default-plugin/@theme/plugin.js
+++ b/packages/core/src/config/__tests__/fixtures/default-plugin/@theme/plugin.js
@@ -1,0 +1,1 @@
+throw new Error('This plugin must never be evaluated.');

--- a/packages/core/src/config/__tests__/fixtures/default-plugin/redocly.yaml
+++ b/packages/core/src/config/__tests__/fixtures/default-plugin/redocly.yaml
@@ -1,0 +1,2 @@
+rules:
+  info-license: error

--- a/packages/core/src/config/__tests__/fixtures/skip-plugin-eval-config.yaml
+++ b/packages/core/src/config/__tests__/fixtures/skip-plugin-eval-config.yaml
@@ -1,0 +1,2 @@
+plugins:
+  - './throwing-plugin.cjs'

--- a/packages/core/src/config/__tests__/fixtures/throwing-plugin.cjs
+++ b/packages/core/src/config/__tests__/fixtures/throwing-plugin.cjs
@@ -1,0 +1,1 @@
+throw new Error('This plugin must never be evaluated.');

--- a/packages/core/src/config/__tests__/resolve-plugins.test.ts
+++ b/packages/core/src/config/__tests__/resolve-plugins.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+import { defaultPlugin } from '../builtIn.js';
 import { loadConfig } from '../load.js';
 
 describe('resolving a plugin', () => {
@@ -24,5 +25,29 @@ describe('resolving a plugin', () => {
     const plugin = config.plugins[0];
 
     expect(plugin.decorators?.oas3).toHaveProperty('test-plugin/inject-x-stats');
+  });
+
+  it('should return only plugin paths without loading plugin code when skipPluginEval is true', async () => {
+    const config = await loadConfig({
+      configPath: path.join(__dirname, 'fixtures/skip-plugin-eval-config.yaml'),
+      skipPluginEval: true,
+    });
+
+    expect(config.plugins).toEqual([
+      { absolutePath: path.join(__dirname, 'fixtures/throwing-plugin.cjs') },
+      defaultPlugin,
+    ]);
+  });
+
+  it('should return the default project plugin path without loading plugin code when skipPluginEval is true', async () => {
+    const config = await loadConfig({
+      configPath: path.join(__dirname, 'fixtures/default-plugin/redocly.yaml'),
+      skipPluginEval: true,
+    });
+
+    expect(config.plugins).toEqual([
+      { absolutePath: path.join(__dirname, 'fixtures/default-plugin/@theme/plugin.js') },
+      defaultPlugin,
+    ]);
   });
 });

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -55,6 +55,7 @@ export type ConfigOptions = {
   configPath?: string;
   externalRefResolver?: BaseResolver;
   customExtends?: string[];
+  skipPluginEval?: boolean;
 };
 
 export async function resolveConfig({
@@ -62,6 +63,7 @@ export async function resolveConfig({
   configPath,
   externalRefResolver,
   customExtends,
+  skipPluginEval,
 }: ConfigOptions): Promise<{
   resolvedConfig: ResolvedConfig;
   resolvedRefMap: ResolvedRefMap;
@@ -107,7 +109,8 @@ export async function resolveConfig({
     pluginsOrPaths = collectConfigPlugins(rootDocument, resolvedRefMap, rootConfigDir);
     const plugins = await resolvePlugins(
       pluginsOrPaths.map((p) => (isPluginResolveInfo(p) ? p.absolutePath : p)),
-      rootConfigDir
+      rootConfigDir,
+      skipPluginEval
     );
     resolvedPlugins = [...plugins, defaultPlugin];
   }
@@ -196,7 +199,8 @@ export const preResolvePluginPath = (
 
 export async function resolvePlugins(
   plugins: (string | Plugin)[],
-  configDir: string
+  configDir: string,
+  skipPluginEval = false
 ): Promise<Plugin[]> {
   if (!plugins) return [];
 
@@ -269,6 +273,31 @@ export async function resolvePlugins(
   }
 
   const resolvedPlugins: Set<string> = new Set();
+
+  if (skipPluginEval) {
+    const pluginRefs: Plugin[] = [];
+    for (const plugin of plugins) {
+      if (!isString(plugin)) {
+        pluginRefs.push(plugin);
+        continue;
+      }
+      const absolutePath = path.isAbsolute(plugin)
+        ? plugin
+        : (
+            preResolvePluginPath(
+              plugin,
+              path.join(configDir, CONFIG_FILE_NAME),
+              configDir
+            ) as PluginResolveInfo
+          ).absolutePath;
+      if (!resolvedPlugins.has(absolutePath)) {
+        resolvedPlugins.add(absolutePath);
+        // Plugin code is intentionally not loaded — the caller gets only the resolved path.
+        pluginRefs.push({ absolutePath } as Plugin);
+      }
+    }
+    return pluginRefs;
+  }
 
   const instances = await Promise.all(
     plugins.map(async (p) => {

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -59,9 +59,10 @@ export async function loadConfig(
     configPath?: string;
     customExtends?: string[];
     externalRefResolver?: BaseResolver;
+    skipPluginEval?: boolean;
   } = {}
 ): Promise<Config> {
-  const { configPath = findConfig(), customExtends, externalRefResolver } = options;
+  const { configPath = findConfig(), customExtends, externalRefResolver, skipPluginEval } = options;
 
   const resolver = externalRefResolver ?? new BaseResolver();
 
@@ -78,6 +79,7 @@ export async function loadConfig(
     customExtends,
     configPath,
     externalRefResolver,
+    skipPluginEval,
   });
 
   const ignore = await loadIgnoreConfig(configPath, resolver);


### PR DESCRIPTION
## What/Why/How?

Adds a `skipPluginEval` option to `loadConfig` (and `resolveConfig`/`resolvePlugins`) that resolves plugin paths without importing or executing any plugin code.
In some cases the consumer only needs to know *which* plugin files a config references — evaluating arbitrary plugin code there is unwanted.

With `loadConfig({ configPath, skipPluginEval: true })`:

- `config.plugins` contains `{ absolutePath }` references only (plus the built-in default plugin), so no rules/decorators/presets are loaded.
- Relative plugin paths, including the default project plugin (`@theme/plugin.js`), are resolved to absolute paths via `preResolvePluginPath`, which only uses `fs.existsSync`/`require.resolve` — resolution, never execution.
- Duplicate plugin references are deduplicated by absolute path, matching the eval path's behavior.

Known limitation (intentional): `extends` entries that reference a plugin preset (`my-plugin/config-name`) still throw in this mode, because presets live in plugin code that is never loaded. Built-in presets (`recommended`, etc.) resolve as usual. This matches the existing browser-mode behavior where string plugins are not loaded either.

## Reference

## Testing

Unit tests in `resolve-plugins.test.ts` use fixture plugins whose module body is `throw new Error(...)` — the tests hard-fail if plugin code is ever evaluated. Covered:

- explicitly listed plugin: only its absolute path is returned;
- default project plugin (`@theme/plugin.js`) discovered by convention: path resolved to absolute, code not loaded.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core config/plugin resolution; skip mode avoids arbitrary code execution but yields incomplete plugin objects and can break `extends` that reference plugin presets, so callers must opt in explicitly.
> 
> **Overview**
> Adds a **`skipPluginEval`** flag on `loadConfig` (threaded through `resolveConfig` and `resolvePlugins`) for callers that only need to know which plugin files a config references.
> 
> When enabled, string plugins are resolved via **`preResolvePluginPath`** (filesystem / `require.resolve` only) and returned as **`{ absolutePath }`** stubs—no `loadPluginModule`, so rules, decorators, and presets from those files are not loaded. The built-in default plugin is still appended, and the usual default project plugin (`@theme/plugin.js`) is discovered and path-resolved the same way. Duplicate entries are deduplicated by absolute path, matching the normal load path.
> 
> Tests use fixtures whose module bodies throw on evaluation to ensure the skip path never runs plugin code (explicit `plugins` entries and convention-based default plugin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a58572c4e1d72c6ca9f15b0166a4600c01b125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->