### PR TITLE
chore: update @redocly/config version to v0.53.1

### DIFF
--- a/.changeset/quick-cameras-yawn.md
+++ b/.changeset/quick-cameras-yawn.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.53.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2604,9 +2604,9 @@
       "link": true
     },
     "node_modules/@redocly/config": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.53.0.tgz",
-      "integrity": "sha512-BH7JXkiqLCZTmH6jJsrJcKOJA0A6iIRkaXpIL2rZcj/Z3IQG1fMoT9vVMixOvZV58PWneMGOPo0Irkjb3Du9lw==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.53.1.tgz",
+      "integrity": "sha512-aOldTWynKS3ZM6u8WkL72d94QBobITv9X6UECiZykgVjdLiAqV737bPVLGKJYPWf0Ryf3zSHgUYALjCj66BkdA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -10310,7 +10310,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.53.0",
+        "@redocly/config": "^0.53.1",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
-    "@redocly/config": "^0.53.0",
+    "@redocly/config": "^0.53.1",
     "ajv": "npm:@redocly/ajv@8.18.1",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -2799,6 +2799,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.apis_additionalProperties.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.apis_additionalProperties.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -3474,9 +3477,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {
@@ -5729,6 +5729,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.apis_additionalProperties.theme.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.apis_additionalProperties.theme.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -6364,9 +6367,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {
@@ -11343,6 +11343,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -12018,9 +12021,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {
@@ -14273,6 +14273,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.theme.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.theme.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -14908,9 +14911,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {
@@ -19289,6 +19289,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.env_additionalProperties.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.env_additionalProperties.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -20610,9 +20613,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {
@@ -25310,6 +25310,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.env_additionalProperties.theme.asyncapi.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.env_additionalProperties.theme.asyncapi.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -25324,7 +25327,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         ],
         "type": "string",
       },
-      "metadata": "rootRedoclyConfigSchema.env_additionalProperties.theme.asyncapi.metadata",
       "samplesMaxInlineArgs": {
         "type": "number",
       },
@@ -25658,18 +25660,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "array",
       },
       "label": {
-        "type": "string",
-      },
-    },
-    "required": undefined,
-  },
-  "rootRedoclyConfigSchema.env_additionalProperties.theme.asyncapi.metadata": {
-    "additionalProperties": {},
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "apiId": {
         "type": "string",
       },
     },
@@ -27733,6 +27723,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.env_additionalProperties.theme.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.env_additionalProperties.theme.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -28860,9 +28853,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {
@@ -33009,6 +32999,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "downloadUrls": "rootRedoclyConfigSchema.graphql.downloadUrls",
+      "excludeFromSearch": {
+        "type": "boolean",
+      },
       "feedback": "rootRedoclyConfigSchema.graphql.feedback",
       "fieldExpandLevel": {
         "type": "number",
@@ -34330,9 +34323,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "string",
       },
       "disableDeepLinks": {
-        "type": "boolean",
-      },
-      "disableRouter": {
         "type": "boolean",
       },
       "disableSearch": {


### PR DESCRIPTION
## What/Why/How?

Bump redocly/config to v0.53.1.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch dependency bump with generated test snapshot updates only; behavior changes are limited to config validation against the updated schema from @redocly/config.
> 
> **Overview**
> Bumps **`@redocly/config`** from `^0.53.0` to **`^0.53.1`** in `@redocly/openapi-core`, with lockfile and changeset updates.
> 
> The refreshed Redocly YAML schema snapshots reflect upstream config schema changes: **`excludeFromSearch`** (boolean) is now recognized on GraphQL-related theme/API config shapes, **`disableRouter`** is no longer in the reflected schema, and AsyncAPI theme **`metadata`** is removed from the snapshot. No application logic changes in this repo beyond aligning validation/types with the new package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb1dcb8f332921a3a4b56b412e748dad69f3d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->