### PR TITLE
feat: keep extends unresolved when skipPluginEval is set

### DIFF
--- a/.changeset/skip-plugin-eval-extends.md
+++ b/.changeset/skip-plugin-eval-extends.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed `skipPluginEval` to keep `extends` unresolved instead of failing when the config extends a plugin preset.

--- a/packages/core/src/bundle/bundle.ts
+++ b/packages/core/src/bundle/bundle.ts
@@ -49,9 +49,10 @@ export function collectConfigPlugins(
 export function bundleConfig(
   document: Document,
   resolvedRefMap: ResolvedRefMap,
-  plugins: Plugin[]
+  plugins: Plugin[],
+  skipPluginEval = false
 ): ResolvedConfig {
-  const visitorsData: ConfigBundlerVisitorData = { plugins };
+  const visitorsData: ConfigBundlerVisitorData = { plugins, skipPluginEval };
   const ctx: BundleContext = {
     problems: [],
     specVersion: 'config',

--- a/packages/core/src/config/__tests__/fixtures/skip-plugin-eval-config.yaml
+++ b/packages/core/src/config/__tests__/fixtures/skip-plugin-eval-config.yaml
@@ -1,2 +1,7 @@
+extends:
+  - 'test-plugin/recommended'
 plugins:
   - './throwing-plugin.cjs'
+apis:
+  main:
+    root: ./openapi.yaml

--- a/packages/core/src/config/__tests__/resolve-plugins.test.ts
+++ b/packages/core/src/config/__tests__/resolve-plugins.test.ts
@@ -39,6 +39,16 @@ describe('resolving a plugin', () => {
     ]);
   });
 
+  it('should keep extends unresolved when skipPluginEval is true', async () => {
+    const config = await loadConfig({
+      configPath: path.join(__dirname, 'fixtures/skip-plugin-eval-config.yaml'),
+      skipPluginEval: true,
+    });
+
+    expect(config.resolvedConfig.extends).toEqual(['test-plugin/recommended']);
+    expect(config.resolvedConfig.apis).toEqual({ main: { root: './openapi.yaml' } });
+  });
+
   it('should return the default project plugin path without loading plugin code when skipPluginEval is true', async () => {
     const config = await loadConfig({
       configPath: path.join(__dirname, 'fixtures/default-plugin/redocly.yaml'),

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -118,10 +118,12 @@ export async function resolveConfig({
   const bundledConfig = bundleConfig(
     rootDocument,
     deepCloneMapWithJSON(resolvedRefMap),
-    resolvedPlugins
+    resolvedPlugins,
+    skipPluginEval
   );
 
-  if (bundledConfig.apis) {
+  // The apis merge relies on `extends` being resolved, which requires evaluated plugins.
+  if (bundledConfig.apis && !skipPluginEval) {
     bundledConfig.apis = Object.fromEntries(
       Object.entries(bundledConfig.apis).map(([key, apiConfig]) => {
         const mergedConfig = mergeExtends([bundledConfig, apiConfig]);

--- a/packages/core/src/config/visitors.ts
+++ b/packages/core/src/config/visitors.ts
@@ -66,11 +66,16 @@ export const pluginsCollectorVisitor = normalizeVisitors(
 
 export type ConfigBundlerVisitorData = {
   plugins: Plugin[];
+  skipPluginEval?: boolean;
 };
 
 function bundlerHandleNode(node: unknown, ctx: UserContext) {
   if (isPlainObject(node) && node.extends) {
-    const { plugins } = ctx.getVisitorData() as ConfigBundlerVisitorData;
+    const { plugins, skipPluginEval } = ctx.getVisitorData() as ConfigBundlerVisitorData;
+    if (skipPluginEval) {
+      // `extends` may reference plugin presets, which are unknown when plugin code is not evaluated.
+      return;
+    }
     const bundled = bundleExtends({ node, ctx, plugins });
     Object.assign(node, bundled);
     delete node.extends;


### PR DESCRIPTION
## What/Why/How?

Follow-up to #2987 (released in #2988).

With `skipPluginEval: true`, a config whose `extends` references a plugin preset (`my-plugin/config-name`) made `loadConfig` throw `Invalid config ...: plugin ... is not included.` — presets live in plugin code, which is exactly what this mode refuses to load. That made the option unusable for real-world configs that use plugin presets.

Now, when `skipPluginEval` is set:

- the config bundler leaves `extends` untouched (no preset resolution at all, including built-ins), so `resolvedConfig` keeps the raw `extends` array;
- the per-api merge of root governance config is skipped too — it requires resolved `extends` (`mergeExtends` rejects configs that still have one).

Plain refs bundling still happens. Behavior without the option is unchanged.

## Reference

## Testing

Added a test: a config with `extends: ['test-plugin/recommended']` and an `apis` entry loads without throwing, keeps `extends` and `apis` as authored, and the fixture plugin still proves no plugin code is evaluated.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to skipPluginEval config loading; normal config resolution is unchanged.
> 
> **Overview**
> Fixes **`loadConfig` with `skipPluginEval: true`** so configs that **`extends` a plugin preset** (e.g. `test-plugin/recommended`) no longer throw *plugin is not included* — presets require evaluated plugin code, which this mode deliberately skips.
> 
> When **`skipPluginEval`** is set, the config bundler **skips `bundleExtends`** and leaves **`extends` as authored** on `resolvedConfig`. **`resolveConfig`** also **skips per-API `mergeExtends`** (that step needs resolved `extends`). **`skipPluginEval`** is passed through **`bundleConfig`** into the bundler visitor. Default behavior without the flag is unchanged; ref bundling still runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5864e674ec6168bac0e654559d70098a7da12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->