### PR TITLE
feat: add experimental coverage command

### DIFF
--- a/.changeset/coverage-command.md
+++ b/.changeset/coverage-command.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': minor
+---
+
+Added the experimental `coverage` command, which reports the documented properties, union branches, and schemas that recorded HTTP traffic never exercised.

--- a/.changeset/drift-multi-parameter-path-segments.md
+++ b/.changeset/drift-multi-parameter-path-segments.md
@@ -1,0 +1,7 @@
+---
+'@redocly/cli': patch
+---
+
+Fixed `drift` and `coverage` failing to match a path template whose segment mixes literal text with parameters, such as `/instances/{worldId}:{instanceId}`.
+Only a segment that was entirely one parameter was recognized, so these templates were compiled as literal text and never matched any request.
+Affected requests were reported as undocumented by `drift` and left out of the `coverage` figures.

--- a/.changeset/respect-har-post-data.md
+++ b/.changeset/respect-har-post-data.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': patch
+---
+
+Fixed `respect --har-output` recording an empty `postData` for every request. Request bodies are now written to the HAR, so a capture replayed through `drift` can have its request bodies validated instead of silently passing.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .idea
 node_modules/
 nodejs/
-coverage/
+# Root-scoped: vitest writes its report here, but `coverage/` unanchored also
+# swallows the `coverage` command's source directory.
+/coverage/
 .vscode/
 yarn.lock
 lib/

--- a/docs/@v2/commands/coverage.md
+++ b/docs/@v2/commands/coverage.md
@@ -14,6 +14,7 @@ The `coverage` command reports:
 
 - documented operations no request reached
 - documented parameters no request sent, and the `enum` values none of them carried
+- documented responses the API never returned
 - documented properties no request or response carried
 - `oneOf` and `anyOf` branches nothing ever matched
 - component schemas nothing reached at all

--- a/docs/@v2/commands/coverage.md
+++ b/docs/@v2/commands/coverage.md
@@ -1,0 +1,135 @@
+# `coverage`
+
+The `coverage` command reports the parts of an OpenAPI description that recorded HTTP traffic never exercised.
+The command reads a traffic log (or a folder of logs), matches each request/response exchange to a documented operation, and lists the documented properties, union branches, and schemas that nothing reached.
+
+{% admonition type="warning" name="Experimental" %}
+This is an experimental feature.
+Its behavior, command, flags, and output may change in future releases.
+
+The `coverage` command supports OpenAPI 3.x descriptions only.
+{% /admonition %}
+
+The `coverage` command reports:
+
+- documented operations no request reached
+- documented properties no request or response carried
+- `oneOf` and `anyOf` branches nothing ever matched
+- component schemas nothing reached at all
+
+This is the opposite direction from [`drift`](./drift.md).
+`drift` judges the traffic against the description and reports what disagrees; it is silent about a description that is never put to the test.
+A `drift` run with no findings is only as meaningful as the share of the description the traffic actually covered, and that share is what `coverage` measures.
+
+An entry in the report is not a defect.
+It is a claim the traffic does not substantiate: the property may need an account state, a permission, or an endpoint the capture never reached.
+Read it as a list of what to exercise next.
+
+## Supported traffic formats
+
+The traffic input can be provided in any of the following formats.
+By default the format is detected automatically from the file contents:
+
+- HAR
+- Kong
+- Nginx JSON
+- Apache JSON
+- NDJSON
+
+## Usage
+
+```bash
+redocly coverage <traffic> --api <api>
+redocly coverage <traffic> --api <api> [--traffic-format=<option>]
+redocly coverage <traffic> --api <api> [--format=<option>] [--output=<file>]
+redocly coverage <traffic> --api <api> [--schema=<name>]
+redocly coverage <traffic> --api <api> [--all]
+```
+
+## Options
+
+| Option           | Type    | Description                                                                                                                                 |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| traffic          | string  | **REQUIRED.** Path to a traffic log file or folder (HAR, Kong, Nginx/Apache JSON, NDJSON).                                                  |
+| --api            | string  | **REQUIRED.** OpenAPI description file or folder to measure coverage against.                                                               |
+| --traffic-format | string  | Traffic input format.<br/>**Possible values:** `auto`, `har`, `kong`, `nginx-json`, `apache-json`, `ndjson`. Default value is `auto`.       |
+| --format         | string  | Output format.<br/>**Possible values:** `stylish`, `json`. Default value is `stylish`.                                                      |
+| --match-mode     | string  | How requests are located via the description `servers`.<br/>**Possible values:** `strict-host`, `basepath`. Default value is `strict-host`. |
+| --schema         | string  | Report only this component schema, by name.                                                                                                 |
+| --all            | boolean | List the operations and schemas nothing reached instead of collapsing them to a count. Default value is `false`.                            |
+| --output, -o     | string  | Write the coverage report (in the format selected with `--format`) to this file instead of stdout.                                          |
+| --config         | string  | Specify path to the [configuration file](../configuration/index.md).                                                                        |
+| --lint-config    | string  | Specify the severity level for the configuration file.<br/>**Possible values:** `warn`, `error`, `off`. Default value is `warn`.            |
+| --help           | boolean | Display help.                                                                                                                               |
+| --version        | boolean | Display version number.                                                                                                                     |
+
+## Examples
+
+### Measure coverage of a HAR capture
+
+```bash
+redocly coverage ./traffic.har --api ./openapi.yaml
+```
+
+Output:
+
+```
+90/304 operations exercised (30%)
+1072/2206 documented properties observed (49%) over 117 of 340 exchange(s)
+
+  Avatar  22/31
+    assetUrl
+    highestPrice
+  NotificationV2  8/8
+    data  oneOf branch 2, 3, 4, 5, 6 never matched
+
+Operations nothing reached — 214
+    pass --all to list them
+
+Schemas nothing reached — 166
+    pass --all to list them
+```
+
+Property coverage is measured over the exchanges that carried a body, because those are the only ones a schema describes.
+The second figure reports both counts: here 117 of the 340 parsed exchanges had one.
+
+### Investigate a single schema
+
+```bash
+redocly coverage ./traffic.har --api ./openapi.yaml --schema Avatar
+```
+
+### List every schema nothing reached
+
+```bash
+redocly coverage ./traffic.har --api ./openapi.yaml --all
+```
+
+### Track coverage over time
+
+The JSON format carries the same figures for a dashboard or a trend check:
+
+```bash
+redocly coverage ./traffic.har --api ./openapi.yaml --format json -o ./coverage.json
+```
+
+## Union branches
+
+A `oneOf` or `anyOf` branch counts as covered only when a value could actually have been that branch.
+Without this, one response marks every alternative as covered and the figure means nothing.
+
+A branch nothing ever matched is worth attention for a second reason: an unexercised union is also an untested one.
+If [`drift`](./drift.md) reports that a union matched more than one branch, the branches listed here are where to start.
+
+## Exit codes
+
+| Exit code | Description                          |
+| --------- | ------------------------------------ |
+| 0         | The report was produced.             |
+| 1         | The command failed to run.           |
+| 2         | The configuration failed to resolve. |
+
+## Related commands
+
+- [`drift`](./drift.md) judges the same traffic against the description and reports what disagrees.
+- [`proxy`](./proxy.md) captures live HTTP traffic into a HAR file that `coverage` can measure.

--- a/docs/@v2/commands/coverage.md
+++ b/docs/@v2/commands/coverage.md
@@ -13,6 +13,7 @@ The `coverage` command supports OpenAPI 3.x descriptions only.
 The `coverage` command reports:
 
 - documented operations no request reached
+- documented parameters no request sent, and the `enum` values none of them carried
 - documented properties no request or response carried
 - `oneOf` and `anyOf` branches nothing ever matched
 - component schemas nothing reached at all
@@ -121,6 +122,17 @@ The JSON format carries the same figures for a dashboard or a trend check:
 ```bash
 redocly coverage ./traffic.har --api ./openapi.yaml --format json -o ./coverage.json
 ```
+
+## Parameters
+
+Query, path, header, and cookie parameters are covered the same way bodies are.
+A parameter counts once a request carried it, and an `enum` value counts once a request carried that value.
+
+This is where a description and its traffic drift apart quietly.
+A parameter the client never sends is one nobody has checked the server still honors, and an `enum` value nothing carried is a branch of the API that has never run.
+Neither shows up as a failure, because nothing went wrong: the request that would have exercised it was never made.
+
+A parameter is matched case-insensitively, since a header arrives in whatever case the client chose.
 
 ## Union branches
 

--- a/docs/@v2/commands/coverage.md
+++ b/docs/@v2/commands/coverage.md
@@ -93,6 +93,15 @@ Schemas nothing reached — 166
 Property coverage is measured over the exchanges that carried a body, because those are the only ones a schema describes.
 The second figure reports both counts: here 117 of the 340 parsed exchanges had one.
 
+## Rejected requests
+
+Everything the traffic carried counts, whatever status came back.
+Sending a body the API rejects is a real test, and the error response it returns is documented behavior worth covering.
+
+Coverage does report the split, because a rejected exchange covers the description without confirming it works.
+When some properties were seen only on exchanges the API did not accept, a second figure gives the count over accepted ones alone.
+A wide gap between the two means much of the coverage rests on requests that failed, which is worth a look before trusting the headline number.
+
 ### Investigate a single schema
 
 ```bash

--- a/docs/@v2/commands/drift.md
+++ b/docs/@v2/commands/drift.md
@@ -113,5 +113,6 @@ redocly drift ./traffic.har --api ./openapi.yaml --format json -o ./drift-report
 
 ## Related commands
 
+- [`coverage`](./coverage.md) measures how much of the description that same traffic actually exercised.
 - [`proxy`](./proxy.md) captures live HTTP traffic into a HAR file that can be replayed through `drift`.
 - [`generate-spec`](./generate-spec.md) infers an OpenAPI description from the same traffic formats.

--- a/docs/@v2/commands/index.md
+++ b/docs/@v2/commands/index.md
@@ -30,6 +30,7 @@ Testing commands:
 - [`respect`](respect.md) Execute API tests described in an Arazzo description.
 - [`generate-arazzo`](generate-arazzo.md) Generate an Arazzo description from an OpenAPI description.
 - [`drift`](drift.md) Detect drift between recorded HTTP traffic and an OpenAPI description [experimental feature].
+- [`coverage`](coverage.md) Report the parts of an OpenAPI description that recorded HTTP traffic never exercised [experimental feature].
 - [`proxy`](proxy.md) Capture live HTTP traffic through a reverse proxy into a HAR file [experimental feature].
 - [`generate-spec`](generate-spec.md) Infer an OpenAPI description from recorded HTTP traffic [experimental feature].
 

--- a/docs/@v2/v2.sidebars.yaml
+++ b/docs/@v2/v2.sidebars.yaml
@@ -14,6 +14,8 @@
           page: commands/bundle.md
         - label: check-config
           page: commands/check-config.md
+        - label: coverage
+          page: commands/coverage.md
         - label: drift
           page: commands/drift.md
         - label: eject

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -1,0 +1,159 @@
+import { summarize } from '../../../commands/coverage/engine/analyse.js';
+import type { Schema } from '../../../commands/coverage/engine/schema.js';
+import { createCoverage, walkRoot } from '../../../commands/coverage/engine/walk.js';
+
+const SPEC: Schema = {
+  openapi: '3.0.3',
+  components: {
+    schemas: {
+      Thing: {
+        type: 'object',
+        properties: {
+          always: { type: 'string' },
+          never: { type: 'string' },
+          nested: { $ref: '#/components/schemas/Nested' },
+          choice: { oneOf: [{ type: 'string' }, { $ref: '#/components/schemas/Nested' }] },
+        },
+      },
+      Nested: {
+        type: 'object',
+        properties: { inner: { type: 'string' }, unreached: { type: 'string' } },
+      },
+    },
+  },
+};
+
+const THING = { $ref: '#/components/schemas/Thing' };
+
+function report(values: unknown[], schemaFilter?: string) {
+  const coverage = createCoverage();
+  for (const value of values) walkRoot(SPEC, coverage, THING, value);
+
+  return summarize(SPEC, coverage, { total: values.length, withBody: values.length }, schemaFilter);
+}
+
+function schemaNamed(values: unknown[], name: string) {
+  const found = report(values).schemas.find((schema) => schema.name === name);
+  if (!found) throw new Error(`no report for ${name}`);
+
+  return found;
+}
+
+describe('coverage', () => {
+  it('credits a property the value carried', () => {
+    expect(schemaNamed([{ always: 'x' }], 'Thing').unusedProperties).toEqual([
+      'choice',
+      'nested',
+      'never',
+    ]);
+  });
+
+  it('reports every property when nothing reached the schema', () => {
+    expect(schemaNamed([], 'Thing').unusedProperties).toEqual([
+      'always',
+      'choice',
+      'nested',
+      'never',
+    ]);
+  });
+
+  it('attributes properties reached through a $ref to the target schema', () => {
+    expect(schemaNamed([{ nested: { inner: 'x' } }], 'Nested').unusedProperties).toEqual([
+      'unreached',
+    ]);
+  });
+
+  it('counts a property present but null as observed', () => {
+    expect(schemaNamed([{ always: null }], 'Thing').unusedProperties).not.toContain('always');
+  });
+
+  it('reports the union branch a value never matched', () => {
+    expect(schemaNamed([{ choice: 'text' }], 'Thing').unusedVariants).toEqual([
+      { path: 'choice', keyword: 'oneOf', branches: [1] },
+    ]);
+  });
+
+  it('reports the other branch when the value takes the object form', () => {
+    expect(schemaNamed([{ choice: { inner: 'x' } }], 'Thing').unusedVariants).toEqual([
+      { path: 'choice', keyword: 'oneOf', branches: [0] },
+    ]);
+  });
+
+  it('reports no unused branch once both have been seen', () => {
+    const values = [{ choice: 'text' }, { choice: { inner: 'x' } }];
+
+    expect(schemaNamed(values, 'Thing').unusedVariants).toEqual([]);
+  });
+
+  it('descends only into the branch that matched', () => {
+    expect(schemaNamed([{ choice: 'text' }], 'Nested').unusedProperties).toEqual([
+      'inner',
+      'unreached',
+    ]);
+  });
+
+  it('lists a schema nothing reached', () => {
+    expect(report([{ always: 'x' }]).unusedSchemas).toEqual(['Nested']);
+  });
+
+  it('omits a schema once a value reached it', () => {
+    expect(report([{ nested: { inner: 'x' } }]).unusedSchemas).toEqual([]);
+  });
+
+  it('narrows to one schema when a filter is given', () => {
+    expect(report([], 'Nested').schemas.map(({ name }) => name)).toEqual(['Nested']);
+  });
+
+  it('counts observed against declared properties across schemas', () => {
+    const result = report([{ always: 'x', nested: { inner: 'y' } }]);
+
+    expect(result.totalProperties).toBe(6);
+    expect(result.seenProperties).toBe(3);
+  });
+});
+
+describe('coverage of a schema composed with allOf', () => {
+  const INHERITING: Schema = {
+    components: {
+      schemas: {
+        Base: { type: 'object', properties: { id: { type: 'string' } } },
+        Child: {
+          allOf: [
+            { $ref: '#/components/schemas/Base' },
+            { type: 'object', properties: { extra: { type: 'string' } } },
+          ],
+        },
+      },
+    },
+  };
+
+  function inherited(value: unknown) {
+    const coverage = createCoverage();
+    walkRoot(INHERITING, coverage, { $ref: '#/components/schemas/Child' }, value);
+
+    return summarize(INHERITING, coverage, { total: 1, withBody: 1 });
+  }
+
+  it('credits an inherited property to the schema that declares it', () => {
+    const result = inherited({ id: 'a', extra: 'b' });
+
+    expect(result.schemas).toEqual([
+      { name: 'Base', seen: 1, count: 1, unusedProperties: [], unusedVariants: [] },
+      { name: 'Child', seen: 1, count: 1, unusedProperties: [], unusedVariants: [] },
+    ]);
+  });
+
+  it('does not report an inherited property as unused on the inheriting schema', () => {
+    expect(inherited({ id: 'a' }).schemas.find(({ name }) => name === 'Child')).toEqual({
+      name: 'Child',
+      seen: 0,
+      count: 1,
+      unusedProperties: ['extra'],
+      unusedVariants: [],
+    });
+  });
+
+  it('does not list a schema the traffic reached as one nothing reached', () => {
+    expect(inherited({ id: 'a', extra: 'b' }).unusedSchemas).toEqual([]);
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -223,6 +223,100 @@ describe('a union with a discriminator', () => {
   });
 });
 
+describe('a union of const literals', () => {
+  const LITERALS: Schema = {
+    components: {
+      schemas: {
+        Status: { oneOf: [{ const: 'active' }, { const: 'archived' }, { const: 'draft' }] },
+        Holder: { type: 'object', properties: { status: { $ref: '#/components/schemas/Status' } } },
+      },
+    },
+  };
+
+  it('credits only the literal the value carried', () => {
+    const coverage = createCoverage();
+    walkRoot(LITERALS, coverage, { $ref: '#/components/schemas/Holder' }, { status: 'archived' });
+
+    expect(
+      summarize(LITERALS, coverage, { total: 1, withBody: 1 }).schemas.find(
+        ({ name }) => name === 'Status'
+      )?.unusedVariants
+    ).toEqual([{ path: '', keyword: 'oneOf', branches: [0, 2] }]);
+  });
+});
+
+describe('a union of same-typed branches split by format', () => {
+  const FORMATS: Schema = {
+    components: {
+      schemas: {
+        Id: {
+          oneOf: [
+            { type: 'string', format: 'uuid' },
+            { type: 'string', format: 'date' },
+          ],
+        },
+        Holder: { type: 'object', properties: { id: { $ref: '#/components/schemas/Id' } } },
+      },
+    },
+  };
+
+  it('credits the branch whose format the value satisfies', () => {
+    const coverage = createCoverage();
+    walkRoot(
+      FORMATS,
+      coverage,
+      { $ref: '#/components/schemas/Holder' },
+      { id: '6fa459ea-ee8a-3ca4-894e-db77e160355e' }
+    );
+
+    expect(
+      summarize(FORMATS, coverage, { total: 1, withBody: 1 }).schemas.find(
+        ({ name }) => name === 'Id'
+      )?.unusedVariants
+    ).toEqual([{ path: '', keyword: 'oneOf', branches: [1] }]);
+  });
+});
+
+describe('unions nested inside sibling branches', () => {
+  const WRAPPER: Schema = {
+    components: {
+      schemas: {
+        Wrapper: {
+          oneOf: [
+            {
+              type: 'object',
+              required: ['a'],
+              properties: { x: { oneOf: [{ type: 'string' }, { type: 'integer' }] } },
+            },
+            {
+              type: 'object',
+              required: ['b'],
+              properties: {
+                x: { oneOf: [{ type: 'boolean' }, { type: 'null' }, { type: 'array' }] },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  it('keeps each branch its own union site', () => {
+    const coverage = createCoverage();
+    walkRoot(WRAPPER, coverage, { $ref: '#/components/schemas/Wrapper' }, { a: 1, x: 'text' });
+
+    expect(
+      summarize(WRAPPER, coverage, { total: 1, withBody: 1 }).schemas.find(
+        ({ name }) => name === 'Wrapper'
+      )?.unusedVariants
+    ).toEqual([
+      { path: '', keyword: 'oneOf', branches: [1] },
+      { path: 'oneOf[0].x', keyword: 'oneOf', branches: [1] },
+      { path: 'oneOf[1].x', keyword: 'oneOf', branches: [0, 1, 2] },
+    ]);
+  });
+});
+
 describe('additionalProperties', () => {
   const MAP: Schema = {
     components: {

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -223,6 +223,39 @@ describe('a union with a discriminator', () => {
   });
 });
 
+describe('component schemas with nothing inside them', () => {
+  const LEAVES: Schema = {
+    components: {
+      schemas: {
+        Status: { type: 'string', enum: ['live', 'draft'] },
+        Count: { type: 'integer' },
+        Tags: { type: 'array', items: { $ref: '#/components/schemas/Status' } },
+        Thing: { type: 'object', properties: { id: { type: 'string' } } },
+      },
+    },
+  };
+
+  it('lists an unreached enum, primitive, or array of refs as nothing reached', () => {
+    const coverage = createCoverage();
+    walkRoot(LEAVES, coverage, { $ref: '#/components/schemas/Thing' }, { id: 'x' });
+
+    expect(summarize(LEAVES, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual([
+      'Count',
+      'Status',
+      'Tags',
+    ]);
+  });
+
+  it('does not clutter the schema list with them', () => {
+    const coverage = createCoverage();
+    walkRoot(LEAVES, coverage, { $ref: '#/components/schemas/Thing' }, { id: 'x' });
+
+    expect(
+      summarize(LEAVES, coverage, { total: 1, withBody: 1 }).schemas.map(({ name }) => name)
+    ).toEqual(['Thing']);
+  });
+});
+
 describe('a union of const literals', () => {
   const LITERALS: Schema = {
     components: {

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -201,6 +201,26 @@ describe('a union with a discriminator', () => {
 
     expect(summarize(PETS, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual(['Dog']);
   });
+
+  it('accepts a mapping written as a bare component name', () => {
+    const mapped: Schema = {
+      components: {
+        schemas: {
+          Pet: {
+            oneOf: [{ $ref: '#/components/schemas/Cat' }, { $ref: '#/components/schemas/Dog' }],
+            discriminator: { propertyName: 'petType', mapping: { kitten: 'Cat' } },
+          },
+          Cat: { type: 'object', properties: { petType: { type: 'string' } } },
+          Dog: { type: 'object', properties: { petType: { type: 'string' } } },
+        },
+      },
+    };
+
+    const coverage = createCoverage();
+    walkRoot(mapped, coverage, { $ref: '#/components/schemas/Pet' }, { petType: 'kitten' });
+
+    expect(summarize(mapped, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual(['Dog']);
+  });
 });
 
 describe('additionalProperties', () => {
@@ -244,6 +264,34 @@ describe('additionalProperties', () => {
     expect(summarize(inheritedMap, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual([
       'Extra',
     ]);
+  });
+});
+
+describe('an inline additionalProperties schema', () => {
+  const COLLIDING: Schema = {
+    components: {
+      schemas: {
+        Bag: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+    },
+  };
+
+  it('does not credit a parent property the payload never carried', () => {
+    const coverage = createCoverage();
+    walkRoot(COLLIDING, coverage, { $ref: '#/components/schemas/Bag' }, { extra: { name: 'y' } });
+
+    expect(
+      summarize(COLLIDING, coverage, { total: 1, withBody: 1 }).schemas.find(
+        ({ name }) => name === 'Bag'
+      )
+    ).toMatchObject({ seen: 0, unusedProperties: ['name'] });
   });
 });
 

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -310,6 +310,38 @@ describe('a union of same-typed branches split by format', () => {
   });
 });
 
+describe('a union branch split by a format inside allOf', () => {
+  const WRAPPED: Schema = {
+    components: {
+      schemas: {
+        Id: {
+          oneOf: [
+            { allOf: [{ type: 'string' }, { format: 'uuid' }] },
+            { allOf: [{ type: 'string' }, { format: 'date' }] },
+          ],
+        },
+        Holder: { type: 'object', properties: { id: { $ref: '#/components/schemas/Id' } } },
+      },
+    },
+  };
+
+  it('ranks by the format the allOf declares', () => {
+    const coverage = createCoverage();
+    walkRoot(
+      WRAPPED,
+      coverage,
+      { $ref: '#/components/schemas/Holder' },
+      { id: '6fa459ea-ee8a-3ca4-894e-db77e160355e' }
+    );
+
+    expect(
+      summarize(WRAPPED, coverage, { total: 1, withBody: 1 }).schemas.find(
+        ({ name }) => name === 'Id'
+      )?.unusedVariants
+    ).toEqual([{ path: '', keyword: 'oneOf', branches: [1] }]);
+  });
+});
+
 describe('unions nested inside sibling branches', () => {
   const WRAPPER: Schema = {
     components: {

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -181,6 +181,45 @@ describe('a union whose branches share a property', () => {
   });
 });
 
+describe('a oneOf whose branches a value fits equally', () => {
+  function spec(keyword: string): Schema {
+    return {
+      components: {
+        schemas: {
+          Media: {
+            [keyword]: [
+              { $ref: '#/components/schemas/Photo' },
+              { $ref: '#/components/schemas/Video' },
+            ],
+          },
+          Photo: { type: 'object', properties: { kind: { type: 'string' } } },
+          Video: { type: 'object', properties: { kind: { type: 'string' } } },
+        },
+      },
+    };
+  }
+
+  function reportFor(keyword: string) {
+    const description = spec(keyword);
+    const coverage = createCoverage();
+    walkRoot(description, coverage, { $ref: '#/components/schemas/Media' }, { kind: 'x' });
+
+    return summarize(description, coverage, { total: 1, withBody: 1 });
+  }
+
+  it('credits one branch only, because oneOf means exactly one', () => {
+    expect(reportFor('oneOf').schemas.find(({ name }) => name === 'Media')?.unusedVariants).toEqual([
+      { path: '', keyword: 'oneOf', branches: [1] },
+    ]);
+  });
+
+  it('credits every fitting branch of an anyOf, which permits more than one', () => {
+    expect(reportFor('anyOf').schemas.find(({ name }) => name === 'Media')?.unusedVariants).toEqual(
+      []
+    );
+  });
+});
+
 describe('a union with a discriminator', () => {
   const PETS: Schema = {
     components: {

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -144,6 +144,65 @@ describe('coverage of a schema that only holds a union', () => {
   });
 });
 
+describe('a union whose branches share a property', () => {
+  const MEDIA: Schema = {
+    components: {
+      schemas: {
+        Media: {
+          oneOf: [{ $ref: '#/components/schemas/Photo' }, { $ref: '#/components/schemas/Video' }],
+        },
+        Photo: {
+          type: 'object',
+          properties: { kind: { type: 'string' }, width: { type: 'integer' } },
+        },
+        Video: {
+          type: 'object',
+          properties: { kind: { type: 'string' }, duration: { type: 'integer' } },
+        },
+      },
+    },
+  };
+
+  function photo() {
+    const coverage = createCoverage();
+    walkRoot(MEDIA, coverage, { $ref: '#/components/schemas/Media' }, { kind: 'photo', width: 10 });
+
+    return summarize(MEDIA, coverage, { total: 1, withBody: 1 });
+  }
+
+  it('credits only the branch the value actually fits', () => {
+    expect(photo().schemas.find(({ name }) => name === 'Media')?.unusedVariants).toEqual([
+      { path: '', keyword: 'oneOf', branches: [1] },
+    ]);
+  });
+
+  it('does not mark the sibling branch as reached', () => {
+    expect(photo().unusedSchemas).toEqual(['Video']);
+  });
+});
+
+describe('a union with a discriminator', () => {
+  const PETS: Schema = {
+    components: {
+      schemas: {
+        Pet: {
+          oneOf: [{ $ref: '#/components/schemas/Cat' }, { $ref: '#/components/schemas/Dog' }],
+          discriminator: { propertyName: 'petType' },
+        },
+        Cat: { type: 'object', properties: { petType: { type: 'string' } } },
+        Dog: { type: 'object', properties: { petType: { type: 'string' } } },
+      },
+    },
+  };
+
+  it('picks the branch the discriminator names, not both', () => {
+    const coverage = createCoverage();
+    walkRoot(PETS, coverage, { $ref: '#/components/schemas/Pet' }, { petType: 'Cat' });
+
+    expect(summarize(PETS, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual(['Dog']);
+  });
+});
+
 describe('additionalProperties', () => {
   const MAP: Schema = {
     components: {

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -223,6 +223,57 @@ describe('additionalProperties', () => {
 
     expect(summarize(MAP, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual(['Extra']);
   });
+
+  it('does not walk a property inherited through allOf against it either', () => {
+    const inheritedMap: Schema = {
+      components: {
+        schemas: {
+          Base: { type: 'object', properties: { name: { type: 'string' } } },
+          Bag: {
+            allOf: [{ $ref: '#/components/schemas/Base' }],
+            additionalProperties: { $ref: '#/components/schemas/Extra' },
+          },
+          Extra: { type: 'object', properties: { note: { type: 'string' } } },
+        },
+      },
+    };
+
+    const coverage = createCoverage();
+    walkRoot(inheritedMap, coverage, { $ref: '#/components/schemas/Bag' }, { name: 'x' });
+
+    expect(summarize(inheritedMap, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual([
+      'Extra',
+    ]);
+  });
+});
+
+describe('a nested inline object', () => {
+  const NESTED: Schema = {
+    components: {
+      schemas: {
+        Person: {
+          type: 'object',
+          properties: {
+            address: {
+              type: 'object',
+              properties: { city: { type: 'string' }, postcode: { type: 'string' } },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it('reports the nested field the traffic never carried', () => {
+    const coverage = createCoverage();
+    walkRoot(NESTED, coverage, { $ref: '#/components/schemas/Person' }, { address: { city: 'x' } });
+
+    expect(
+      summarize(NESTED, coverage, { total: 1, withBody: 1 }).schemas.find(
+        ({ name }) => name === 'Person'
+      )
+    ).toMatchObject({ seen: 2, count: 3, unusedProperties: ['address.postcode'] });
+  });
 });
 
 describe('coverage of a schema composed with allOf', () => {

--- a/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/analyse.test.ts
@@ -112,6 +112,60 @@ describe('coverage', () => {
   });
 });
 
+describe('coverage of a schema that only holds a union', () => {
+  const UNIONS: Schema = {
+    components: {
+      schemas: {
+        Shape: {
+          oneOf: [{ $ref: '#/components/schemas/Circle' }, { $ref: '#/components/schemas/Square' }],
+        },
+        Circle: { type: 'object', required: ['radius'], properties: { radius: { type: 'number' } } },
+        Square: { type: 'object', required: ['side'], properties: { side: { type: 'number' } } },
+        Holder: { type: 'object', properties: { shape: { $ref: '#/components/schemas/Shape' } } },
+      },
+    },
+  };
+
+  function circle() {
+    const coverage = createCoverage();
+    walkRoot(UNIONS, coverage, { $ref: '#/components/schemas/Holder' }, { shape: { radius: 1 } });
+
+    return summarize(UNIONS, coverage, { total: 1, withBody: 1 });
+  }
+
+  it('does not call a union schema unreached when a value went through it', () => {
+    expect(circle().unusedSchemas).toEqual(['Square']);
+  });
+
+  it('reports the branch that never matched', () => {
+    expect(circle().schemas.find(({ name }) => name === 'Shape')?.unusedVariants).toEqual([
+      { path: '', keyword: 'oneOf', branches: [1] },
+    ]);
+  });
+});
+
+describe('additionalProperties', () => {
+  const MAP: Schema = {
+    components: {
+      schemas: {
+        Bag: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: { $ref: '#/components/schemas/Extra' },
+        },
+        Extra: { type: 'object', properties: { note: { type: 'string' } } },
+      },
+    },
+  };
+
+  it('does not walk a declared property against the additionalProperties schema', () => {
+    const coverage = createCoverage();
+    walkRoot(MAP, coverage, { $ref: '#/components/schemas/Bag' }, { name: 'x' });
+
+    expect(summarize(MAP, coverage, { total: 1, withBody: 1 }).unusedSchemas).toEqual(['Extra']);
+  });
+});
+
 describe('coverage of a schema composed with allOf', () => {
   const INHERITING: Schema = {
     components: {
@@ -138,14 +192,15 @@ describe('coverage of a schema composed with allOf', () => {
     const result = inherited({ id: 'a', extra: 'b' });
 
     expect(result.schemas).toEqual([
-      { name: 'Base', seen: 1, count: 1, unusedProperties: [], unusedVariants: [] },
-      { name: 'Child', seen: 1, count: 1, unusedProperties: [], unusedVariants: [] },
+      { name: 'Base', reached: true, seen: 1, count: 1, unusedProperties: [], unusedVariants: [] },
+      { name: 'Child', reached: true, seen: 1, count: 1, unusedProperties: [], unusedVariants: [] },
     ]);
   });
 
   it('does not report an inherited property as unused on the inheriting schema', () => {
     expect(inherited({ id: 'a' }).schemas.find(({ name }) => name === 'Child')).toEqual({
       name: 'Child',
+      reached: true,
       seen: 0,
       count: 1,
       unusedProperties: ['extra'],

--- a/packages/cli/src/__tests__/commands/coverage/operations.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/operations.test.ts
@@ -44,3 +44,23 @@ describe('operation coverage', () => {
     expect(report([]).operations.total).toBe(3);
   });
 });
+
+describe('a path item behind a $ref', () => {
+  const REFERENCED: Schema = {
+    paths: {
+      '/thing': { $ref: '#/components/pathItems/Thing' },
+    },
+    components: {
+      pathItems: {
+        Thing: { get: { operationId: 'getThing', responses: {} } },
+      },
+      schemas: {},
+    },
+  };
+
+  it('counts the operations the referenced path item declares', () => {
+    const result = summarize(REFERENCED, createCoverage(), { total: 0, withBody: 0 }, undefined, new Set(['get /thing']));
+
+    expect(result.operations).toMatchObject({ seen: 1, total: 1, unused: [] });
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/operations.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/operations.test.ts
@@ -1,0 +1,46 @@
+import { summarize } from '../../../commands/coverage/engine/analyse.js';
+import type { Schema } from '../../../commands/coverage/engine/schema.js';
+import { createCoverage } from '../../../commands/coverage/engine/walk.js';
+
+const SPEC: Schema = {
+  paths: {
+    '/thing': {
+      parameters: [{ name: 'x', in: 'query' }],
+      get: { operationId: 'getThing', tags: ['things'], responses: {} },
+      put: { operationId: 'putThing', tags: ['things'], responses: {} },
+    },
+    '/other': {
+      get: { operationId: 'getOther', responses: {} },
+    },
+  },
+  components: { schemas: {} },
+};
+
+function report(exercised: string[]) {
+  return summarize(SPEC, createCoverage(), { total: 0, withBody: 0 }, undefined, new Set(exercised));
+}
+
+describe('operation coverage', () => {
+  it('counts operations the traffic reached', () => {
+    expect(report(['get /thing']).operations).toMatchObject({ seen: 1, total: 3 });
+  });
+
+  it('lists the operations nothing reached', () => {
+    expect(report(['get /thing']).operations.unused).toEqual([
+      'GET /other  getOther',
+      'PUT /thing  putThing',
+    ]);
+  });
+
+  it('reports every operation as unused when there is no traffic', () => {
+    expect(report([]).operations).toMatchObject({ seen: 0, total: 3 });
+  });
+
+  it('reports none unused once every operation is reached', () => {
+    expect(report(['get /thing', 'put /thing', 'get /other']).operations.unused).toEqual([]);
+  });
+
+  it('ignores a path-level parameters entry, which is not an operation', () => {
+    expect(report([]).operations.total).toBe(3);
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/parameters.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/parameters.test.ts
@@ -1,0 +1,122 @@
+import {
+  collectParameters,
+  createParameterUse,
+  recordParameters,
+  summarizeParameters,
+} from '../../../commands/coverage/engine/parameters.js';
+import type { Schema } from '../../../commands/coverage/engine/schema.js';
+
+const SPEC: Schema = {
+  paths: {
+    '/stores/{storeId}': {
+      parameters: [{ name: 'storeId', in: 'path', required: true, schema: { type: 'string' } }],
+      get: {
+        operationId: 'getStore',
+        parameters: [
+          { name: 'sellerId', in: 'query', required: true, schema: { type: 'string' } },
+          {
+            name: 'status',
+            in: 'query',
+            schema: { type: 'string', enum: ['live', 'draft', 'archived'] },
+          },
+          { name: 'x-region', in: 'header', schema: { type: 'string' } },
+        ],
+      },
+    },
+  },
+};
+
+function use(query: Record<string, string>, pathParams: Record<string, string> = {}) {
+  const parameterUse = createParameterUse();
+
+  recordParameters(parameterUse, 'get /stores/{storeId}', {
+    query: new URLSearchParams(query),
+    pathParams,
+    headers: {},
+  });
+
+  return parameterUse;
+}
+
+describe('collectParameters', () => {
+  it('merges the path item parameters with the operation ones', () => {
+    const declared = collectParameters(SPEC).get('get /stores/{storeId}');
+
+    expect(declared?.map(({ name }) => name).sort()).toEqual([
+      'sellerId',
+      'status',
+      'storeId',
+      'x-region',
+    ]);
+  });
+
+  it('carries the values an enum pins a parameter to', () => {
+    const declared = collectParameters(SPEC).get('get /stores/{storeId}');
+
+    expect(declared?.find(({ name }) => name === 'status')?.values).toEqual([
+      'live',
+      'draft',
+      'archived',
+    ]);
+  });
+});
+
+describe('summarizeParameters', () => {
+  const declared = collectParameters(SPEC);
+
+  it('reports a documented parameter nothing ever sent', () => {
+    const result = summarizeParameters(declared, use({ status: 'live' }, { storeId: 'st_1' }));
+
+    expect(result.unused).toEqual([
+      'GET /stores/{storeId}  header.x-region',
+      'GET /stores/{storeId}  query.sellerId',
+    ]);
+  });
+
+  it('counts the parameters the traffic did send', () => {
+    const result = summarizeParameters(declared, use({ status: 'live' }, { storeId: 'st_1' }));
+
+    expect(result).toMatchObject({ seen: 2, total: 4 });
+  });
+
+  it('reports the enum values nothing ever used', () => {
+    const result = summarizeParameters(declared, use({ status: 'live' }, { storeId: 'st_1' }));
+
+    expect(result.unusedValues).toEqual([
+      'GET /stores/{storeId}  query.status=archived',
+      'GET /stores/{storeId}  query.status=draft',
+    ]);
+  });
+
+  it('reports nothing unused once every parameter and value appeared', () => {
+    const parameterUse = createParameterUse();
+    for (const status of ['live', 'draft', 'archived']) {
+      recordParameters(parameterUse, 'get /stores/{storeId}', {
+        query: new URLSearchParams({ status, sellerId: 'sel_1' }),
+        pathParams: { storeId: 'st_1' },
+        headers: { 'x-region': 'us' },
+      });
+    }
+
+    const result = summarizeParameters(declared, parameterUse);
+
+    expect(result).toMatchObject({ seen: 4, total: 4, unused: [], unusedValues: [] });
+  });
+
+  it('reads a cookie parameter out of the cookie header', () => {
+    const spec: Schema = {
+      paths: {
+        '/x': { get: { parameters: [{ name: 'session', in: 'cookie' }] } },
+      },
+    };
+    const parameterUse = createParameterUse();
+
+    recordParameters(parameterUse, 'get /x', {
+      query: new URLSearchParams(),
+      pathParams: {},
+      headers: { cookie: 'session=abc; other=1' },
+    });
+
+    expect(summarizeParameters(collectParameters(spec), parameterUse).unused).toEqual([]);
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
@@ -5,6 +5,7 @@ const REPORT: CoverageReport = {
   exchanges: { total: 3, withBody: 2 },
   operations: { seen: 1, total: 2, unused: ['GET /health  getHealth'] },
   seenProperties: 3,
+  seenPropertiesAccepted: 3,
   totalProperties: 6,
   schemas: [
     {
@@ -37,6 +38,21 @@ describe('renderCoverage', () => {
     ]);
   });
 
+  it('names the accepted-only figure when some coverage came from rejected traffic', () => {
+    const output = renderCoverage(
+      { ...REPORT, seenProperties: 3, seenPropertiesAccepted: 1 },
+      { format: 'stylish', all: false }
+    );
+
+    expect(output).toContain('1 of those came from a response the API accepted');
+  });
+
+  it('stays quiet about the split when every exchange was accepted', () => {
+    expect(renderCoverage(REPORT, { format: 'stylish', all: false })).not.toContain(
+      'came from a response the API accepted'
+    );
+  });
+
   it('ends with a trailing newline, as the other commands render', () => {
     expect(renderCoverage(REPORT, { format: 'stylish', all: false })).toMatch(/\n$/);
   });
@@ -66,6 +82,7 @@ describe('renderCoverage', () => {
       exchanges: { total: 1, withBody: 1 },
       operations: { seen: 1, total: 1, unused: [] },
       seenProperties: 0,
+      seenPropertiesAccepted: 0,
       totalProperties: 0,
       schemas: [
         {
@@ -96,6 +113,7 @@ describe('renderCoverage', () => {
       exchanges: { total: 0, withBody: 0 },
       operations: { seen: 0, total: 0, unused: [] },
       seenProperties: 0,
+      seenPropertiesAccepted: 0,
       totalProperties: 0,
       schemas: [],
       unusedSchemas: [],

--- a/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
@@ -4,6 +4,7 @@ import { renderCoverage } from '../../../commands/coverage/reporter.js';
 const REPORT: CoverageReport = {
   exchanges: { total: 3, withBody: 2 },
   operations: { seen: 1, total: 2, unused: ['GET /health  getHealth'] },
+  parameters: { seen: 0, total: 0, unused: [], unusedValues: [] },
   seenProperties: 3,
   seenPropertiesAccepted: 3,
   totalProperties: 6,
@@ -29,11 +30,12 @@ const REPORT: CoverageReport = {
 };
 
 describe('renderCoverage', () => {
-  it('leads with both headline figures', () => {
+  it('leads with the headline figures', () => {
     const output = renderCoverage(REPORT, { format: 'stylish', all: false });
 
-    expect(output.split('\n').slice(0, 2)).toEqual([
+    expect(output.split('\n').slice(0, 3)).toEqual([
       '1/2 operations exercised (50%)',
+      '0/0 documented parameters sent (0%)',
       '3/6 documented properties observed (50%) over 2 of 3 exchange(s)',
     ]);
   });
@@ -44,12 +46,12 @@ describe('renderCoverage', () => {
       { format: 'stylish', all: false }
     );
 
-    expect(output).toContain('1 of those came from a response the API accepted');
+    expect(output).toContain('1/6 observed on an exchange the API accepted');
   });
 
   it('stays quiet about the split when every exchange was accepted', () => {
     expect(renderCoverage(REPORT, { format: 'stylish', all: false })).not.toContain(
-      'came from a response the API accepted'
+      'observed on an exchange the API accepted'
     );
   });
 
@@ -81,6 +83,7 @@ describe('renderCoverage', () => {
     const unions: CoverageReport = {
       exchanges: { total: 1, withBody: 1 },
       operations: { seen: 1, total: 1, unused: [] },
+      parameters: { seen: 0, total: 0, unused: [], unusedValues: [] },
       seenProperties: 0,
       seenPropertiesAccepted: 0,
       totalProperties: 0,
@@ -112,6 +115,7 @@ describe('renderCoverage', () => {
     const empty: CoverageReport = {
       exchanges: { total: 0, withBody: 0 },
       operations: { seen: 0, total: 0, unused: [] },
+      parameters: { seen: 0, total: 0, unused: [], unusedValues: [] },
       seenProperties: 0,
       seenPropertiesAccepted: 0,
       totalProperties: 0,

--- a/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
@@ -9,12 +9,20 @@ const REPORT: CoverageReport = {
   schemas: [
     {
       name: 'User',
+      reached: true,
       seen: 3,
       count: 4,
       unusedProperties: ['neverSent'],
       unusedVariants: [{ path: 'badge', keyword: 'oneOf', branches: [1] }],
     },
-    { name: 'Badge', seen: 0, count: 1, unusedProperties: ['name'], unusedVariants: [] },
+    {
+      name: 'Badge',
+      reached: false,
+      seen: 0,
+      count: 1,
+      unusedProperties: ['name'],
+      unusedVariants: [],
+    },
   ],
   unusedSchemas: ['Badge'],
 };
@@ -51,6 +59,30 @@ describe('renderCoverage', () => {
     const output = renderCoverage(REPORT, { format: 'stylish', all: true });
 
     expect(output).toContain('badge  oneOf branch 1 never matched');
+  });
+
+  it('shows a reached schema whose only finding is an unmatched branch', () => {
+    const unions: CoverageReport = {
+      exchanges: { total: 1, withBody: 1 },
+      operations: { seen: 1, total: 1, unused: [] },
+      seenProperties: 0,
+      totalProperties: 0,
+      schemas: [
+        {
+          name: 'Shape',
+          reached: true,
+          seen: 0,
+          count: 0,
+          unusedProperties: [],
+          unusedVariants: [{ path: '', keyword: 'oneOf', branches: [1] }],
+        },
+      ],
+      unusedSchemas: [],
+    };
+
+    expect(renderCoverage(unions, { format: 'stylish', all: false })).toContain(
+      '(root)  oneOf branch 1 never matched'
+    );
   });
 
   it('renders valid JSON carrying the same figures', () => {

--- a/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
@@ -1,0 +1,76 @@
+import type { CoverageReport } from '../../../commands/coverage/engine/analyse.js';
+import { renderCoverage } from '../../../commands/coverage/reporter.js';
+
+const REPORT: CoverageReport = {
+  exchanges: { total: 3, withBody: 2 },
+  operations: { seen: 1, total: 2, unused: ['GET /health  getHealth'] },
+  seenProperties: 3,
+  totalProperties: 6,
+  schemas: [
+    {
+      name: 'User',
+      seen: 3,
+      count: 4,
+      unusedProperties: ['neverSent'],
+      unusedVariants: [{ path: 'badge', keyword: 'oneOf', branches: [1] }],
+    },
+    { name: 'Badge', seen: 0, count: 1, unusedProperties: ['name'], unusedVariants: [] },
+  ],
+  unusedSchemas: ['Badge'],
+};
+
+describe('renderCoverage', () => {
+  it('leads with both headline figures', () => {
+    const output = renderCoverage(REPORT, { format: 'stylish', all: false });
+
+    expect(output.split('\n').slice(0, 2)).toEqual([
+      '1/2 operations exercised (50%)',
+      '3/6 documented properties observed (50%) over 2 of 3 exchange(s)',
+    ]);
+  });
+
+  it('ends with a trailing newline, as the other commands render', () => {
+    expect(renderCoverage(REPORT, { format: 'stylish', all: false })).toMatch(/\n$/);
+  });
+
+  it('collapses schemas nothing reached unless --all is passed', () => {
+    const output = renderCoverage(REPORT, { format: 'stylish', all: false });
+
+    expect(output).toContain('pass --all to list them');
+    expect(output).not.toContain('    Badge');
+  });
+
+  it('lists them when --all is passed', () => {
+    const output = renderCoverage(REPORT, { format: 'stylish', all: true });
+
+    expect(output).toContain('    Badge');
+    expect(output).toContain('    GET /health  getHealth');
+  });
+
+  it('marks a fully covered schema and names an unmatched branch', () => {
+    const output = renderCoverage(REPORT, { format: 'stylish', all: true });
+
+    expect(output).toContain('badge  oneOf branch 1 never matched');
+  });
+
+  it('renders valid JSON carrying the same figures', () => {
+    const parsed = JSON.parse(renderCoverage(REPORT, { format: 'json', all: false }));
+
+    expect(parsed).toMatchObject({ seenProperties: 3, operations: { seen: 1, total: 2 } });
+  });
+
+  it('reports zero rather than dividing by zero on an empty description', () => {
+    const empty: CoverageReport = {
+      exchanges: { total: 0, withBody: 0 },
+      operations: { seen: 0, total: 0, unused: [] },
+      seenProperties: 0,
+      totalProperties: 0,
+      schemas: [],
+      unusedSchemas: [],
+    };
+
+    expect(renderCoverage(empty, { format: 'stylish', all: false })).toContain(
+      '0/0 operations exercised (0%)'
+    );
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/reporter.test.ts
@@ -5,6 +5,7 @@ const REPORT: CoverageReport = {
   exchanges: { total: 3, withBody: 2 },
   operations: { seen: 1, total: 2, unused: ['GET /health  getHealth'] },
   parameters: { seen: 0, total: 0, unused: [], unusedValues: [] },
+  statuses: { seen: 0, total: 0, unused: [] },
   seenProperties: 3,
   seenPropertiesAccepted: 3,
   totalProperties: 6,
@@ -33,9 +34,10 @@ describe('renderCoverage', () => {
   it('leads with the headline figures', () => {
     const output = renderCoverage(REPORT, { format: 'stylish', all: false });
 
-    expect(output.split('\n').slice(0, 3)).toEqual([
+    expect(output.split('\n').slice(0, 4)).toEqual([
       '1/2 operations exercised (50%)',
       '0/0 documented parameters sent (0%)',
+      '0/0 documented responses returned (0%)',
       '3/6 documented properties observed (50%) over 2 of 3 exchange(s)',
     ]);
   });
@@ -84,6 +86,7 @@ describe('renderCoverage', () => {
       exchanges: { total: 1, withBody: 1 },
       operations: { seen: 1, total: 1, unused: [] },
       parameters: { seen: 0, total: 0, unused: [], unusedValues: [] },
+      statuses: { seen: 0, total: 0, unused: [] },
       seenProperties: 0,
       seenPropertiesAccepted: 0,
       totalProperties: 0,
@@ -116,6 +119,7 @@ describe('renderCoverage', () => {
       exchanges: { total: 0, withBody: 0 },
       operations: { seen: 0, total: 0, unused: [] },
       parameters: { seen: 0, total: 0, unused: [], unusedValues: [] },
+      statuses: { seen: 0, total: 0, unused: [] },
       seenProperties: 0,
       seenPropertiesAccepted: 0,
       totalProperties: 0,

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -80,6 +80,28 @@ describe('declared', () => {
     expect(declared(SPEC, SPEC.components.schemas.Either)).toEqual([]);
   });
 
+  it('names a property once when two allOf branches both declare it', () => {
+    const overlapping: Schema = {
+      allOf: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'object', properties: { a: { type: 'string' }, b: { type: 'string' } } },
+      ],
+    };
+
+    expect(declared(SPEC, overlapping).map(([name]) => name).sort()).toEqual(['a', 'b']);
+  });
+
+  it('reaches a property nested in an inline object, as the walk records it', () => {
+    const nested: Schema = {
+      type: 'object',
+      properties: {
+        address: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    };
+
+    expect(declared(SPEC, nested).map(([name]) => name).sort()).toEqual(['address', 'address.city']);
+  });
+
   it('stops at a $ref inside allOf, which the target reports under its own name', () => {
     const names = declared(SPEC, SPEC.components.schemas.Composed).map(([name]) => name);
 
@@ -129,6 +151,11 @@ describe('matches', () => {
     expect(matches(SPEC, nullableString, 'x')).toBe(true);
     expect(matches(SPEC, nullableString, null)).toBe(true);
     expect(matches(SPEC, nullableString, 42)).toBe(false);
+  });
+
+  it('accepts null for an OpenAPI 3.0 nullable branch', () => {
+    expect(matches(SPEC, { type: 'string', nullable: true }, null)).toBe(true);
+    expect(matches(SPEC, { type: 'string' }, null)).toBe(false);
   });
 
   it('rejects a branch whose $ref points nowhere', () => {

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -76,8 +76,10 @@ describe('declared', () => {
     expect(names.sort()).toEqual(['a', 'b']);
   });
 
-  it('does not merge properties across oneOf branches, which are alternatives', () => {
-    expect(declared(SPEC, SPEC.components.schemas.Either)).toEqual([]);
+  it('keeps oneOf branches apart rather than merging them, since they are alternatives', () => {
+    const names = declared(SPEC, SPEC.components.schemas.Either).map(([name]) => name);
+
+    expect(names.sort()).toEqual(['oneOf[0].a', 'oneOf[1].b']);
   });
 
   it('names a property once when two allOf branches both declare it', () => {

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -153,6 +153,12 @@ describe('matches', () => {
     expect(matches(SPEC, nullableString, 42)).toBe(false);
   });
 
+  it('honours an OpenAPI 3.1 const', () => {
+    expect(matches(SPEC, { const: 'a' }, 'a')).toBe(true);
+    expect(matches(SPEC, { const: 'a' }, 'b')).toBe(false);
+    expect(matches(SPEC, { const: 0 }, 0)).toBe(true);
+  });
+
   it('accepts a non-object value when the type array also allows one', () => {
     const either = { type: ['object', 'string'] };
 

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -1,0 +1,124 @@
+import {
+  declared,
+  matches,
+  resolve,
+  type Schema,
+} from '../../../commands/coverage/engine/schema.js';
+
+const SPEC: Schema = {
+  components: {
+    schemas: {
+      Named: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } },
+      Merged: {
+        allOf: [
+          { type: 'object', properties: { a: { type: 'string' } } },
+          { type: 'object', properties: { b: { type: 'string' } } },
+        ],
+      },
+      Either: {
+        oneOf: [
+          { type: 'object', properties: { a: { type: 'string' } } },
+          { type: 'object', properties: { b: { type: 'string' } } },
+        ],
+      },
+      Composed: {
+        allOf: [
+          { $ref: '#/components/schemas/Named' },
+          { type: 'object', properties: { extra: { type: 'string' } } },
+        ],
+      },
+    },
+  },
+};
+
+describe('resolve', () => {
+  it('returns the schema untouched when there is no $ref', () => {
+    const schema = { type: 'string' };
+
+    expect(resolve({}, schema)).toEqual({ schema });
+  });
+
+  it('follows a local $ref and reports the target name', () => {
+    expect(resolve(SPEC, { $ref: '#/components/schemas/Named' }).name).toBe('Named');
+  });
+
+  it('yields no schema for a $ref that points nowhere', () => {
+    expect(resolve(SPEC, { $ref: '#/components/schemas/Absent' }).schema).toBeUndefined();
+  });
+
+  it('decodes the ~1 and ~0 escapes in a pointer segment', () => {
+    const spec: Schema = { paths: { '/a~b': { get: { type: 'string' } } } };
+
+    expect(resolve(spec, { $ref: '#/paths/~1a~0b/get' }).schema).toEqual({ type: 'string' });
+  });
+});
+
+describe('declared', () => {
+  it('merges properties across allOf branches', () => {
+    const names = declared(SPEC, SPEC.components.schemas.Merged).map(([name]) => name);
+
+    expect(names.sort()).toEqual(['a', 'b']);
+  });
+
+  it('does not merge properties across oneOf branches, which are alternatives', () => {
+    expect(declared(SPEC, SPEC.components.schemas.Either)).toEqual([]);
+  });
+
+  it('stops at a $ref inside allOf, which the target reports under its own name', () => {
+    const names = declared(SPEC, SPEC.components.schemas.Composed).map(([name]) => name);
+
+    expect(names).toEqual(['extra']);
+  });
+});
+
+
+describe('matches', () => {
+  const ref = { $ref: '#/components/schemas/Named' };
+
+  it('accepts a value carrying the required properties', () => {
+    expect(matches(SPEC, ref, { id: 'x' })).toBe(true);
+  });
+
+  it('rejects an object missing a required property', () => {
+    expect(matches(SPEC, ref, { other: 'x' })).toBe(false);
+  });
+
+  it('rejects an array where an object is expected', () => {
+    expect(matches(SPEC, ref, [])).toBe(false);
+  });
+
+  it('rejects null where an object is expected', () => {
+    expect(matches(SPEC, ref, null)).toBe(false);
+  });
+
+  it('separates integer from fractional numbers', () => {
+    expect(matches(SPEC, { type: 'integer' }, 1)).toBe(true);
+    expect(matches(SPEC, { type: 'integer' }, 1.5)).toBe(false);
+    expect(matches(SPEC, { type: 'number' }, 1.5)).toBe(true);
+  });
+
+  it('distinguishes null from a string', () => {
+    expect(matches(SPEC, { type: 'null' }, null)).toBe(true);
+    expect(matches(SPEC, { type: 'string' }, null)).toBe(false);
+  });
+
+  it('honours enum membership', () => {
+    expect(matches(SPEC, { enum: ['a', 'b'] }, 'a')).toBe(true);
+    expect(matches(SPEC, { enum: ['a', 'b'] }, 'c')).toBe(false);
+  });
+
+  it('rejects a branch whose $ref points nowhere', () => {
+    expect(matches(SPEC, { $ref: '#/components/schemas/Absent' }, {})).toBe(false);
+  });
+
+  it('rejects a value an allOf-composed branch cannot be', () => {
+    const composed = { $ref: '#/components/schemas/Composed' };
+
+    expect(matches(SPEC, composed, 'not-an-object')).toBe(false);
+    expect(matches(SPEC, composed, { id: 'x' })).toBe(true);
+  });
+
+  it('applies a required property inherited through allOf', () => {
+    expect(matches(SPEC, { $ref: '#/components/schemas/Composed' }, { extra: 'x' })).toBe(false);
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -153,6 +153,14 @@ describe('matches', () => {
     expect(matches(SPEC, nullableString, 42)).toBe(false);
   });
 
+  it('accepts a non-object value when the type array also allows one', () => {
+    const either = { type: ['object', 'string'] };
+
+    expect(matches(SPEC, either, 'x')).toBe(true);
+    expect(matches(SPEC, either, {})).toBe(true);
+    expect(matches(SPEC, either, 42)).toBe(false);
+  });
+
   it('accepts null for an OpenAPI 3.0 nullable branch', () => {
     expect(matches(SPEC, { type: 'string', nullable: true }, null)).toBe(true);
     expect(matches(SPEC, { type: 'string' }, null)).toBe(false);

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -153,6 +153,28 @@ describe('matches', () => {
     expect(matches(SPEC, nullableString, 42)).toBe(false);
   });
 
+  it('accepts null for a nullable enum or const', () => {
+    expect(matches(SPEC, { enum: ['a', 'b'], nullable: true }, null)).toBe(true);
+    expect(matches(SPEC, { const: 'a', nullable: true }, null)).toBe(true);
+    expect(matches(SPEC, { enum: ['a', 'b'] }, null)).toBe(false);
+  });
+
+  it('applies an enum reached through allOf', () => {
+    const wrapped = {
+      allOf: [{ type: 'string' }, { enum: ['live', 'draft'] }],
+    };
+
+    expect(matches(SPEC, wrapped, 'live')).toBe(true);
+    expect(matches(SPEC, wrapped, 'other')).toBe(false);
+  });
+
+  it('applies a const reached through allOf', () => {
+    const wrapped = { allOf: [{ type: 'string' }, { const: 'only' }] };
+
+    expect(matches(SPEC, wrapped, 'only')).toBe(true);
+    expect(matches(SPEC, wrapped, 'other')).toBe(false);
+  });
+
   it('honours an OpenAPI 3.1 const', () => {
     expect(matches(SPEC, { const: 'a' }, 'a')).toBe(true);
     expect(matches(SPEC, { const: 'a' }, 'b')).toBe(false);

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -194,6 +194,28 @@ describe('matches', () => {
     expect(matches(SPEC, { type: 'string' }, null)).toBe(false);
   });
 
+  it('requires a value to satisfy one alternative of a nested union', () => {
+    const spec: Schema = {
+      components: {
+        schemas: {
+          Inner: { oneOf: [{ type: 'string' }, { type: 'boolean' }] },
+        },
+      },
+    };
+    const inner = { $ref: '#/components/schemas/Inner' };
+
+    expect(matches(spec, inner, 'text')).toBe(true);
+    expect(matches(spec, inner, true)).toBe(true);
+    expect(matches(spec, inner, 42)).toBe(false);
+  });
+
+  it('applies a union reached through allOf', () => {
+    const wrapped = { allOf: [{ anyOf: [{ type: 'string' }, { type: 'boolean' }] }] };
+
+    expect(matches(SPEC, wrapped, 'text')).toBe(true);
+    expect(matches(SPEC, wrapped, 42)).toBe(false);
+  });
+
   it('rejects a branch whose $ref points nowhere', () => {
     expect(matches(SPEC, { $ref: '#/components/schemas/Absent' }, {})).toBe(false);
   });

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -153,10 +153,15 @@ describe('matches', () => {
     expect(matches(SPEC, nullableString, 42)).toBe(false);
   });
 
-  it('accepts null for a nullable enum or const', () => {
-    expect(matches(SPEC, { enum: ['a', 'b'], nullable: true }, null)).toBe(true);
-    expect(matches(SPEC, { const: 'a', nullable: true }, null)).toBe(true);
-    expect(matches(SPEC, { enum: ['a', 'b'] }, null)).toBe(false);
+  it('still holds a nullable enum to the values it lists', () => {
+    // `nullable` relaxes the type, but the enum keeps listing what is allowed,
+    // so a description that means to permit null has to say so. `drift` reads
+    // it the same way, and the two have to agree on what a value satisfies.
+    const nullable = { type: 'string', enum: ['a', 'b'], nullable: true };
+
+    expect(matches(SPEC, nullable, null)).toBe(false);
+    expect(matches(SPEC, nullable, 'a')).toBe(true);
+    expect(matches(SPEC, { ...nullable, enum: ['a', 'b', null] }, null)).toBe(true);
   });
 
   it('applies an enum reached through allOf', () => {

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -123,6 +123,14 @@ describe('matches', () => {
     expect(matches(SPEC, { enum: ['a', 'b'] }, 'c')).toBe(false);
   });
 
+  it('honours an OpenAPI 3.1 type array', () => {
+    const nullableString = { type: ['string', 'null'] };
+
+    expect(matches(SPEC, nullableString, 'x')).toBe(true);
+    expect(matches(SPEC, nullableString, null)).toBe(true);
+    expect(matches(SPEC, nullableString, 42)).toBe(false);
+  });
+
   it('rejects a branch whose $ref points nowhere', () => {
     expect(matches(SPEC, { $ref: '#/components/schemas/Absent' }, {})).toBe(false);
   });

--- a/packages/cli/src/__tests__/commands/coverage/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/schema.test.ts
@@ -46,6 +46,22 @@ describe('resolve', () => {
     expect(resolve(SPEC, { $ref: '#/components/schemas/Absent' }).schema).toBeUndefined();
   });
 
+  it('follows a chain of aliases to the schema that actually declares something', () => {
+    const spec: Schema = {
+      components: {
+        schemas: {
+          Alias: { $ref: '#/components/schemas/Real' },
+          Real: { type: 'object', properties: { id: { type: 'string' } } },
+        },
+      },
+    };
+
+    expect(resolve(spec, { $ref: '#/components/schemas/Alias' })).toEqual({
+      schema: spec.components.schemas.Real,
+      name: 'Real',
+    });
+  });
+
   it('decodes the ~1 and ~0 escapes in a pointer segment', () => {
     const spec: Schema = { paths: { '/a~b': { get: { type: 'string' } } } };
 

--- a/packages/cli/src/__tests__/commands/coverage/sites.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/sites.test.ts
@@ -1,0 +1,68 @@
+import type { Schema } from '../../../commands/coverage/engine/schema.js';
+import { collectSites, siteKey } from '../../../commands/coverage/engine/sites.js';
+
+describe('siteKey', () => {
+  it('omits the separator at the root of a schema', () => {
+    expect(siteKey('Thing', '', 'oneOf')).toBe('Thing#oneOf');
+  });
+
+  it('joins the owner and the property path', () => {
+    expect(siteKey('Thing', 'a.b', 'anyOf')).toBe('Thing.a.b#anyOf');
+  });
+});
+
+describe('collectSites', () => {
+  it('finds a union nested under a property', () => {
+    const schema: Schema = {
+      type: 'object',
+      properties: { choice: { oneOf: [{ type: 'string' }, { type: 'integer' }] } },
+    };
+
+    expect([...collectSites(schema, 'Holder').values()]).toEqual([
+      { owner: 'Holder', path: 'choice', keyword: 'oneOf', count: 2 },
+    ]);
+  });
+
+  it('attributes a union inside array items to the array own path', () => {
+    const schema: Schema = {
+      type: 'object',
+      properties: {
+        list: { type: 'array', items: { anyOf: [{ type: 'string' }, { type: 'integer' }] } },
+      },
+    };
+
+    expect([...collectSites(schema, 'Holder').keys()]).toEqual(['Holder.list#anyOf']);
+  });
+
+  it('finds a union under additionalProperties', () => {
+    const schema: Schema = {
+      type: 'object',
+      additionalProperties: { oneOf: [{ type: 'string' }, { type: 'integer' }] },
+    };
+
+    expect([...collectSites(schema, 'Holder').keys()]).toEqual(['Holder#oneOf']);
+  });
+
+  it('descends through allOf without recording it as a variant', () => {
+    const schema: Schema = {
+      allOf: [{ type: 'object', properties: { a: { oneOf: [{ type: 'string' }, {}] } } }],
+    };
+
+    expect([...collectSites(schema, 'Holder').keys()]).toEqual(['Holder.a#oneOf']);
+  });
+
+  it('stops at a $ref, leaving that schema to be enumerated under its own name', () => {
+    const outer: Schema = {
+      type: 'object',
+      properties: { inner: { $ref: '#/components/schemas/Inner' } },
+    };
+
+    expect(collectSites(outer, 'Outer').size).toBe(0);
+  });
+
+  it('finds nothing in a schema with no union at all', () => {
+    expect(collectSites({ type: 'object', properties: { a: { type: 'string' } } }, 'Plain').size).toBe(
+      0
+    );
+  });
+});

--- a/packages/cli/src/__tests__/commands/coverage/statuses.test.ts
+++ b/packages/cli/src/__tests__/commands/coverage/statuses.test.ts
@@ -1,0 +1,77 @@
+import type { Schema } from '../../../commands/coverage/engine/schema.js';
+import {
+  collectStatuses,
+  createStatusUse,
+  matchStatusKey,
+  recordStatus,
+  summarizeStatuses,
+} from '../../../commands/coverage/engine/statuses.js';
+
+const SPEC: Schema = {
+  paths: {
+    '/things': {
+      get: {
+        operationId: 'listThings',
+        responses: { '200': {}, '404': {}, default: {} },
+      },
+    },
+  },
+};
+
+describe('matchStatusKey', () => {
+  it('prefers the exact status over the class and the default', () => {
+    expect(matchStatusKey(['200', '2XX', 'default'], 200)).toBe('200');
+  });
+
+  it('falls back to the class when the exact status is absent', () => {
+    expect(matchStatusKey(['2XX', 'default'], 201)).toBe('2XX');
+  });
+
+  it('accepts the lowercase class form, as drift does', () => {
+    expect(matchStatusKey(['2xx', 'default'], 201)).toBe('2xx');
+  });
+
+  it('falls back to default last', () => {
+    expect(matchStatusKey(['200', 'default'], 503)).toBe('default');
+  });
+
+  it('matches nothing when the description documents no fitting response', () => {
+    expect(matchStatusKey(['200'], 503)).toBeUndefined();
+  });
+});
+
+describe('collectStatuses', () => {
+  it('lists the responses each operation documents', () => {
+    expect(collectStatuses(SPEC).get('get /things')).toEqual(['200', '404', 'default']);
+  });
+});
+
+describe('summarizeStatuses', () => {
+  const declared = collectStatuses(SPEC);
+
+  it('reports the documented responses the traffic never produced', () => {
+    const use = createStatusUse();
+    recordStatus(use, 'get /things', 200, ['200', '404', 'default']);
+
+    const result = summarizeStatuses(declared, use);
+
+    expect(result.unused).toEqual(['GET /things  404', 'GET /things  default']);
+    expect(result).toMatchObject({ seen: 1, total: 3 });
+  });
+
+  it('counts a status reached through its class', () => {
+    const spec: Schema = { paths: { '/x': { get: { responses: { '2XX': {} } } } } };
+    const use = createStatusUse();
+    recordStatus(use, 'get /x', 201, ['2XX']);
+
+    expect(summarizeStatuses(collectStatuses(spec), use)).toMatchObject({
+      seen: 1,
+      total: 1,
+      unused: [],
+    });
+  });
+
+  it('reports every response when nothing reached the operation', () => {
+    expect(summarizeStatuses(declared, createStatusUse())).toMatchObject({ seen: 0, total: 3 });
+  });
+});

--- a/packages/cli/src/__tests__/commands/drift/compile-openapi-path.test.ts
+++ b/packages/cli/src/__tests__/commands/drift/compile-openapi-path.test.ts
@@ -1,0 +1,58 @@
+import { compileOpenApiPath } from '../../../commands/drift/utils/http.js';
+
+describe('compileOpenApiPath', () => {
+  it('compiles a segment that is a single parameter', () => {
+    const { regex, params } = compileOpenApiPath('/users/{userId}');
+
+    expect(params).toEqual(['userId']);
+    expect(regex.exec('/users/usr_abc')?.[1]).toBe('usr_abc');
+  });
+
+  it('does not let a parameter span a path separator', () => {
+    const { regex } = compileOpenApiPath('/users/{userId}');
+
+    expect(regex.exec('/users/usr_abc/friends')).toBeNull();
+  });
+
+  it('compiles two parameters separated by a literal inside one segment', () => {
+    const { regex, params } = compileOpenApiPath('/instances/{worldId}:{instanceId}');
+
+    expect(params).toEqual(['worldId', 'instanceId']);
+
+    const match = regex.exec(
+      '/instances/wrld_a:85981~group(grp_b)~groupAccessType(public)~region(us)'
+    );
+    expect(match?.[1]).toBe('wrld_a');
+    expect(match?.[2]).toBe('85981~group(grp_b)~groupAccessType(public)~region(us)');
+  });
+
+  it('splits on the first separator when the trailing value holds another', () => {
+    const { regex } = compileOpenApiPath('/instances/{worldId}:{instanceId}');
+    const match = regex.exec('/instances/wrld_a:12345~region(us):extra');
+
+    expect(match?.[1]).toBe('wrld_a');
+    expect(match?.[2]).toBe('12345~region(us):extra');
+  });
+
+  it('keeps matching a multi-parameter segment when a suffix segment follows', () => {
+    const { regex } = compileOpenApiPath('/instances/{worldId}:{instanceId}/shortName');
+
+    expect(regex.exec('/instances/wrld_a:123~private(usr_b)/shortName')?.[2]).toBe(
+      '123~private(usr_b)'
+    );
+  });
+
+  it('ranks a partially literal segment above a bare parameter', () => {
+    expect(compileOpenApiPath('/instances/{worldId}:{instanceId}').score).toBeGreaterThan(
+      compileOpenApiPath('/instances/{instanceId}').score
+    );
+  });
+
+  it('treats a segment with no parameters as a literal', () => {
+    const { regex, params } = compileOpenApiPath('/instances/recent');
+
+    expect(params).toEqual([]);
+    expect(regex.exec('/instances/anything')).toBeNull();
+    expect(regex.exec('/instances/recent')).not.toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/commands/respect/har-logs/helpers/build-post-data.test.ts
+++ b/packages/cli/src/__tests__/commands/respect/har-logs/helpers/build-post-data.test.ts
@@ -1,0 +1,60 @@
+import { buildPostData } from '../../../../../commands/respect/har-logs/helpers/build-post-data.js';
+
+describe('buildPostData', () => {
+  it('records a JSON body with the content type the request declared', () => {
+    const headers = { 'content-type': 'application/json' };
+
+    expect(buildPostData('{"bio":"x"}', headers)).toEqual({
+      mimeType: 'application/json',
+      text: '{"bio":"x"}',
+    });
+  });
+
+  it('matches the content-type header regardless of its casing', () => {
+    expect(buildPostData('{}', { 'Content-Type': 'application/json' }).mimeType).toBe(
+      'application/json'
+    );
+  });
+
+  it('reads the content type from the flat array header form', () => {
+    const headers = ['accept', '*/*', 'content-type', 'application/json'];
+
+    expect(buildPostData('{}', headers).mimeType).toBe('application/json');
+  });
+
+  it('reads the content type from a Headers-like object', () => {
+    const headers = new Map([['content-type', 'application/json']]);
+
+    expect(buildPostData('{}', headers).mimeType).toBe('application/json');
+  });
+
+  it('falls back to application/octet-stream when no content type was declared', () => {
+    expect(buildPostData('raw', {}).mimeType).toBe('application/octet-stream');
+  });
+
+  it('returns an empty object for a request with no body, as before', () => {
+    expect(buildPostData(undefined, {})).toEqual({});
+  });
+
+  it('treats an empty string body as no body', () => {
+    expect(buildPostData('', {})).toEqual({});
+  });
+
+  it('serializes a URLSearchParams body', () => {
+    const body = new URLSearchParams({ a: '1', b: '2' });
+
+    expect(buildPostData(body, {}).text).toBe('a=1&b=2');
+  });
+
+  it('does not attempt to serialize a stream body', () => {
+    expect(buildPostData(Buffer.from('binary'), {})).toEqual({});
+  });
+
+  it('omits a non-string body rather than recording "[object Object]"', () => {
+    expect(buildPostData({ bio: 'x' }, { 'content-type': 'application/json' })).toEqual({});
+  });
+
+  it('omits a FormData body, which cannot be read without consuming it', () => {
+    expect(buildPostData(new FormData(), { 'content-type': 'multipart/form-data' })).toEqual({});
+  });
+});

--- a/packages/cli/src/commands/coverage/README.md
+++ b/packages/cli/src/commands/coverage/README.md
@@ -1,0 +1,55 @@
+# coverage (experimental)
+
+Report the parts of an OpenAPI description that recorded HTTP traffic never exercised.
+
+> Experimental: the command, flags, and output are subject to change.
+
+The `coverage` command:
+
+- Reads traffic logs (HAR, Kong, Nginx/Apache JSON, NDJSON) through the `drift` parsers.
+- Matches each request/response exchange to a documented operation through the `drift` matcher.
+- Walks each body against the schema that describes it and records what the value reached.
+- Reports what nothing reached:
+  - documented operations no request reached
+  - documented properties no request or response carried
+  - `oneOf`/`anyOf` branches nothing ever matched
+  - component schemas nothing reached at all
+
+Body schema selection reuses `drift`'s `pickSchemaByMime` and its status-class fallback (exact status, then `2XX`, then `default`), so the two commands agree on which schema describes a given exchange.
+
+The `coverage` command has **no extra runtime dependencies**: spec loading reuses `@redocly/openapi-core`, and the traffic parsing, spec loading, and operation matching are shared with `drift`.
+
+## Relationship to `drift`
+
+`drift` judges traffic against the description and reports what disagrees. It cannot report on a description that was never put to the test, so a clean `drift` run means only that nothing was wrong *in the part the traffic covered*. `coverage` measures that part.
+
+## Why this is a command and not a `drift` rule
+
+A `TrafficRule` is invoked once per exchange, has no finalize hook, and receives only the matched operation through `RuleContext`. Coverage is a whole-run measurement compared against the whole description, so neither constraint fits.
+
+## Why the description is loaded twice
+
+`drift`'s `loadOpenApiIndex` bundles with `dereference: true`, which deep-clones every `$ref` target. Nothing under `paths` then shares object identity with `components.schemas`, so a value's schema cannot be traced back to the component it came from — and coverage is reported per component.
+
+`coverage` therefore bundles a second time with `dereference: false`, uses `drift`'s index purely to match an exchange to an operation, and looks that operation up in the referenced document by method and path template. The alternative — stamping a name onto each node during dereferencing — would mean changing a loader four rules already depend on.
+
+## Layout
+
+| Path                | Role                                                     |
+| ------------------- | -------------------------------------------------------- |
+| `index.ts`          | Command handler: load, match, walk.                      |
+| `engine/schema.ts`  | `$ref` resolution, declared properties, branch matching. |
+| `engine/sites.ts`   | Static enumeration of every union site per schema.       |
+| `engine/walk.ts`    | Walking a value against its schema.                      |
+| `engine/analyse.ts` | Turning what was reached into what was not.              |
+| `reporter.ts`       | `stylish` and `json` output.                             |
+
+## Usage
+
+```bash
+redocly coverage <traffic> --api <api>
+redocly coverage ./traffic.har --api ./openapi.yaml --schema Avatar
+redocly coverage ./traffic.har --api ./openapi.yaml --format json -o ./coverage.json
+```
+
+See `docs/@v2/commands/coverage.md` for the full option reference.

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -3,6 +3,7 @@ import { isPlainObject, isRef } from '@redocly/openapi-core';
 import { isHttpMethod } from '../../drift/openapi/loader.js';
 import type { ParameterCoverage } from './parameters.js';
 import { declared, resolve, type Schema } from './schema.js';
+import type { StatusCoverage } from './statuses.js';
 import { collectSites, siteKey } from './sites.js';
 import type { Coverage } from './walk.js';
 
@@ -40,6 +41,7 @@ export interface CoverageReport {
   exchanges: ExchangeCounts;
   operations: OperationCoverage;
   parameters: ParameterCoverage;
+  statuses: StatusCoverage;
   seenProperties: number;
   /**
    * The same count over exchanges the API accepted. Testing a rejection is real
@@ -84,7 +86,7 @@ export function summarize(
   schemaFilter?: string,
   exercisedOperations: Set<string> = new Set(),
   seenPropertiesAccepted?: number
-): Omit<CoverageReport, 'parameters'> {
+): Omit<CoverageReport, 'parameters' | 'statuses'> {
   const schemas: SchemaCoverage[] = [];
   const unusedSchemas: string[] = [];
   let seenProperties = 0;

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -39,6 +39,12 @@ export interface CoverageReport {
   exchanges: ExchangeCounts;
   operations: OperationCoverage;
   seenProperties: number;
+  /**
+   * The same count over exchanges the API accepted. Testing a rejection is real
+   * coverage, so it stays in `seenProperties`; the gap between the two says how
+   * much of the figure a broken run could be propping up.
+   */
+  seenPropertiesAccepted: number;
   totalProperties: number;
   schemas: SchemaCoverage[];
   unusedSchemas: string[];
@@ -74,7 +80,8 @@ export function summarize(
   coverage: Coverage,
   exchanges: ExchangeCounts,
   schemaFilter?: string,
-  exercisedOperations: Set<string> = new Set()
+  exercisedOperations: Set<string> = new Set(),
+  seenPropertiesAccepted?: number
 ): CoverageReport {
   const schemas: SchemaCoverage[] = [];
   const unusedSchemas: string[] = [];
@@ -120,6 +127,7 @@ export function summarize(
     exchanges,
     operations: summarizeOperations(spec, exercisedOperations),
     seenProperties,
+    seenPropertiesAccepted: seenPropertiesAccepted ?? seenProperties,
     totalProperties,
     schemas: schemas.sort((a, b) => a.name.localeCompare(b.name)),
     unusedSchemas: unusedSchemas.sort(),

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -1,6 +1,7 @@
 import { isPlainObject, isRef } from '@redocly/openapi-core';
 
 import { isHttpMethod } from '../../drift/openapi/loader.js';
+import type { ParameterCoverage } from './parameters.js';
 import { declared, resolve, type Schema } from './schema.js';
 import { collectSites, siteKey } from './sites.js';
 import type { Coverage } from './walk.js';
@@ -38,6 +39,7 @@ export interface ExchangeCounts {
 export interface CoverageReport {
   exchanges: ExchangeCounts;
   operations: OperationCoverage;
+  parameters: ParameterCoverage;
   seenProperties: number;
   /**
    * The same count over exchanges the API accepted. Testing a rejection is real
@@ -82,7 +84,7 @@ export function summarize(
   schemaFilter?: string,
   exercisedOperations: Set<string> = new Set(),
   seenPropertiesAccepted?: number
-): CoverageReport {
+): Omit<CoverageReport, 'parameters'> {
   const schemas: SchemaCoverage[] = [];
   const unusedSchemas: string[] = [];
   let seenProperties = 0;

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from '@redocly/openapi-core';
+import { isPlainObject, isRef } from '@redocly/openapi-core';
 
 import { isHttpMethod } from '../../drift/openapi/loader.js';
 import { declared, type Schema } from './schema.js';
@@ -13,6 +13,8 @@ export interface UnusedVariant {
 
 export interface SchemaCoverage {
   name: string;
+  /** Whether a value reached this schema, regardless of what it carried. */
+  reached: boolean;
   seen: number;
   count: number;
   unusedProperties: string[];
@@ -80,6 +82,8 @@ export function summarize(
 
   for (const [name, schema] of Object.entries(components)) {
     if (schemaFilter && name !== schemaFilter) continue;
+    // An alias declares nothing of its own; the schema it points at reports it.
+    if (isRef(schema)) continue;
 
     const names = declared(spec, schema).map(([property]) => property);
     const sites = collectSites(schema, name);
@@ -101,11 +105,12 @@ export function summarize(
       .sort((a, b) => a.path.localeCompare(b.path));
 
     const seen = names.length - unusedProperties.length;
-    if (seen === 0 && !coverage.properties.has(name)) unusedSchemas.push(name);
+    const reached = coverage.visited.has(name);
+    if (!reached) unusedSchemas.push(name);
 
     totalProperties += names.length;
     seenProperties += seen;
-    schemas.push({ name, seen, count: names.length, unusedProperties, unusedVariants });
+    schemas.push({ name, reached, seen, count: names.length, unusedProperties, unusedVariants });
   }
 
   return {

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -1,7 +1,7 @@
 import { isPlainObject, isRef } from '@redocly/openapi-core';
 
 import { isHttpMethod } from '../../drift/openapi/loader.js';
-import { declared, type Schema } from './schema.js';
+import { declared, resolve, type Schema } from './schema.js';
 import { collectSites, siteKey } from './sites.js';
 import type { Coverage } from './walk.js';
 
@@ -50,7 +50,10 @@ function summarizeOperations(spec: Schema, exercised: Set<string>): OperationCov
   let total = 0;
 
   for (const [pathTemplate, item] of Object.entries(spec.paths ?? {}) as [string, Schema][]) {
-    for (const [method, operation] of Object.entries(item ?? {}) as [string, Schema][]) {
+    const { schema: pathItem } = resolve(spec, item);
+    if (!pathItem) continue;
+
+    for (const [method, operation] of Object.entries(pathItem) as [string, Schema][]) {
       // A path item also carries `parameters`, `summary`, and `$ref`, none of
       // which are operations.
       if (!isHttpMethod(method) || !isPlainObject(operation)) continue;

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -1,0 +1,119 @@
+import { isPlainObject } from '@redocly/openapi-core';
+
+import { isHttpMethod } from '../../drift/openapi/loader.js';
+import { declared, type Schema } from './schema.js';
+import { collectSites, siteKey } from './sites.js';
+import type { Coverage } from './walk.js';
+
+export interface UnusedVariant {
+  path: string;
+  keyword: string;
+  branches: number[];
+}
+
+export interface SchemaCoverage {
+  name: string;
+  seen: number;
+  count: number;
+  unusedProperties: string[];
+  unusedVariants: UnusedVariant[];
+}
+
+export interface OperationCoverage {
+  seen: number;
+  total: number;
+  /** `GET /path  operationId`, for the operations nothing reached. */
+  unused: string[];
+}
+
+export interface ExchangeCounts {
+  /** Exchanges parsed from the traffic logs. */
+  total: number;
+  /** Those carrying a body a schema described, the only ones coverage can read. */
+  withBody: number;
+}
+
+export interface CoverageReport {
+  exchanges: ExchangeCounts;
+  operations: OperationCoverage;
+  seenProperties: number;
+  totalProperties: number;
+  schemas: SchemaCoverage[];
+  unusedSchemas: string[];
+}
+
+/** Which documented operations the traffic reached, keyed as `method path`. */
+function summarizeOperations(spec: Schema, exercised: Set<string>): OperationCoverage {
+  const unused: string[] = [];
+  let total = 0;
+
+  for (const [pathTemplate, item] of Object.entries(spec.paths ?? {}) as [string, Schema][]) {
+    for (const [method, operation] of Object.entries(item ?? {}) as [string, Schema][]) {
+      // A path item also carries `parameters`, `summary`, and `$ref`, none of
+      // which are operations.
+      if (!isHttpMethod(method) || !isPlainObject(operation)) continue;
+
+      total += 1;
+      if (exercised.has(`${method} ${pathTemplate}`)) continue;
+
+      const { operationId } = operation as Schema;
+      unused.push(`${method.toUpperCase()} ${pathTemplate}${operationId ? `  ${operationId}` : ''}`);
+    }
+  }
+
+  return { seen: total - unused.length, total, unused: unused.sort() };
+}
+
+export function summarize(
+  spec: Schema,
+  coverage: Coverage,
+  exchanges: ExchangeCounts,
+  schemaFilter?: string,
+  exercisedOperations: Set<string> = new Set()
+): CoverageReport {
+  const schemas: SchemaCoverage[] = [];
+  const unusedSchemas: string[] = [];
+  let seenProperties = 0;
+  let totalProperties = 0;
+
+  const components = (spec.components?.schemas ?? {}) as Record<string, Schema>;
+
+  for (const [name, schema] of Object.entries(components)) {
+    if (schemaFilter && name !== schemaFilter) continue;
+
+    const names = declared(spec, schema).map(([property]) => property);
+    const sites = collectSites(schema, name);
+    if (names.length === 0 && sites.size === 0) continue;
+
+    const seenPropertyPaths = coverage.properties.get(name) ?? new Set<string>();
+    const unusedProperties = names.filter((property) => !seenPropertyPaths.has(property)).sort();
+
+    const unusedVariants = [...sites.values()]
+      .map(({ path, keyword, count }) => {
+        const seenBranches = coverage.variants.get(siteKey(name, path, keyword)) ?? new Set<number>();
+        const branches = [...Array.from({ length: count }).keys()].filter(
+          (index) => !seenBranches.has(index)
+        );
+
+        return { path, keyword, branches };
+      })
+      .filter(({ branches }) => branches.length > 0)
+      .sort((a, b) => a.path.localeCompare(b.path));
+
+    const seen = names.length - unusedProperties.length;
+    if (seen === 0 && !coverage.properties.has(name)) unusedSchemas.push(name);
+
+    totalProperties += names.length;
+    seenProperties += seen;
+    schemas.push({ name, seen, count: names.length, unusedProperties, unusedVariants });
+  }
+
+  return {
+    exchanges,
+    operations: summarizeOperations(spec, exercisedOperations),
+    seenProperties,
+    totalProperties,
+    schemas: schemas.sort((a, b) => a.name.localeCompare(b.name)),
+    unusedSchemas: unusedSchemas.sort(),
+  };
+}

--- a/packages/cli/src/commands/coverage/engine/analyse.ts
+++ b/packages/cli/src/commands/coverage/engine/analyse.ts
@@ -97,6 +97,11 @@ export function summarize(
 
     const names = declared(spec, schema).map(([property]) => property);
     const sites = collectSites(schema, name);
+    const reached = coverage.visited.has(name);
+
+    // An enum, a primitive, or an array of `$ref`s holds nothing to break down,
+    // but the traffic still either reached it or did not.
+    if (!reached) unusedSchemas.push(name);
     if (names.length === 0 && sites.size === 0) continue;
 
     const seenPropertyPaths = coverage.properties.get(name) ?? new Set<string>();
@@ -115,8 +120,6 @@ export function summarize(
       .sort((a, b) => a.path.localeCompare(b.path));
 
     const seen = names.length - unusedProperties.length;
-    const reached = coverage.visited.has(name);
-    if (!reached) unusedSchemas.push(name);
 
     totalProperties += names.length;
     seenProperties += seen;

--- a/packages/cli/src/commands/coverage/engine/parameters.ts
+++ b/packages/cli/src/commands/coverage/engine/parameters.ts
@@ -1,0 +1,167 @@
+import { isPlainObject } from '@redocly/openapi-core';
+
+import { isHttpMethod } from '../../drift/openapi/loader.js';
+import { resolve, type Schema } from './schema.js';
+
+export interface DeclaredParameter {
+  name: string;
+  in: string;
+  required: boolean;
+  /** The values an `enum` pins the parameter to, empty when it pins none. */
+  values: unknown[];
+}
+
+export interface ParameterCoverage {
+  seen: number;
+  total: number;
+  /** `GET /path  query.sellerId`, for the parameters nothing sent. */
+  unused: string[];
+  /** `GET /path  query.status=archived`, for the enum values nothing used. */
+  unusedValues: string[];
+}
+
+export interface ParameterUse {
+  /** Operation key → the `in.name` of every parameter a request carried. */
+  sent: Map<string, Set<string>>;
+  /** Operation key and `in.name` → the values requests carried. */
+  values: Map<string, Set<string>>;
+}
+
+export interface RequestParameters {
+  query: URLSearchParams;
+  pathParams: Record<string, string>;
+  headers: Record<string, string>;
+}
+
+export function createParameterUse(): ParameterUse {
+  return { sent: new Map(), values: new Map() };
+}
+
+function parameterKey(parameter: { in: string; name: string }): string {
+  return `${parameter.in}.${parameter.name}`;
+}
+
+function label(operationKey: string, suffix: string): string {
+  const [method, ...rest] = operationKey.split(' ');
+
+  return `${method.toUpperCase()} ${rest.join(' ')}  ${suffix}`;
+}
+
+/** Every parameter each operation documents, keyed as `method path`. */
+export function collectParameters(spec: Schema): Map<string, DeclaredParameter[]> {
+  const byOperation = new Map<string, DeclaredParameter[]>();
+
+  for (const [pathTemplate, item] of Object.entries(spec.paths ?? {}) as [string, Schema][]) {
+    const { schema: pathItem } = resolve(spec, item);
+    if (!pathItem) continue;
+
+    for (const [method, operation] of Object.entries(pathItem) as [string, Schema][]) {
+      if (!isHttpMethod(method) || !isPlainObject(operation)) continue;
+
+      // A parameter on the operation replaces the path item's one of the same
+      // name and location, so the operation's entries are read last.
+      const declared = new Map<string, DeclaredParameter>();
+      const listed = [...(pathItem.parameters ?? []), ...((operation as Schema).parameters ?? [])];
+
+      for (const entry of listed as Schema[]) {
+        const { schema: parameter } = resolve(spec, entry);
+        if (!parameter?.name || !parameter.in) continue;
+
+        const { schema: parameterSchema } = resolve(spec, parameter.schema);
+        declared.set(parameterKey(parameter as { in: string; name: string }), {
+          name: parameter.name,
+          in: parameter.in,
+          required: parameter.required === true,
+          values: parameterSchema?.enum ?? [],
+        });
+      }
+
+      byOperation.set(`${method} ${pathTemplate}`, [...declared.values()]);
+    }
+  }
+
+  return byOperation;
+}
+
+function cookiesOf(headers: Record<string, string>): Record<string, string> {
+  const header = headers.cookie ?? headers.Cookie;
+  if (!header) return {};
+
+  return Object.fromEntries(
+    header
+      .split(';')
+      .map((pair) => pair.split('='))
+      .filter(([name]) => name?.trim())
+      .map(([name, ...value]) => [name.trim(), value.join('=').trim()])
+  );
+}
+
+/** Note which documented parameters one request carried, and with what values. */
+export function recordParameters(
+  use: ParameterUse,
+  operationKey: string,
+  request: RequestParameters
+): void {
+  const carried: [string, string][] = [
+    ...[...request.query.entries()].map(
+      ([name, value]) => [`query.${name}`, value] as [string, string]
+    ),
+    ...Object.entries(request.pathParams).map(
+      ([name, value]) => [`path.${name}`, value] as [string, string]
+    ),
+    ...Object.entries(request.headers).map(
+      ([name, value]) => [`header.${name}`, value] as [string, string]
+    ),
+    ...Object.entries(cookiesOf(request.headers)).map(
+      ([name, value]) => [`cookie.${name}`, value] as [string, string]
+    ),
+  ];
+
+  if (!use.sent.has(operationKey)) use.sent.set(operationKey, new Set());
+
+  for (const [key, value] of carried) {
+    use.sent.get(operationKey)!.add(key.toLowerCase());
+
+    const valueKey = `${operationKey} ${key.toLowerCase()}`;
+    if (!use.values.has(valueKey)) use.values.set(valueKey, new Set());
+    use.values.get(valueKey)!.add(value);
+  }
+}
+
+/** Which documented parameters, and which of their pinned values, the traffic reached. */
+export function summarizeParameters(
+  declared: Map<string, DeclaredParameter[]>,
+  use: ParameterUse
+): ParameterCoverage {
+  const unused: string[] = [];
+  const unusedValues: string[] = [];
+  let total = 0;
+  let seen = 0;
+
+  for (const [operationKey, parameters] of declared) {
+    // A header name arrives in whatever case the client sent, so both sides are
+    // compared lowercased.
+    const sent = use.sent.get(operationKey) ?? new Set<string>();
+
+    for (const parameter of parameters) {
+      const key = parameterKey(parameter).toLowerCase();
+      total += 1;
+
+      if (!sent.has(key)) {
+        unused.push(label(operationKey, parameterKey(parameter)));
+        continue;
+      }
+
+      seen += 1;
+
+      const used = use.values.get(`${operationKey} ${key}`) ?? new Set<string>();
+      for (const value of parameter.values) {
+        if (used.has(String(value))) continue;
+
+        unusedValues.push(label(operationKey, `${parameterKey(parameter)}=${String(value)}`));
+      }
+    }
+  }
+
+  return { seen, total, unused: unused.sort(), unusedValues: unusedValues.sort() };
+}

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -97,28 +97,14 @@ function compose(spec: Schema, schema: Schema, depth = 0): Composition {
   return composition;
 }
 
-/**
- * Whether a value plausibly satisfies a branch. Without this a union credits
- * every alternative from a single value, and every branch reads as covered no
- * matter what the API actually returned.
- */
-export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
-  const { schema: target } = resolve(spec, schema);
-  if (!target) return false;
+/** OpenAPI 3.1 allows a list of types, 3.0 only a single one. */
+function typesOf(type: string | string[] | undefined): string[] {
+  if (Array.isArray(type)) return type;
 
-  if (target.enum) return target.enum.includes(value as never);
+  return type ? [type] : [];
+}
 
-  const { type, required, names } = compose(spec, target);
-
-  if (type === 'object' || names.size > 0) {
-    if (!isPlainObject(value)) return false;
-
-    const keys = new Set(Object.keys(value));
-    if (!required.every((key) => keys.has(key))) return false;
-
-    return names.size === 0 || [...keys].some((key) => names.has(key));
-  }
-
+function matchesType(type: string, value: unknown): boolean {
   if (type === 'array') return Array.isArray(value);
   if (type === 'string') return typeof value === 'string';
   if (type === 'boolean') return typeof value === 'boolean';
@@ -127,4 +113,85 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
   if (type === 'null') return value === null;
 
   return true;
+}
+
+/**
+ * Whether a value could satisfy a branch at all. This is the hard filter only:
+ * choosing between the branches that survive it is `fit`'s job, because a value
+ * that merely shares a property name with a branch has not exercised it.
+ */
+export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
+  const { schema: target } = resolve(spec, schema);
+  if (!target) return false;
+
+  if (target.enum) return target.enum.includes(value as never);
+
+  const { type, required, names } = compose(spec, target);
+  const types = typesOf(type);
+
+  if (types.includes('object') || (types.length === 0 && names.size > 0)) {
+    if (!isPlainObject(value)) return types.includes('null') && value === null;
+
+    const keys = new Set(Object.keys(value));
+
+    return required.every((key) => keys.has(key));
+  }
+
+  if (types.length === 0) return true;
+
+  return types.some((one) => matchesType(one, value));
+}
+
+/** How many of a value's own properties a branch declares. */
+export function fit(spec: Schema, schema: Schema, value: unknown): number {
+  if (!isPlainObject(value)) return 0;
+
+  const { schema: target } = resolve(spec, schema);
+  if (!target) return 0;
+
+  const { names } = compose(spec, target);
+
+  return Object.keys(value).filter((key) => names.has(key)).length;
+}
+
+/**
+ * The branch a `discriminator` names, which settles the choice outright when
+ * the description provides one.
+ */
+function discriminated(parent: Schema, branches: Schema[], value: unknown): number | undefined {
+  const propertyName = parent.discriminator?.propertyName;
+  if (!propertyName || !isPlainObject(value)) return undefined;
+
+  const key = value[propertyName];
+  if (typeof key !== 'string') return undefined;
+
+  const mapped = parent.discriminator.mapping?.[key] ?? `#/components/schemas/${key}`;
+  const index = branches.findIndex((branch) => isRef(branch) && branch.$ref === mapped);
+
+  return index === -1 ? undefined : index;
+}
+
+/**
+ * The branch indices a value exercises. Where several remain possible, only the
+ * best fitting ones count: crediting every branch a value merely could be makes
+ * union coverage meaningless.
+ */
+export function selectBranches(
+  spec: Schema,
+  parent: Schema,
+  branches: Schema[],
+  value: unknown
+): number[] {
+  const named = discriminated(parent, branches, value);
+  if (named !== undefined) return [named];
+
+  const possible = branches
+    .map((branch, index) => ({ branch, index }))
+    .filter(({ branch }) => matches(spec, branch, value));
+  if (possible.length <= 1) return possible.map(({ index }) => index);
+
+  const scored = possible.map(({ branch, index }) => ({ index, score: fit(spec, branch, value) }));
+  const best = Math.max(...scored.map(({ score }) => score));
+
+  return scored.filter(({ score }) => score === best).map(({ index }) => index);
 }

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -91,12 +91,17 @@ interface Composition {
   nullable: boolean;
   required: string[];
   names: Set<string>;
+  /** Wrapped so that a literal `undefined` stays distinguishable from absence. */
+  literal?: { values: unknown[] };
 }
 
 /**
- * The constraints a value has to satisfy, gathered across `allOf` and through
+ * Every constraint a value has to satisfy, gathered across `allOf` and through
  * the `$ref`s inside it. A composed schema states nothing itself, so reading
  * only its own keywords would accept any value at all.
+ *
+ * This is the single place constraints are collected. `matches` reads nothing
+ * off a schema directly, so a keyword handled here is handled everywhere.
  */
 function compose(spec: Schema, schema: Schema, depth = 0): Composition {
   const { schema: target } = resolve(spec, schema);
@@ -107,6 +112,7 @@ function compose(spec: Schema, schema: Schema, depth = 0): Composition {
     nullable: target.nullable === true,
     required: [...(target.required ?? [])],
     names: new Set(Object.keys(target.properties ?? {})),
+    literal: literalOf(target),
   };
 
   for (const sub of target.allOf ?? []) {
@@ -114,11 +120,20 @@ function compose(spec: Schema, schema: Schema, depth = 0): Composition {
 
     composition.type ??= inherited.type;
     composition.nullable ||= inherited.nullable;
+    composition.literal ??= inherited.literal;
     composition.required.push(...inherited.required);
     for (const name of inherited.names) composition.names.add(name);
   }
 
   return composition;
+}
+
+/** The values a schema pins itself to, whether by `enum` or by 3.1's `const`. */
+function literalOf(schema: Schema): { values: unknown[] } | undefined {
+  if (Array.isArray(schema.enum)) return { values: schema.enum };
+  if ('const' in schema) return { values: [schema.const] };
+
+  return undefined;
 }
 
 /** OpenAPI 3.1 allows a list of types, 3.0 only a single one. */
@@ -149,15 +164,15 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
   const { schema: target } = resolve(spec, schema);
   if (!target) return false;
 
-  if (target.enum) return target.enum.includes(value as never);
-  // OpenAPI 3.1 spells a single-value enum this way, and a union of literals is
-  // otherwise indistinguishable: every branch would accept every value.
-  if ('const' in target) return target.const === value;
-
-  const { type, nullable, required, names } = compose(spec, target);
+  const { type, nullable, required, names, literal } = compose(spec, target);
   const types = typesOf(type);
 
+  // Nullability outranks every other constraint: a nullable enum still takes null.
   if (value === null && nullable) return true;
+
+  // Without this a union of literals is indistinguishable, and every branch
+  // accepts every value of the shared type.
+  if (literal) return literal.values.includes(value);
 
   // Properties without a `type` still describe an object.
   const objectish = types.includes('object') || (types.length === 0 && names.size > 0);

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -13,6 +13,15 @@ export const VARIANT_KEYWORDS = ['oneOf', 'anyOf'] as const;
 export const MAX_DEPTH = 40;
 
 /**
+ * The path inside one branch of a union. Sibling branches can each declare the
+ * same property, so without the branch in the path they collide: their sites
+ * overwrite each other and their properties read as one.
+ */
+export function branchPath(path: string, keyword: string, index: number): string {
+  return `${path ? `${path}.` : ''}${keyword}[${index}]`;
+}
+
+/**
  * Follow a local `$ref`, reporting the component name it pointed at.
  *
  * Coverage groups its results by schema name, so it reads a bundled document
@@ -76,6 +85,16 @@ export function declared(spec: Schema, schema: Schema, path = '', depth = 0): [s
     if (isRef(sub)) continue;
 
     found.push(...declared(spec, sub, path, depth + 1));
+  }
+
+  // Alternatives are kept apart under their own branch path, the way the walk
+  // records them. Merging them would read as one shape nothing ever sends.
+  for (const keyword of VARIANT_KEYWORDS) {
+    for (const [index, branch] of ((target[keyword] ?? []) as Schema[]).entries()) {
+      if (isRef(branch)) continue;
+
+      found.push(...declared(spec, branch, branchPath(path, keyword, index), depth + 1));
+    }
   }
 
   if (target.items && !isRef(target.items)) {
@@ -179,6 +198,7 @@ function discriminated(
 export function selectBranches(
   spec: Schema,
   parent: Schema,
+  keyword: string,
   branches: Schema[],
   value: unknown
 ): number[] {
@@ -192,6 +212,10 @@ export function selectBranches(
 
   const scored = possible.map(({ branch, index }) => ({ index, score: fit(spec, branch, value) }));
   const best = Math.max(...scored.map(({ score }) => score));
+  const winners = scored.filter(({ score }) => score === best).map(({ index }) => index);
 
-  return scored.filter(({ score }) => score === best).map(({ index }) => index);
+  // `anyOf` lets a value be several of its alternatives at once, so each one it
+  // fits was exercised. `oneOf` means exactly one, so a tie is the description
+  // being ambiguous rather than the value having covered both.
+  return keyword === 'oneOf' ? winners.slice(0, 1) : winners;
 }

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -1,0 +1,118 @@
+import { isPlainObject, isRef, unescapePointerFragment } from '@redocly/openapi-core';
+
+// A schema node is an arbitrary JSON Schema object; narrowing it to `unknown`
+// would force a cast at every keyword access.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Schema = Record<string, any>;
+
+/** `oneOf`/`anyOf` are alternatives a value selects between; `allOf` always applies. */
+export const VARIANT_KEYWORDS = ['oneOf', 'anyOf'] as const;
+
+export const MAX_DEPTH = 40;
+
+/**
+ * Follow a local `$ref`, reporting the component name it pointed at.
+ *
+ * Coverage groups its results by schema name, so it reads a bundled document
+ * that still carries `$ref`s. `drift` cannot supply one: its loader bundles
+ * with `dereference: true`, which deep-clones every target, leaving no way to
+ * tell which component a value belongs to.
+ */
+export function resolve(
+  spec: Schema,
+  schema: Schema | undefined
+): { schema?: Schema; name?: string } {
+  if (!schema) return {};
+  if (!isRef(schema)) return { schema };
+
+  const pointer = schema.$ref.replace(/^#\//, '').split('/').map(unescapePointerFragment);
+  let node: Schema | undefined = spec;
+  for (const segment of pointer) {
+    node = node?.[segment];
+  }
+
+  return { schema: node, name: pointer.at(-1) };
+}
+
+/**
+ * Property names a schema declares itself, following `allOf` but leaving a
+ * `$ref` inside it alone: the target reports those under its own name, so
+ * counting them here too would report them as unused on both schemas.
+ */
+export function declared(spec: Schema, schema: Schema, depth = 0): [string, Schema][] {
+  if (depth > MAX_DEPTH) return [];
+
+  const { schema: target } = resolve(spec, schema);
+  if (!target) return [];
+
+  return [
+    ...(Object.entries(target.properties ?? {}) as [string, Schema][]),
+    ...(target.allOf ?? []).flatMap((sub: Schema) =>
+      isRef(sub) ? [] : declared(spec, sub, depth + 1)
+    ),
+  ];
+}
+
+interface Composition {
+  type?: string;
+  required: string[];
+  names: Set<string>;
+}
+
+/**
+ * The constraints a value has to satisfy, gathered across `allOf` and through
+ * the `$ref`s inside it. A composed schema states nothing itself, so reading
+ * only its own keywords would accept any value at all.
+ */
+function compose(spec: Schema, schema: Schema, depth = 0): Composition {
+  const { schema: target } = resolve(spec, schema);
+  if (!target || depth > MAX_DEPTH) return { required: [], names: new Set() };
+
+  const composition: Composition = {
+    type: target.type,
+    required: [...(target.required ?? [])],
+    names: new Set(Object.keys(target.properties ?? {})),
+  };
+
+  for (const sub of target.allOf ?? []) {
+    const inherited = compose(spec, sub, depth + 1);
+
+    composition.type ??= inherited.type;
+    composition.required.push(...inherited.required);
+    for (const name of inherited.names) composition.names.add(name);
+  }
+
+  return composition;
+}
+
+/**
+ * Whether a value plausibly satisfies a branch. Without this a union credits
+ * every alternative from a single value, and every branch reads as covered no
+ * matter what the API actually returned.
+ */
+export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
+  const { schema: target } = resolve(spec, schema);
+  if (!target) return false;
+
+  if (target.enum) return target.enum.includes(value as never);
+
+  const { type, required, names } = compose(spec, target);
+
+  if (type === 'object' || names.size > 0) {
+    if (!isPlainObject(value)) return false;
+
+    const keys = new Set(Object.keys(value));
+    if (!required.every((key) => keys.has(key))) return false;
+
+    return names.size === 0 || [...keys].some((key) => names.has(key));
+  }
+
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'integer') return typeof value === 'number' && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number';
+  if (type === 'null') return value === null;
+
+  return true;
+}

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -1,5 +1,7 @@
 import { isPlainObject, isRef, unescapePointerFragment } from '@redocly/openapi-core';
 
+import { SchemaValidator } from '../../drift/engine/schema-validator.js';
+
 // A schema node is an arbitrary JSON Schema object; narrowing it to `unknown`
 // would force a cast at every keyword access.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,164 +87,60 @@ export function declared(spec: Schema, schema: Schema, path = '', depth = 0): [s
   return [...byPath.values()];
 }
 
-interface Composition {
-  type?: string | string[];
-  format?: string;
-  /** OpenAPI 3.0 spells a nullable value this way; 3.1 puts `null` in `type`. */
-  nullable: boolean;
-  required: string[];
-  names: Set<string>;
-  /** Wrapped so that a literal `undefined` stays distinguishable from absence. */
-  literal?: { values: unknown[] };
-  /** One entry per `oneOf`/`anyOf`; a value has to satisfy a branch of each. */
-  unions: Schema[][];
-}
+const validator = new SchemaValidator();
+const validatable = new WeakMap<Schema, Schema>();
 
 /**
- * Every constraint a value has to satisfy, gathered across `allOf` and through
- * the `$ref`s inside it. A composed schema states nothing itself, so reading
- * only its own keywords would accept any value at all.
+ * A branch in the form Ajv can compile.
  *
- * This is the single place constraints are collected. `matches` reads nothing
- * off a schema directly, so a keyword handled here is handled everywhere.
+ * Coverage reads a description that still carries `$ref`s, and a pointer like
+ * `#/components/schemas/User` resolves against the root Ajv compiles. Putting
+ * the components beside the branch gives those pointers something to find.
+ *
+ * Memoized because the validator caches compiled schemas by object identity,
+ * so a fresh wrapper per call would recompile every branch of every exchange.
  */
-function compose(spec: Schema, schema: Schema, depth = 0): Composition {
-  const { schema: target } = resolve(spec, schema);
-  if (!target || depth > MAX_DEPTH) {
-    return { nullable: false, required: [], names: new Set(), unions: [] };
-  }
+function forValidation(spec: Schema, schema: Schema): Schema {
+  const cached = validatable.get(schema);
+  if (cached) return cached;
 
-  const composition: Composition = {
-    type: target.type,
-    format: target.format,
-    nullable: target.nullable === true,
-    required: [...(target.required ?? [])],
-    names: new Set(Object.keys(target.properties ?? {})),
-    literal: literalOf(target),
-    unions: VARIANT_KEYWORDS.filter((keyword) => target[keyword]?.length).map(
-      (keyword) => target[keyword] as Schema[]
-    ),
-  };
+  const wrapped: Schema = { allOf: [schema], components: spec.components };
+  validatable.set(schema, wrapped);
 
-  for (const sub of target.allOf ?? []) {
-    const inherited = compose(spec, sub, depth + 1);
-
-    composition.type ??= inherited.type;
-    composition.format ??= inherited.format;
-    composition.nullable ||= inherited.nullable;
-    composition.literal ??= inherited.literal;
-    composition.required.push(...inherited.required);
-    composition.unions.push(...inherited.unions);
-    for (const name of inherited.names) composition.names.add(name);
-  }
-
-  return composition;
-}
-
-/** The values a schema pins itself to, whether by `enum` or by 3.1's `const`. */
-function literalOf(schema: Schema): { values: unknown[] } | undefined {
-  if (Array.isArray(schema.enum)) return { values: schema.enum };
-  if ('const' in schema) return { values: [schema.const] };
-
-  return undefined;
-}
-
-/** OpenAPI 3.1 allows a list of types, 3.0 only a single one. */
-function typesOf(type: string | string[] | undefined): string[] {
-  if (Array.isArray(type)) return type;
-
-  return type ? [type] : [];
-}
-
-function matchesType(type: string, value: unknown): boolean {
-  if (type === 'object') return isPlainObject(value);
-  if (type === 'array') return Array.isArray(value);
-  if (type === 'string') return typeof value === 'string';
-  if (type === 'boolean') return typeof value === 'boolean';
-  if (type === 'integer') return typeof value === 'number' && Number.isInteger(value);
-  if (type === 'number') return typeof value === 'number';
-  if (type === 'null') return value === null;
-
-  return true;
+  return wrapped;
 }
 
 /**
- * Whether a value could satisfy a branch at all. This is the hard filter only:
- * choosing between the branches that survive it is `fit`'s job, because a value
- * that merely shares a property name with a branch has not exercised it.
+ * Whether a value satisfies a branch, decided by the same validator `drift`
+ * judges traffic with. Hand-reading keywords here only ever covered the ones
+ * someone had thought of, and every gap credited a branch nothing exercised.
  */
-export function matches(spec: Schema, schema: Schema, value: unknown, depth = 0): boolean {
-  const { schema: target } = resolve(spec, schema);
-  if (!target) return false;
-
-  const { type, nullable, required, names, literal, unions } = compose(spec, target);
-  const types = typesOf(type);
-
-  // Nullability outranks every other constraint: a nullable enum still takes null.
-  if (value === null && nullable) return true;
-
-  // Without this a union of literals is indistinguishable, and every branch
-  // accepts every value of the shared type.
-  if (literal) return literal.values.includes(value);
-
-  // A schema whose only constraint is a nested union states nothing itself, so
-  // without this it accepts every value and its branches all read as covered.
-  if (depth <= MAX_DEPTH) {
-    const satisfied = unions.every((branches) =>
-      branches.some((branch) => matches(spec, branch, value, depth + 1))
-    );
-    if (!satisfied) return false;
-  }
-
-  // Properties without a `type` still describe an object.
-  const objectish = types.includes('object') || (types.length === 0 && names.size > 0);
-
-  if (objectish && isPlainObject(value)) {
-    const keys = new Set(Object.keys(value));
-
-    return required.every((key) => keys.has(key));
-  }
-
-  // A 3.1 type array can allow an object alongside other types, so a non-object
-  // value still has the rest of the list to satisfy.
-  if (types.length === 0) return unions.length > 0 || !objectish;
-
-  return types.some((one) => matchesType(one, value));
+export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
+  return validator.validate(forValidation(spec, schema), value).valid;
 }
 
 /** Every property name a schema carries, including the ones it composes in. */
-export function composedNames(spec: Schema, schema: Schema): Set<string> {
-  return compose(spec, schema).names;
+export function composedNames(spec: Schema, schema: Schema, depth = 0): Set<string> {
+  const { schema: target } = resolve(spec, schema);
+  if (!target || depth > MAX_DEPTH) return new Set();
+
+  const names = new Set(Object.keys(target.properties ?? {}));
+  for (const sub of target.allOf ?? []) {
+    for (const name of composedNames(spec, sub, depth + 1)) names.add(name);
+  }
+
+  return names;
 }
 
 /**
- * The `format`s worth telling apart when two branches share a type. Used only
- * to rank branches, never to reject a value: OpenAPI treats `format` as
- * advisory, so a stricter reading here would drop valid coverage.
+ * How much of a value a branch accounts for. The validator says which branches
+ * a value could be; where several could, the one declaring most of what the
+ * value carries is the one it exercised.
  */
-const FORMAT_TESTS: Record<string, (value: string) => boolean> = {
-  uuid: (value) => /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(value),
-  date: (value) => /^\d{4}-\d{2}-\d{2}$/.test(value),
-  'date-time': (value) => !Number.isNaN(Date.parse(value)) && /[T ]/.test(value),
-  email: (value) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value),
-  uri: (value) => /^[a-z][a-z0-9+.-]*:/i.test(value),
-  ipv4: (value) => /^(\d{1,3}\.){3}\d{1,3}$/.test(value),
-};
-
-/** How much of a value a branch accounts for, used to rank the branches it could be. */
 export function fit(spec: Schema, schema: Schema, value: unknown): number {
-  const { schema: target } = resolve(spec, schema);
-  if (!target) return 0;
-
-  const { names, format } = compose(spec, target);
-
-  if (typeof value === 'string') {
-    const test = format ? FORMAT_TESTS[format] : undefined;
-
-    return test?.(value) ? 1 : 0;
-  }
-
   if (!isPlainObject(value)) return 0;
+
+  const names = composedNames(spec, schema);
 
   return Object.keys(value).filter((key) => names.has(key)).length;
 }

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -129,6 +129,7 @@ function typesOf(type: string | string[] | undefined): string[] {
 }
 
 function matchesType(type: string, value: unknown): boolean {
+  if (type === 'object') return isPlainObject(value);
   if (type === 'array') return Array.isArray(value);
   if (type === 'string') return typeof value === 'string';
   if (type === 'boolean') return typeof value === 'boolean';
@@ -155,15 +156,18 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
 
   if (value === null && nullable) return true;
 
-  if (types.includes('object') || (types.length === 0 && names.size > 0)) {
-    if (!isPlainObject(value)) return types.includes('null') && value === null;
+  // Properties without a `type` still describe an object.
+  const objectish = types.includes('object') || (types.length === 0 && names.size > 0);
 
+  if (objectish && isPlainObject(value)) {
     const keys = new Set(Object.keys(value));
 
     return required.every((key) => keys.has(key));
   }
 
-  if (types.length === 0) return true;
+  // A 3.1 type array can allow an object alongside other types, so a non-object
+  // value still has the rest of the list to satisfy.
+  if (types.length === 0) return !objectish;
 
   return types.some((one) => matchesType(one, value));
 }
@@ -189,15 +193,24 @@ export function fit(spec: Schema, schema: Schema, value: unknown): number {
  * The branch a `discriminator` names, which settles the choice outright when
  * the description provides one.
  */
-function discriminated(parent: Schema, branches: Schema[], value: unknown): number | undefined {
+function discriminated(
+  spec: Schema,
+  parent: Schema,
+  branches: Schema[],
+  value: unknown
+): number | undefined {
   const propertyName = parent.discriminator?.propertyName;
   if (!propertyName || !isPlainObject(value)) return undefined;
 
   const key = value[propertyName];
   if (typeof key !== 'string') return undefined;
 
-  const mapped = parent.discriminator.mapping?.[key] ?? `#/components/schemas/${key}`;
-  const index = branches.findIndex((branch) => isRef(branch) && branch.$ref === mapped);
+  // A mapping value is either a `$ref` or a bare component name, and without a
+  // mapping the value itself names the component.
+  const mapped: string = parent.discriminator.mapping?.[key] ?? key;
+  const wanted = mapped.includes('/') ? mapped.split('/').at(-1) : mapped;
+
+  const index = branches.findIndex((branch) => resolve(spec, branch).name === wanted);
 
   return index === -1 ? undefined : index;
 }
@@ -213,7 +226,7 @@ export function selectBranches(
   branches: Schema[],
   value: unknown
 ): number[] {
-  const named = discriminated(parent, branches, value);
+  const named = discriminated(spec, parent, branches, value);
   if (named !== undefined) return [named];
 
   const possible = branches

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -87,12 +87,15 @@ export function declared(spec: Schema, schema: Schema, path = '', depth = 0): [s
 
 interface Composition {
   type?: string | string[];
+  format?: string;
   /** OpenAPI 3.0 spells a nullable value this way; 3.1 puts `null` in `type`. */
   nullable: boolean;
   required: string[];
   names: Set<string>;
   /** Wrapped so that a literal `undefined` stays distinguishable from absence. */
   literal?: { values: unknown[] };
+  /** One entry per `oneOf`/`anyOf`; a value has to satisfy a branch of each. */
+  unions: Schema[][];
 }
 
 /**
@@ -105,23 +108,31 @@ interface Composition {
  */
 function compose(spec: Schema, schema: Schema, depth = 0): Composition {
   const { schema: target } = resolve(spec, schema);
-  if (!target || depth > MAX_DEPTH) return { nullable: false, required: [], names: new Set() };
+  if (!target || depth > MAX_DEPTH) {
+    return { nullable: false, required: [], names: new Set(), unions: [] };
+  }
 
   const composition: Composition = {
     type: target.type,
+    format: target.format,
     nullable: target.nullable === true,
     required: [...(target.required ?? [])],
     names: new Set(Object.keys(target.properties ?? {})),
     literal: literalOf(target),
+    unions: VARIANT_KEYWORDS.filter((keyword) => target[keyword]?.length).map(
+      (keyword) => target[keyword] as Schema[]
+    ),
   };
 
   for (const sub of target.allOf ?? []) {
     const inherited = compose(spec, sub, depth + 1);
 
     composition.type ??= inherited.type;
+    composition.format ??= inherited.format;
     composition.nullable ||= inherited.nullable;
     composition.literal ??= inherited.literal;
     composition.required.push(...inherited.required);
+    composition.unions.push(...inherited.unions);
     for (const name of inherited.names) composition.names.add(name);
   }
 
@@ -160,11 +171,11 @@ function matchesType(type: string, value: unknown): boolean {
  * choosing between the branches that survive it is `fit`'s job, because a value
  * that merely shares a property name with a branch has not exercised it.
  */
-export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
+export function matches(spec: Schema, schema: Schema, value: unknown, depth = 0): boolean {
   const { schema: target } = resolve(spec, schema);
   if (!target) return false;
 
-  const { type, nullable, required, names, literal } = compose(spec, target);
+  const { type, nullable, required, names, literal, unions } = compose(spec, target);
   const types = typesOf(type);
 
   // Nullability outranks every other constraint: a nullable enum still takes null.
@@ -173,6 +184,15 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
   // Without this a union of literals is indistinguishable, and every branch
   // accepts every value of the shared type.
   if (literal) return literal.values.includes(value);
+
+  // A schema whose only constraint is a nested union states nothing itself, so
+  // without this it accepts every value and its branches all read as covered.
+  if (depth <= MAX_DEPTH) {
+    const satisfied = unions.every((branches) =>
+      branches.some((branch) => matches(spec, branch, value, depth + 1))
+    );
+    if (!satisfied) return false;
+  }
 
   // Properties without a `type` still describe an object.
   const objectish = types.includes('object') || (types.length === 0 && names.size > 0);
@@ -185,7 +205,7 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
 
   // A 3.1 type array can allow an object alongside other types, so a non-object
   // value still has the rest of the list to satisfy.
-  if (types.length === 0) return !objectish;
+  if (types.length === 0) return unions.length > 0 || !objectish;
 
   return types.some((one) => matchesType(one, value));
 }
@@ -214,15 +234,15 @@ export function fit(spec: Schema, schema: Schema, value: unknown): number {
   const { schema: target } = resolve(spec, schema);
   if (!target) return 0;
 
+  const { names, format } = compose(spec, target);
+
   if (typeof value === 'string') {
-    const test = target.format ? FORMAT_TESTS[target.format] : undefined;
+    const test = format ? FORMAT_TESTS[format] : undefined;
 
     return test?.(value) ? 1 : 0;
   }
 
   if (!isPlainObject(value)) return 0;
-
-  const { names } = compose(spec, target);
 
   return Object.keys(value).filter((key) => names.has(key)).length;
 }

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -51,22 +51,44 @@ export function resolve(
  * `$ref` inside it alone: the target reports those under its own name, so
  * counting them here too would report them as unused on both schemas.
  */
-export function declared(spec: Schema, schema: Schema, depth = 0): [string, Schema][] {
+export function declared(spec: Schema, schema: Schema, path = '', depth = 0): [string, Schema][] {
   if (depth > MAX_DEPTH) return [];
 
   const { schema: target } = resolve(spec, schema);
   if (!target) return [];
 
-  return [
-    ...(Object.entries(target.properties ?? {}) as [string, Schema][]),
-    ...(target.allOf ?? []).flatMap((sub: Schema) =>
-      isRef(sub) ? [] : declared(spec, sub, depth + 1)
-    ),
-  ];
+  const found: [string, Schema][] = [];
+
+  for (const [property, sub] of Object.entries(target.properties ?? {}) as [string, Schema][]) {
+    const propertyPath = path ? `${path}.${property}` : property;
+
+    found.push([propertyPath, sub]);
+
+    // The walk records a nested inline object under a dotted path, so the two
+    // have to enumerate the same shape or the nested gaps never surface. A
+    // `$ref` still stops it: the walk reports what is behind one by its name.
+    if (!isRef(sub)) found.push(...declared(spec, sub, propertyPath, depth + 1));
+  }
+
+  for (const sub of target.allOf ?? []) {
+    if (isRef(sub)) continue;
+
+    found.push(...declared(spec, sub, path, depth + 1));
+  }
+
+  if (target.items && !isRef(target.items)) {
+    found.push(...declared(spec, target.items, path, depth + 1));
+  }
+
+  const byPath = new Map(found.map((entry) => [entry[0], entry]));
+
+  return [...byPath.values()];
 }
 
 interface Composition {
-  type?: string;
+  type?: string | string[];
+  /** OpenAPI 3.0 spells a nullable value this way; 3.1 puts `null` in `type`. */
+  nullable: boolean;
   required: string[];
   names: Set<string>;
 }
@@ -78,10 +100,11 @@ interface Composition {
  */
 function compose(spec: Schema, schema: Schema, depth = 0): Composition {
   const { schema: target } = resolve(spec, schema);
-  if (!target || depth > MAX_DEPTH) return { required: [], names: new Set() };
+  if (!target || depth > MAX_DEPTH) return { nullable: false, required: [], names: new Set() };
 
   const composition: Composition = {
     type: target.type,
+    nullable: target.nullable === true,
     required: [...(target.required ?? [])],
     names: new Set(Object.keys(target.properties ?? {})),
   };
@@ -90,6 +113,7 @@ function compose(spec: Schema, schema: Schema, depth = 0): Composition {
     const inherited = compose(spec, sub, depth + 1);
 
     composition.type ??= inherited.type;
+    composition.nullable ||= inherited.nullable;
     composition.required.push(...inherited.required);
     for (const name of inherited.names) composition.names.add(name);
   }
@@ -126,8 +150,10 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
 
   if (target.enum) return target.enum.includes(value as never);
 
-  const { type, required, names } = compose(spec, target);
+  const { type, nullable, required, names } = compose(spec, target);
   const types = typesOf(type);
+
+  if (value === null && nullable) return true;
 
   if (types.includes('object') || (types.length === 0 && names.size > 0)) {
     if (!isPlainObject(value)) return types.includes('null') && value === null;
@@ -140,6 +166,11 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
   if (types.length === 0) return true;
 
   return types.some((one) => matchesType(one, value));
+}
+
+/** Every property name a schema carries, including the ones it composes in. */
+export function composedNames(spec: Schema, schema: Schema): Set<string> {
+  return compose(spec, schema).names;
 }
 
 /** How many of a value's own properties a branch declares. */

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -25,13 +25,25 @@ export function resolve(
   if (!schema) return {};
   if (!isRef(schema)) return { schema };
 
-  const pointer = schema.$ref.replace(/^#\//, '').split('/').map(unescapePointerFragment);
-  let node: Schema | undefined = spec;
-  for (const segment of pointer) {
-    node = node?.[segment];
+  // A component can be a bare alias for another one, so follow the chain to the
+  // schema that actually declares something.
+  let node: Schema | undefined = schema;
+  let name: string | undefined;
+  for (let depth = 0; isRef(node) && depth <= MAX_DEPTH; depth += 1) {
+    const pointer: string[] = node.$ref
+      .replace(/^#\//, '')
+      .split('/')
+      .map(unescapePointerFragment);
+    let target: Schema | undefined = spec;
+    for (const segment of pointer) {
+      target = target?.[segment];
+    }
+
+    node = target;
+    name = pointer.at(-1);
   }
 
-  return { schema: node, name: pointer.at(-1) };
+  return { schema: node, name };
 }
 
 /**

--- a/packages/cli/src/commands/coverage/engine/schema.ts
+++ b/packages/cli/src/commands/coverage/engine/schema.ts
@@ -150,6 +150,9 @@ export function matches(spec: Schema, schema: Schema, value: unknown): boolean {
   if (!target) return false;
 
   if (target.enum) return target.enum.includes(value as never);
+  // OpenAPI 3.1 spells a single-value enum this way, and a union of literals is
+  // otherwise indistinguishable: every branch would accept every value.
+  if ('const' in target) return target.const === value;
 
   const { type, nullable, required, names } = compose(spec, target);
   const types = typesOf(type);
@@ -177,12 +180,32 @@ export function composedNames(spec: Schema, schema: Schema): Set<string> {
   return compose(spec, schema).names;
 }
 
-/** How many of a value's own properties a branch declares. */
-export function fit(spec: Schema, schema: Schema, value: unknown): number {
-  if (!isPlainObject(value)) return 0;
+/**
+ * The `format`s worth telling apart when two branches share a type. Used only
+ * to rank branches, never to reject a value: OpenAPI treats `format` as
+ * advisory, so a stricter reading here would drop valid coverage.
+ */
+const FORMAT_TESTS: Record<string, (value: string) => boolean> = {
+  uuid: (value) => /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(value),
+  date: (value) => /^\d{4}-\d{2}-\d{2}$/.test(value),
+  'date-time': (value) => !Number.isNaN(Date.parse(value)) && /[T ]/.test(value),
+  email: (value) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value),
+  uri: (value) => /^[a-z][a-z0-9+.-]*:/i.test(value),
+  ipv4: (value) => /^(\d{1,3}\.){3}\d{1,3}$/.test(value),
+};
 
+/** How much of a value a branch accounts for, used to rank the branches it could be. */
+export function fit(spec: Schema, schema: Schema, value: unknown): number {
   const { schema: target } = resolve(spec, schema);
   if (!target) return 0;
+
+  if (typeof value === 'string') {
+    const test = target.format ? FORMAT_TESTS[target.format] : undefined;
+
+    return test?.(value) ? 1 : 0;
+  }
+
+  if (!isPlainObject(value)) return 0;
 
   const { names } = compose(spec, target);
 

--- a/packages/cli/src/commands/coverage/engine/sites.ts
+++ b/packages/cli/src/commands/coverage/engine/sites.ts
@@ -1,0 +1,54 @@
+import { isPlainObject } from '@redocly/openapi-core';
+
+import { MAX_DEPTH, VARIANT_KEYWORDS, type Schema } from './schema.js';
+
+export interface Site {
+  owner: string;
+  path: string;
+  keyword: string;
+  count: number;
+}
+
+/**
+ * Identifies one union site. `owner` resets at every `$ref`, so a site belongs
+ * to the nearest named schema and stays stable as the description is edited.
+ */
+export function siteKey(owner: string, path: string, keyword: string): string {
+  return `${owner}${path ? `.${path}` : ''}#${keyword}`;
+}
+
+/**
+ * Every union site inside one named schema. Stops at `$ref` because the target
+ * is enumerated under its own name.
+ */
+export function collectSites(
+  schema: Schema | undefined,
+  owner: string,
+  path = '',
+  sites = new Map<string, Site>(),
+  depth = 0
+): Map<string, Site> {
+  if (!schema || depth > MAX_DEPTH || typeof schema.$ref === 'string') return sites;
+
+  for (const keyword of VARIANT_KEYWORDS) {
+    const branches: Schema[] | undefined = schema[keyword];
+    if (!branches?.length) continue;
+
+    sites.set(siteKey(owner, path, keyword), { owner, path, keyword, count: branches.length });
+    for (const branch of branches) collectSites(branch, owner, path, sites, depth + 1);
+  }
+
+  for (const branch of schema.allOf ?? []) collectSites(branch, owner, path, sites, depth + 1);
+
+  for (const [property, sub] of Object.entries(schema.properties ?? {}) as [string, Schema][]) {
+    collectSites(sub, owner, path ? `${path}.${property}` : property, sites, depth + 1);
+  }
+
+  collectSites(schema.items, owner, path, sites, depth + 1);
+
+  if (isPlainObject(schema.additionalProperties)) {
+    collectSites(schema.additionalProperties, owner, path, sites, depth + 1);
+  }
+
+  return sites;
+}

--- a/packages/cli/src/commands/coverage/engine/sites.ts
+++ b/packages/cli/src/commands/coverage/engine/sites.ts
@@ -1,6 +1,6 @@
 import { isPlainObject } from '@redocly/openapi-core';
 
-import { MAX_DEPTH, VARIANT_KEYWORDS, type Schema } from './schema.js';
+import { branchPath, MAX_DEPTH, VARIANT_KEYWORDS, type Schema } from './schema.js';
 
 export interface Site {
   owner: string;
@@ -17,14 +17,6 @@ export function siteKey(owner: string, path: string, keyword: string): string {
   return `${owner}${path ? `.${path}` : ''}#${keyword}`;
 }
 
-/**
- * The path inside one branch of a union. Sibling branches can each declare a
- * union at the same property, so without the branch in the path those nested
- * sites share a key and overwrite each other.
- */
-export function branchPath(path: string, keyword: string, index: number): string {
-  return `${path ? `${path}.` : ''}${keyword}[${index}]`;
-}
 
 /**
  * Every union site inside one named schema. Stops at `$ref` because the target

--- a/packages/cli/src/commands/coverage/engine/sites.ts
+++ b/packages/cli/src/commands/coverage/engine/sites.ts
@@ -18,6 +18,15 @@ export function siteKey(owner: string, path: string, keyword: string): string {
 }
 
 /**
+ * The path inside one branch of a union. Sibling branches can each declare a
+ * union at the same property, so without the branch in the path those nested
+ * sites share a key and overwrite each other.
+ */
+export function branchPath(path: string, keyword: string, index: number): string {
+  return `${path ? `${path}.` : ''}${keyword}[${index}]`;
+}
+
+/**
  * Every union site inside one named schema. Stops at `$ref` because the target
  * is enumerated under its own name.
  */
@@ -35,7 +44,9 @@ export function collectSites(
     if (!branches?.length) continue;
 
     sites.set(siteKey(owner, path, keyword), { owner, path, keyword, count: branches.length });
-    for (const branch of branches) collectSites(branch, owner, path, sites, depth + 1);
+    for (const [index, branch] of branches.entries()) {
+      collectSites(branch, owner, branchPath(path, keyword, index), sites, depth + 1);
+    }
   }
 
   for (const branch of schema.allOf ?? []) collectSites(branch, owner, path, sites, depth + 1);

--- a/packages/cli/src/commands/coverage/engine/statuses.ts
+++ b/packages/cli/src/commands/coverage/engine/statuses.ts
@@ -1,0 +1,93 @@
+import { isPlainObject } from '@redocly/openapi-core';
+
+import { isHttpMethod } from '../../drift/openapi/loader.js';
+import { resolve, type Schema } from './schema.js';
+
+export interface StatusCoverage {
+  seen: number;
+  total: number;
+  /** `GET /path  404`, for the documented responses nothing produced. */
+  unused: string[];
+}
+
+/** Operation key → the response keys the traffic produced. */
+export type StatusUse = Map<string, Set<string>>;
+
+export function createStatusUse(): StatusUse {
+  return new Map();
+}
+
+/**
+ * The response a status falls under: the exact code, then its class, then
+ * `default`. `drift` accepts the lowercase class form too, and the two have to
+ * agree on which response describes an exchange.
+ */
+export function matchStatusKey(documented: string[], status: number | undefined): string | undefined {
+  if (status === undefined) return documented.includes('default') ? 'default' : undefined;
+
+  const statusClass = `${Math.floor(status / 100)}XX`;
+  const candidates = [String(status), statusClass, statusClass.toLowerCase(), 'default'];
+
+  return candidates.find((candidate) => documented.includes(candidate));
+}
+
+/** Every response each operation documents, keyed as `method path`. */
+export function collectStatuses(spec: Schema): Map<string, string[]> {
+  const byOperation = new Map<string, string[]>();
+
+  for (const [pathTemplate, item] of Object.entries(spec.paths ?? {}) as [string, Schema][]) {
+    const { schema: pathItem } = resolve(spec, item);
+    if (!pathItem) continue;
+
+    for (const [method, operation] of Object.entries(pathItem) as [string, Schema][]) {
+      if (!isHttpMethod(method) || !isPlainObject(operation)) continue;
+
+      const { responses } = operation as Schema;
+      byOperation.set(`${method} ${pathTemplate}`, Object.keys(responses ?? {}));
+    }
+  }
+
+  return byOperation;
+}
+
+/** Note which documented response one exchange produced. */
+export function recordStatus(
+  use: StatusUse,
+  operationKey: string,
+  status: number | undefined,
+  documented: string[]
+): void {
+  const key = matchStatusKey(documented, status);
+  if (!key) return;
+
+  if (!use.has(operationKey)) use.set(operationKey, new Set());
+  use.get(operationKey)!.add(key);
+}
+
+/** Which documented responses the traffic produced. */
+export function summarizeStatuses(
+  declared: Map<string, string[]>,
+  use: StatusUse
+): StatusCoverage {
+  const unused: string[] = [];
+  let total = 0;
+  let seen = 0;
+
+  for (const [operationKey, statuses] of declared) {
+    const produced = use.get(operationKey) ?? new Set<string>();
+    const [method, ...rest] = operationKey.split(' ');
+
+    for (const status of statuses) {
+      total += 1;
+
+      if (produced.has(status)) {
+        seen += 1;
+        continue;
+      }
+
+      unused.push(`${method.toUpperCase()} ${rest.join(' ')}  ${status}`);
+    }
+  }
+
+  return { seen, total, unused: unused.sort() };
+}

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -1,0 +1,79 @@
+import { isPlainObject } from '@redocly/openapi-core';
+
+import { MAX_DEPTH, matches, resolve, VARIANT_KEYWORDS, type Schema } from './schema.js';
+import { siteKey } from './sites.js';
+
+export interface Coverage {
+  /** Named schema → property paths a value carried. */
+  properties: Map<string, Set<string>>;
+  /** Union site key → branch indices a value matched. */
+  variants: Map<string, Set<number>>;
+}
+
+export function createCoverage(): Coverage {
+  return { properties: new Map(), variants: new Map() };
+}
+
+interface WalkContext {
+  spec: Schema;
+  coverage: Coverage;
+  /** Nearest named schema, so an inline sub-schema attributes to something stable. */
+  owner: string;
+  prefix: string;
+  depth: number;
+}
+
+export function walk(schema: Schema | undefined, value: unknown, context: WalkContext): void {
+  if (!schema || value === undefined || context.depth > MAX_DEPTH) return;
+
+  const { schema: target, name } = resolve(context.spec, schema);
+  if (!target) return;
+
+  const next: WalkContext = name
+    ? { ...context, owner: name, prefix: '', depth: context.depth + 1 }
+    : { ...context, depth: context.depth + 1 };
+
+  for (const keyword of VARIANT_KEYWORDS) {
+    const branches: Schema[] | undefined = target[keyword];
+    if (!branches?.length) continue;
+
+    const key = siteKey(next.owner, next.prefix, keyword);
+    if (!next.coverage.variants.has(key)) next.coverage.variants.set(key, new Set());
+
+    for (const [index, branch] of branches.entries()) {
+      if (!matches(next.spec, branch, value)) continue;
+
+      next.coverage.variants.get(key)!.add(index);
+      walk(branch, value, next);
+    }
+  }
+
+  for (const branch of target.allOf ?? []) walk(branch, value, next);
+
+  if (Array.isArray(value)) {
+    for (const item of value) walk(target.items, item, next);
+    return;
+  }
+
+  if (!isPlainObject(value)) return;
+
+  for (const [property, sub] of Object.entries(target.properties ?? {}) as [string, Schema][]) {
+    if (!(property in value)) continue;
+
+    const path = next.prefix ? `${next.prefix}.${property}` : property;
+    if (!next.coverage.properties.has(next.owner)) {
+      next.coverage.properties.set(next.owner, new Set());
+    }
+    next.coverage.properties.get(next.owner)!.add(path);
+
+    walk(sub, (value as Record<string, unknown>)[property], { ...next, prefix: path });
+  }
+
+  if (isPlainObject(target.additionalProperties)) {
+    for (const item of Object.values(value)) walk(target.additionalProperties, item, next);
+  }
+}
+
+export function walkRoot(spec: Schema, coverage: Coverage, schema: Schema, value: unknown): void {
+  walk(schema, value, { spec, coverage, owner: '(inline)', prefix: '', depth: 0 });
+}

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -8,10 +8,16 @@ export interface Coverage {
   properties: Map<string, Set<string>>;
   /** Union site key → branch indices a value matched. */
   variants: Map<string, Set<number>>;
+  /**
+   * Named schemas a value reached. Tracked apart from `properties` because a
+   * schema can be reached without carrying one: a union holds only branches,
+   * and an object can inherit every property it has.
+   */
+  visited: Set<string>;
 }
 
 export function createCoverage(): Coverage {
-  return { properties: new Map(), variants: new Map() };
+  return { properties: new Map(), variants: new Map(), visited: new Set() };
 }
 
 interface WalkContext {
@@ -32,6 +38,8 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
   const next: WalkContext = name
     ? { ...context, owner: name, prefix: '', depth: context.depth + 1 }
     : { ...context, depth: context.depth + 1 };
+
+  if (name) next.coverage.visited.add(name);
 
   for (const keyword of VARIANT_KEYWORDS) {
     const branches: Schema[] | undefined = target[keyword];
@@ -69,8 +77,15 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
     walk(sub, (value as Record<string, unknown>)[property], { ...next, prefix: path });
   }
 
+  // `additionalProperties` describes only the keys `properties` does not.
   if (isPlainObject(target.additionalProperties)) {
-    for (const item of Object.values(value)) walk(target.additionalProperties, item, next);
+    const declaredKeys = new Set(Object.keys(target.properties ?? {}));
+
+    for (const [key, item] of Object.entries(value)) {
+      if (declaredKeys.has(key)) continue;
+
+      walk(target.additionalProperties, item, next);
+    }
   }
 }
 

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -8,7 +8,7 @@ import {
   VARIANT_KEYWORDS,
   type Schema,
 } from './schema.js';
-import { siteKey } from './sites.js';
+import { branchPath, siteKey } from './sites.js';
 
 export interface Coverage {
   /** Named schema → property paths a value carried. */
@@ -64,7 +64,7 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
 
     for (const index of selectBranches(next.spec, target, branches, value)) {
       next.coverage.variants.get(key)!.add(index);
-      walk(branches[index], value, next);
+      walk(branches[index], value, { ...next, prefix: branchPath(next.prefix, keyword, index) });
     }
   }
 

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -1,6 +1,13 @@
 import { isPlainObject } from '@redocly/openapi-core';
 
-import { MAX_DEPTH, resolve, selectBranches, VARIANT_KEYWORDS, type Schema } from './schema.js';
+import {
+  composedNames,
+  MAX_DEPTH,
+  resolve,
+  selectBranches,
+  VARIANT_KEYWORDS,
+  type Schema,
+} from './schema.js';
 import { siteKey } from './sites.js';
 
 export interface Coverage {
@@ -75,9 +82,10 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
     walk(sub, (value as Record<string, unknown>)[property], { ...next, prefix: path });
   }
 
-  // `additionalProperties` describes only the keys `properties` does not.
+  // `additionalProperties` describes only the keys the schema does not declare,
+  // counting the ones it composes in through `allOf`.
   if (isPlainObject(target.additionalProperties)) {
-    const declaredKeys = new Set(Object.keys(target.properties ?? {}));
+    const declaredKeys = composedNames(next.spec, target);
 
     for (const [key, item] of Object.entries(value)) {
       if (declaredKeys.has(key)) continue;

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -1,6 +1,7 @@
 import { isPlainObject } from '@redocly/openapi-core';
 
 import {
+  branchPath,
   composedNames,
   MAX_DEPTH,
   resolve,
@@ -8,7 +9,7 @@ import {
   VARIANT_KEYWORDS,
   type Schema,
 } from './schema.js';
-import { branchPath, siteKey } from './sites.js';
+import { siteKey } from './sites.js';
 
 export interface Coverage {
   /** Named schema → property paths a value carried. */
@@ -62,7 +63,7 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
     const key = siteKey(next.owner, next.prefix, keyword);
     if (!next.coverage.variants.has(key)) next.coverage.variants.set(key, new Set());
 
-    for (const index of selectBranches(next.spec, target, branches, value)) {
+    for (const index of selectBranches(next.spec, target, keyword, branches, value)) {
       next.coverage.variants.get(key)!.add(index);
       walk(branches[index], value, { ...next, prefix: branchPath(next.prefix, keyword, index) });
     }

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -1,6 +1,6 @@
 import { isPlainObject } from '@redocly/openapi-core';
 
-import { MAX_DEPTH, matches, resolve, VARIANT_KEYWORDS, type Schema } from './schema.js';
+import { MAX_DEPTH, resolve, selectBranches, VARIANT_KEYWORDS, type Schema } from './schema.js';
 import { siteKey } from './sites.js';
 
 export interface Coverage {
@@ -48,11 +48,9 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
     const key = siteKey(next.owner, next.prefix, keyword);
     if (!next.coverage.variants.has(key)) next.coverage.variants.set(key, new Set());
 
-    for (const [index, branch] of branches.entries()) {
-      if (!matches(next.spec, branch, value)) continue;
-
+    for (const index of selectBranches(next.spec, target, branches, value)) {
       next.coverage.variants.get(key)!.add(index);
-      walk(branch, value, next);
+      walk(branches[index], value, next);
     }
   }
 

--- a/packages/cli/src/commands/coverage/engine/walk.ts
+++ b/packages/cli/src/commands/coverage/engine/walk.ts
@@ -34,6 +34,12 @@ interface WalkContext {
   owner: string;
   prefix: string;
   depth: number;
+  /**
+   * Whether the walk is inside an inline `additionalProperties`. Those values
+   * sit outside the owner's property paths, so recording their names would
+   * credit a parent property that shares one.
+   */
+  mapped: boolean;
 }
 
 export function walk(schema: Schema | undefined, value: unknown, context: WalkContext): void {
@@ -42,8 +48,9 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
   const { schema: target, name } = resolve(context.spec, schema);
   if (!target) return;
 
+  // A `$ref` puts the walk back inside a named schema, where paths count again.
   const next: WalkContext = name
-    ? { ...context, owner: name, prefix: '', depth: context.depth + 1 }
+    ? { ...context, owner: name, prefix: '', depth: context.depth + 1, mapped: false }
     : { ...context, depth: context.depth + 1 };
 
   if (name) next.coverage.visited.add(name);
@@ -74,10 +81,12 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
     if (!(property in value)) continue;
 
     const path = next.prefix ? `${next.prefix}.${property}` : property;
-    if (!next.coverage.properties.has(next.owner)) {
-      next.coverage.properties.set(next.owner, new Set());
+    if (!next.mapped) {
+      if (!next.coverage.properties.has(next.owner)) {
+        next.coverage.properties.set(next.owner, new Set());
+      }
+      next.coverage.properties.get(next.owner)!.add(path);
     }
-    next.coverage.properties.get(next.owner)!.add(path);
 
     walk(sub, (value as Record<string, unknown>)[property], { ...next, prefix: path });
   }
@@ -90,11 +99,11 @@ export function walk(schema: Schema | undefined, value: unknown, context: WalkCo
     for (const [key, item] of Object.entries(value)) {
       if (declaredKeys.has(key)) continue;
 
-      walk(target.additionalProperties, item, next);
+      walk(target.additionalProperties, item, { ...next, mapped: true });
     }
   }
 }
 
 export function walkRoot(spec: Schema, coverage: Coverage, schema: Schema, value: unknown): void {
-  walk(schema, value, { spec, coverage, owner: '(inline)', prefix: '', depth: 0 });
+  walk(schema, value, { spec, coverage, owner: '(inline)', prefix: '', depth: 0, mapped: false });
 }

--- a/packages/cli/src/commands/coverage/index.ts
+++ b/packages/cli/src/commands/coverage/index.ts
@@ -149,6 +149,7 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
   const schemasByOperation = collectSchemas(spec);
 
   const coverage = createCoverage();
+  const acceptedCoverage = createCoverage();
   const exercisedOperations = new Set<string>();
   let exchangeIndex = 0;
   let walked = 0;
@@ -173,6 +174,9 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
       const entry = schemasByOperation.get(key);
       if (!entry) continue;
 
+      const status = exchange.response?.status;
+      const accepted = status !== undefined && status >= 200 && status < 300;
+
       const pairs: [Schema | undefined, unknown][] = [
         [
           bodySchema(spec, responseHolder(entry.responses, exchange.response?.status), exchange.response?.contentType),
@@ -187,6 +191,9 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
 
         used = true;
         walkRoot(spec, coverage, schema, value);
+        // Tracked a second time so the report can say how much of the figure
+        // rests on exchanges the API accepted.
+        if (accepted) walkRoot(spec, acceptedCoverage, schema, value);
       }
 
       if (used) walked += 1;
@@ -202,7 +209,9 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
     coverage,
     { total: exchangeIndex, withBody: walked },
     argv.schema,
-    exercisedOperations
+    exercisedOperations,
+    summarize(spec, acceptedCoverage, { total: exchangeIndex, withBody: walked }, argv.schema)
+      .seenProperties
   );
   const rendered = renderCoverage(report, { format: argv.format, all: Boolean(argv.all) });
 

--- a/packages/cli/src/commands/coverage/index.ts
+++ b/packages/cli/src/commands/coverage/index.ts
@@ -23,6 +23,13 @@ import {
   recordParameters,
   summarizeParameters,
 } from './engine/parameters.js';
+import {
+  collectStatuses,
+  createStatusUse,
+  matchStatusKey,
+  recordStatus,
+  summarizeStatuses,
+} from './engine/statuses.js';
 import { resolve, type Schema } from './engine/schema.js';
 import { createCoverage, walkRoot } from './engine/walk.js';
 import { renderCoverage, type CoverageFormat } from './reporter.js';
@@ -130,18 +137,9 @@ function bodySchema(
 }
 
 function responseHolder(responses: Schema, status: number | undefined): Schema | undefined {
-  if (status === undefined) return responses.default;
+  const key = matchStatusKey(Object.keys(responses), status);
 
-  const statusClass = `${Math.floor(status / 100)}XX`;
-
-  // `drift` accepts the lowercase form too, and the two have to agree on which
-  // schema describes a response.
-  return (
-    responses[String(status)] ??
-    responses[statusClass] ??
-    responses[statusClass.toLowerCase()] ??
-    responses.default
-  );
+  return key ? responses[key] : undefined;
 }
 
 export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>): Promise<void> {
@@ -158,6 +156,8 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
   const acceptedCoverage = createCoverage();
   const declaredParameters = collectParameters(spec);
   const parameterUse = createParameterUse();
+  const declaredStatuses = collectStatuses(spec);
+  const statusUse = createStatusUse();
   const exercisedOperations = new Set<string>();
   let exchangeIndex = 0;
   let walked = 0;
@@ -183,6 +183,7 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
         pathParams: matched.pathParams,
         headers: exchange.request.headers,
       });
+      recordStatus(statusUse, key, exchange.response?.status, declaredStatuses.get(key) ?? []);
 
       const entry = schemasByOperation.get(key);
       if (!entry) continue;
@@ -228,6 +229,7 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
         .seenProperties
     ),
     parameters: summarizeParameters(declaredParameters, parameterUse),
+    statuses: summarizeStatuses(declaredStatuses, statusUse),
   };
   const rendered = renderCoverage(report, { format: argv.format, all: Boolean(argv.all) });
 

--- a/packages/cli/src/commands/coverage/index.ts
+++ b/packages/cli/src/commands/coverage/index.ts
@@ -89,7 +89,16 @@ function bodySchema(
 function responseHolder(responses: Schema, status: number | undefined): Schema | undefined {
   if (status === undefined) return responses.default;
 
-  return responses[String(status)] ?? responses[`${Math.floor(status / 100)}XX`] ?? responses.default;
+  const statusClass = `${Math.floor(status / 100)}XX`;
+
+  // `drift` accepts the lowercase form too, and the two have to agree on which
+  // schema describes a response.
+  return (
+    responses[String(status)] ??
+    responses[statusClass] ??
+    responses[statusClass.toLowerCase()] ??
+    responses.default
+  );
 }
 
 export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>): Promise<void> {

--- a/packages/cli/src/commands/coverage/index.ts
+++ b/packages/cli/src/commands/coverage/index.ts
@@ -17,6 +17,12 @@ import type { MatchMode, TrafficFormat } from '../drift/types/index.js';
 import { listFilesRecursively, normalizeFsPath } from '../drift/utils/files.js';
 import { pickSchemaByMime } from '../drift/utils/http.js';
 import { summarize } from './engine/analyse.js';
+import {
+  collectParameters,
+  createParameterUse,
+  recordParameters,
+  summarizeParameters,
+} from './engine/parameters.js';
 import { resolve, type Schema } from './engine/schema.js';
 import { createCoverage, walkRoot } from './engine/walk.js';
 import { renderCoverage, type CoverageFormat } from './reporter.js';
@@ -150,6 +156,8 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
 
   const coverage = createCoverage();
   const acceptedCoverage = createCoverage();
+  const declaredParameters = collectParameters(spec);
+  const parameterUse = createParameterUse();
   const exercisedOperations = new Set<string>();
   let exchangeIndex = 0;
   let walked = 0;
@@ -170,6 +178,11 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
 
       const key = operationKey(matched.operation.method, matched.operation.pathTemplate);
       exercisedOperations.add(key);
+      recordParameters(parameterUse, key, {
+        query: exchange.request.query,
+        pathParams: matched.pathParams,
+        headers: exchange.request.headers,
+      });
 
       const entry = schemasByOperation.get(key);
       if (!entry) continue;
@@ -204,15 +217,18 @@ export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>
     return exitWithError('No HTTP exchanges were parsed from the provided traffic files.');
   }
 
-  const report = summarize(
-    spec,
-    coverage,
-    { total: exchangeIndex, withBody: walked },
-    argv.schema,
-    exercisedOperations,
-    summarize(spec, acceptedCoverage, { total: exchangeIndex, withBody: walked }, argv.schema)
-      .seenProperties
-  );
+  const report = {
+    ...summarize(
+      spec,
+      coverage,
+      { total: exchangeIndex, withBody: walked },
+      argv.schema,
+      exercisedOperations,
+      summarize(spec, acceptedCoverage, { total: exchangeIndex, withBody: walked }, argv.schema)
+        .seenProperties
+    ),
+    parameters: summarizeParameters(declaredParameters, parameterUse),
+  };
   const rendered = renderCoverage(report, { format: argv.format, all: Boolean(argv.all) });
 
   if (argv.output) {

--- a/packages/cli/src/commands/coverage/index.ts
+++ b/packages/cli/src/commands/coverage/index.ts
@@ -1,0 +1,170 @@
+import { bundle, isPlainObject, logger, type Config } from '@redocly/openapi-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { VerifyConfigOptions } from '../../types.js';
+import { exitWithError } from '../../utils/error.js';
+import type { CommandArgs } from '../../wrapper.js';
+import { selectTrafficParser } from '../drift/log-formats/registry.js';
+import { isHttpMethod, loadOpenApiIndex } from '../drift/openapi/loader.js';
+import { matchOperation } from '../drift/openapi/matcher.js';
+import type { MatchMode, TrafficFormat } from '../drift/types/index.js';
+import { listFilesRecursively, normalizeFsPath } from '../drift/utils/files.js';
+import { pickSchemaByMime } from '../drift/utils/http.js';
+import { summarize } from './engine/analyse.js';
+import { resolve, type Schema } from './engine/schema.js';
+import { createCoverage, walkRoot } from './engine/walk.js';
+import { renderCoverage, type CoverageFormat } from './reporter.js';
+
+export type CoverageArgv = {
+  traffic: string;
+  api: string;
+  'traffic-format': TrafficFormat;
+  format: CoverageFormat;
+  'match-mode'?: MatchMode;
+  schema?: string;
+  all?: boolean;
+  output?: string;
+} & VerifyConfigOptions;
+
+/**
+ * A bundled description that still carries `$ref`s.
+ *
+ * `drift`'s index cannot serve here: it bundles with `dereference: true`, which
+ * deep-clones every target, so a value's schema can no longer be traced back to
+ * the component it came from — and coverage is reported per component.
+ */
+async function loadReferencedSpec(specPath: string, config: Config): Promise<Schema> {
+  const { bundle: bundled } = await bundle({ ref: specPath, config, dereference: false });
+
+  return bundled.parsed as Schema;
+}
+
+async function writeReport(output: string, content: string): Promise<void> {
+  const resolved = normalizeFsPath(output);
+
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, content, 'utf8');
+}
+
+function operationKey(method: string, pathTemplate: string): string {
+  return `${method.toLowerCase()} ${pathTemplate}`;
+}
+
+/** Request and response body schemas per operation, keyed by method and path. */
+function collectSchemas(spec: Schema): Map<string, { request?: Schema; responses: Schema }> {
+  const byOperation = new Map<string, { request?: Schema; responses: Schema }>();
+
+  for (const [pathTemplate, item] of Object.entries(spec.paths ?? {}) as [string, Schema][]) {
+    for (const [method, operation] of Object.entries(item) as [string, Schema][]) {
+      if (!isHttpMethod(method) || !isPlainObject(operation)) continue;
+
+      const { requestBody, responses } = operation as Schema;
+      byOperation.set(operationKey(method, pathTemplate), {
+        request: requestBody,
+        responses: responses ?? {},
+      });
+    }
+  }
+
+  return byOperation;
+}
+
+/**
+ * The schema describing a body, selected the same way `drift` selects it:
+ * exact status, then the `2XX` class, then `default`, and the content entry by
+ * mime with wildcard fallbacks.
+ */
+function bodySchema(
+  spec: Schema,
+  holder: Schema | undefined,
+  contentType: string | undefined
+): Schema | undefined {
+  const { schema: resolved } = resolve(spec, holder);
+  const content = resolved?.content;
+
+  return content ? (pickSchemaByMime(content, contentType) as Schema | undefined)?.schema : undefined;
+}
+
+function responseHolder(responses: Schema, status: number | undefined): Schema | undefined {
+  if (status === undefined) return responses.default;
+
+  return responses[String(status)] ?? responses[`${Math.floor(status / 100)}XX`] ?? responses.default;
+}
+
+export async function handleCoverage({ argv, config }: CommandArgs<CoverageArgv>): Promise<void> {
+  const trafficFiles = await listFilesRecursively(argv.traffic);
+  if (trafficFiles.length === 0) {
+    return exitWithError('No traffic files found in the provided traffic path.');
+  }
+
+  const index = await loadOpenApiIndex(argv.api, config);
+  const spec = await loadReferencedSpec(argv.api, config);
+  const schemasByOperation = collectSchemas(spec);
+
+  const coverage = createCoverage();
+  const exercisedOperations = new Set<string>();
+  let exchangeIndex = 0;
+  let walked = 0;
+
+  for (const trafficFile of trafficFiles) {
+    const parser = await selectTrafficParser(trafficFile, argv['traffic-format']);
+    if (!parser) {
+      logger.warn(`Skipping traffic file with unrecognized format: ${trafficFile}\n`);
+      continue;
+    }
+
+    for await (const parsed of parser.parse(trafficFile)) {
+      const exchange = { ...parsed, index: exchangeIndex };
+      exchangeIndex += 1;
+
+      const matched = matchOperation(index, exchange, argv['match-mode'] ?? 'strict-host');
+      if (!matched) continue;
+
+      const key = operationKey(matched.operation.method, matched.operation.pathTemplate);
+      exercisedOperations.add(key);
+
+      const entry = schemasByOperation.get(key);
+      if (!entry) continue;
+
+      const pairs: [Schema | undefined, unknown][] = [
+        [
+          bodySchema(spec, responseHolder(entry.responses, exchange.response?.status), exchange.response?.contentType),
+          exchange.response?.bodyJson,
+        ],
+        [bodySchema(spec, entry.request, exchange.request.contentType), exchange.request.bodyJson],
+      ];
+
+      let used = false;
+      for (const [schema, value] of pairs) {
+        if (!schema || value === undefined) continue;
+
+        used = true;
+        walkRoot(spec, coverage, schema, value);
+      }
+
+      if (used) walked += 1;
+    }
+  }
+
+  if (exchangeIndex === 0) {
+    return exitWithError('No HTTP exchanges were parsed from the provided traffic files.');
+  }
+
+  const report = summarize(
+    spec,
+    coverage,
+    { total: exchangeIndex, withBody: walked },
+    argv.schema,
+    exercisedOperations
+  );
+  const rendered = renderCoverage(report, { format: argv.format, all: Boolean(argv.all) });
+
+  if (argv.output) {
+    await writeReport(argv.output, rendered);
+    logger.info(`Coverage report written to: ${normalizeFsPath(argv.output)}\n`);
+    return;
+  }
+
+  logger.output(rendered);
+}

--- a/packages/cli/src/commands/coverage/index.ts
+++ b/packages/cli/src/commands/coverage/index.ts
@@ -1,4 +1,4 @@
-import { bundle, isPlainObject, logger, type Config } from '@redocly/openapi-core';
+import { BaseResolver, bundle, isPlainObject, logger, type Config } from '@redocly/openapi-core';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -6,7 +6,12 @@ import type { VerifyConfigOptions } from '../../types.js';
 import { exitWithError } from '../../utils/error.js';
 import type { CommandArgs } from '../../wrapper.js';
 import { selectTrafficParser } from '../drift/log-formats/registry.js';
-import { isHttpMethod, loadOpenApiIndex } from '../drift/openapi/loader.js';
+import {
+  detectOpenApi3Spec,
+  isHttpMethod,
+  loadOpenApiIndex,
+  resolveSpecFiles,
+} from '../drift/openapi/loader.js';
 import { matchOperation } from '../drift/openapi/matcher.js';
 import type { MatchMode, TrafficFormat } from '../drift/types/index.js';
 import { listFilesRecursively, normalizeFsPath } from '../drift/utils/files.js';
@@ -35,9 +40,38 @@ export type CoverageArgv = {
  * the component it came from — and coverage is reported per component.
  */
 async function loadReferencedSpec(specPath: string, config: Config): Promise<Schema> {
-  const { bundle: bundled } = await bundle({ ref: specPath, config, dereference: false });
+  const { specFiles } = await resolveSpecFiles(specPath);
+  const externalRefResolver = new BaseResolver(config.resolve);
+  const roots: { file: string; parsed: Schema }[] = [];
 
-  return bundled.parsed as Schema;
+  for (const specFile of specFiles) {
+    const resolvedDocument = await externalRefResolver.resolveDocument(null, specFile, true);
+    // A folder holds the files a root description references as well, and only
+    // the roots describe operations.
+    if (resolvedDocument instanceof Error || !detectOpenApi3Spec(resolvedDocument)) continue;
+
+    const { bundle: bundled } = await bundle({
+      config,
+      doc: resolvedDocument,
+      externalRefResolver,
+      dereference: false,
+    });
+    roots.push({ file: specFile, parsed: bundled.parsed as Schema });
+  }
+
+  if (roots.length === 0) {
+    return exitWithError(`No OpenAPI 3.x description found at: ${specPath}`);
+  }
+
+  if (roots.length > 1) {
+    return exitWithError(
+      `Coverage measures one description at a time, but ${specPath} holds several:\n` +
+        roots.map(({ file }) => `  ${normalizeFsPath(file)}`).join('\n') +
+        '\nPoint --api at one of them.'
+    );
+  }
+
+  return roots[0].parsed;
 }
 
 async function writeReport(output: string, content: string): Promise<void> {
@@ -56,7 +90,10 @@ function collectSchemas(spec: Schema): Map<string, { request?: Schema; responses
   const byOperation = new Map<string, { request?: Schema; responses: Schema }>();
 
   for (const [pathTemplate, item] of Object.entries(spec.paths ?? {}) as [string, Schema][]) {
-    for (const [method, operation] of Object.entries(item) as [string, Schema][]) {
+    const { schema: pathItem } = resolve(spec, item);
+    if (!pathItem) continue;
+
+    for (const [method, operation] of Object.entries(pathItem) as [string, Schema][]) {
       if (!isHttpMethod(method) || !isPlainObject(operation)) continue;
 
       const { requestBody, responses } = operation as Schema;

--- a/packages/cli/src/commands/coverage/reporter.ts
+++ b/packages/cli/src/commands/coverage/reporter.ts
@@ -23,8 +23,18 @@ function stylish(report: CoverageReport, all: boolean): string {
       report.seenProperties,
       report.totalProperties
     )}%) over ${report.exchanges.withBody} of ${report.exchanges.total} exchange(s)`,
-    '',
   ];
+
+  if (report.seenPropertiesAccepted < report.seenProperties) {
+    lines.push(
+      `${report.seenPropertiesAccepted} of those came from a response the API accepted (${percentage(
+        report.seenPropertiesAccepted,
+        report.totalProperties
+      )}%)`
+    );
+  }
+
+  lines.push('');
 
   for (const { name, reached, seen, count, unusedProperties, unusedVariants } of report.schemas) {
     if (!reached && !all) continue;

--- a/packages/cli/src/commands/coverage/reporter.ts
+++ b/packages/cli/src/commands/coverage/reporter.ts
@@ -12,12 +12,16 @@ function percentage(seen: number, total: number): number {
 }
 
 function stylish(report: CoverageReport, all: boolean): string {
-  const { operations } = report;
+  const { operations, parameters } = report;
 
   const lines = [
     `${operations.seen}/${operations.total} operations exercised (${percentage(
       operations.seen,
       operations.total
+    )}%)`,
+    `${parameters.seen}/${parameters.total} documented parameters sent (${percentage(
+      parameters.seen,
+      parameters.total
     )}%)`,
     `${report.seenProperties}/${report.totalProperties} documented properties observed (${percentage(
       report.seenProperties,
@@ -27,7 +31,9 @@ function stylish(report: CoverageReport, all: boolean): string {
 
   if (report.seenPropertiesAccepted < report.seenProperties) {
     lines.push(
-      `${report.seenPropertiesAccepted} of those came from a response the API accepted (${percentage(
+      `${report.seenPropertiesAccepted}/${
+        report.totalProperties
+      } observed on an exchange the API accepted (${percentage(
         report.seenPropertiesAccepted,
         report.totalProperties
       )}%)`
@@ -50,6 +56,8 @@ function stylish(report: CoverageReport, all: boolean): string {
 
   for (const [title, entries] of [
     ['Operations nothing reached', report.operations.unused],
+    ['Parameters nothing sent', parameters.unused],
+    ['Parameter values nothing used', parameters.unusedValues],
     ['Schemas nothing reached', report.unusedSchemas],
   ] as const) {
     if (entries.length === 0) continue;

--- a/packages/cli/src/commands/coverage/reporter.ts
+++ b/packages/cli/src/commands/coverage/reporter.ts
@@ -1,0 +1,57 @@
+import type { CoverageReport } from './engine/analyse.js';
+
+export type CoverageFormat = 'stylish' | 'json';
+
+export interface RenderOptions {
+  format: CoverageFormat;
+  all: boolean;
+}
+
+function percentage(seen: number, total: number): number {
+  return total === 0 ? 0 : Math.round((seen / total) * 100);
+}
+
+function stylish(report: CoverageReport, all: boolean): string {
+  const { operations } = report;
+
+  const lines = [
+    `${operations.seen}/${operations.total} operations exercised (${percentage(
+      operations.seen,
+      operations.total
+    )}%)`,
+    `${report.seenProperties}/${report.totalProperties} documented properties observed (${percentage(
+      report.seenProperties,
+      report.totalProperties
+    )}%) over ${report.exchanges.withBody} of ${report.exchanges.total} exchange(s)`,
+    '',
+  ];
+
+  for (const { name, seen, count, unusedProperties, unusedVariants } of report.schemas) {
+    if (seen === 0 && !all) continue;
+
+    const clean = unusedProperties.length === 0 && unusedVariants.length === 0;
+    lines.push(`${clean ? '✓' : ' '} ${name}  ${seen}/${count}`);
+
+    for (const property of unusedProperties) lines.push(`    ${property}`);
+    for (const { path, keyword, branches } of unusedVariants) {
+      lines.push(`    ${path || '(root)'}  ${keyword} branch ${branches.join(', ')} never matched`);
+    }
+  }
+
+  for (const [title, entries] of [
+    ['Operations nothing reached', report.operations.unused],
+    ['Schemas nothing reached', report.unusedSchemas],
+  ] as const) {
+    if (entries.length === 0) continue;
+
+    lines.push('', `${title} — ${entries.length}`);
+    if (all) for (const entry of entries) lines.push(`    ${entry}`);
+    else lines.push('    pass --all to list them');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderCoverage(report: CoverageReport, { format, all }: RenderOptions): string {
+  return format === 'json' ? `${JSON.stringify(report, null, 2)}\n` : stylish(report, all);
+}

--- a/packages/cli/src/commands/coverage/reporter.ts
+++ b/packages/cli/src/commands/coverage/reporter.ts
@@ -12,7 +12,7 @@ function percentage(seen: number, total: number): number {
 }
 
 function stylish(report: CoverageReport, all: boolean): string {
-  const { operations, parameters } = report;
+  const { operations, parameters, statuses } = report;
 
   const lines = [
     `${operations.seen}/${operations.total} operations exercised (${percentage(
@@ -22,6 +22,10 @@ function stylish(report: CoverageReport, all: boolean): string {
     `${parameters.seen}/${parameters.total} documented parameters sent (${percentage(
       parameters.seen,
       parameters.total
+    )}%)`,
+    `${statuses.seen}/${statuses.total} documented responses returned (${percentage(
+      statuses.seen,
+      statuses.total
     )}%)`,
     `${report.seenProperties}/${report.totalProperties} documented properties observed (${percentage(
       report.seenProperties,
@@ -58,6 +62,7 @@ function stylish(report: CoverageReport, all: boolean): string {
     ['Operations nothing reached', report.operations.unused],
     ['Parameters nothing sent', parameters.unused],
     ['Parameter values nothing used', parameters.unusedValues],
+    ['Responses nothing returned', statuses.unused],
     ['Schemas nothing reached', report.unusedSchemas],
   ] as const) {
     if (entries.length === 0) continue;

--- a/packages/cli/src/commands/coverage/reporter.ts
+++ b/packages/cli/src/commands/coverage/reporter.ts
@@ -26,8 +26,8 @@ function stylish(report: CoverageReport, all: boolean): string {
     '',
   ];
 
-  for (const { name, seen, count, unusedProperties, unusedVariants } of report.schemas) {
-    if (seen === 0 && !all) continue;
+  for (const { name, reached, seen, count, unusedProperties, unusedVariants } of report.schemas) {
+    if (!reached && !all) continue;
 
     const clean = unusedProperties.length === 0 && unusedVariants.length === 0;
     lines.push(`${clean ? '✓' : ' '} ${name}  ${seen}/${count}`);

--- a/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
+++ b/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
@@ -1,4 +1,4 @@
-import { compileOpenApiPath } from '../../../commands/drift/utils/http.js';
+import { compileOpenApiPath } from '../utils/http.js';
 
 describe('compileOpenApiPath', () => {
   it('compiles a segment that is a single parameter', () => {

--- a/packages/cli/src/commands/drift/openapi/loader.ts
+++ b/packages/cli/src/commands/drift/openapi/loader.ts
@@ -187,7 +187,7 @@ function toOperationId(
   return `${method.toUpperCase()} ${pathTemplate}`;
 }
 
-function detectOpenApi3Spec(document: Document): SpecVersion | null {
+export function detectOpenApi3Spec(document: Document): SpecVersion | null {
   try {
     const specVersion = detectSpec(document.parsed);
     return getMajorSpecVersion(specVersion) === 'oas3' ? specVersion : null;
@@ -374,7 +374,7 @@ function finalizeIndex(
  * Resolve the OpenAPI spec input (a single file or a folder) into a flat list
  * of spec file paths that openapi-core can bundle individually.
  */
-async function resolveSpecFiles(
+export async function resolveSpecFiles(
   specPath: string
 ): Promise<{ specFiles: string[]; fromDirectory: boolean }> {
   const stats = await stat(specPath);

--- a/packages/cli/src/commands/drift/openapi/loader.ts
+++ b/packages/cli/src/commands/drift/openapi/loader.ts
@@ -34,7 +34,7 @@ type HttpMethod = (typeof HTTP_METHODS)[number];
 
 const PARAMETER_LOCATIONS = new Set(['query', 'header', 'path', 'cookie']);
 
-function isHttpMethod(value: string): value is HttpMethod {
+export function isHttpMethod(value: string): value is HttpMethod {
   return (HTTP_METHODS as readonly string[]).includes(value);
 }
 

--- a/packages/cli/src/commands/drift/utils/http.ts
+++ b/packages/cli/src/commands/drift/utils/http.ts
@@ -167,14 +167,36 @@ export function compileOpenApiPath(pathTemplate: string): {
         return '';
       }
 
-      const paramMatch = segment.match(/^\{([^}]+)\}$/);
-      if (paramMatch) {
+      // A segment may hold several parameters around literal text, as in
+      // `/instances/{worldId}:{instanceId}`. Matching the whole segment as one
+      // parameter would miss those, and treating it as a literal never matches.
+      const paramsBefore = params.length;
+      let compiled = '';
+      let literalLength = 0;
+      let offset = 0;
+
+      for (const paramMatch of segment.matchAll(/\{([^}]+)\}/g)) {
+        const literal = segment.slice(offset, paramMatch.index);
+
+        compiled += escapeRegex(literal);
+        literalLength += literal.length;
         params.push(paramMatch[1]);
-        return '([^/]+)';
+        compiled += '([^/]+?)';
+        offset = paramMatch.index + paramMatch[0].length;
       }
 
-      score += 2;
-      return escapeRegex(segment);
+      const trailing = segment.slice(offset);
+      compiled += escapeRegex(trailing);
+      literalLength += trailing.length;
+
+      if (params.length === paramsBefore) {
+        score += 2;
+      } else if (literalLength > 0) {
+        // More specific than a bare parameter, less so than a whole literal.
+        score += 1;
+      }
+
+      return compiled;
     })
     .join('/');
 

--- a/packages/cli/src/commands/respect/har-logs/helpers/build-post-data.ts
+++ b/packages/cli/src/commands/respect/har-logs/helpers/build-post-data.ts
@@ -1,0 +1,35 @@
+import { buildHeaders } from './build-headers.js';
+
+/**
+ * The HAR `postData` entry for a request body.
+ *
+ * Without this the capture records the request line and headers but not what
+ * was sent, so anything reading the HAR back — `drift`'s request-body
+ * validation, for one — silently has nothing to check.
+ */
+export function buildPostData(
+  body: unknown,
+  headers: any = {}
+): { mimeType?: string; text?: string } {
+  const text = serializeBody(body);
+  if (text === undefined || text === '') return {};
+
+  // Via `buildHeaders`, so every shape a request can carry its headers in is
+  // handled the same way here as it is for the entry's `headers` list.
+  const contentType = buildHeaders(headers).find(
+    ({ name }) => String(name).toLowerCase() === 'content-type'
+  )?.value;
+
+  return {
+    mimeType: typeof contentType === 'string' ? contentType : 'application/octet-stream',
+    text,
+  };
+}
+
+/** Only bodies that are already text; a stream or binary body is left out. */
+function serializeBody(body: unknown): string | undefined {
+  if (typeof body === 'string') return body;
+  if (body instanceof URLSearchParams) return body.toString();
+
+  return undefined;
+}

--- a/packages/cli/src/commands/respect/har-logs/with-har.ts
+++ b/packages/cli/src/commands/respect/har-logs/with-har.ts
@@ -12,6 +12,7 @@ import { URL } from 'url';
 
 import { addHeaders } from './helpers/add-headers.js';
 import { buildHeaders } from './helpers/build-headers.js';
+import { buildPostData } from './helpers/build-post-data.js';
 import { buildRequestCookies } from './helpers/build-request-cookies.js';
 import { buildResponseCookies } from './helpers/build-response-cookies.js';
 import { getDuration } from './helpers/get-duration.js';
@@ -43,6 +44,7 @@ export const withHar: WithHar = function <T extends typeof fetch>(
     const startTime = process.hrtime();
 
     const url = new URL(typeof input === 'string' ? input : input.url);
+    const postData = buildPostData(options.body, options.headers || {});
 
     const entry = {
       _compressed: false,
@@ -82,8 +84,8 @@ export const withHar: WithHar = function <T extends typeof fetch>(
           value,
         })),
         headersSize: -1,
-        bodySize: -1,
-        postData: {},
+        bodySize: postData.text === undefined ? -1 : Buffer.byteLength(postData.text),
+        postData,
         httpVersion: 'HTTP/1.1',
       },
       response: {},

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,8 @@ import { hideBin } from 'yargs/helpers';
 import { handleLogin, handleLogout } from './commands/auth.js';
 import type { BuildDocsArgv } from './commands/build-docs/types.js';
 import { handleBundle } from './commands/bundle.js';
+import { type CoverageArgv } from './commands/coverage/index.js';
+import { type CoverageFormat } from './commands/coverage/reporter.js';
 import type { ReportFormat } from './commands/drift/engine/reporter.js';
 import { type DriftArgv } from './commands/drift/index.js';
 import type { FindingSeverity, MatchMode, TrafficFormat } from './commands/drift/types/index.js';
@@ -1152,6 +1154,73 @@ yargs(hideBin(process.argv))
     async (argv) => {
       const { handleDrift } = await import('./commands/drift/index.js');
       commandWrapper(handleDrift)(argv as Arguments<DriftArgv>);
+    }
+  )
+  .command(
+    'coverage <traffic>',
+    'Report which documented properties, union branches, and schemas recorded traffic never exercised [experimental].',
+    (yargs) =>
+      yargs
+        .env('REDOCLY_CLI_COVERAGE')
+        .positional('traffic', {
+          describe: 'Path to a traffic log file or folder (HAR, Kong, Nginx/Apache JSON, NDJSON).',
+          type: 'string',
+        })
+        .option({
+          api: {
+            description: 'OpenAPI description file or folder to measure coverage against.',
+            type: 'string',
+            demandOption: true,
+          },
+          'traffic-format': {
+            description: 'Traffic input format.',
+            choices: [
+              'auto',
+              'har',
+              'kong',
+              'nginx-json',
+              'apache-json',
+              'ndjson',
+            ] as ReadonlyArray<TrafficFormat>,
+            default: 'auto' as TrafficFormat,
+          },
+          format: {
+            description: 'Use a specific output format.',
+            choices: ['stylish', 'json'] as ReadonlyArray<CoverageFormat>,
+            default: 'stylish' as CoverageFormat,
+          },
+          'match-mode': {
+            description:
+              'Endpoint matching mode (how requests are located via the description servers).',
+            choices: ['strict-host', 'basepath'] as ReadonlyArray<MatchMode>,
+            default: 'strict-host' as MatchMode,
+          },
+          schema: {
+            description: 'Report only this component schema.',
+            type: 'string',
+          },
+          all: {
+            description:
+              'List the operations and schemas nothing reached instead of collapsing them to a count.',
+            type: 'boolean',
+            default: false,
+          },
+          output: {
+            description:
+              'Write the coverage report (in the format selected with --format) to this file instead of stdout.',
+            type: 'string',
+            alias: 'o',
+          },
+          config: { description: 'Path to the config file.', type: 'string' },
+          'lint-config': {
+            description: 'Severity level for config file linting.',
+            choices: ['warn', 'error', 'off'] as ReadonlyArray<RuleSeverity>,
+            default: 'warn' as RuleSeverity,
+          },
+        }),
+    async (argv) => {
+      const { handleCoverage } = await import('./commands/coverage/index.js');
+      commandWrapper(handleCoverage)(argv as Arguments<CoverageArgv>);
     }
   )
   .command(

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -3,6 +3,7 @@ import type { RuleSeverity } from '@redocly/openapi-core';
 import type { LoginArgv, LogoutArgv } from './commands/auth.js';
 import type { BuildDocsArgv } from './commands/build-docs/types.js';
 import type { BundleArgv } from './commands/bundle.js';
+import type { CoverageArgv } from './commands/coverage/index.js';
 import type { DriftArgv } from './commands/drift/index.js';
 import type { EjectArgv } from './commands/eject.js';
 import type { GenerateArazzoCommandArgv } from './commands/generate-arazzo.js';
@@ -45,6 +46,7 @@ export type CommandArgv =
   | EjectArgv
   | RespectArgv
   | DriftArgv
+  | CoverageArgv
   | ProxyArgv
   | GenerateArazzoCommandArgv;
 

--- a/tests/e2e/coverage/__snapshots__/coverage-all.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-all.txt
@@ -1,5 +1,6 @@
 2/3 operations exercised (67%)
-6/11 documented properties observed (55%) over 2 of 2 exchange(s)
+7/11 documented properties observed (64%) over 3 of 3 exchange(s)
+6 of those came from a response the API accepted (55%)
 
   Badge  0/1
     name
@@ -11,8 +12,7 @@
     (root)  oneOf branch 1 never matched
   Square  0/1
     side
-  UpdateUserRequest  1/2
-    neverSent
+✓ UpdateUserRequest  2/2
   User  3/4
     neverSent
     badge  oneOf branch 1 never matched

--- a/tests/e2e/coverage/__snapshots__/coverage-all.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-all.txt
@@ -1,5 +1,6 @@
 2/3 operations exercised (67%)
 2/3 documented parameters sent (67%)
+2/4 documented responses returned (50%)
 7/11 documented properties observed (64%) over 3 of 3 exchange(s)
 6/11 observed on an exchange the API accepted (55%)
 
@@ -26,6 +27,10 @@ Parameters nothing sent — 1
 
 Parameter values nothing used — 1
     GET /users/{userId}  query.include=shape
+
+Responses nothing returned — 2
+    GET /health  200
+    GET /users/{userId}  404
 
 Schemas nothing reached — 3
     Badge

--- a/tests/e2e/coverage/__snapshots__/coverage-all.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-all.txt
@@ -1,21 +1,27 @@
 2/3 operations exercised (67%)
-4/8 documented properties observed (50%) over 2 of 2 exchange(s)
+6/11 documented properties observed (55%) over 2 of 2 exchange(s)
 
   Badge  0/1
     name
+✓ Circle  1/1
   Health  0/1
     status
 ✓ Identified  1/1
+  Shape  0/0
+    (root)  oneOf branch 1 never matched
+  Square  0/1
+    side
   UpdateUserRequest  1/2
     neverSent
-  User  2/3
+  User  3/4
     neverSent
     badge  oneOf branch 1 never matched
 
 Operations nothing reached — 1
     GET /health  getHealth
 
-Schemas nothing reached — 2
+Schemas nothing reached — 3
     Badge
     Health
+    Square
 

--- a/tests/e2e/coverage/__snapshots__/coverage-all.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-all.txt
@@ -1,6 +1,7 @@
 2/3 operations exercised (67%)
+2/3 documented parameters sent (67%)
 7/11 documented properties observed (64%) over 3 of 3 exchange(s)
-6 of those came from a response the API accepted (55%)
+6/11 observed on an exchange the API accepted (55%)
 
   Badge  0/1
     name
@@ -19,6 +20,12 @@
 
 Operations nothing reached — 1
     GET /health  getHealth
+
+Parameters nothing sent — 1
+    GET /users/{userId}  query.neverSentParam
+
+Parameter values nothing used — 1
+    GET /users/{userId}  query.include=shape
 
 Schemas nothing reached — 3
     Badge

--- a/tests/e2e/coverage/__snapshots__/coverage-all.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-all.txt
@@ -1,0 +1,21 @@
+2/3 operations exercised (67%)
+4/8 documented properties observed (50%) over 2 of 2 exchange(s)
+
+  Badge  0/1
+    name
+  Health  0/1
+    status
+✓ Identified  1/1
+  UpdateUserRequest  1/2
+    neverSent
+  User  2/3
+    neverSent
+    badge  oneOf branch 1 never matched
+
+Operations nothing reached — 1
+    GET /health  getHealth
+
+Schemas nothing reached — 2
+    Badge
+    Health
+

--- a/tests/e2e/coverage/__snapshots__/coverage-json.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-json.txt
@@ -117,6 +117,14 @@
     "unusedValues": [
       "GET /users/{userId}  query.include=shape"
     ]
+  },
+  "statuses": {
+    "seen": 2,
+    "total": 4,
+    "unused": [
+      "GET /health  200",
+      "GET /users/{userId}  404"
+    ]
   }
 }
 

--- a/tests/e2e/coverage/__snapshots__/coverage-json.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-json.txt
@@ -10,11 +10,12 @@
       "GET /health  getHealth"
     ]
   },
-  "seenProperties": 4,
-  "totalProperties": 8,
+  "seenProperties": 6,
+  "totalProperties": 11,
   "schemas": [
     {
       "name": "Badge",
+      "reached": false,
       "seen": 0,
       "count": 1,
       "unusedProperties": [
@@ -23,7 +24,16 @@
       "unusedVariants": []
     },
     {
+      "name": "Circle",
+      "reached": true,
+      "seen": 1,
+      "count": 1,
+      "unusedProperties": [],
+      "unusedVariants": []
+    },
+    {
       "name": "Health",
+      "reached": false,
       "seen": 0,
       "count": 1,
       "unusedProperties": [
@@ -33,13 +43,41 @@
     },
     {
       "name": "Identified",
+      "reached": true,
       "seen": 1,
       "count": 1,
       "unusedProperties": [],
       "unusedVariants": []
     },
     {
+      "name": "Shape",
+      "reached": true,
+      "seen": 0,
+      "count": 0,
+      "unusedProperties": [],
+      "unusedVariants": [
+        {
+          "path": "",
+          "keyword": "oneOf",
+          "branches": [
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Square",
+      "reached": false,
+      "seen": 0,
+      "count": 1,
+      "unusedProperties": [
+        "side"
+      ],
+      "unusedVariants": []
+    },
+    {
       "name": "UpdateUserRequest",
+      "reached": true,
       "seen": 1,
       "count": 2,
       "unusedProperties": [
@@ -49,8 +87,9 @@
     },
     {
       "name": "User",
-      "seen": 2,
-      "count": 3,
+      "reached": true,
+      "seen": 3,
+      "count": 4,
       "unusedProperties": [
         "neverSent"
       ],
@@ -67,7 +106,8 @@
   ],
   "unusedSchemas": [
     "Badge",
-    "Health"
+    "Health",
+    "Square"
   ]
 }
 

--- a/tests/e2e/coverage/__snapshots__/coverage-json.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-json.txt
@@ -1,7 +1,7 @@
 {
   "exchanges": {
-    "total": 2,
-    "withBody": 2
+    "total": 3,
+    "withBody": 3
   },
   "operations": {
     "seen": 2,
@@ -10,7 +10,8 @@
       "GET /health  getHealth"
     ]
   },
-  "seenProperties": 6,
+  "seenProperties": 7,
+  "seenPropertiesAccepted": 6,
   "totalProperties": 11,
   "schemas": [
     {
@@ -78,11 +79,9 @@
     {
       "name": "UpdateUserRequest",
       "reached": true,
-      "seen": 1,
+      "seen": 2,
       "count": 2,
-      "unusedProperties": [
-        "neverSent"
-      ],
+      "unusedProperties": [],
       "unusedVariants": []
     },
     {

--- a/tests/e2e/coverage/__snapshots__/coverage-json.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-json.txt
@@ -1,0 +1,73 @@
+{
+  "exchanges": {
+    "total": 2,
+    "withBody": 2
+  },
+  "operations": {
+    "seen": 2,
+    "total": 3,
+    "unused": [
+      "GET /health  getHealth"
+    ]
+  },
+  "seenProperties": 4,
+  "totalProperties": 8,
+  "schemas": [
+    {
+      "name": "Badge",
+      "seen": 0,
+      "count": 1,
+      "unusedProperties": [
+        "name"
+      ],
+      "unusedVariants": []
+    },
+    {
+      "name": "Health",
+      "seen": 0,
+      "count": 1,
+      "unusedProperties": [
+        "status"
+      ],
+      "unusedVariants": []
+    },
+    {
+      "name": "Identified",
+      "seen": 1,
+      "count": 1,
+      "unusedProperties": [],
+      "unusedVariants": []
+    },
+    {
+      "name": "UpdateUserRequest",
+      "seen": 1,
+      "count": 2,
+      "unusedProperties": [
+        "neverSent"
+      ],
+      "unusedVariants": []
+    },
+    {
+      "name": "User",
+      "seen": 2,
+      "count": 3,
+      "unusedProperties": [
+        "neverSent"
+      ],
+      "unusedVariants": [
+        {
+          "path": "badge",
+          "keyword": "oneOf",
+          "branches": [
+            1
+          ]
+        }
+      ]
+    }
+  ],
+  "unusedSchemas": [
+    "Badge",
+    "Health"
+  ]
+}
+

--- a/tests/e2e/coverage/__snapshots__/coverage-json.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-json.txt
@@ -107,6 +107,16 @@
     "Badge",
     "Health",
     "Square"
-  ]
+  ],
+  "parameters": {
+    "seen": 2,
+    "total": 3,
+    "unused": [
+      "GET /users/{userId}  query.neverSentParam"
+    ],
+    "unusedValues": [
+      "GET /users/{userId}  query.include=shape"
+    ]
+  }
 }
 

--- a/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
@@ -1,7 +1,7 @@
 2/3 operations exercised (67%)
-2/3 documented properties observed (67%) over 2 of 2 exchange(s)
+3/4 documented properties observed (75%) over 2 of 2 exchange(s)
 
-  User  2/3
+  User  3/4
     neverSent
     badge  oneOf branch 1 never matched
 

--- a/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
@@ -1,4 +1,5 @@
 2/3 operations exercised (67%)
+2/3 documented parameters sent (67%)
 3/4 documented properties observed (75%) over 3 of 3 exchange(s)
 
   User  3/4
@@ -6,5 +7,11 @@
     badge  oneOf branch 1 never matched
 
 Operations nothing reached — 1
+    pass --all to list them
+
+Parameters nothing sent — 1
+    pass --all to list them
+
+Parameter values nothing used — 1
     pass --all to list them
 

--- a/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
@@ -1,5 +1,6 @@
 2/3 operations exercised (67%)
 2/3 documented parameters sent (67%)
+2/4 documented responses returned (50%)
 3/4 documented properties observed (75%) over 3 of 3 exchange(s)
 
   User  3/4
@@ -13,5 +14,8 @@ Parameters nothing sent — 1
     pass --all to list them
 
 Parameter values nothing used — 1
+    pass --all to list them
+
+Responses nothing returned — 2
     pass --all to list them
 

--- a/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
@@ -1,5 +1,5 @@
 2/3 operations exercised (67%)
-3/4 documented properties observed (75%) over 2 of 2 exchange(s)
+3/4 documented properties observed (75%) over 3 of 3 exchange(s)
 
   User  3/4
     neverSent

--- a/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-schema-filter.txt
@@ -1,0 +1,10 @@
+2/3 operations exercised (67%)
+2/3 documented properties observed (67%) over 2 of 2 exchange(s)
+
+  User  2/3
+    neverSent
+    badge  oneOf branch 1 never matched
+
+Operations nothing reached — 1
+    pass --all to list them
+

--- a/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
@@ -1,5 +1,6 @@
 2/3 operations exercised (67%)
 2/3 documented parameters sent (67%)
+2/4 documented responses returned (50%)
 7/11 documented properties observed (64%) over 3 of 3 exchange(s)
 6/11 observed on an exchange the API accepted (55%)
 
@@ -19,6 +20,9 @@ Parameters nothing sent — 1
     pass --all to list them
 
 Parameter values nothing used — 1
+    pass --all to list them
+
+Responses nothing returned — 2
     pass --all to list them
 
 Schemas nothing reached — 3

--- a/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
@@ -1,6 +1,7 @@
 2/3 operations exercised (67%)
+2/3 documented parameters sent (67%)
 7/11 documented properties observed (64%) over 3 of 3 exchange(s)
-6 of those came from a response the API accepted (55%)
+6/11 observed on an exchange the API accepted (55%)
 
 ✓ Circle  1/1
 ✓ Identified  1/1
@@ -12,6 +13,12 @@
     badge  oneOf branch 1 never matched
 
 Operations nothing reached — 1
+    pass --all to list them
+
+Parameters nothing sent — 1
+    pass --all to list them
+
+Parameter values nothing used — 1
     pass --all to list them
 
 Schemas nothing reached — 3

--- a/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
@@ -1,16 +1,19 @@
 2/3 operations exercised (67%)
-4/8 documented properties observed (50%) over 2 of 2 exchange(s)
+6/11 documented properties observed (55%) over 2 of 2 exchange(s)
 
+✓ Circle  1/1
 ✓ Identified  1/1
+  Shape  0/0
+    (root)  oneOf branch 1 never matched
   UpdateUserRequest  1/2
     neverSent
-  User  2/3
+  User  3/4
     neverSent
     badge  oneOf branch 1 never matched
 
 Operations nothing reached — 1
     pass --all to list them
 
-Schemas nothing reached — 2
+Schemas nothing reached — 3
     pass --all to list them
 

--- a/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
@@ -1,12 +1,12 @@
 2/3 operations exercised (67%)
-6/11 documented properties observed (55%) over 2 of 2 exchange(s)
+7/11 documented properties observed (64%) over 3 of 3 exchange(s)
+6 of those came from a response the API accepted (55%)
 
 ✓ Circle  1/1
 ✓ Identified  1/1
   Shape  0/0
     (root)  oneOf branch 1 never matched
-  UpdateUserRequest  1/2
-    neverSent
+✓ UpdateUserRequest  2/2
   User  3/4
     neverSent
     badge  oneOf branch 1 never matched

--- a/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
+++ b/tests/e2e/coverage/__snapshots__/coverage-stylish.txt
@@ -1,0 +1,16 @@
+2/3 operations exercised (67%)
+4/8 documented properties observed (50%) over 2 of 2 exchange(s)
+
+✓ Identified  1/1
+  UpdateUserRequest  1/2
+    neverSent
+  User  2/3
+    neverSent
+    badge  oneOf branch 1 never matched
+
+Operations nothing reached — 1
+    pass --all to list them
+
+Schemas nothing reached — 2
+    pass --all to list them
+

--- a/tests/e2e/coverage/coverage.test.ts
+++ b/tests/e2e/coverage/coverage.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { cleanupOutput } from '../helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
+const fixtures = join(__dirname, 'fixtures');
+const snapshots = join(__dirname, '__snapshots__');
+
+function runCoverage(args: string[]): { output: string; code: number | null } {
+  const result = spawnSync('node', [indexEntryPoint, 'coverage', ...args], {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    cwd: fixtures,
+    env: { ...process.env, NODE_ENV: 'test', NO_COLOR: 'TRUE', FORCE_COLOR: '0' },
+  });
+
+  if (result.error) {
+    throw new Error(`Command execution failed: ${result.error.message}`);
+  }
+
+  const out = result.stdout?.toString() ?? '';
+  const err = result.stderr?.toString() ?? '';
+
+  return { output: cleanupOutput(`${out}\n${err}`), code: result.status };
+}
+
+async function matchSnapshot(name: string, output: string): Promise<void> {
+  await expect(output).toMatchFileSnapshot(join(snapshots, `${name}.txt`));
+}
+
+describe('E2E coverage', () => {
+  it('reports operations, properties, variants, and schemas nothing reached', async () => {
+    const { output, code } = runCoverage(['traffic.har', '--api', 'openapi.yaml']);
+
+    expect(code).toBe(0);
+    await matchSnapshot('coverage-stylish', output);
+  });
+
+  it('lists what it collapses when --all is passed', async () => {
+    const { output, code } = runCoverage(['traffic.har', '--api', 'openapi.yaml', '--all']);
+
+    expect(code).toBe(0);
+    await matchSnapshot('coverage-all', output);
+  });
+
+  it('emits a machine-readable report with --format json', async () => {
+    const { output, code } = runCoverage([
+      'traffic.har',
+      '--api',
+      'openapi.yaml',
+      '--format',
+      'json',
+    ]);
+
+    expect(code).toBe(0);
+    await matchSnapshot('coverage-json', output);
+  });
+
+  it('narrows to a single schema with --schema', async () => {
+    const { output, code } = runCoverage([
+      'traffic.har',
+      '--api',
+      'openapi.yaml',
+      '--schema',
+      'User',
+    ]);
+
+    expect(code).toBe(0);
+    await matchSnapshot('coverage-schema-filter', output);
+  });
+
+  // Not snapshotted: the stack trace names minified chunks, which change on
+  // every build. `drift` reports a missing traffic path the same way.
+  it('fails when the traffic path does not exist', () => {
+    const { output, code } = runCoverage(['absent.har', '--api', 'openapi.yaml']);
+
+    expect(code).toBe(1);
+    expect(output).toContain("ENOENT: no such file or directory, stat 'absent.har'");
+  });
+});

--- a/tests/e2e/coverage/coverage.test.ts
+++ b/tests/e2e/coverage/coverage.test.ts
@@ -72,6 +72,13 @@ describe('E2E coverage', () => {
     await matchSnapshot('coverage-schema-filter', output);
   });
 
+  it('accepts a folder for --api, as the flag documents', async () => {
+    const { output, code } = runCoverage(['traffic.har', '--api', '.']);
+
+    expect(code).toBe(0);
+    await matchSnapshot('coverage-stylish', output);
+  });
+
   // Not snapshotted: the stack trace names minified chunks, which change on
   // every build. `drift` reports a missing traffic path the same way.
   it('fails when the traffic path does not exist', () => {

--- a/tests/e2e/coverage/fixtures/openapi.yaml
+++ b/tests/e2e/coverage/fixtures/openapi.yaml
@@ -32,6 +32,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '404':
+          description: Never returned by the fixture traffic.
     put:
       operationId: updateUser
       requestBody:

--- a/tests/e2e/coverage/fixtures/openapi.yaml
+++ b/tests/e2e/coverage/fixtures/openapi.yaml
@@ -1,0 +1,84 @@
+openapi: 3.0.3
+info:
+  title: Coverage fixture
+  version: 1.0.0
+servers:
+  - url: http://api.example.com
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+    put:
+      operationId: updateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: The updated user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /health:
+    get:
+      operationId: getHealth
+      responses:
+        '200':
+          description: Never called by the fixture traffic.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+components:
+  schemas:
+    Identified:
+      type: object
+      properties:
+        id:
+          type: string
+    User:
+      allOf:
+        - $ref: '#/components/schemas/Identified'
+        - type: object
+          properties:
+            bio:
+              type: string
+            neverSent:
+              type: string
+            badge:
+              oneOf:
+                - type: string
+                - $ref: '#/components/schemas/Badge'
+    Badge:
+      type: object
+      properties:
+        name:
+          type: string
+    UpdateUserRequest:
+      type: object
+      properties:
+        bio:
+          type: string
+        neverSent:
+          type: string
+    Health:
+      type: object
+      properties:
+        status:
+          type: string

--- a/tests/e2e/coverage/fixtures/openapi.yaml
+++ b/tests/e2e/coverage/fixtures/openapi.yaml
@@ -65,6 +65,26 @@ components:
               oneOf:
                 - type: string
                 - $ref: '#/components/schemas/Badge'
+            shape:
+              $ref: '#/components/schemas/Shape'
+    Shape:
+      oneOf:
+        - $ref: '#/components/schemas/Circle'
+        - $ref: '#/components/schemas/Square'
+    Circle:
+      type: object
+      required:
+        - radius
+      properties:
+        radius:
+          type: number
+    Square:
+      type: object
+      required:
+        - side
+      properties:
+        side:
+          type: number
     Badge:
       type: object
       properties:

--- a/tests/e2e/coverage/fixtures/openapi.yaml
+++ b/tests/e2e/coverage/fixtures/openapi.yaml
@@ -14,6 +14,17 @@ paths:
           required: true
           schema:
             type: string
+        - name: include
+          in: query
+          schema:
+            type: string
+            enum:
+              - badge
+              - shape
+        - name: neverSentParam
+          in: query
+          schema:
+            type: string
       responses:
         '200':
           description: A user.

--- a/tests/e2e/coverage/fixtures/traffic.har
+++ b/tests/e2e/coverage/fixtures/traffic.har
@@ -40,6 +40,26 @@
           }
         }
       }
+      ,
+      {
+        "startedDateTime": "2024-01-01T00:00:02.000Z",
+        "request": {
+          "method": "PUT",
+          "url": "http://api.example.com/users/usr_2",
+          "headers": [
+            { "name": "Host", "value": "api.example.com" },
+            { "name": "Content-Type", "value": "application/json" }
+          ],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"neverSent\":\"rejected\"}"
+          }
+        },
+        "response": {
+          "status": 400,
+          "content": { "mimeType": "application/json", "text": "{\"error\":\"bad\"}" }
+        }
+      }
     ]
   }
 }

--- a/tests/e2e/coverage/fixtures/traffic.har
+++ b/tests/e2e/coverage/fixtures/traffic.har
@@ -7,7 +7,7 @@
         "startedDateTime": "2024-01-01T00:00:00.000Z",
         "request": {
           "method": "GET",
-          "url": "http://api.example.com/users/usr_1",
+          "url": "http://api.example.com/users/usr_1?include=badge",
           "headers": [{ "name": "Host", "value": "api.example.com" }]
         },
         "response": {

--- a/tests/e2e/coverage/fixtures/traffic.har
+++ b/tests/e2e/coverage/fixtures/traffic.har
@@ -1,0 +1,45 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": { "name": "fixture", "version": "1.0" },
+    "entries": [
+      {
+        "startedDateTime": "2024-01-01T00:00:00.000Z",
+        "request": {
+          "method": "GET",
+          "url": "http://api.example.com/users/usr_1",
+          "headers": [{ "name": "Host", "value": "api.example.com" }]
+        },
+        "response": {
+          "status": 200,
+          "content": {
+            "mimeType": "application/json",
+            "text": "{\"id\":\"usr_1\",\"bio\":\"hello\",\"badge\":\"gold\"}"
+          }
+        }
+      },
+      {
+        "startedDateTime": "2024-01-01T00:00:01.000Z",
+        "request": {
+          "method": "PUT",
+          "url": "http://api.example.com/users/usr_1",
+          "headers": [
+            { "name": "Host", "value": "api.example.com" },
+            { "name": "Content-Type", "value": "application/json" }
+          ],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"bio\":\"updated\"}"
+          }
+        },
+        "response": {
+          "status": 200,
+          "content": {
+            "mimeType": "application/json",
+            "text": "{\"id\":\"usr_1\",\"bio\":\"updated\",\"badge\":\"gold\"}"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/e2e/coverage/fixtures/traffic.har
+++ b/tests/e2e/coverage/fixtures/traffic.har
@@ -14,7 +14,7 @@
           "status": 200,
           "content": {
             "mimeType": "application/json",
-            "text": "{\"id\":\"usr_1\",\"bio\":\"hello\",\"badge\":\"gold\"}"
+            "text": "{\"id\":\"usr_1\",\"bio\":\"hello\",\"badge\":\"gold\",\"shape\":{\"radius\":1}}"
           }
         }
       },


### PR DESCRIPTION
## What/Why/How?

> [!NOTE]
> This was heavily assisted by Anthropic's Opus 5. I've reviewed the code to the best of my ability, but if there's any obvious issues I didn't catch, let me know.

`drift` reports where traffic and the description disagree, but says nothing about the parts no traffic reached. A clean `drift` run means only that nothing was wrong in the portion the traffic covered. `coverage` measures that portion.

The command parses a traffic log, matches each exchange to a documented operation through `drift`'s matcher, walks each body against the schema that describes it, and reports what nothing reached: operations, properties, `oneOf`/`anyOf` branches, and component schemas.

It adds no runtime dependencies. Spec loading reuses `@redocly/openapi-core`; traffic parsing, operation matching, and mime selection come from `drift`.

It bundles the description a second time with `dereference: false`. `drift`'s loader dereferences, deep-cloning every `$ref` target, so nothing under `paths` shares identity with `components.schemas`. Without that identity a value cannot be traced back to the component it came from, and coverage is reported per component.

## Reference

Stacked on #2992, #2994. This branch includes that commit until it merges.

## Testing

Unit tests cover the engine: `$ref` resolution, declared properties, union-site enumeration, branch matching, walking, and summarizing. E2E runs the built CLI over a HAR fixture in stylish, JSON, `--all`, and `--schema` modes, plus the missing-traffic-path case. The fixture composes `User` with `allOf` so inherited properties are credited to the schema that declares them.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines)
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines

The command reads traffic logs and a description, both already handled as untrusted input by `drift`, and writes the report only to the path given by `--output`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new experimental command reuses drift matching and shared path-regex logic, so regressions could affect drift routing; behavior is heavily tested but the feature surface (schema walking, unions, dual spec load) is non-trivial.
> 
> **Overview**
> Introduces the experimental **`coverage`** command: it ingests the same traffic formats as **`drift`**, matches exchanges via **`drift`**’s matcher, walks request/response bodies against documented schemas (with **`dereference: false`** bundling so coverage can attribute hits to component schemas), and reports **unexercised** operations, parameters, responses, properties, union branches, and schemas in **stylish** or **JSON** output (`--schema`, `--all`, `--output`).
> 
> **`drift`** path compilation now supports segments that mix literals and multiple parameters (e.g. `/instances/{worldId}:{instanceId}`), with scoring so more specific templates win—fixing missed matches for both **`drift`** and **`coverage`**.
> 
> **`respect --har-output`** now populates HAR **`postData`** (and **`bodySize`**) for string/`URLSearchParams` bodies via **`buildPostData`**, so replays can validate request bodies.
> 
> Docs, changesets, unit/e2e tests, and a root **`/coverage/`** **`.gitignore`** entry (so Vitest reports don’t hide the command source tree) round out the change; **`drift`** loader helpers are exported for **`coverage`** reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f52750768ee59bbf383be0b2c3830bfc7fb4f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->