### PR TITLE
fix(drift): match path segments that mix literal text with parameters

### DIFF
--- a/.changeset/drift-multi-parameter-path-segments.md
+++ b/.changeset/drift-multi-parameter-path-segments.md
@@ -1,0 +1,7 @@
+---
+'@redocly/cli': patch
+---
+
+Fixed `drift` and `coverage` failing to match a path template whose segment mixes literal text with parameters, such as `/instances/{worldId}:{instanceId}`.
+Only a segment that was entirely one parameter was recognized, so these templates were compiled as literal text and never matched any request.
+Affected requests were reported as undocumented by `drift` and left out of the `coverage` figures.

--- a/.changeset/drift-multi-parameter-path-segments.md
+++ b/.changeset/drift-multi-parameter-path-segments.md
@@ -3,5 +3,3 @@
 ---
 
 Fixed `drift` and `coverage` failing to match a path template whose segment mixes literal text with parameters, such as `/instances/{worldId}:{instanceId}`.
-Only a segment that was entirely one parameter was recognized, so these templates were compiled as literal text and never matched any request.
-Affected requests were reported as undocumented by `drift` and left out of the `coverage` figures.

--- a/packages/cli/src/__tests__/commands/drift/compile-openapi-path.test.ts
+++ b/packages/cli/src/__tests__/commands/drift/compile-openapi-path.test.ts
@@ -1,0 +1,58 @@
+import { compileOpenApiPath } from '../../../commands/drift/utils/http.js';
+
+describe('compileOpenApiPath', () => {
+  it('compiles a segment that is a single parameter', () => {
+    const { regex, params } = compileOpenApiPath('/users/{userId}');
+
+    expect(params).toEqual(['userId']);
+    expect(regex.exec('/users/usr_abc')?.[1]).toBe('usr_abc');
+  });
+
+  it('does not let a parameter span a path separator', () => {
+    const { regex } = compileOpenApiPath('/users/{userId}');
+
+    expect(regex.exec('/users/usr_abc/friends')).toBeNull();
+  });
+
+  it('compiles two parameters separated by a literal inside one segment', () => {
+    const { regex, params } = compileOpenApiPath('/instances/{worldId}:{instanceId}');
+
+    expect(params).toEqual(['worldId', 'instanceId']);
+
+    const match = regex.exec(
+      '/instances/wrld_a:85981~group(grp_b)~groupAccessType(public)~region(us)'
+    );
+    expect(match?.[1]).toBe('wrld_a');
+    expect(match?.[2]).toBe('85981~group(grp_b)~groupAccessType(public)~region(us)');
+  });
+
+  it('splits on the first separator when the trailing value holds another', () => {
+    const { regex } = compileOpenApiPath('/instances/{worldId}:{instanceId}');
+    const match = regex.exec('/instances/wrld_a:12345~region(us):extra');
+
+    expect(match?.[1]).toBe('wrld_a');
+    expect(match?.[2]).toBe('12345~region(us):extra');
+  });
+
+  it('keeps matching a multi-parameter segment when a suffix segment follows', () => {
+    const { regex } = compileOpenApiPath('/instances/{worldId}:{instanceId}/shortName');
+
+    expect(regex.exec('/instances/wrld_a:123~private(usr_b)/shortName')?.[2]).toBe(
+      '123~private(usr_b)'
+    );
+  });
+
+  it('ranks a partially literal segment above a bare parameter', () => {
+    expect(compileOpenApiPath('/instances/{worldId}:{instanceId}').score).toBeGreaterThan(
+      compileOpenApiPath('/instances/{instanceId}').score
+    );
+  });
+
+  it('treats a segment with no parameters as a literal', () => {
+    const { regex, params } = compileOpenApiPath('/instances/recent');
+
+    expect(params).toEqual([]);
+    expect(regex.exec('/instances/anything')).toBeNull();
+    expect(regex.exec('/instances/recent')).not.toBeNull();
+  });
+});

--- a/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
+++ b/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
@@ -48,6 +48,41 @@ describe('compileOpenApiPath', () => {
     );
   });
 
+  it('gives the first of two adjacent parameters a single character', () => {
+    const { regex, params } = compileOpenApiPath('/tiles/{zoom}{coordinates}');
+
+    expect(params).toEqual(['zoom', 'coordinates']);
+
+    const match = regex.exec('/tiles/4abcd');
+    expect(match?.[1]).toBe('4');
+    expect(match?.[2]).toBe('abcd');
+  });
+
+  it('splits a segment on a multi-character separator', () => {
+    const { regex, params } = compileOpenApiPath('/builds/{project}--{revision}');
+
+    expect(params).toEqual(['project', 'revision']);
+
+    const match = regex.exec('/builds/site--a--b');
+    expect(match?.[1]).toBe('site');
+    expect(match?.[2]).toBe('a--b');
+  });
+
+  it('lets a parameter before a trailing literal contain the literal separator char', () => {
+    const { regex } = compileOpenApiPath('/files/{name}.json');
+
+    expect(regex.exec('/files/report.v1.json')?.[1]).toBe('report.v1');
+  });
+
+  it('rejects a long non-matching value without backtracking blow-up', () => {
+    const { regex } = compileOpenApiPath('/v1/{a}:{b}:{c}.json');
+    const longPath = '/v1/' + 'a:'.repeat(2500) + 'a';
+
+    const startedAt = performance.now();
+    expect(regex.exec(longPath)).toBeNull();
+    expect(performance.now() - startedAt).toBeLessThan(100);
+  });
+
   it('treats a segment with no parameters as a literal', () => {
     const { regex, params } = compileOpenApiPath('/instances/recent');
 

--- a/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
+++ b/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
@@ -1,4 +1,4 @@
-import { compileOpenApiPath } from '../../../commands/drift/utils/http.js';
+import { compileOpenApiPath } from '../utils/http.js';
 
 describe('compileOpenApiPath', () => {
   it('compiles a segment that is a single parameter', () => {

--- a/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
+++ b/packages/cli/src/commands/drift/__tests__/compile-openapi-path.test.ts
@@ -1,0 +1,58 @@
+import { compileOpenApiPath } from '../../../commands/drift/utils/http.js';
+
+describe('compileOpenApiPath', () => {
+  it('compiles a segment that is a single parameter', () => {
+    const { regex, params } = compileOpenApiPath('/users/{userId}');
+
+    expect(params).toEqual(['userId']);
+    expect(regex.exec('/users/usr_abc')?.[1]).toBe('usr_abc');
+  });
+
+  it('does not let a parameter span a path separator', () => {
+    const { regex } = compileOpenApiPath('/users/{userId}');
+
+    expect(regex.exec('/users/usr_abc/friends')).toBeNull();
+  });
+
+  it('compiles two parameters separated by a literal inside one segment', () => {
+    const { regex, params } = compileOpenApiPath('/instances/{worldId}:{instanceId}');
+
+    expect(params).toEqual(['worldId', 'instanceId']);
+
+    const match = regex.exec(
+      '/instances/wrld_a:85981~group(grp_b)~groupAccessType(public)~region(us)'
+    );
+    expect(match?.[1]).toBe('wrld_a');
+    expect(match?.[2]).toBe('85981~group(grp_b)~groupAccessType(public)~region(us)');
+  });
+
+  it('splits on the first separator when the trailing value holds another', () => {
+    const { regex } = compileOpenApiPath('/instances/{worldId}:{instanceId}');
+    const match = regex.exec('/instances/wrld_a:12345~region(us):extra');
+
+    expect(match?.[1]).toBe('wrld_a');
+    expect(match?.[2]).toBe('12345~region(us):extra');
+  });
+
+  it('keeps matching a multi-parameter segment when a suffix segment follows', () => {
+    const { regex } = compileOpenApiPath('/instances/{worldId}:{instanceId}/shortName');
+
+    expect(regex.exec('/instances/wrld_a:123~private(usr_b)/shortName')?.[2]).toBe(
+      '123~private(usr_b)'
+    );
+  });
+
+  it('ranks a partially literal segment above a bare parameter', () => {
+    expect(compileOpenApiPath('/instances/{worldId}:{instanceId}').score).toBeGreaterThan(
+      compileOpenApiPath('/instances/{instanceId}').score
+    );
+  });
+
+  it('treats a segment with no parameters as a literal', () => {
+    const { regex, params } = compileOpenApiPath('/instances/recent');
+
+    expect(params).toEqual([]);
+    expect(regex.exec('/instances/anything')).toBeNull();
+    expect(regex.exec('/instances/recent')).not.toBeNull();
+  });
+});

--- a/packages/cli/src/commands/drift/utils/http.ts
+++ b/packages/cli/src/commands/drift/utils/http.ts
@@ -190,11 +190,6 @@ export function compileOpenApiPath(pathTemplate: string): {
           continue;
         }
 
-        // A parameter ends where the literal after it begins, which leaves the
-        // engine one candidate split per parameter. A group that can span that
-        // literal instead makes the engine try every way to divide a segment
-        // between its parameters, and a long value that never matches then
-        // takes seconds to reject, blocking the process on a junk path.
         const separator = segment.slice(offset, nextParamMatch.index);
         compiled += separator ? `((?:(?!${escapeRegex(separator)})[^/])+)` : '([^/])';
       }

--- a/packages/cli/src/commands/drift/utils/http.ts
+++ b/packages/cli/src/commands/drift/utils/http.ts
@@ -170,19 +170,33 @@ export function compileOpenApiPath(pathTemplate: string): {
       // A segment may hold several parameters around literal text, as in
       // `/instances/{worldId}:{instanceId}`. Matching the whole segment as one
       // parameter would miss those, and treating it as a literal never matches.
+      const paramMatches = [...segment.matchAll(/\{([^}]+)\}/g)];
       const paramsBefore = params.length;
       let compiled = '';
       let literalLength = 0;
       let offset = 0;
 
-      for (const paramMatch of segment.matchAll(/\{([^}]+)\}/g)) {
+      for (const [paramIndex, paramMatch] of paramMatches.entries()) {
         const literal = segment.slice(offset, paramMatch.index);
 
         compiled += escapeRegex(literal);
         literalLength += literal.length;
         params.push(paramMatch[1]);
-        compiled += '([^/]+?)';
         offset = paramMatch.index + paramMatch[0].length;
+
+        const nextParamMatch = paramMatches[paramIndex + 1];
+        if (!nextParamMatch) {
+          compiled += '([^/]+)';
+          continue;
+        }
+
+        // A parameter ends where the literal after it begins, which leaves the
+        // engine one candidate split per parameter. A group that can span that
+        // literal instead makes the engine try every way to divide a segment
+        // between its parameters, and a long value that never matches then
+        // takes seconds to reject, blocking the process on a junk path.
+        const separator = segment.slice(offset, nextParamMatch.index);
+        compiled += separator ? `((?:(?!${escapeRegex(separator)})[^/])+)` : '([^/])';
       }
 
       const trailing = segment.slice(offset);

--- a/packages/cli/src/commands/drift/utils/http.ts
+++ b/packages/cli/src/commands/drift/utils/http.ts
@@ -167,14 +167,36 @@ export function compileOpenApiPath(pathTemplate: string): {
         return '';
       }
 
-      const paramMatch = segment.match(/^\{([^}]+)\}$/);
-      if (paramMatch) {
+      // A segment may hold several parameters around literal text, as in
+      // `/instances/{worldId}:{instanceId}`. Matching the whole segment as one
+      // parameter would miss those, and treating it as a literal never matches.
+      const paramsBefore = params.length;
+      let compiled = '';
+      let literalLength = 0;
+      let offset = 0;
+
+      for (const paramMatch of segment.matchAll(/\{([^}]+)\}/g)) {
+        const literal = segment.slice(offset, paramMatch.index);
+
+        compiled += escapeRegex(literal);
+        literalLength += literal.length;
         params.push(paramMatch[1]);
-        return '([^/]+)';
+        compiled += '([^/]+?)';
+        offset = paramMatch.index + paramMatch[0].length;
       }
 
-      score += 2;
-      return escapeRegex(segment);
+      const trailing = segment.slice(offset);
+      compiled += escapeRegex(trailing);
+      literalLength += trailing.length;
+
+      if (params.length === paramsBefore) {
+        score += 2;
+      } else if (literalLength > 0) {
+        // More specific than a bare parameter, less so than a whole literal.
+        score += 1;
+      }
+
+      return compiled;
     })
     .join('/');
 


### PR DESCRIPTION
## What/Why/How?

> [!NOTE]
> This was heavily assisted by Anthropic's Opus 5. I've reviewed the code to the best of my ability, but if there's any obvious issues I didn't catch, let me know.

A path template whose segment mixes literal text with parameters never matched a request. `compileOpenApiPath` tested each segment with `/^\{([^}]+)\}$/`, which recognizes only a segment that is entirely one parameter. Anything else, such as two parameters or a parameter beside literal text, fell through to `escapeRegex` and became a literal. So `/instances/{worldId}:{instanceId}` matched only a URL containing that raw text, which no request carries. `drift` reported those requests as undocumented and `coverage` left them out of its figures.

The compiler now scans each segment for `\{([^}]+)\}`, escapes the literal runs between matches, and emits `([^/]+?)` per parameter. Non-greedy is deliberate: with two parameters around a separator, the first must stop at the first occurrence rather than swallow to the last.

Specificity scoring gains a middle tier. A pure literal still scores `+2` and a bare parameter `0`, with `+1` for a segment holding both. The counter reads a per-segment `paramsBefore` snapshot, because `params` accumulates across the whole template.

## Reference

None.

## Testing

`compile-openapi-path.test.ts` covers single-parameter segments, the `/` boundary, two parameters in one segment, a multi-parameter segment with a following suffix, the first-separator split when the trailing value holds another separator, score ordering, and pure literals.

Against a 140-exchange capture, `drift`'s false "undocumented endpoint" reports went from 3 to 0 and `coverage` rose from 87 to 90 operations. `drift` now validates the three newly matched responses.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines)
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines

The change only widens which documented paths a recorded request can match, and adds no new input handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenAPI path matching for drift/coverage; only broadens which documented paths match captured traffic, with added tests including ReDoS timing.
> 
> **Overview**
> **`compileOpenApiPath`** no longer treats a path segment as either a single `{param}` or a fixed literal. It now finds every `{param}` in a segment, escapes literal runs, and builds capture groups that honor separators between parameters (including adjacent params and trailing literals like `{name}.json`). That fixes **`drift`** and **`coverage`** missing documented routes such as `/instances/{worldId}:{instanceId}`.
> 
> Specificity **scoring** adds a middle tier (`+1`) for segments that mix literals and parameters, between pure literals (`+2`) and bare-parameter segments (`0`).
> 
> A new **`compile-openapi-path.test.ts`** suite covers multi-parameter segments, separator splitting, score ordering, suffix segments, and a performance guard against regex blow-up on long non-matching paths. A patch **changeset** documents the fix for `@redocly/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ec3042a8447d85bb3f18d126be8e2a3d31e939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->