### PR TITLE
docs(core): document skipPluginEval option in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -182,8 +182,8 @@ async function loadConfig(options?: {
 }): Promise<Config>;
 ```
 
-With `skipPluginEval`, `config.plugins` contains only the absolute paths of the referenced plugins, so use it to find out which plugin files a config points to without running their code.
-In this mode `extends` is kept as authored, because presets live in plugin code: neither plugin nor built-in presets are resolved, and the root config isn't merged into the `apis` entries.
+Use `skipPluginEval` to read a config without executing any plugin code, for example when the plugins come from an untrusted source.
+The returned config is incomplete: rules and decorators from plugins aren't loaded, and `extends` isn't resolved, so the presets it lists are ignored.
 
 ### `lintConfig`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -177,8 +177,13 @@ async function loadConfig(options?: {
   configPath?: string;
   // allows to add custom `extends` instead of the one from the config file
   customExtends?: string[];
+  // whether to resolve plugin paths without importing the plugin code
+  skipPluginEval?: boolean;
 }): Promise<Config>;
 ```
+
+With `skipPluginEval`, `config.plugins` contains only the absolute paths of the referenced plugins, so use it to find out which plugin files a config points to without running their code.
+Note that `extends` entries referencing a plugin preset, such as `my-plugin/config-name`, throw an error in this mode; built-in presets, such as `recommended`, still work.
 
 ### `lintConfig`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -183,7 +183,7 @@ async function loadConfig(options?: {
 ```
 
 With `skipPluginEval`, `config.plugins` contains only the absolute paths of the referenced plugins, so use it to find out which plugin files a config points to without running their code.
-Note that `extends` entries referencing a plugin preset, such as `my-plugin/config-name`, throw an error in this mode; built-in presets, such as `recommended`, still work.
+In this mode `extends` is kept as authored, because presets live in plugin code: neither plugin nor built-in presets are resolved, and the root config isn't merged into the `apis` entries.
 
 ### `lintConfig`
 


### PR DESCRIPTION
## What/Why/How?

Documents the `skipPluginEval` option of `loadConfig` in the public `openapi-core` README.

## Reference

https://github.com/Redocly/redocly-cli/pull/2987#discussion_r3684145631

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines
