### PR TITLE
docs: update OAD version that generate-spec generates

### DIFF
--- a/docs/@v2/commands/generate-spec.md
+++ b/docs/@v2/commands/generate-spec.md
@@ -7,7 +7,7 @@ The command reads a traffic log (or a folder of logs), builds a deterministic ba
 This is an experimental feature.
 Its behavior, command, flags, and output may change in future releases.
 
-The `generate-spec` command generates OpenAPI 3.1 descriptions only.
+The `generate-spec` command generates OpenAPI 3.2 descriptions only.
 {% /admonition %}
 
 ## Supported traffic formats


### PR DESCRIPTION
## What/Why/How?

There was a typo in docs. `generate-spec` generates OAD in version 3.2 only

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [ ] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no code or behavior changes.
> 
> **Overview**
> Corrects a documentation typo in the `generate-spec` command page: the experimental admonition now states that output is **OpenAPI 3.2** only, matching the command implementation and internal CLI docs (previously said 3.1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b84c1137788a575392b26853bcbc4a843d2bfee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->