### PR TITLE
chore: collect lint rules with problems

### DIFF
--- a/docs/@v2/usage-data.md
+++ b/docs/@v2/usage-data.md
@@ -19,6 +19,7 @@ When a command is run, the following data is collected:
 - Node.js and NPM versions
 - whether the `redocly.yaml` configuration file exists
 - API specification type and version
+- names of lint rules that reported errors, warnings, or ignored problems
 - Arazzo x-security authentication types
 - platform (Linux, macOS, Windows)
 - anonymous ID (a randomly generated identifier that doesn't contain personal information)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,9 +2580,9 @@
       "link": true
     },
     "node_modules/@redocly/cli-otel": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.4.tgz",
-      "integrity": "sha512-INh/9ngnXQNYh4MPpSjJiDhDZStyJiruTRFoS6T0bLNLUAlK1QcN5Ft00/Kqp9BJi9eaKu6k1vrIp893L6xjvg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.5.tgz",
+      "integrity": "sha512-SkwB7B7A2c+vx6tLvgly6NngwR51Q8PMFXkWTl/zm6ukOQSdKoJzCl8v5bdtLQb4h0cWWjkCi4QU1Ogn4UvG+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10247,7 +10247,7 @@
         "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/sdk-trace-node": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.41.1",
-        "@redocly/cli-otel": "0.3.4",
+        "@redocly/cli-otel": "0.3.5",
         "@redocly/client-generator": "0.3.0",
         "@redocly/openapi-core": "2.44.0",
         "@redocly/respect-core": "2.44.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-trace-node": "2.8.0",
     "@opentelemetry/semantic-conventions": "1.41.1",
-    "@redocly/cli-otel": "0.3.4",
+    "@redocly/cli-otel": "0.3.5",
     "@redocly/client-generator": "0.3.0",
     "@redocly/openapi-core": "2.44.0",
     "@redocly/respect-core": "2.44.0",

--- a/packages/cli/src/__tests__/wrapper.test.ts
+++ b/packages/cli/src/__tests__/wrapper.test.ts
@@ -1,4 +1,9 @@
-import { type Config, detectSpec, makeDocumentFromString } from '@redocly/openapi-core';
+import {
+  type Config,
+  type NormalizedProblem,
+  detectSpec,
+  makeDocumentFromString,
+} from '@redocly/openapi-core';
 import * as process from 'node:process';
 
 import { handleLint } from '../commands/lint.js';
@@ -136,6 +141,30 @@ describe('commandWrapper', () => {
         spec_version: 'graphql',
         spec_keyword: undefined,
         spec_full_version: undefined,
+      })
+    );
+  });
+
+  it('should collect the names of lint rules that reported problems', async () => {
+    vi.mocked(loadConfigAndHandleErrors).mockImplementation(async () => {
+      return { resolvedConfig: { telemetry: 'on' } } as Config;
+    });
+    vi.mocked(handleLint).mockImplementation(async ({ collectResults: collectLintResults }) => {
+      collectLintResults?.([
+        { ruleId: 'no-unused-components', severity: 'error' },
+        { ruleId: 'info-license', severity: 'warn' },
+        { ruleId: 'operation-summary', severity: 'warn', ignored: true },
+      ] as NormalizedProblem[]);
+    });
+    process.env.REDOCLY_TELEMETRY = 'on';
+
+    const wrappedHandler = commandWrapper(handleLint);
+    await wrappedHandler({} as any);
+    expect(sendTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lint_rules_with_errors: ['no-unused-components'],
+        lint_rules_with_warnings: ['info-license'],
+        lint_rules_with_ignored_problems: ['operation-summary'],
       })
     );
   });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -44,6 +44,7 @@ export async function handleLint({
   config,
   version,
   collectSpecData,
+  collectResults,
 }: CommandArgs<LintArgv>) {
   const apis = await getFallbackApisOrExit(argv.apis, config);
 
@@ -83,6 +84,8 @@ export async function handleLint({
         config: aliasConfig,
         collectSpecData,
       });
+
+      collectResults?.(results);
 
       const fileTotals = getTotals(results);
       totals.errors += fileTotals.errors;

--- a/packages/cli/src/utils/__tests__/telemetry.test.ts
+++ b/packages/cli/src/utils/__tests__/telemetry.test.ts
@@ -29,6 +29,9 @@ it('sendTelemetry calls all telemetry functions', async () => {
     respect_x_security_auth_types: undefined,
     respect_source_description_types: undefined,
     respect_criterion_object_types: undefined,
+    lint_rules_with_errors: undefined,
+    lint_rules_with_warnings: undefined,
+    lint_rules_with_ignored_problems: undefined,
   });
 
   expect(respondWithinMs).toHaveBeenCalled();

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -43,6 +43,9 @@ export async function sendTelemetry({
   respect_x_security_auth_types,
   respect_source_description_types,
   respect_criterion_object_types,
+  lint_rules_with_errors,
+  lint_rules_with_warnings,
+  lint_rules_with_ignored_problems,
 }: {
   config: Config | undefined;
   argv: Arguments<CommandArgv> | undefined;
@@ -54,6 +57,9 @@ export async function sendTelemetry({
   respect_x_security_auth_types: string[] | undefined;
   respect_source_description_types: string[] | undefined;
   respect_criterion_object_types: string[] | undefined;
+  lint_rules_with_errors: string[] | undefined;
+  lint_rules_with_warnings: string[] | undefined;
+  lint_rules_with_ignored_problems: string[] | undefined;
 }): Promise<void> {
   try {
     if (!argv) {
@@ -113,6 +119,15 @@ export async function sendTelemetry({
           majorSpecVersion === 'arazzo1' && respect_criterion_object_types?.length
             ? JSON.stringify(respect_criterion_object_types)
             : undefined,
+        lint_rules_with_errors: lint_rules_with_errors?.length
+          ? JSON.stringify(lint_rules_with_errors)
+          : undefined,
+        lint_rules_with_warnings: lint_rules_with_warnings?.length
+          ? JSON.stringify(lint_rules_with_warnings)
+          : undefined,
+        lint_rules_with_ignored_problems: lint_rules_with_ignored_problems?.length
+          ? JSON.stringify(lint_rules_with_ignored_problems)
+          : undefined,
       },
     ];
 

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -7,8 +7,9 @@ import {
   getMajorSpecVersion,
   isGraphqlRef,
   type Config,
-  type CollectFn,
+  type CollectSpecData,
   type Exact,
+  type NormalizedProblem,
   type SpecVersion,
 } from '@redocly/openapi-core';
 import type { Arguments } from 'yargs';
@@ -24,11 +25,14 @@ import {
   collectCriterionObjectTypes,
 } from './utils/telemetry.js';
 
+export type CollectResults = (results: NormalizedProblem[]) => void;
+
 export type CommandArgs<T extends CommandArgv> = {
   argv: T;
   config: Config;
   version: string;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
+  collectResults?: CollectResults;
 };
 
 export function commandWrapper<T extends CommandArgv>(
@@ -45,7 +49,7 @@ export function commandWrapper<T extends CommandArgv>(
     const respectXSecurityAuthTypes = new Set<string>();
     const respectSourceDescriptionTypes = new Set<string>();
     const respectCriterionObjectTypes = new Set<string>();
-    const collectSpecData: CollectFn = ({ parsed: document, source }) => {
+    const collectSpecData: CollectSpecData = ({ parsed: document, source }) => {
       specVersion = 'unknown';
       specKeyword = undefined;
       specFullVersion = undefined;
@@ -83,6 +87,24 @@ export function commandWrapper<T extends CommandArgv>(
         collectCriterionObjectTypes(document, respectCriterionObjectTypes);
       }
     };
+    const lintRulesWithErrors = new Set<string>();
+    const lintRulesWithWarnings = new Set<string>();
+    const lintRulesWithIgnoredProblems = new Set<string>();
+    const collectResults: CollectResults = (results) => {
+      try {
+        for (const problem of results) {
+          if (problem.ignored) {
+            lintRulesWithIgnoredProblems.add(problem.ruleId);
+          } else if (problem.severity === 'error') {
+            lintRulesWithErrors.add(problem.ruleId);
+          } else {
+            lintRulesWithWarnings.add(problem.ruleId);
+          }
+        }
+      } catch (err) {
+        // Do nothing.
+      }
+    };
 
     try {
       if (argv.config && !doesYamlFileExist(argv.config)) {
@@ -92,7 +114,7 @@ export function commandWrapper<T extends CommandArgv>(
       telemetry = config.resolvedConfig.telemetry;
       code = 1;
       if (typeof commandHandler === 'function') {
-        await commandHandler({ argv, config, version, collectSpecData });
+        await commandHandler({ argv, config, version, collectSpecData, collectResults });
       }
       code = 0;
     } catch (err) {
@@ -121,6 +143,9 @@ export function commandWrapper<T extends CommandArgv>(
           respect_x_security_auth_types: [...respectXSecurityAuthTypes],
           respect_source_description_types: [...respectSourceDescriptionTypes],
           respect_criterion_object_types: [...respectCriterionObjectTypes],
+          lint_rules_with_errors: [...lintRulesWithErrors],
+          lint_rules_with_warnings: [...lintRulesWithWarnings],
+          lint_rules_with_ignored_problems: [...lintRulesWithIgnoredProblems],
         });
       }
       process.once('beforeExit', () => {

--- a/packages/cli/src/wrapper.ts
+++ b/packages/cli/src/wrapper.ts
@@ -97,7 +97,7 @@ export function commandWrapper<T extends CommandArgv>(
             lintRulesWithIgnoredProblems.add(problem.ruleId);
           } else if (problem.severity === 'error') {
             lintRulesWithErrors.add(problem.ruleId);
-          } else {
+          } else if (problem.severity === 'warn') {
             lintRulesWithWarnings.add(problem.ruleId);
           }
         }

--- a/packages/core/src/bundle/bundle.ts
+++ b/packages/core/src/bundle/bundle.ts
@@ -16,7 +16,7 @@ import {
 } from '../resolve.js';
 import type { NormalizedNodeType } from '../types/index.js';
 import { NormalizedConfigTypes } from '../types/redocly-yaml.js';
-import type { CollectFn } from '../utils/types.js';
+import type { CollectSpecData } from '../utils/types.js';
 import { walkDocument, type NormalizedProblem, type WalkContext } from '../walk.js';
 import { bundleDocument, type CoreBundleOptions } from './bundle-document.js';
 
@@ -77,7 +77,7 @@ export async function bundle(
   opts: {
     ref?: string;
     doc?: Document;
-    collectSpecData?: CollectFn;
+    collectSpecData?: CollectSpecData;
   } & CoreBundleOptions
 ) {
   const {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,7 +130,7 @@ export { logger, type LoggerInterface } from './logger.js';
 export { HandledError } from './utils/error.js';
 export { isSupportedExtension } from './utils/is-supported-extension.js';
 export { isBrowser } from './env.js';
-export type { CollectFn, Exact } from './utils/types.js';
+export type { CollectSpecData, Exact } from './utils/types.js';
 export type * from './typings/openapi.js';
 export type * from './typings/swagger.js';
 export type * from './typings/asyncapi3.js';

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -10,7 +10,7 @@ import { NoUnresolvedRefs } from './rules/common/no-unresolved-refs.js';
 import { Struct } from './rules/common/struct.js';
 import { normalizeTypes, type NodeType } from './types/index.js';
 import { createConfigTypes } from './types/redocly-yaml.js';
-import type { CollectFn } from './utils/types.js';
+import type { CollectSpecData } from './utils/types.js';
 import {
   normalizeVisitors,
   type Arazzo1Visitor,
@@ -36,7 +36,7 @@ export async function lint(opts: {
   ref: string;
   config: Config;
   externalRefResolver?: BaseResolver;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
 }) {
   const { ref, externalRefResolver = new BaseResolver(opts.config.resolve) } = opts;
   const document = (await externalRefResolver.resolveDocument(null, ref, true)) as Document;

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -1,5 +1,5 @@
 import type { Document } from '../resolve.js';
 
-export type CollectFn = (document: Partial<Document>) => void;
+export type CollectSpecData = (document: Partial<Document>) => void;
 
 export type Exact<T extends object> = T & { [key: string]: undefined };

--- a/packages/respect-core/src/generate.ts
+++ b/packages/respect-core/src/generate.ts
@@ -1,4 +1,4 @@
-import { type BaseResolver, type CollectFn, type Config } from '@redocly/openapi-core';
+import { type BaseResolver, type CollectSpecData, type Config } from '@redocly/openapi-core';
 
 import { generateArazzoDescription } from './modules/arazzo-description-generator/index.js';
 
@@ -7,7 +7,7 @@ export type GenerateArazzoOptions = {
   outputFile?: string;
   config: Config;
   version: string;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
   externalRefResolver?: BaseResolver;
   base?: string;
 };

--- a/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
+++ b/packages/respect-core/src/modules/flow-runner/get-test-description-from-file.ts
@@ -5,7 +5,7 @@ import {
   bundle,
   createConfig,
   type BaseResolver,
-  type CollectFn,
+  type CollectSpecData,
   type LoggerInterface,
   type NormalizedProblem,
 } from '@redocly/openapi-core';
@@ -19,7 +19,7 @@ type BundleArazzoOptions = {
   filePath: string;
   base?: string;
   externalRefResolver?: BaseResolver;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
   version?: string;
   logger: LoggerInterface;
   skipLint?: boolean;

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -1,4 +1,4 @@
-import type { CollectFn, Config } from '@redocly/openapi-core';
+import type { CollectSpecData, Config } from '@redocly/openapi-core';
 import { blue, red } from 'colorette';
 import { basename, dirname, resolve } from 'node:path';
 
@@ -38,7 +38,7 @@ export async function runTestFile({
   executedStepsCount,
 }: {
   options: RunOptions;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
   executedStepsCount: ExecutedStepsCount;
 }) {
   const workflowOptions = {

--- a/packages/respect-core/src/run.ts
+++ b/packages/respect-core/src/run.ts
@@ -1,6 +1,6 @@
 import {
   type Config,
-  type CollectFn,
+  type CollectSpecData,
   type LoggerInterface,
   type BaseResolver,
 } from '@redocly/openapi-core';
@@ -22,7 +22,7 @@ export type RespectOptions = {
   maxSteps: number;
   maxFetchTimeout: number;
   executionTimeout?: number;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
   requestFileLoader: { getFileBody: (filePath: string) => Promise<Blob> };
   envVariables?: Record<string, string>;
   version?: string;
@@ -79,7 +79,7 @@ async function runFile({
   options: RunOptions;
   startedAt: number;
   executedStepsCount: ExecutedStepsCount;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
 }): Promise<RunFileResult> {
   const result = await runTestFile({ options, collectSpecData, executedStepsCount });
 

--- a/packages/respect-core/src/types.ts
+++ b/packages/respect-core/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   Config,
-  CollectFn,
+  CollectSpecData,
   RuleSeverity,
   LoggerInterface,
   BaseResolver,
@@ -101,7 +101,7 @@ export type CommandArgs<T> = {
   argv: T;
   config: Config;
   version: string;
-  collectSpecData?: CollectFn;
+  collectSpecData?: CollectSpecData;
 };
 
 export interface RequestContext {


### PR DESCRIPTION
## What/Why/How?

- Collected data for linting rules problems.
- Renamed the `CollectFn` type to `CollectSpecData`.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and lint plumbing only; collects rule IDs already defined in config, with existing opt-out and sanitization patterns. No change to lint behavior or rule execution.
> 
> **Overview**
> Extends **anonymized CLI telemetry** so lint runs report which **rule IDs** fired, grouped into errors, warnings, and ignored problems (rule names only—no file paths or message text).
> 
> `commandWrapper` passes a new `collectResults` callback into commands; `handleLint` invokes it after each API’s lint pass. Those rule sets are JSON-stringified in `sendTelemetry` alongside existing fields. Usage data docs list this collection.
> 
> **Rename only:** `CollectFn` → `CollectSpecData` in openapi-core and respect-core exports/call sites. `@redocly/cli-otel` dev dependency **0.3.4 → 0.3.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4800ed2b605f36f737489ada8d1b4e10be45674e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->