### PR TITLE
fix: report unexpected fields on AsyncAPI messages

### DIFF
--- a/.changeset/evil-taxis-ring.md
+++ b/.changeset/evil-taxis-ring.md
@@ -1,10 +1,6 @@
 ---
-'@redocly/openapi-core': minor
-'@redocly/cli': minor
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
 ---
 
 Fixed the `struct` rule to report unexpected fields on AsyncAPI 3 messages and message traits.
-Previously any field was accepted, and the linter skipped everything nested under an unexpected field.
-Added the missing `deprecated` field to both objects.
-
-**Note**: linting output may include new `struct` errors for AsyncAPI 3 descriptions with fields that are not part of the Message Object.

--- a/.changeset/evil-taxis-ring.md
+++ b/.changeset/evil-taxis-ring.md
@@ -1,0 +1,10 @@
+---
+'@redocly/openapi-core': minor
+'@redocly/cli': minor
+---
+
+Fixed the `struct` rule to report unexpected fields on AsyncAPI 3 messages and message traits.
+Previously any field was accepted, and the linter skipped everything nested under an unexpected field.
+Added the missing `deprecated` field to both objects.
+
+**Note**: linting output may include new `struct` errors for AsyncAPI 3 descriptions with fields that are not part of the Message Object.

--- a/packages/core/src/rules/async3/__tests__/struct.test.ts
+++ b/packages/core/src/rules/async3/__tests__/struct.test.ts
@@ -50,4 +50,34 @@ describe('Async3 struct', () => {
       ]
     `);
   });
+
+  it('should allow specification extensions on a message and a message trait', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        asyncapi: '3.0.0'
+        info:
+          title: Account Service
+          version: 1.0.0
+        channels:
+          userSignedup:
+            address: user/signedup
+            messages:
+              UserSignedUp:
+                x-internal: true
+                payload:
+                  type: object
+                traits:
+                  - x-vendor-id: 42
+      `,
+      'asyncapi.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { struct: 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/core/src/rules/async3/__tests__/struct.test.ts
+++ b/packages/core/src/rules/async3/__tests__/struct.test.ts
@@ -1,0 +1,53 @@
+import { outdent } from 'outdent';
+
+import { parseYamlToDocument, replaceSourceWithRef } from '../../../../__tests__/utils.js';
+import { createConfig } from '../../../config/index.js';
+import { lintDocument } from '../../../lint.js';
+import { BaseResolver } from '../../../resolve.js';
+
+describe('Async3 struct', () => {
+  it('should report an unexpected property on a message', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        asyncapi: '3.0.0'
+        info:
+          title: Account Service
+          version: 1.0.0
+        channels:
+          userSignedup:
+            address: user/signedup
+            messages:
+              UserSignedUp:
+                UserSignedUp:
+                  payload:
+                    type: nonsense
+      `,
+      'asyncapi.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { struct: 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "from": undefined,
+          "location": [
+            {
+              "pointer": "#/channels/userSignedup/messages/UserSignedUp/UserSignedUp",
+              "reportOnKey": true,
+              "source": "asyncapi.yaml",
+            },
+          ],
+          "message": "Property \`UserSignedUp\` is not expected here.",
+          "ruleId": "struct",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/types/asyncapi3.ts
+++ b/packages/core/src/types/asyncapi3.ts
@@ -213,7 +213,6 @@ const Message: NodeType = {
       description:
         'A verbose explanation of the message. CommonMark syntax can be used for rich text representation.',
     },
-    deprecated: { type: 'boolean' },
     tags: 'TagList',
     externalDocs: 'ExternalDocs',
     bindings: 'MessageBindings',
@@ -286,7 +285,6 @@ const MessageTrait: NodeType = {
       description:
         'A verbose explanation of the message. CommonMark syntax can be used for rich text representation.',
     },
-    deprecated: { type: 'boolean' },
     tags: 'TagList',
     externalDocs: 'ExternalDocs',
     bindings: 'MessageBindings',

--- a/packages/core/src/types/asyncapi3.ts
+++ b/packages/core/src/types/asyncapi3.ts
@@ -213,13 +213,13 @@ const Message: NodeType = {
       description:
         'A verbose explanation of the message. CommonMark syntax can be used for rich text representation.',
     },
+    deprecated: { type: 'boolean' },
     tags: 'TagList',
     externalDocs: 'ExternalDocs',
     bindings: 'MessageBindings',
     examples: 'MessageExampleList',
     traits: 'MessageTraitList',
   },
-  additionalProperties: {},
   description: 'Describes a message received on a given channel and operation.',
 };
 
@@ -286,12 +286,12 @@ const MessageTrait: NodeType = {
       description:
         'A verbose explanation of the message. CommonMark syntax can be used for rich text representation.',
     },
+    deprecated: { type: 'boolean' },
     tags: 'TagList',
     externalDocs: 'ExternalDocs',
     bindings: 'MessageBindings',
     examples: 'MessageExampleList',
   },
-  additionalProperties: {},
   description:
     'Describes a trait that MAY be applied to a Message Object. This object MAY contain any property from the Message Object, except payload and traits.',
 };

--- a/tests/e2e/bundle/async3/UserSignedUp.yaml
+++ b/tests/e2e/bundle/async3/UserSignedUp.yaml
@@ -1,11 +1,10 @@
-UserSignedUp:
-  payload:
-    type: object
-    properties:
-      displayName:
-        type: string
-        description: Name of the user
-      email:
-        type: string
-        format: email
-        description: Email of the user
+payload:
+  type: object
+  properties:
+    displayName:
+      type: string
+      description: Name of the user
+    email:
+      type: string
+      format: email
+      description: Email of the user

--- a/tests/e2e/bundle/async3/snapshot.txt
+++ b/tests/e2e/bundle/async3/snapshot.txt
@@ -8,38 +8,6 @@ channels:
     address: user/signedup
     messages:
       UserSignedUp:
-        UserSignedUp:
-          payload:
-            type: object
-            properties:
-              displayName:
-                type: string
-                description: Name of the user
-              email:
-                type: string
-                format: email
-                description: Email of the user
-operations:
-  sendUserSignedup:
-    action: send
-    channel:
-      $ref: '#/channels/userSignedup'
-    messages:
-      - UserSignedUp:
-          payload:
-            type: object
-            properties:
-              displayName:
-                type: string
-                description: Name of the user
-              email:
-                type: string
-                format: email
-                description: Email of the user
-components:
-  messages:
-    UserSignedUp:
-      UserSignedUp:
         payload:
           type: object
           properties:
@@ -50,6 +18,35 @@ components:
               type: string
               format: email
               description: Email of the user
+operations:
+  sendUserSignedup:
+    action: send
+    channel:
+      $ref: '#/channels/userSignedup'
+    messages:
+      - payload:
+          type: object
+          properties:
+            displayName:
+              type: string
+              description: Name of the user
+            email:
+              type: string
+              format: email
+              description: Email of the user
+components:
+  messages:
+    UserSignedUp:
+      payload:
+        type: object
+        properties:
+          displayName:
+            type: string
+            description: Name of the user
+          email:
+            type: string
+            format: email
+            description: Email of the user
 
 bundling simple.yml using configuration for api 'main'...
 📦 Created a bundle for simple.yml at stdout <test>ms.

--- a/tests/e2e/stats/stats-async2-json/async.yaml
+++ b/tests/e2e/stats/stats-async2-json/async.yaml
@@ -20,7 +20,7 @@ channels:
     subscribe:
       operationId: userSignedUp
       tags:
-        - test-tag
+        - name: test-tag
       message:
         $ref: '#/components/messages/UserSignedUp'
 

--- a/tests/e2e/stats/stats-async2-stylish/async.yaml
+++ b/tests/e2e/stats/stats-async2-stylish/async.yaml
@@ -20,7 +20,7 @@ channels:
     subscribe:
       operationId: userSignedUp
       tags:
-        - test-tag
+        - name: test-tag
       message:
         $ref: '#/components/messages/UserSignedUp'
 

--- a/tests/e2e/stats/stats-async3-stylish/asyncapi3.yaml
+++ b/tests/e2e/stats/stats-async3-stylish/asyncapi3.yaml
@@ -3,11 +3,11 @@ info:
   title: AsyncAPI 3.x Example
   version: 1.0.0
   description: Minimal AsyncAPI 3.x example for stats testing
-tags:
-  - name: test-tag
-externalDocs:
-  description: External docs
-  url: https://example.com
+  tags:
+    - name: test-tag
+  externalDocs:
+    description: External docs
+    url: https://example.com
 
 channels:
   userSignedup:
@@ -23,7 +23,7 @@ operations:
   sendUserSignedup:
     action: send
     tags:
-      - test-tag
+      - name: test-tag
     channel:
       $ref: '#/channels/userSignedup'
     messages:

--- a/tests/e2e/stats/stats-async3-stylish/snapshot.txt
+++ b/tests/e2e/stats/stats-async3-stylish/snapshot.txt
@@ -1,5 +1,5 @@
 🚗 References: 4 
-📦 External Documents: 0 
+📦 External Documents: 1 
 📈 Schemas: 1 
 👉 Parameters: 0 
 📡 Channels: 1 


### PR DESCRIPTION
## What/Why/How?

`Message` in the AsyncAPI 3 types had `additionalProperties: {}`, so any field was accepted on a message

## Reference

https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageObject

## Testing

- updated tests

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-definition tightening for AsyncAPI 3 lint only; may surface new struct errors on documents that incorrectly used extra message fields.
> 
> **Overview**
> Fixes AsyncAPI 3 linting so the **`struct`** rule flags invalid keys on **message** and **message trait** objects instead of accepting any property.
> 
> The **`Message`** and **`MessageTrait`** node types in `asyncapi3.ts` previously had `additionalProperties: {}`, which let stray fields (e.g. a duplicated message name nested under the message body) pass validation. Removing that override aligns validation with the spec’s allowed fields while **`x-`** extensions still work.
> 
> Adds unit tests for unexpected properties and for allowed extensions on messages and traits. E2E fixtures are updated to valid AsyncAPI shapes (flat message payloads, proper tag objects) so bundle and stats tests match the stricter checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe48029a8b0d9bcdb25c0a16a3e48da6a701f9a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->