### PR TITLE
fix: resolve remote $refs with query parameters

### DIFF
--- a/.changeset/remote-ref-query-params.md
+++ b/.changeset/remote-ref-query-params.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed resolving remote `$ref`s with query parameters in the URL.

--- a/.changeset/remote-ref-query-params.md
+++ b/.changeset/remote-ref-query-params.md
@@ -3,4 +3,4 @@
 '@redocly/cli': patch
 ---
 
-Fixed resolving remote `$ref`s with query parameters in the URL.
+Fixed an issue where remote `$ref`s with query parameters in the URL were not resolved.

--- a/packages/core/src/__tests__/resolve.test.ts
+++ b/packages/core/src/__tests__/resolve.test.ts
@@ -613,3 +613,45 @@ describe('collect refs', () => {
     });
   });
 });
+
+describe('remote refs with query strings', () => {
+  it('should resolve a pointer into a remote file with a query string', async () => {
+    const plainTextFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            outdent`
+              openapi: 3.1.0
+              paths:
+                /api/invoices:
+                  get:
+                    operationId: listInvoices
+            `
+          ),
+        headers: { get: () => 'text/plain; charset=utf-8' },
+      })
+    );
+    const rootDocument = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        paths:
+          /test:
+            $ref: 'https://localhost/test.yaml?ref=blah#/paths/~1api~1invoices'
+      `,
+      'foobar.yaml'
+    );
+
+    const resolvedRefs = await resolveDocument({
+      rootDocument,
+      externalRefResolver: new BaseResolver({
+        http: { customFetch: plainTextFetch as any, headers: [] },
+      }),
+      rootType: normalizeTypes(Oas3Types).Root,
+    });
+
+    const resolvedRef = Array.from(resolvedRefs.values())[0];
+    expect(resolvedRef.resolved).toBe(true);
+    expect(resolvedRef.node).toEqual({ get: { operationId: 'listInvoices' } });
+  });
+});

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -143,8 +143,12 @@ export class BaseResolver {
       return { source, parsed: source.body };
     }
 
+    const filename = isAbsoluteUrl(source.absoluteRef)
+      ? new URL(source.absoluteRef).pathname
+      : source.absoluteRef;
+
     if (
-      !isSupportedExtension(source.absoluteRef) &&
+      !isSupportedExtension(filename) &&
       !source.mimeType?.match(/(json|yaml|openapi)/) &&
       !isRoot // always parse root
     ) {


### PR DESCRIPTION
## What/Why/How?
Fixed resolving remote `$ref`s with query parameters in the URL.
## Reference

Fixes https://github.com/Redocly/redocly-cli/issues/1545

## Testing

Added a unit test, tested locally.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to how remote document paths are classified for parsing; no auth or fetch URL behavior changes beyond fixing query-string refs.
> 
> **Overview**
> Remote `$ref` URLs that include **query parameters** (for example `https://host/spec.yaml?ref=blah#/paths/...`) are now resolved correctly instead of being treated as non-parseable content.
> 
> In `parseDocument`, extension and YAML parsing decisions for absolute URLs now use the URL **pathname** (e.g. `test.yaml`) rather than the full string including `?query`, so `.yaml`/`.json` remote refs still parse as OpenAPI/YAML while the fetch URL remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7939fd0a87eab3c6590bdbf11a3556e6830011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->