### PR TITLE
fix(cli): reuse Node's compile cache to speed up startup

### DIFF
--- a/.changeset/large-pumas-shave.md
+++ b/.changeset/large-pumas-shave.md
@@ -2,5 +2,5 @@
 '@redocly/cli': patch
 ---
 
-Reduced CLI startup time by about 20% on Node 22.8 and later by reusing Node's on-disk compile cache.
+Reduced CLI startup time on Node 22.8 and later reusing Node's on-disk compile cache.
 Set `NODE_DISABLE_COMPILE_CACHE=1` to turn it off.

--- a/.changeset/large-pumas-shave.md
+++ b/.changeset/large-pumas-shave.md
@@ -1,0 +1,6 @@
+---
+'@redocly/cli': patch
+---
+
+Reduced CLI startup time by about 20% on Node 22.8 and later by reusing Node's on-disk compile cache.
+Set `NODE_DISABLE_COMPILE_CACHE=1` to turn it off.

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,3 +1,9 @@
 #!/usr/bin/env node
 
-import '../lib/index.js';
+import nodeModule from 'node:module';
+
+// Reusing V8's on-disk code cache cuts about 40ms off startup. Available from Node 22.8.
+nodeModule.enableCompileCache?.();
+
+// Imported dynamically so the cache is enabled before the bundle is compiled.
+await import('../lib/index.js');


### PR DESCRIPTION
## What/Why/How?

`bin/cli.js` now calls `module.enableCompileCache()` before loading the bundle, so V8 reuses an on-disk code cache instead of re-compiling the ~224 kB entry chunk on every run.

Measured on Node v26.3.0 / macOS arm64 with `hyperfine --warmup 3 --runs 25`:

| Command | Before | After | Delta |
| --- | --- | --- | --- |
| `redocly --help` | 220.6 ms ± 6.4 | 184.1 ms ± 9.4 | −37 ms, **1.20× faster** |
| `redocly lint tests/smoke/basic/openapi.yaml` | 403.4 ms ± 16.1 | 374.5 ms ± 34.7 | −29 ms, 1.08× faster |

The saving is a roughly constant ~30–50 ms of parse/compile work, so it shows up most on short commands.

Two implementation details worth reviewing:

- The `import '../lib/index.js'` had to become `await import(...)`. Static ESM imports are hoisted and evaluated before any statement in the file, so the cache would be enabled too late.
- `enableCompileCache` is called optionally (`?.()`). It landed in Node 22.8 and was never backported to 20.x, and `engines` still allows `>=20.19 <21`. On those versions the call is skipped and nothing changes.

Costs:

- The first run after an install (or a Node upgrade) pays a one-time ~49 ms penalty to write the cache.
- About 5.3 MB in `$TMPDIR/node-compile-cache/<node-version>-<arch>-<hash>-<uid>`, regenerated per Node version and invalidated when the bundle changes.
- The API is unflagged as of Node 24.15 / 25.4, experimental on 22.x and 23.x. It returns a status object and never throws, so a failure to enable the cache cannot break a command.

Users can opt out with `NODE_DISABLE_COMPILE_CACHE=1`.

## Reference

- [`module.enableCompileCache()`](https://nodejs.org/api/module.html#moduleenablecompilecacheoptions)
- [`NODE_DISABLE_COMPILE_CACHE=1`](https://nodejs.org/api/cli.html#node_disable_compile_cache1)

## Testing

Benchmarks above. Manually verified against the current build that output and exit codes are unchanged: `--version` and `--help` exit 0, `lint` on a valid description exits 0, `lint` on a missing file exits 1, and `NODE_DISABLE_COMPILE_CACHE=1` still works.

Draft because the full suite has not been run on this branch yet — please confirm CI is green before merging.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

No new dependencies and no new input handling. The cache directory is Node's own, resolved by Node from `TMPDIR`/`NODE_COMPILE_CACHE`, and holds compiled output of code we already ship.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only change using Node’s optional compile-cache API; no auth, data handling, or new dependencies, and older Node versions simply skip the call.
> 
> **Overview**
> The CLI entrypoint now enables Node’s on-disk V8 compile cache **before** loading `lib/index.js`, which avoids re-parsing the large entry bundle on every invocation (roughly 30–50 ms on short commands on Node 22.8+).
> 
> Because static ESM imports run first, the main bundle load was switched from a top-level `import` to **`await import('../lib/index.js')`** so `nodeModule.enableCompileCache?.()` runs in time. On Node versions without the API (e.g. some 20.x builds), the optional call is skipped and behavior stays the same.
> 
> A patch changeset notes the startup improvement and that **`NODE_DISABLE_COMPILE_CACHE=1`** disables the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc7aa30713f89082c9b4ac423119b5d053bdffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->