### PR TITLE
fix: update @redocly/ajv to version ^8.18.3 across packages

### DIFF
--- a/.changeset/dedupe-ajv-alias.md
+++ b/.changeset/dedupe-ajv-alias.md
@@ -1,0 +1,7 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/respect-core': patch
+'@redocly/cli': patch
+---
+
+Updated `@redocly/ajv` to `^8.18.3`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10311,7 +10311,7 @@
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
         "@redocly/config": "^0.53.1",
-        "ajv": "npm:@redocly/ajv@8.18.1",
+        "ajv": "npm:@redocly/ajv@^8.18.3",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "graphql": "^16.14.1",
@@ -10335,9 +10335,9 @@
     },
     "packages/core/node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -10393,7 +10393,7 @@
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.1",
         "@redocly/openapi-core": "2.46.0",
-        "ajv": "npm:@redocly/ajv@8.18.1",
+        "ajv": "npm:@redocly/ajv@^8.18.3",
         "better-ajv-errors": "^2.0.3",
         "colorette": "^2.0.20",
         "json-pointer": "^0.6.2",
@@ -10424,9 +10424,9 @@
     },
     "packages/respect-core/node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10309,7 +10309,7 @@
       "version": "2.46.0",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.18.1",
+        "@redocly/ajv": "^8.18.3",
         "@redocly/config": "^0.53.1",
         "ajv": "npm:@redocly/ajv@^8.18.3",
         "ajv-formats": "^3.0.1",
@@ -10391,7 +10391,7 @@
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "^8.18.1",
+        "@redocly/ajv": "^8.18.3",
         "@redocly/openapi-core": "2.46.0",
         "ajv": "npm:@redocly/ajv@^8.18.3",
         "better-ajv-errors": "^2.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
     "Roman Hotsiy <roman@redocly.com> (https://redocly.com/)"
   ],
   "dependencies": {
-    "@redocly/ajv": "^8.18.1",
+    "@redocly/ajv": "^8.18.3",
     "@redocly/config": "^0.53.1",
     "ajv": "npm:@redocly/ajv@^8.18.3",
     "ajv-formats": "^3.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@redocly/ajv": "^8.18.1",
     "@redocly/config": "^0.53.1",
-    "ajv": "npm:@redocly/ajv@8.18.1",
+    "ajv": "npm:@redocly/ajv@^8.18.3",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",
     "graphql": "^16.14.1",

--- a/packages/respect-core/package.json
+++ b/packages/respect-core/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "@noble/hashes": "^1.8.0",
-    "@redocly/ajv": "^8.18.1",
+    "@redocly/ajv": "^8.18.3",
     "@redocly/openapi-core": "2.46.0",
     "ajv": "npm:@redocly/ajv@^8.18.3",
     "better-ajv-errors": "^2.0.3",

--- a/packages/respect-core/package.json
+++ b/packages/respect-core/package.json
@@ -49,7 +49,7 @@
     "@noble/hashes": "^1.8.0",
     "@redocly/ajv": "^8.18.1",
     "@redocly/openapi-core": "2.46.0",
-    "ajv": "npm:@redocly/ajv@8.18.1",
+    "ajv": "npm:@redocly/ajv@^8.18.3",
     "better-ajv-errors": "^2.0.3",
     "colorette": "^2.0.20",
     "json-pointer": "^0.6.2",


### PR DESCRIPTION
## What/Why/How?
`openapi-core` and `respect-core` declared `@redocly/ajv` twice — once under its own name with a caret range, and once aliased as `ajv` pinned to an exact version — so the two drifted apart as soon as a patch shipped, installing two copies of the same library. Aligning both to a caret range collapses them to one, removing ~230 KB of duplicated code from bundles.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines
