### PR TITLE
chore: audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4940,9 +4940,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -5874,9 +5874,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7590,9 +7590,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -8397,9 +8397,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8490,9 +8490,9 @@
       "license": "MIT"
     },
     "node_modules/redoc/node_modules/@redocly/openapi-core": {
-      "version": "1.34.18",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
-      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
+      "version": "1.34.19",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz",
+      "integrity": "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8501,7 +8501,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"


### PR DESCRIPTION
## What/Why/How?

Updates transitive dependencies in `package-lock.json` to their latest patch versions:

| Package | From | To |
| --- | --- | --- |
| `js-yaml` | 4.3.0 | 4.3.1 |
| `js-yaml` (legacy 3.x) | 3.15.0 | 3.15.1 |
| `dompurify` | 3.4.12 | 3.4.13 |
| `nanoid` | 3.3.16 | 3.3.18 |
| `@redocly/openapi-core` (transitive) | 1.34.18 | 1.34.19 |

No `package.json` changes — lockfile only.

## Reference
close https://github.com/Redocly/redocly-cli/pull/3030
https://github.com/Redocly/redocly-cli/pull/3032

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level lockfile updates with no application source changes; typical low-risk dependency maintenance.
> 
> **Overview**
> **Lockfile-only** patch bumps for transitive dev dependencies—no `package.json` changes.
> 
> Updates include `dompurify` (3.4.12 → 3.4.13), `nanoid` (3.3.16 → 3.3.18), `js-yaml` at 4.3.1 and legacy 3.15.1, and `@redocly/openapi-core` (1.34.18 → 1.34.19) under `redoc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f847b9de4c369001e76890d42d497012fb4d47ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->