### PR TITLE
fix: do not run nested visitors with a stale parent on shared $refs

### DIFF
--- a/.changeset/quiet-bears-allow.md
+++ b/.changeset/quiet-bears-allow.md
@@ -3,4 +3,4 @@
 '@redocly/openapi-core': patch
 ---
 
-Fixed an issue where rule reported a duplicate parameter when two or more `$ref`s point to the same path item.
+Fixed an issue where rule incorrectly reported a duplicate parameter when two or more `$ref`s pointed to the same path item.

--- a/.changeset/quiet-bears-allow.md
+++ b/.changeset/quiet-bears-allow.md
@@ -1,0 +1,6 @@
+---
+'@redocly/cli': patch
+'@redocly/openapi-core': patch
+---
+
+Fixed an issue where rule reported a duplicate parameter when two or more `$ref`s point to the same path item.

--- a/packages/core/src/__tests__/walk.test.ts
+++ b/packages/core/src/__tests__/walk.test.ts
@@ -731,6 +731,129 @@ describe('walk order', () => {
     `);
   });
 
+  it('should not visit a nested rule when another rule re-enters a shared $ref-ed node', async () => {
+    const calls: string[] = [];
+
+    const testRuleSet: Oas3RuleSet = {
+      nested: () => ({
+        PathItem: {
+          Operation: {
+            Parameter(param: any, _ctx: any, parents: any) {
+              calls.push(`param ${param.name} > op ${parents.Operation.operationId}`);
+            },
+          },
+        },
+      }),
+      callbacks: () => ({
+        PathItem: {
+          Operation: {
+            Callback: {
+              PathItem: {
+                Operation(op: any) {
+                  calls.push(`callback op ${op.operationId}`);
+                },
+              },
+            },
+          },
+        },
+      }),
+    };
+
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        paths:
+          /sample:
+            get:
+              operationId: get
+              callbacks:
+                first:
+                  'uri-1':
+                    $ref: '#/components/pathItems/shared'
+                second:
+                  'uri-2':
+                    $ref: '#/components/pathItems/shared'
+        components:
+          pathItems:
+            shared:
+              post:
+                operationId: notify
+                parameters:
+                  - name: x-shared
+                    in: header
+      `,
+      ''
+    );
+
+    await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({
+        plugins: [{ id: 'test', rules: { oas3: testRuleSet } }],
+        rules: {
+          'test/nested': 'error',
+          'test/callbacks': 'error',
+        },
+      }),
+    });
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        "callback op notify",
+        "param x-shared > op notify",
+        "callback op notify",
+      ]
+    `);
+  });
+
+  it('should visit nested rules for keys written next to a $ref', async () => {
+    const calls: string[] = [];
+
+    const testRuleSet: Oas3RuleSet = {
+      test: () => ({
+        NamedSchemas: {
+          Schema: {
+            Schema(_schema: any, ctx: any) {
+              calls.push(ctx.location.pointer);
+            },
+          },
+        },
+      }),
+    };
+
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        paths: {}
+        components:
+          schemas:
+            Base:
+              type: object
+            WithSiblings:
+              $ref: '#/components/schemas/Base'
+              properties:
+                sibling:
+                  type: string
+      `,
+      ''
+    );
+
+    await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({
+        plugins: [{ id: 'test', rules: { oas3: testRuleSet } }],
+        rules: { 'test/test': 'error' },
+      }),
+    });
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        "#/components/schemas/WithSiblings/properties/sibling",
+      ]
+    `);
+  });
+
   it('should visit and do not recurse for circular refs top-level', async () => {
     const calls: string[] = [];
 

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -152,6 +152,7 @@ export function walkDocument<T extends BaseVisitor>(opts: {
   const composedRefWalkId = (type: NormalizedNodeType, location: Location) =>
     `${type.name}::${location.absolutePointer}`;
   const ignoredNodes = new Set<string>();
+  const walkingNodeByType: Record<string, unknown> = {};
 
   // Pre-compute combined enter/leave arrays per type to avoid per-node array allocations
   const anyEnter = normalizedVisitors.any.enter as VisitorNode<any>[];
@@ -300,6 +301,8 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           if (
             (context.parent && // if nested
               context.parent.activatedOn &&
+              context.parent.activatedOn.value.node ===
+                walkingNodeByType[context.parent.type.name] &&
               context.activatedOn?.value.withParentNode !== context.parent.activatedOn.value.node &&
               // do not enter if visited by parent children (it works thanks because deeper visitors are sorted before)
               context.parent.activatedOn.value.nextLevelTypeActivated?.value !== type) ||
@@ -342,6 +345,9 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           }
         }
       }
+
+      const prevWalkingNode = walkingNodeByType[type.name];
+      walkingNodeByType[type.name] = resolvedNode;
 
       if (visitedBySome || !isNodeSeen) {
         seenNodesPerType[type.name] = seenNodesPerType[type.name] || new Set();
@@ -406,6 +412,8 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           }
         }
       }
+
+      walkingNodeByType[type.name] = prevWalkingNode;
 
       const currentLeaveVisitors =
         combinedLeave[type.name] || (normalizedVisitors[type.name]?.leave || []).concat(anyLeave);

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -152,6 +152,7 @@ export function walkDocument<T extends BaseVisitor>(opts: {
   const composedRefWalkId = (type: NormalizedNodeType, location: Location) =>
     `${type.name}::${location.absolutePointer}`;
   const ignoredNodes = new Set<string>();
+  const walkingNodeByType: Record<string, unknown> = {};
 
   // Pre-compute combined enter/leave arrays per type to avoid per-node array allocations
   const anyEnter = normalizedVisitors.any.enter as VisitorNode<any>[];
@@ -309,6 +310,8 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           if (
             (context.parent && // if nested
               context.parent.activatedOn &&
+              context.parent.activatedOn.value.node ===
+                walkingNodeByType[context.parent.type.name] &&
               context.activatedOn?.value.withParentNode !== context.parent.activatedOn.value.node &&
               // do not enter if visited by parent children (it works thanks because deeper visitors are sorted before)
               context.parent.activatedOn.value.nextLevelTypeActivated?.value !== type) ||
@@ -351,6 +354,9 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           }
         }
       }
+
+      const prevWalkingNode = walkingNodeByType[type.name];
+      walkingNodeByType[type.name] = resolvedNode;
 
       if (visitedBySome || !isNodeSeen) {
         seenNodesPerType[type.name] = seenNodesPerType[type.name] || new Set();
@@ -416,6 +422,8 @@ export function walkDocument<T extends BaseVisitor>(opts: {
           }
         }
       }
+
+      walkingNodeByType[type.name] = prevWalkingNode;
 
       const currentLeaveVisitors =
         combinedLeave[type.name] || (normalizedVisitors[type.name]?.leave || []).concat(anyLeave);

--- a/tests/e2e/lint/shared-path-item-in-callbacks/openapi.yaml
+++ b/tests/e2e/lint/shared-path-item-in-callbacks/openapi.yaml
@@ -1,0 +1,36 @@
+openapi: 3.1.0
+info:
+  title: Example OpenAPI 3.1 definition.
+  version: 1.0
+
+paths:
+  /sample:
+    get:
+      operationId: getSample
+      summary: example summary
+      responses:
+        '200':
+          description: example description
+      callbacks:
+        onEventA:
+          'https://callbacks.example.com/a':
+            $ref: '#/components/pathItems/notify'
+        onEventB:
+          'https://callbacks.example.com/b':
+            $ref: '#/components/pathItems/notify'
+
+components:
+  pathItems:
+    notify:
+      post:
+        operationId: notify
+        summary: example summary
+        parameters:
+          - in: header
+            name: x-signature
+            required: true
+            schema:
+              type: string
+        responses:
+          '200':
+            description: example description

--- a/tests/e2e/lint/shared-path-item-in-callbacks/openapi.yaml
+++ b/tests/e2e/lint/shared-path-item-in-callbacks/openapi.yaml
@@ -18,6 +18,8 @@ paths:
         onEventB:
           'https://callbacks.example.com/b':
             $ref: '#/components/pathItems/notify'
+  /notify:
+    $ref: '#/components/pathItems/notify'
 
 components:
   pathItems:

--- a/tests/e2e/lint/shared-path-item-in-callbacks/redocly.yaml
+++ b/tests/e2e/lint/shared-path-item-in-callbacks/redocly.yaml
@@ -1,0 +1,7 @@
+apis:
+  main:
+    root: ./openapi.yaml
+
+rules:
+  operation-parameters-unique: error
+  path-parameters-defined: error

--- a/tests/e2e/lint/shared-path-item-in-callbacks/snapshot.txt
+++ b/tests/e2e/lint/shared-path-item-in-callbacks/snapshot.txt
@@ -1,0 +1,6 @@
+
+validating openapi.yaml using lint rules for api 'main'...
+openapi.yaml: validated in <test>ms
+
+Woohoo! Your API description is valid. 🎉
+


### PR DESCRIPTION
## What/Why/How?

`operation-parameters-unique` reported a duplicate parameter that is not there. It happens when the same path item is reused through `$ref`, for example from two callbacks, and the reported location points at an operation that has no `parameters` at all.

The reason is in the walker. Two `$ref`s to the same path item resolve to one object, so the walker enters it twice. On the second entry it does not call the rule's `enter` hooks again, because it already called them for that node — but it still calls the rule's nested `Parameter` visitor. So the visitor runs with the state and the parent location left over from the first entry, and reports a parameter it had already counted.

Added a guard: a nested visitor now runs only if the node its parent hook sits on is the node the walker is really inside. On the second entry the `Parameter` visitor stays quiet, and the rule reports only what it actually saw. `operation-parameters-unique` is not the only rule with this shape — `spec-querystring-parameters` had the same problem.

## Reference

Closes https://github.com/Redocly/redocly-cli/issues/2829

## Testing

- https://github.com/Redocly/redocly/actions/runs/33093171908/job/98591935934?pr=26673 ✅

## Screenshots (optional)

`x-signature` is declared once, in one list:

```yaml
paths:
  /sample:
    get:                                  # no parameters here
      callbacks:
        onEventA:
          'https://callbacks.example.com/a':
            $ref: '#/components/pathItems/notify'
        onEventB:
          'https://callbacks.example.com/b':
            $ref: '#/components/pathItems/notify'
components:
  pathItems:
    notify:
      post:
        parameters:
          - in: header
            name: x-signature            # declared once, used in both callbacks
```

Before: 
```sh
validating openapi.yaml using lint rules for api 'main'...
[1] openapi.yaml:9:7 at #/paths/~1sample/get/parameters/0

Operations must have unique `name` + `in` parameters. Repeats of `in:header` + `name:x-signature`.

 7 |   /sample:
 8 |     get:
 9 |       operationId: getSample
   |       ^^^^^^^^^^^^^^^^^^^^^^
10 |       summary: example summary
   |       ^^^^^^^^^^^^^^^^^^^^^^^^

Error was generated by the operation-parameters-unique rule.

❌ Validation failed with 1 error.
```

After: 
```sh
validating openapi.yaml using lint rules for api 'main'...
openapi.yaml: validated in 4ms

Woohoo! Your API description is valid. 🎉
```

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [x] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lint walking behavior for all nested visitors and shared `$ref` re-entries; low security impact but could affect rule results across the ecosystem.
> 
> **Overview**
> Fixes **false duplicate-parameter lint** when the same path item is reached through multiple `$ref`s (e.g. two callbacks or a path plus callbacks). Rules like `operation-parameters-unique` could fire on an operation that has no `parameters` because nested visitors still ran after a second walk into the same resolved object, using parent context from the first visit.
> 
> The OpenAPI document walker in `walk.ts` now tracks the **active node per type** (`walkingNodeByType`) for the current descent. Nested rule visitors activate only when the parent hook’s node matches that active node, so a re-entry into a shared `$ref` target does not re-run nested visitors with leftover parent state. Sibling keys beside `$ref` keep working as before.
> 
> Adds unit coverage for callback + shared path item refs and composed `$ref` siblings, plus an e2e lint fixture that expects a clean pass for reused `components/pathItems`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9158410070637c9d851ef7d4dd944b7e407fb36a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->