### PR TITLE
chore: bump redocly/mock-server version

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           run_install: false
-          version: 10.33.0
+          version: 11.22.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "@faker-js/faker": "^9.9.0",
-        "@redocly/mock-server": "^0.7.0",
+        "@redocly/mock-server": "^0.10.0",
         "@tanstack/react-query": "^5.0.0",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^22.15.3",
@@ -2819,18 +2819,18 @@
       "license": "MIT"
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.7.0.tgz",
-      "integrity": "sha512-gr9e1aq5iKy+AN3F+NwFC4cbi15XCdL1HTpfZudV9jg2OqTPRMZd1RNvFQvKUF0UZq+TLLpR88KmD+ufiVAX0w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0.tgz",
+      "integrity": "sha512-162k659ADkMva40DJ7MdLZ3ic4ohWr2gkIw9hdEk6KxWKP1zfnbTmZGLiSC1DSFDWKctRmFWJ/7Tj8hqtsSbJg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
-        "@redocly/openapi-core": "2.30.5",
+        "@redocly/openapi-core": "2.45.0",
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.3.1",
         "openapi-sampler": "^1.7.2",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
@@ -2855,30 +2855,21 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/config": {
-      "version": "0.48.2",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.2.tgz",
-      "integrity": "sha512-DUHthTRdj+caAQWCtJae4yzvxaUDuwQkFsZFVaAEyORd8Bt8K2wYso61jYZuR/kQZaDejfUREtQTVVZ5VYTqgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "2.7.2"
-      }
-    },
     "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.5.tgz",
-      "integrity": "sha512-ikljMaow1wX3GoRvLiJvqOq8H3f6XsuMBZqCGmeY0+UPmlnVhrvW8m/gC1vkKcGNvYINUrgi/Z6dBtzQ7854wA==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.45.0.tgz",
+      "integrity": "sha512-a8NsUpiE4M3sfNEI+BuEHNqslcn19nE2AP1mw5hvDnEsnJRDCgPk+Sy1zyQCCnmiisk9vy+XlVzFXPraPrAW4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.48.1",
+        "@redocly/config": "^0.53.1",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
+        "graphql": "^16.14.1",
         "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^5.2.2",
         "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -2923,6 +2914,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/@redocly/mock-server/node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -2955,34 +2969,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@types/json-schema": "^7.0.9",
-        "ts-algebra": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@redocly/mock-server/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -3005,13 +2991,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@redocly/mock-server/node_modules/ts-algebra": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
-      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@redocly/mock-server/node_modules/yargs": {
       "version": "17.7.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@faker-js/faker": "^9.9.0",
-    "@redocly/mock-server": "^0.7.0",
+    "@redocly/mock-server": "^0.10.0",
     "@tanstack/react-query": "^5.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^22.15.3",


### PR DESCRIPTION
## What/Why/How?
Bump `@redocly/mock-server` to latest - `^0.10.0`
Bump `pnpm` version in the `performance.yaml`, as `Rebilly/api-definitions` [now requires pnpm ≥ 11](https://github.com/Rebilly/api-definitions/commit/1bfdd49ef452639a915e7870b0d1f2c582716ba0)

## Reference
**npm audit report**

- JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases - [CVE-2026-53550](https://github.com/advisories/GHSA-h67p-54hq-rp68) 
- js-yaml: YAML merge-key chains can force quadratic CPU consumption - [CVE-2026-59869](https://github.com/advisories/GHSA-52cp-r559-cp3m)
- JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported - [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump for a dev tool; no runtime or CLI logic changes, though e2e tests that use the mock server may behave slightly differently on the new mock-server/openapi-core stack.
> 
> **Overview**
> Bumps the **devDependency** `@redocly/mock-server` from `^0.7.0` to `^0.10.0` in `package.json` and refreshes `package-lock.json`.
> 
> The lockfile update pulls in newer transitive packages (notably `@redocly/openapi-core` 2.45.0 and updated `js-yaml`), addressing npm audit findings for **js-yaml** DoS issues (CVE-2026-53550, CVE-2026-59869, GHSA-5p4m-2wfm-xmqj). No CLI or package source changes—only dependency versions used by e2e mock servers (e.g. `createMockServer` in generate-client tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7022c37a7de356c584cb99bbf37d730e18876092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->