### PR TITLE
fix: name the rule when a configurable rule is missing its assertions block

### DIFF
--- a/.changeset/configurable-rule-missing-assertions.md
+++ b/.changeset/configurable-rule-missing-assertions.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed the unclear error raised when a configurable rule, or one of its `where` entries, is missing the `assertions` block. The message now names the rule instead of failing with `Cannot read properties of undefined (reading 'pattern')`. This covers both the OpenAPI and the GraphQL paths.

--- a/.changeset/configurable-rule-missing-assertions.md
+++ b/.changeset/configurable-rule-missing-assertions.md
@@ -2,4 +2,4 @@
 '@redocly/openapi-core': patch
 ---
 
-Fixed the unclear error raised when a configurable rule, or one of its `where` entries, is missing the `assertions` block. The message now names the rule instead of failing with `Cannot read properties of undefined (reading 'pattern')`. This covers both the OpenAPI and the GraphQL paths.
+Improved the error message raised when a configurable rule is missing the `assertions` block.

--- a/packages/core/src/graphql/assertions.ts
+++ b/packages/core/src/graphql/assertions.ts
@@ -51,6 +51,10 @@ export const GraphqlAssertions: GraphqlRule = (
     const kind = assertion.subject?.type as GraphqlNodeKind | undefined;
     if (!kind) continue;
 
+    if (!isPlainObject(assertion.assertions)) {
+      throw new Error(`${assertion.assertionId}: 'assertions' (Object) is required`);
+    }
+
     const assertsToApply = getGraphqlAssertsToApply(assertion);
     const whereMatchers = buildWhereMatchers(assertion);
 
@@ -72,6 +76,11 @@ function buildWhereMatchers(assertion: Assertion): WhereMatcher[] {
     if (!isString(definition.subject?.type)) {
       throw new Error(
         `${assertion.assertionId} -> where -> [${index}]: 'type' (String) is required`
+      );
+    }
+    if (!isPlainObject(definition.assertions)) {
+      throw new Error(
+        `${assertion.assertionId} -> where -> [${index}]: 'assertions' (Object) is required`
       );
     }
     return {

--- a/packages/core/src/rules/common/assertions/__tests__/index.test.ts
+++ b/packages/core/src/rules/common/assertions/__tests__/index.test.ts
@@ -97,4 +97,32 @@ describe('Oas3 assertions', () => {
       ]
     `);
   });
+
+  it('should throw a named error when the assertions block is missing', () => {
+    const rule = {
+      'rule/no-assertions': {
+        assertionId: 'rule/no-assertions',
+        subject: { type: 'Operation', property: 'summary' },
+      },
+    };
+
+    expect(() => Assertions(rule as any)).toThrow(
+      "rule/no-assertions: 'assertions' (Object) is required"
+    );
+  });
+
+  it('should throw a named error when the assertions block is missing in a where clause', () => {
+    const rule = {
+      'rule/no-assertions-in-where': {
+        assertionId: 'rule/no-assertions-in-where',
+        subject: { type: 'Operation', property: 'summary' },
+        assertions: { pattern: '/example/' },
+        where: [{ subject: { type: 'PathItem' } }],
+      },
+    };
+
+    expect(() => Assertions(rule as any)).toThrow(
+      "rule/no-assertions-in-where -> where -> [0]: 'assertions' (Object) is required"
+    );
+  });
 });

--- a/packages/core/src/rules/common/assertions/index.ts
+++ b/packages/core/src/rules/common/assertions/index.ts
@@ -58,6 +58,10 @@ export const Assertions = (opts: Record<string, Assertion>) => {
       throw new Error(`${assertion.assertionId}: 'type' (String) is required`);
     }
 
+    if (!isPlainObject(assertion.assertions)) {
+      throw new Error(`${assertion.assertionId}: 'assertions' (Object) is required`);
+    }
+
     const subjectVisitor = buildSubjectVisitor(assertion.assertionId, assertion);
     const visitorObject = buildVisitorObject(assertion, subjectVisitor);
     visitors.push(visitorObject);

--- a/packages/core/src/rules/common/assertions/utils.ts
+++ b/packages/core/src/rules/common/assertions/utils.ts
@@ -1,6 +1,7 @@
 import type { AssertionContext, AssertResult } from '../../../config/index.js';
 import { colorize } from '../../../logger.js';
 import { isRef, isAbsoluteUrl } from '../../../ref-utils.js';
+import { isPlainObject } from '../../../utils/is-plain-object.js';
 import { isString } from '../../../utils/is-string.js';
 import { isTruthy } from '../../../utils/is-truthy.js';
 import { keysOf } from '../../../utils/keys-of.js';
@@ -162,6 +163,12 @@ export function buildVisitorObject(
     if (!isString(assertionDefinitionNode.subject?.type)) {
       throw new Error(
         `${assertion.assertionId} -> where -> [${index}]: 'type' (String) is required`
+      );
+    }
+
+    if (!isPlainObject(assertionDefinitionNode.assertions)) {
+      throw new Error(
+        `${assertion.assertionId} -> where -> [${index}]: 'assertions' (Object) is required`
       );
     }
 

--- a/packages/core/src/rules/graphql/__tests__/assertions.test.ts
+++ b/packages/core/src/rules/graphql/__tests__/assertions.test.ts
@@ -495,4 +495,49 @@ describe('GraphQL configurable rules (rule/*)', () => {
       ]
     `);
   });
+
+  it('fails with a named error when the assertions block is missing', async () => {
+    const config = await createConfig(
+      outdent`
+        rules:
+          rule/graphql-no-assertions:
+            subject:
+              type: ObjectTypeDefinition
+      `
+    );
+
+    await expect(
+      lintFromString({
+        source: 'type Correct { name: String! }',
+        absoluteRef: 'schema.graphql',
+        config,
+      })
+    ).rejects.toThrow("rule/graphql-no-assertions: 'assertions' (Object) is required");
+  });
+
+  it('fails with a named error when the assertions block is missing in a where clause', async () => {
+    const config = await createConfig(
+      outdent`
+        rules:
+          rule/graphql-no-assertions-in-where:
+            subject:
+              type: FieldDefinition
+            assertions:
+              casing: camelCase
+            where:
+              - subject:
+                  type: ObjectTypeDefinition
+      `
+    );
+
+    await expect(
+      lintFromString({
+        source: 'type Correct { name: String! }',
+        absoluteRef: 'schema.graphql',
+        config,
+      })
+    ).rejects.toThrow(
+      "rule/graphql-no-assertions-in-where -> where -> [0]: 'assertions' (Object) is required"
+    );
+  });
 });


### PR DESCRIPTION
## What/Why/How?

A configurable rule declared without its `assertions` block dies with a message that says nothing about the config:

```
Something went wrong when processing openapi.yaml:

  - Cannot read properties of undefined (reading 'pattern')
```

`getAssertsToApply` reads `assertion.assertions[assertName]` for the first key of `asserts`, which is `pattern`, so that is where the `undefined` surfaces.

The config schema already declares the block as mandatory. `ConfigurableRule` and `Where` in `packages/core/src/types/redocly-yaml.ts` both carry `required: ['subject', 'assertions']`, so no valid configuration is being turned away here. The runtime simply was not checking what the schema promises, and `redocly lint` still ran the rule after the config struct warning.

The change adds that check next to the `'type' (String) is required` guards that were already there, in the four places a configurable rule definition gets built:

- `rules/common/assertions/index.ts`, the rule itself
- `rules/common/assertions/utils.ts`, each `where` entry
- `graphql/assertions.ts`, both of the same two spots

The GraphQL path keeps its own `if (!kind) continue`, so a rule with no subject type is still skipped rather than rejected. Only the missing `assertions` block now raises, which is what the OpenAPI path already did.

After:

```
Something went wrong when processing openapi.yaml:

  - rule/test: 'assertions' (Object) is required
```

## Reference

Closes #2185.

## Testing

Two unit tests in `packages/core/src/rules/common/assertions/__tests__/index.test.ts` for the rule and its `where` entry, and two in `packages/core/src/rules/graphql/__tests__/assertions.test.ts` that go through `lintFromString` against a schema. All four fail on `main` with the `Cannot read properties of undefined` message.

```
VITEST_SUITE=unit npx vitest run packages/core/src/rules/common/assertions packages/core/src/rules/graphql
```

The whole `packages/core` suite was run on `main` and on this branch back to back, on Windows with Node 22.20. `main` gives 36 failed and 1015 passed, the branch gives 36 failed and 1019 passed, so the only difference is the four tests added here. Those 36 are pre-existing path and snapshot mismatches on Windows and none of them touch assertions.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 --> The docs already describe `assertions` as part of the rule shape, so nothing there changes.

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 --> The change only turns an unhandled `TypeError` into a named error before any document is read.
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change at rule-build time; no lint behavior change for valid configs, only clearer failures for invalid ones.
> 
> **Overview**
> Configurable rules without an `assertions` object no longer crash with `Cannot read properties of undefined (reading 'pattern')` during lint setup. **Runtime checks** now mirror the config schema and throw named errors like `rule/test: 'assertions' (Object) is required`.
> 
> The same validation is applied for **top-level rules** and for each **`where`** entry, on both the **OpenAPI** path (`rules/common/assertions/index.ts`, `utils.ts`) and the **GraphQL** path (`graphql/assertions.ts`). GraphQL still skips rules with no subject `type`; only a missing `assertions` block is rejected.
> 
> Unit and GraphQL lint tests cover the rule-level and `where`-level cases. A patch changeset documents the improved error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb017e04cd3f1498f56f009da13f0bef06c6b533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->