### PR TITLE
fix: detect duplicated enum values that are objects or arrays

### DIFF
--- a/.changeset/duplicated-enum-values-structural.md
+++ b/.changeset/duplicated-enum-values-structural.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Fixed the `no-duplicated-enum-values` rule missing duplicated enum values that are objects or arrays, and printing `[object Object]` when it did report one.

--- a/.changeset/duplicated-enum-values-structural.md
+++ b/.changeset/duplicated-enum-values-structural.md
@@ -2,4 +2,6 @@
 '@redocly/openapi-core': patch
 ---
 
-Fixed the `no-duplicated-enum-values` rule missing duplicated enum values that are objects or arrays, and printing `[object Object]` when it did report one.
+Fixed an issue where the `no-duplicated-enum-values` rule didn't report duplicated enum values that are objects or arrays.
+
+Fixed an issue where the `no-duplicated-enum-values` rule printed `[object Object]` when reporting duplicate values.

--- a/packages/core/src/rules/common/__tests__/no-duplicated-enum-values.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-duplicated-enum-values.test.ts
@@ -71,4 +71,127 @@ describe('no-duplicated-enum-values', () => {
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
   });
+
+  it('should report duplicated object enum values', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            Foo:
+              type: object
+              enum:
+                - id: 1
+                  name: foo
+                - id: 2
+                  name: bar
+                - id: 1
+                  name: foo
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-duplicated-enum-values': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "location": [
+            {
+              "pointer": "#/components/schemas/Foo/enum/2",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Duplicated enum value found: '{"id":1,"name":"foo"}'.",
+          "reference": "https://redocly.com/docs/cli/rules/common/no-duplicated-enum-values",
+          "ruleId": "no-duplicated-enum-values",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
+
+  it('should report duplicated object enum values written in a different key order', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            Foo:
+              type: object
+              enum:
+                - id: 1
+                  name: foo
+                - name: foo
+                  id: 1
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-duplicated-enum-values': 'error' } }),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].location[0].pointer).toBe('#/components/schemas/Foo/enum/1');
+  });
+
+  it('should report duplicated array enum values', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            Foo:
+              type: array
+              enum:
+                - [1, 2]
+                - [3]
+                - [1, 2]
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-duplicated-enum-values': 'error' } }),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].location[0].pointer).toBe('#/components/schemas/Foo/enum/2');
+    expect(results[0].message).toBe(`Duplicated enum value found: '[1,2]'.`);
+  });
+
+  it('should not report on unique object enum values', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          schemas:
+            Foo:
+              type: object
+              enum:
+                - id: 1
+                - id: 2
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-duplicated-enum-values': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/core/src/rules/common/no-duplicated-enum-values.ts
+++ b/packages/core/src/rules/common/no-duplicated-enum-values.ts
@@ -1,7 +1,13 @@
 import type { Oas3Schema } from '../../typings/openapi.js';
 import type { Oas2Schema } from '../../typings/swagger.js';
+import { dequal } from '../../utils/dequal.js';
+import { isPlainObject } from '../../utils/is-plain-object.js';
 import type { Arazzo1Rule, Async2Rule, Async3Rule, Oas2Rule, Oas3Rule } from '../../visitors.js';
 import type { UserContext } from '../../walk.js';
+
+function isStructuredValue(value: unknown): boolean {
+  return isPlainObject(value) || Array.isArray(value);
+}
 
 export const NoDuplicatedEnumValues:
   | Oas3Rule
@@ -12,16 +18,33 @@ export const NoDuplicatedEnumValues:
   return {
     Schema(schema: Oas2Schema | Oas3Schema, { report, location }: UserContext) {
       if (!Array.isArray(schema.enum)) return;
-      const seenValues = new Set();
+      // A Set compares objects and arrays by identity, and two enum entries written the same way
+      // are separate nodes, so structured values need a structural comparison instead.
+      // Primitives keep the Set, which is what large enums of codes and names are made of.
+      const seenPrimitives = new Set();
+      const seenStructures: unknown[] = [];
+
       for (const [index, value] of schema.enum.entries()) {
-        if (seenValues.has(value)) {
+        const isStructured = isStructuredValue(value);
+        const isDuplicated = isStructured
+          ? seenStructures.some((seenValue) => dequal(seenValue, value))
+          : seenPrimitives.has(value);
+
+        if (isDuplicated) {
           report({
-            message: `Duplicated enum value found: '${value}'.`,
+            message: `Duplicated enum value found: '${
+              isStructured ? JSON.stringify(value) : value
+            }'.`,
             location: location.child(['enum', index]),
             reference: 'https://redocly.com/docs/cli/rules/common/no-duplicated-enum-values',
           });
         }
-        seenValues.add(value);
+
+        if (isStructured) {
+          seenStructures.push(value);
+        } else {
+          seenPrimitives.add(value);
+        }
       }
     },
   };


### PR DESCRIPTION
## What/Why/How?

`no-duplicated-enum-values` only catches duplicates whose values are primitives. The values it has already seen go into a `Set`:

```ts
const seenValues = new Set();
for (const [index, value] of schema.enum.entries()) {
  if (seenValues.has(value)) {
```

A `Set` compares objects and arrays by identity, and two enum entries written the same way are separate nodes after parsing, so they never collide. Measured on `main` at af879b25, with `no-duplicated-enum-values: error`:

```
enum: [{id: 1, name: foo}, {id: 2, name: bar}, {id: 1, name: foo}]   ->  no error
enum: [[1, 2], [3], [1, 2]]                                          ->  no error
enum: [foo, bar, foo]                                                ->  reported
```

The documentation states the requirement without a carve out: *"Requires all values in an `enum` to be unique"*, and JSON Schema defines enum equality structurally, so `{a: 1, b: 2}` and `{b: 2, a: 1}` are the same value.

There is a second defect in the same block. The value goes straight into a template string, so on the one path where objects do collide today, a YAML anchor reused through an alias, the message is unreadable:

```yaml
enum:
  - &a {x: 1}
  - *a
```

```
main:       Duplicated enum value found: '[object Object]'.
this branch: Duplicated enum value found: '{"x":1}'.
```

The fix keeps the `Set` for primitives, which is what a large enum of codes or names is made of, and compares structured values with `dequal`. That helper already lives in `packages/core/src/utils/dequal.ts` and is used for the same purpose in `bundle-visitor.ts` and `scorecards.ts`, so this adds no new dependency and no new comparison semantics to the codebase. It also gives key order independence for free, which a serialise and compare approach would not.

The linear scan over structured values is quadratic in the number of them. I kept the `Set` fast path precisely so that the common large enum, all strings, stays linear; an enum with enough object members for the scan to matter is not a shape I could find in the fixtures.

Nothing changes for primitives, including the message text, which is why the existing snapshot in the rule tests is untouched.

## Reference

No issue, I found this reading the rule after #3040. The rule arrived in #3008.

## Testing

Four tests added to `packages/core/src/rules/common/__tests__/no-duplicated-enum-values.test.ts`:

- duplicated object values are reported, with the serialised value in the message
- duplicated object values written in a different key order are reported
- duplicated array values are reported
- unique object values are not reported, which is the guard against the rule degrading into reporting everything

The first three fail on `main`, the first two and the third for a missing error and the message assertion for the wrong text. The fourth passes before and after.

```
VITEST_SUITE=unit vitest run packages/core/src/rules/common/__tests__/no-duplicated-enum-values.test.ts
  Tests  6 passed (6)
```

`npm run typecheck` is clean. `oxlint` and `oxfmt --check` are clean on both changed files.

On the whole unit suite I get 55 failures in 24 files, and I want to be straight about it: the same 55 fail on a clean `main` checkout on this machine, which is Windows with npm 10.9.3 against the `>=11` the repo asks for, and most of them are path separator snapshots. My branch runs 3094 passed against 3090 on `main`, which is exactly the four tests added here and no change anywhere else. I did not run the e2e suite.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines)
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [x] New package installed? - No new package
- [x] Documentation update has been considered: the rule page already states the requirement without exceptions, so it describes the fixed behaviour rather than the current one

## Security

- [x] The security impact of the change has been considered: the rule reads parsed values and reports, and `JSON.stringify` on a value with a cycle would throw, which cannot happen here because the input comes from a YAML or JSON document
- [x] Code follows company security practices and guidelines

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped lint-rule change with tests only; primitive enum behavior and messages are unchanged.
> 
> **Overview**
> **`no-duplicated-enum-values`** now treats object and array enum members as duplicates when they are structurally equal (including different key order), instead of relying on a `Set` that only matched primitives by value.
> 
> Structured duplicates are tracked with **`dequal`**; primitives still use a **`Set`**. Diagnostic text for objects/arrays uses **`JSON.stringify`** so messages no longer show `[object Object]`.
> 
> Unit tests cover object/array duplicates, key-order independence, unique objects, and message formatting. A patch **changeset** is included for `@redocly/openapi-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9582d4fca37d30b824781437cfa2ceb7f786e95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->