### PR TITLE
chore: remove missing 2.45.1 version from changelog

### DIFF
--- a/docs/@v2/changelog.md
+++ b/docs/@v2/changelog.md
@@ -29,17 +29,11 @@ toc:
 
 ### Patch Changes
 
-- Updated @redocly/openapi-core to v2.46.0.
-
-## 2.45.1 (2026-08-06)
-
-### Patch Changes
-
 - Fixed the `struct` rule to report unexpected fields on AsyncAPI 3 messages and message traits.
 - Reduced CLI startup time on Node 22.8 and later reusing Node's on-disk compile cache.
   Set `NODE_DISABLE_COMPILE_CACHE=1` to turn it off.
 - Fixed an issue where remote `$ref`s with query parameters in the URL were not resolved.
-- Updated @redocly/openapi-core to v2.45.1.
+- Updated @redocly/openapi-core to v2.46.0.
 
 ## 2.45.0 (2026-08-06)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -22,17 +22,11 @@
 
 ### Patch Changes
 
-- Updated @redocly/openapi-core to v2.46.0.
-
-## 2.45.1
-
-### Patch Changes
-
 - Fixed the `struct` rule to report unexpected fields on AsyncAPI 3 messages and message traits.
 - Reduced CLI startup time on Node 22.8 and later reusing Node's on-disk compile cache.
   Set `NODE_DISABLE_COMPILE_CACHE=1` to turn it off.
 - Fixed an issue where remote `$ref`s with query parameters in the URL were not resolved.
-- Updated @redocly/openapi-core to v2.45.1.
+- Updated @redocly/openapi-core to v2.46.0.
 
 ## 2.45.0
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -21,8 +21,6 @@
 
 - Added the `spec-ref-siblings` rule that reports properties placed next to a `$ref` which the specification does not allow.
 
-## 2.45.1
-
 ### Patch Changes
 
 - Fixed the `struct` rule to report unexpected fields on AsyncAPI 3 messages and message traits.

--- a/packages/respect-core/CHANGELOG.md
+++ b/packages/respect-core/CHANGELOG.md
@@ -19,12 +19,6 @@
 
 - Updated @redocly/openapi-core to v2.46.0.
 
-## 2.45.1
-
-### Patch Changes
-
-- Updated @redocly/openapi-core to v2.45.1.
-
 ## 2.45.0
 
 ### Patch Changes

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -22,7 +22,7 @@
     "cli-2.32.1": "npm:@redocly/cli@2.32.1",
     "cli-2.34.0": "npm:@redocly/cli@2.34.0",
     "cli-2.45.0": "npm:@redocly/cli@2.45.0",
-    "cli-2.45.1": "npm:@redocly/cli@2.45.1",
+    "cli-2.46.0": "npm:@redocly/cli@2.46.0",
     "cli-latest": "npm:@redocly/cli@latest",
     "cli-next": "file:../../redocly-cli.tgz"
   },


### PR DESCRIPTION
## What/Why/How?

Removed the missing `2.45.1` version from the changelog and benchmark.
`2.45.1` was never released due to external `GitHub` issues.
The changes originally planned for this version were actually released in `2.46.0`.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and benchmark dependency metadata only; no runtime or API behavior changes.
> 
> **Overview**
> Removes **2.45.1** from release history because that version was never published; its notes are folded into **2.46.0** where they apply.
> 
> **Changelogs** (`docs/@v2/changelog.md`, `packages/cli`, `packages/core`, `packages/respect-core`): drops the `## 2.45.1` sections. For the main CLI/docs changelogs, the former 2.45.1 patch bullets (AsyncAPI `struct` fixes, Node compile cache, remote `$ref` query params) now sit under **2.46.0**, and the openapi-core bump line under 2.46.0 is corrected from `v2.45.1` to `v2.46.0`. Core loses the duplicate 2.45.1 heading while keeping those fixes under 2.46.0; respect-core only removes the stub 2.45.1 entry.
> 
> **Performance tests**: `_enhancedDependencies` swaps `cli-2.45.1` for `cli-2.46.0` so benchmarks track a real release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba651468aeda22cc1f690727169f1a4d4b9cc945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->