### PR TITLE
fix: resolve $refs and validate AsyncAPI 3 Multi Format Schema Object

### DIFF
--- a/.changeset/ninety-phones-bow.md
+++ b/.changeset/ninety-phones-bow.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed an issue where the `bundle` command didn't resolve `$ref`s inside an AsyncAPI 3 Multi Format Schema Object.

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -1524,6 +1524,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
           "Ros2OperationBinding",
           "Ros2QosPolicies",
           "Ros2MessageBinding",
+          "MultiFormatSchema",
           "OperationReply",
           "OperationReplyAddress",
           "NamedTags",

--- a/packages/core/src/types/asyncapi3.ts
+++ b/packages/core/src/types/asyncapi3.ts
@@ -182,19 +182,11 @@ const Parameter: NodeType = {
 const Message: NodeType = {
   extensionsPrefix: 'x-',
   properties: {
-    headers: 'Schema',
-    payload: (value: Record<string, unknown>) => {
-      if (!!value && value?.['schemaFormat']) {
-        return {
-          properties: {
-            schema: 'Schema',
-            schemaFormat: { type: 'string' },
-          },
-          required: ['schema', 'schemaFormat'],
-        };
-      } else {
-        return 'Schema';
-      }
+    headers: (value: unknown) => {
+      return isPlainObject(value) && 'schema' in value ? 'MultiFormatSchema' : 'Schema';
+    },
+    payload: (value: unknown) => {
+      return isPlainObject(value) && 'schema' in value ? 'MultiFormatSchema' : 'Schema';
     },
     correlationId: 'CorrelationId',
 
@@ -259,16 +251,7 @@ const MessageTrait: NodeType = {
   extensionsPrefix: 'x-',
   properties: {
     headers: (value: unknown) => {
-      if (typeof value === 'function' || isPlainObject(value)) {
-        return {
-          properties: {
-            schema: 'Schema',
-            schemaFormat: { type: 'string' },
-          },
-        };
-      } else {
-        return 'Schema';
-      }
+      return isPlainObject(value) && 'schema' in value ? 'MultiFormatSchema' : 'Schema';
     },
     correlationId: 'CorrelationId',
 
@@ -564,6 +547,23 @@ const MessageBindings: NodeType = {
   },
 };
 
+const MultiFormatSchema: NodeType = {
+  extensionsPrefix: 'x-',
+  properties: {
+    schema: 'Schema',
+    schemaFormat: { type: 'string' },
+  },
+  description:
+    'Represents a schema definition. Unlike the Schema Object, it supports multiple schema formats or languages.',
+};
+
+const NamedSchemas: NodeType = {
+  properties: {},
+  additionalProperties: (value: unknown) => {
+    return isPlainObject(value) && 'schema' in value ? 'MultiFormatSchema' : 'Schema';
+  },
+};
+
 export const AsyncApi3Types: Record<string, NodeType> = {
   ...AsyncApiBindings,
   ...Ros2Bindings,
@@ -580,6 +580,7 @@ export const AsyncApi3Types: Record<string, NodeType> = {
   Tag,
   Dependencies,
   Schema,
+  MultiFormatSchema,
   Discriminator,
   DiscriminatorMapping,
   SchemaProperties,
@@ -610,7 +611,7 @@ export const AsyncApi3Types: Record<string, NodeType> = {
   NamedOperations: mapOf('Operation'),
   NamedOperationReplies: mapOf('OperationReply'),
   NamedOperationRelyAddresses: mapOf('OperationReplyAddress'),
-  NamedSchemas: mapOf('Schema'),
+  NamedSchemas,
   NamedMessages: mapOf('Message'),
   NamedMessageTraits: mapOf('MessageTrait'),
   NamedOperationTraits: mapOf('OperationTrait'),

--- a/tests/e2e/bundle/async3-multi-format-schema/MessageHeaders.yaml
+++ b/tests/e2e/bundle/async3-multi-format-schema/MessageHeaders.yaml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  correlationId:
+    type: string
+    description: Correlation ID set by the producer

--- a/tests/e2e/bundle/async3-multi-format-schema/UserSignedUp.yaml
+++ b/tests/e2e/bundle/async3-multi-format-schema/UserSignedUp.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  displayName:
+    type: string
+    description: Name of the user
+  email:
+    type: string
+    format: email
+    description: Email of the user

--- a/tests/e2e/bundle/async3-multi-format-schema/asyncapi.yaml
+++ b/tests/e2e/bundle/async3-multi-format-schema/asyncapi.yaml
@@ -1,0 +1,50 @@
+asyncapi: 3.0.0
+info:
+  title: Account Service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels:
+  userSignedup:
+    address: user/signedup
+    messages:
+      UserSignedUpMultiFormat:
+        title: Multi-format headers and payload
+        headers:
+          schemaFormat: 'application/vnd.aai.asyncapi+yaml;version=3.0.0'
+          schema:
+            $ref: ./MessageHeaders.yaml
+        payload:
+          schemaFormat: 'application/vnd.aai.asyncapi+yaml;version=3.0.0'
+          schema:
+            $ref: ./UserSignedUp.yaml
+        traits:
+          - headers:
+              schemaFormat: 'application/vnd.aai.asyncapi+yaml;version=3.0.0'
+              schema:
+                $ref: ./MessageHeaders.yaml
+      UserSignedUpWithoutSchemaFormat:
+        title: Multi-format payload relying on the default schemaFormat
+        payload:
+          schema:
+            $ref: ./UserSignedUp.yaml
+      UserSignedUpPlain:
+        title: Plain Schema Object headers and payload
+        headers:
+          $ref: ./MessageHeaders.yaml
+        payload:
+          $ref: ./UserSignedUp.yaml
+operations:
+  sendUserSignedup:
+    action: send
+    channel:
+      $ref: '#/channels/userSignedup'
+    messages:
+      - $ref: '#/channels/userSignedup/messages/UserSignedUpMultiFormat'
+      - $ref: '#/channels/userSignedup/messages/UserSignedUpWithoutSchemaFormat'
+      - $ref: '#/channels/userSignedup/messages/UserSignedUpPlain'
+components:
+  schemas:
+    ReusableMultiFormat:
+      schemaFormat: 'application/vnd.aai.asyncapi+yaml;version=3.0.0'
+      schema:
+        $ref: ./UserSignedUp.yaml

--- a/tests/e2e/bundle/async3-multi-format-schema/redocly.yaml
+++ b/tests/e2e/bundle/async3-multi-format-schema/redocly.yaml
@@ -1,0 +1,3 @@
+apis:
+  main:
+    root: ./asyncapi.yaml

--- a/tests/e2e/bundle/async3-multi-format-schema/snapshot.txt
+++ b/tests/e2e/bundle/async3-multi-format-schema/snapshot.txt
@@ -1,0 +1,69 @@
+asyncapi: 3.0.0
+info:
+  title: Account Service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels:
+  userSignedup:
+    address: user/signedup
+    messages:
+      UserSignedUpMultiFormat:
+        title: Multi-format headers and payload
+        headers:
+          schemaFormat: application/vnd.aai.asyncapi+yaml;version=3.0.0
+          schema:
+            $ref: '#/components/schemas/MessageHeaders'
+        payload:
+          schemaFormat: application/vnd.aai.asyncapi+yaml;version=3.0.0
+          schema:
+            $ref: '#/components/schemas/UserSignedUp'
+        traits:
+          - headers:
+              schemaFormat: application/vnd.aai.asyncapi+yaml;version=3.0.0
+              schema:
+                $ref: '#/components/schemas/MessageHeaders'
+      UserSignedUpWithoutSchemaFormat:
+        title: Multi-format payload relying on the default schemaFormat
+        payload:
+          schema:
+            $ref: '#/components/schemas/UserSignedUp'
+      UserSignedUpPlain:
+        title: Plain Schema Object headers and payload
+        headers:
+          $ref: '#/components/schemas/MessageHeaders'
+        payload:
+          $ref: '#/components/schemas/UserSignedUp'
+operations:
+  sendUserSignedup:
+    action: send
+    channel:
+      $ref: '#/channels/userSignedup'
+    messages:
+      - $ref: '#/channels/userSignedup/messages/UserSignedUpMultiFormat'
+      - $ref: '#/channels/userSignedup/messages/UserSignedUpWithoutSchemaFormat'
+      - $ref: '#/channels/userSignedup/messages/UserSignedUpPlain'
+components:
+  schemas:
+    ReusableMultiFormat:
+      schemaFormat: application/vnd.aai.asyncapi+yaml;version=3.0.0
+      schema:
+        $ref: '#/components/schemas/UserSignedUp'
+    MessageHeaders:
+      type: object
+      properties:
+        correlationId:
+          type: string
+          description: Correlation ID set by the producer
+    UserSignedUp:
+      type: object
+      properties:
+        displayName:
+          type: string
+          description: Name of the user
+        email:
+          type: string
+          format: email
+          description: Email of the user
+
+bundling asyncapi.yaml using configuration for api 'main'...
+📦 Created a bundle for asyncapi.yaml at stdout <test>ms.


### PR DESCRIPTION
## What/Why/How?

AsyncAPI 3 allows two shapes for `headers`, `payload`, and `components.schemas`: a Schema Object, or a Multi Format Schema Object that holds the schema in `schema` and its format in `schemaFormat`. 

The type definitions used an anonymous node type for the multi-format shape. Two defects followed:

1. `resolveType` normalizes only types that pass `isNamedType`, so it returned the anonymous type unchanged. The `schema` property kept the raw string `'Schema'`.
2. The walker demotes a type without a name to `scalar` and stops. It never entered `schema`, so the bundler never found the `$ref` inside it.

Found in https://github.com/Redocly/redocly/pull/26390

## Reference

https://www.asyncapi.com/docs/reference/specification/v3.0.0#multiFormatSchemaObject
https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageObject
https://www.asyncapi.com/docs/reference/specification/v3.0.0#componentsObject

## Testing

- added e2e test

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-system fix for AsyncAPI 3 schema walking only; no auth, data, or runtime behavior outside bundling/validation.
> 
> **Overview**
> Fixes `bundle` (and walking/validation) skipping `$ref`s inside AsyncAPI 3 Multi Format Schema Objects.
> 
> Anonymous inline types for the `{ schema, schemaFormat }` shape were not named, so `resolveType` left `schema` as a raw string and the walker treated the node as a scalar. This adds a named `MultiFormatSchema` type and uses it for `headers`, `payload`, message-trait `headers`, and `components.schemas` when the value has a `schema` property (plain Schema Objects still work). An e2e bundle fixture covers multi-format, default-format, and plain schema cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb46f2d03e07053173f7e266d33471d6089c241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->