### PR TITLE
chore: update snapshots

### DIFF
--- a/tests/e2e/respect/inputs-passed-to-step-target-workflow-and-remapped/__snapshots__/inputs-passed-to-step-target-workflow-and-remapped.test.ts.snap
+++ b/tests/e2e/respect/inputs-passed-to-step-target-workflow-and-remapped/__snapshots__/inputs-passed-to-step-target-workflow-and-remapped.test.ts.snap
@@ -52,7 +52,7 @@ exports[`should pass inputs to step target workflow with additional input parame
  
     ✓ success criteria check - $statusCode == 400
     ✓ success criteria check - $[?@.title == 'Validation failed']
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/inputs-passed-to-step-target-workflow/__snapshots__/inputs-passed-to-step-target-workflow.test.ts.snap
+++ b/tests/e2e/respect/inputs-passed-to-step-target-workflow/__snapshots__/inputs-passed-to-step-target-workflow.test.ts.snap
@@ -52,7 +52,7 @@ exports[`should pass inputs to step target workflow with additional input parame
  
     ✓ success criteria check - $statusCode == 400
     ✓ success criteria check - $[?@.title == 'Validation failed']
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/inputs-with-cli-and-env/__snapshots__/inputs-with-cli-and-env.test.ts.snap
+++ b/tests/e2e/respect/inputs-with-cli-and-env/__snapshots__/inputs-with-cli-and-env.test.ts.snap
@@ -147,7 +147,7 @@ exports[`should use inputs from CLI and env 1`] = `
  
     ✓ success criteria check - $statusCode == 400
     ✓ success criteria check - $[?@.title == 'Validation failed']
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/mask-input-secrets/__snapshots__/mask-input-secrets.test.ts.snap
+++ b/tests/e2e/respect/mask-input-secrets/__snapshots__/mask-input-secrets.test.ts.snap
@@ -118,7 +118,7 @@ exports[`should hide sensitive input values 1`] = `
  
     ✓ success criteria check - $statusCode == 400
     ✓ success criteria check - $[?@.title == 'Validation failed']
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/outputs-access-syntax-variations/__snapshots__/outputs-access-syntax-variations.test.ts.snap
+++ b/tests/e2e/respect/outputs-access-syntax-variations/__snapshots__/outputs-access-syntax-variations.test.ts.snap
@@ -142,7 +142,7 @@ exports[`should resolve outputs access syntax variations 1`] = `
  
     ✓ success criteria check - $statusCode == 400
     ✓ success criteria check - $workflows.get-menu-items.outputs.itemsCount == 0
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/replacements/__snapshots__/replacements.test.ts.snap
+++ b/tests/e2e/respect/replacements/__snapshots__/replacements.test.ts.snap
@@ -76,7 +76,7 @@ exports[`should replace values in the request body 1`] = `
       } 
  
     ✓ success criteria check - $statusCode == 400
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/reusable-components/__snapshots__/reusable-components.test.ts.snap
+++ b/tests/e2e/respect/reusable-components/__snapshots__/reusable-components.test.ts.snap
@@ -187,7 +187,7 @@ exports[`should use inputs from CLI and env to map with resolved refs 1`] = `
       } 
  
     ✓ success criteria check - $statusCode == 400
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  

--- a/tests/e2e/respect/reveal-masked-input-secrets/__snapshots__/reveal-masked-input-secrets.test.ts.snap
+++ b/tests/e2e/respect/reveal-masked-input-secrets/__snapshots__/reveal-masked-input-secrets.test.ts.snap
@@ -118,7 +118,7 @@ exports[`should reveal masked input values 1`] = `
  
     ✓ success criteria check - $statusCode == 400
     ✓ success criteria check - $[?@.title == 'Validation failed']
-    ✓ status code check - $statusCode in [201, 400, 401, 500]
+    ✓ status code check - $statusCode in [201, 400, 500]
     ✓ content-type check
     ✓ schema check
  


### PR DESCRIPTION
## What/Why/How?
After changing the CafeAPI tests started to fail. I updated the snapshots regarding changes.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Snapshot-only test updates with no production or security logic changes.
> 
> **Overview**
> Updates Respect e2e snapshots so `POST /oauth2/register` status-code checks expect `[201, 400, 500]` instead of `[201, 400, 401, 500]`.
> 
> This matches CafeAPI OpenAPI response changes that dropped `401` from that operation. No product code is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f02da194db2dda8c778e7e997c6d388ac4b7901f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->