### PR TITLE
fix(lint): report every value when type is an array in no-enum-type-mismatch

### DIFF
--- a/.changeset/swift-pears-repeat.md
+++ b/.changeset/swift-pears-repeat.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed an issue where `no-enum-type-mismatch` dropped violations and reported the wrong location when `type` was written as an array.

--- a/.changeset/swift-pears-repeat.md
+++ b/.changeset/swift-pears-repeat.md
@@ -3,4 +3,4 @@
 '@redocly/cli': patch
 ---
 
-Fixed an issue where `no-enum-type-mismatch` dropped violations and reported the wrong location when `type` was written as an array.
+Fixed an issue where `no-enum-type-mismatch` dropped violations and reported a wrong location when `type` was written as an array.

--- a/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
@@ -166,6 +166,96 @@ describe('Oas3 typed enum', () => {
     `);
   });
 
+  it('should report a mismatched value that shares its text with a matching one', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.1.0
+          paths:
+            /some:
+              get:
+                responses:
+                  '200':
+                    content:
+                      application/json:
+                        schema:
+                          type:
+                            - string
+                          enum:
+                            - 1
+                            - '1'
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-enum-type-mismatch': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "location": [
+            {
+              "pointer": "#/paths/~1some/get/responses/200/content/application~1json/schema/enum/0",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Enum value \`1\` must be of allowed types: \`string\`.",
+          "reference": "https://redocly.com/docs/cli/rules/common/no-enum-type-mismatch",
+          "ruleId": "no-enum-type-mismatch",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
+
+  it('should point at the offending value when it is not a string', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+          openapi: 3.1.0
+          paths:
+            /some:
+              get:
+                responses:
+                  '200':
+                    content:
+                      application/json:
+                        schema:
+                          type:
+                            - boolean
+                          enum:
+                            - zz
+                            - 2
+        `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-enum-type-mismatch': 'error' } }),
+    });
+
+    expect(
+      replaceSourceWithRef(results).map((problem) => [problem.message, problem.location[0].pointer])
+    ).toMatchInlineSnapshot(`
+      [
+        [
+          "Enum value \`zz\` must be of allowed types: \`boolean\`.",
+          "#/paths/~1some/get/responses/200/content/application~1json/schema/enum/0",
+        ],
+        [
+          "Enum value \`2\` must be of allowed types: \`boolean\`.",
+          "#/paths/~1some/get/responses/200/content/application~1json/schema/enum/1",
+        ],
+      ]
+    `);
+  });
+
   it('should not crash on null schema when there is struct rule', async () => {
     const document = parseYamlToDocument(
       outdent`

--- a/packages/core/src/rules/common/no-enum-type-mismatch.ts
+++ b/packages/core/src/rules/common/no-enum-type-mismatch.ts
@@ -29,27 +29,18 @@ export const NoEnumTypeMismatch:
       }
 
       if (schema.enum && schema.type && Array.isArray(schema.type)) {
-        const mismatchedResults: { [key: string]: string[] } = {};
-        for (const enumValue of schema.enum) {
-          mismatchedResults[enumValue] = [];
+        const types = schema.type as string[];
 
-          for (const type of schema.type) {
-            const valid = matchesJsonSchemaType(
-              enumValue,
-              type as string,
-              schema.nullable as boolean
-            );
-            if (!valid) mismatchedResults[enumValue].push(type);
-          }
+        for (let index = 0; index < schema.enum.length; index++) {
+          const enumValue = schema.enum[index];
+          const matchesAnyType = types.some((type) =>
+            matchesJsonSchemaType(enumValue, type, schema.nullable as boolean)
+          );
+          if (matchesAnyType) continue;
 
-          if (mismatchedResults[enumValue].length !== schema.type.length)
-            delete mismatchedResults[enumValue];
-        }
-
-        for (const mismatchedKey of Object.keys(mismatchedResults)) {
           report({
-            message: `Enum value \`${mismatchedKey}\` must be of allowed types: \`${schema.type}\`.`,
-            location: location.child(['enum', schema.enum.indexOf(mismatchedKey)]),
+            message: `Enum value \`${enumValue}\` must be of allowed types: \`${schema.type}\`.`,
+            location: location.child(['enum', index]),
             reference: 'https://redocly.com/docs/cli/rules/common/no-enum-type-mismatch',
           });
         }


### PR DESCRIPTION
When `type` is written as an array, `no-enum-type-mismatch` drops violations and points at an index that does not exist.

```yaml
openapi: 3.1.0
# ...
schema:
  type:
    - string
  enum:
    - 1
    - '1'
```

`redocly lint` says the description is valid. Writing the same constraint as `type: string` reports the number, so the array form loses it. It is not about single element arrays either: `type: [string, boolean]` with the same enum is also silent.

The second symptom shows up as soon as the offending value is not a string:

```yaml
schema:
  type:
    - boolean
  enum:
    - zz
    - 2
```

Both are reported, but `2` comes out first at pointer `.../schema/enum/-1`, before `zz` at `enum/0`. That pointer goes out through `lint -f json`, `--format=checkstyle` and `--generate-ignore-file`, and `getAstNodeByPointer` does `items[parseInt('-1', 10)]`, gets `undefined` and breaks, so the codeframe underlines the whole `enum` sequence instead of the entry.

Both come from the accumulator in the array branch being keyed by the enum value:

```ts
const mismatchedResults: { [key: string]: string[] } = {};
for (const enumValue of schema.enum) {
  mismatchedResults[enumValue] = [];
```

Object keys are strings, so `1` and `'1'` land on `"1"`. The second pass resets the entry, the string passes, and the `delete` then removes the report the number had earned. The location does `schema.enum.indexOf(mismatchedKey)` with a key that came back out of `Object.keys`, so it is always a string: `[2].indexOf('2')` is `-1`. `Object.keys` also hoists integer-like keys, which is why the order flips.

The scalar branch right above already does it the plain way, iterating the values and reporting each one. I made the array branch do the same and drop the accumulator: for each value in order, report it when it matches none of the listed types. The message and the reference are unchanged.

Two tests, one per symptom, both failing on `main`: the first returns `[]` there, the second returns `2` at `enum/-1` before `zz` at `enum/0`.

`vitest run packages/core` gives the same 34 failures before and after (they are pre-existing here, mostly config and component-name suites), with 1037 passing before and 1039 after. `oxlint` reports nothing on the rule and `oxfmt --check` is clean on all three files. Changeset added.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines)
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered

The rule's [documentation page](https://redocly.com/docs/cli/rules/common/no-enum-type-mismatch) already describes the behaviour this restores, so I did not change it. It says the rule requires every `enum` value to conform to the schema's `type`, and lists OAS 3.1 as supported.

## Security

- [x] The security impact of the change has been considered
- [ ] Code follows company security practices and guidelines

Nothing here reads input in a new way. The rule looks at the same `schema.enum` and `schema.type` it always did; what changes is that a value is no longer able to hide behind another one that shares its string form. If anything the linter now reports strictly more, which is the safer direction for a validation rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only validation logic with stricter, more accurate reporting; no auth, data, or runtime API changes.
> 
> **Overview**
> Fixes **`no-enum-type-mismatch`** when `schema.type` is a JSON Schema type array (OpenAPI 3.1). The array branch no longer buckets mismatches in an object keyed by enum values, which had been dropping reports when `1` and `'1'` collided and emitting bad pointers like `enum/-1` for non-string offenders.
> 
> It now walks `enum` by index: each value that matches none of the listed types is reported at `enum/{index}`, consistent with the scalar `type` path. Two regression tests cover the silent mismatch and the wrong-location cases. A patch changeset notes the fix for `@redocly/openapi-core` and `@redocly/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed6daf35600d62193e8212f610f276561542d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->