### PR TITLE
chore: bump vite in generate-client example fixtures

### DIFF
--- a/tests/e2e/generate-client/examples/baked-setup/package.json
+++ b/tests/e2e/generate-client/examples/baked-setup/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/configure-and-middleware/package.json
+++ b/tests/e2e/generate-client/examples/configure-and-middleware/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/custom-generator/package.json
+++ b/tests/e2e/generate-client/examples/custom-generator/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/fetch-functions/package.json
+++ b/tests/e2e/generate-client/examples/fetch-functions/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/mock/package.json
+++ b/tests/e2e/generate-client/examples/mock/package.json
@@ -12,7 +12,7 @@
     "@redocly/cli": "latest",
     "msw": "^2.0.0",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   },
   "msw": {
     "workerDirectory": [

--- a/tests/e2e/generate-client/examples/multi-instance/package.json
+++ b/tests/e2e/generate-client/examples/multi-instance/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/package-runtime/package.json
+++ b/tests/e2e/generate-client/examples/package-runtime/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/sse-streaming/package.json
+++ b/tests/e2e/generate-client/examples/sse-streaming/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/tanstack-query/package.json
+++ b/tests/e2e/generate-client/examples/tanstack-query/package.json
@@ -19,6 +19,6 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/e2e/generate-client/examples/zod/package.json
+++ b/tests/e2e/generate-client/examples/zod/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@redocly/cli": "latest",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0",
+    "vite": "^6.4.3",
     "zod": "^4.0.0"
   }
 }


### PR DESCRIPTION
## What/Why/How?

Bumps `vite` from `^5.4.0` to `^6.4.3` in all 10 `tests/e2e/generate-client/examples/*` fixtures to resolve the open Dependabot alerts. 
Vite 5.x has no backported fix (the vulnerable range is `<= 6.4.2`), so this is a minimal major bump to the first fixed line.

## Reference

CVE-2026-39365, CVE-2026-53571, CVE-2026-53632 

## Testing

- `npm install` resolves vite 6.4.3
- `generate` and `build` pass

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump in test/example fixtures; no production or core CLI code changes. Vite 6 is a major version, so e2e example builds could still break if configs are incompatible.
> 
> **Overview**
> Bumps `vite` from `^5.4.0` to `^6.4.3` in all ten `tests/e2e/generate-client/examples` fixtures.
> 
> This is a security-driven major bump (Vite 5 has no backported fix for the reported CVEs). No application or generator code is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca99d951c4ad3f71c2557e1e28762871b199096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->