### PR TITLE
fix: keep the ejected example compatible across releases

### DIFF
--- a/.changeset/ninety-banks-try.md
+++ b/.changeset/ninety-banks-try.md
@@ -1,6 +1,0 @@
----
-'@redocly/client-generator': patch
-'@redocly/cli': patch
----
-
-Removed the incorrect warning that the `python`, `go`, and `php` generators ignore `--runtime`; the module runtime applies to them.

--- a/.changeset/ninety-banks-try.md
+++ b/.changeset/ninety-banks-try.md
@@ -1,0 +1,6 @@
+---
+'@redocly/client-generator': patch
+'@redocly/cli': patch
+---
+
+Removed the incorrect warning that the `python`, `go`, and `php` generators ignore `--runtime`; the module runtime applies to them.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
             npx changeset version
             npm i
             node scripts/post-changeset.js
+            node scripts/refresh-ejected-example.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/client-generator/src/generators/__tests__/index.test.ts
+++ b/packages/client-generator/src/generators/__tests__/index.test.ts
@@ -80,8 +80,9 @@ describe('validateGenerators', () => {
       validateGenerators(['php'], { runtime: 'inline', argsStyle: 'grouped' }, undefined, 'split');
       const messages = warn.mock.calls.map(([message]) => message).join('');
       expect(messages).toContain('the "php" generator ignores outputMode');
-      expect(messages).toContain('the "php" generator ignores runtime');
       expect(messages).toContain('the "php" generator ignores argsStyle');
+      // `runtime` applies to every runtime-embedding generator since module mode landed.
+      expect(messages).not.toContain('ignores runtime');
 
       // Defaults must stay quiet: only an EXPLICIT option warns.
       warn.mockClear();

--- a/packages/client-generator/src/generators/meta.ts
+++ b/packages/client-generator/src/generators/meta.ts
@@ -24,13 +24,13 @@ function tanstackQuery(framework: 'react' | 'vue' | 'svelte' | 'solid'): Builtin
 }
 
 /**
- * The TypeScript-only knobs a standalone language SDK cannot apply: it always emits
- * one self-contained file with the runtime embedded, and each language passes inputs
- * its own idiomatic way (keyword arguments, named arguments, a params struct).
+ * The TypeScript-only knobs a standalone language SDK cannot apply: the client is
+ * always one module (`runtime: module` adds its runtime files beside it), and each
+ * language passes inputs its own idiomatic way (keyword arguments, named arguments,
+ * a params struct).
  */
 const LANGUAGE_SDK_NOT_APPLICABLE: BuiltinMeta['notApplicable'] = {
-  outputMode: 'it always emits one self-contained file',
-  runtime: 'the runtime is always embedded in the generated file',
+  outputMode: 'the client is always one module (`split` applies to the TypeScript client)',
   argsStyle: "inputs follow the target language's own idiom",
   importExt: 'the generated file has no relative imports',
 };

--- a/scripts/refresh-ejected-example.mjs
+++ b/scripts/refresh-ejected-example.mjs
@@ -1,0 +1,38 @@
+// Re-stamp the checked-in ejected-generator example with the current
+// @redocly/client-generator version. The example is a frozen user copy, and its
+// `requiresGenerator: '^<version>'` caret range treats a 0.x minor bump as breaking
+// (deliberately), so a release that bumps the package would otherwise fail the
+// examples job with "Generator 'php' needs @redocly/client-generator ^<old>".
+// Runs from the release workflow's `version` block, after `changeset version`.
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { version } = JSON.parse(readFileSync('packages/client-generator/package.json', 'utf-8'));
+const generatorsDir = 'tests/e2e/generate-client/examples/ejected-generator/generators';
+
+const HEADER = /Ejected from @redocly\/client-generator@\d+\.\d+\.\d+(?:-[\w.]+)?/g;
+const REQUIRES = /requiresGenerator: '\^\d+\.\d+\.\d+(?:-[\w.]+)?'/g;
+
+let touched = 0;
+for (const entry of readdirSync(generatorsDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const dir = join(generatorsDir, entry.name);
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith('.ts')) continue;
+    const path = join(dir, name);
+    const source = readFileSync(path, 'utf-8');
+    const updated = source
+      .replaceAll(HEADER, `Ejected from @redocly/client-generator@${version}`)
+      .replaceAll(REQUIRES, `requiresGenerator: '^${version}'`);
+    if (updated !== source) {
+      writeFileSync(path, updated, 'utf-8');
+      touched++;
+    }
+  }
+}
+console.log(
+  touched === 0
+    ? `refresh-ejected-example: already at ${version}, nothing to do`
+    : `refresh-ejected-example: stamped ${touched} file(s) with ${version}`
+);

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/client.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/client.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/descriptor.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/descriptor.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/index.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/index.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.
@@ -211,10 +211,9 @@ export default {
   docs: phpDocs,
   errorModes: ["throw"],
   notApplicable: {
-    "outputMode": "it always emits one self-contained file",
-    "runtime": "the runtime is always embedded in the generated file",
+    "outputMode": "the client is always one module (`split` applies to the TypeScript client)",
     "argsStyle": "inputs follow the target language's own idiom",
     "importExt": "the generated file has no relative imports"
   },
-  requiresGenerator: '^0.3.7',
+  requiresGenerator: '^0.3.8',
 };

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/models.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/models.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/naming.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/naming.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/operations.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/operations.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/pagination.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/pagination.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.

--- a/tests/e2e/generate-client/examples/ejected-generator/generators/php/types.ts
+++ b/tests/e2e/generate-client/examples/ejected-generator/generators/php/types.ts
@@ -1,4 +1,4 @@
-// Ejected from @redocly/client-generator@0.3.7 — the built-in "php" generator.
+// Ejected from @redocly/client-generator@0.3.8 — the built-in "php" generator.
 // This file is yours: edit freely; the generated client stays machine-owned and is
 // rebuilt by `redocly generate-client`. Newer generator versions merge in with
 // `redocly eject-generator php --update`.


### PR DESCRIPTION
## What this fixes

The release PR's `examples` job fails on every `@redocly/client-generator` 0.x minor bump (see the failure on #3049):

```
Generator "php" needs @redocly/client-generator ^0.3.7; this CLI ships 0.4.0.
```

The checked-in ejected example (`tests/e2e/generate-client/examples/ejected-generator/generators/php/`) records `requiresGenerator: '^<version>'` at eject time, and caret on a 0.x version pins the minor, so the compatibility gate correctly rejects the example the moment `changeset version` bumps the package.

## The fix

1. **`scripts/refresh-ejected-example.mjs`** re-stamps the example's provenance headers and `requiresGenerator` range with the current package version. Idempotent; skips non-`.ts` entries.
2. **`release.yaml`** runs it in the changesets `version` block, after `post-changeset.js`, so every release PR carries the stamped example and the `examples` job stays green. The example is stamped to the current `0.3.8` in this PR, so the script's output is verifiable in the diff.

## A related bug this surfaced

`LANGUAGE_SDK_NOT_APPLICABLE` still declared `runtime: 'the runtime is always embedded in the generated file'`, which stopped being true when the `python`/`go`/`php` generators gained `--runtime module`. Selecting module mode for a language SDK printed a bogus "ignores runtime" warning while honoring the option. Removed the entry, reworded the `outputMode` reason, updated the warning unit test, and synced the ejected example's contract block. No changeset: module runtime ships in the still-unreleased 0.4.0, so the warning never reached users.

## Verification

- `npm run unit -- packages/client-generator`: 75 files / 1248 tests green.
- The exact failing CI steps locally: `regenerate-examples.mjs` (22 clients, the ejected generator loads and regenerates cleanly) and `typecheck:examples`.
- e2e: eject, examples, module-runtime green.
- The refresh script round-trips: stamps 8 files on a version change, no-ops when already current.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NhwgmWzvAYidYGMKFqGMa
