### PR TITLE
chore: change docs about `eject-generator` command

### DIFF
--- a/docs/@v2/guides/customize-client-generation.md
+++ b/docs/@v2/guides/customize-client-generation.md
@@ -76,7 +76,7 @@ See the [`baked-setup` example](https://github.com/Redocly/redocly-cli/tree/main
 ## Eject
 
 The quickest method to get a customized generator is
-[`redocly eject-generator <name>`](../commands/eject-generator.md).
+the [`eject-generator`](../commands/eject-generator.md) command.
 The command copies any built-in generator into `./generators/` as its TypeScript source folder — editable source that you own.
 An ejected generator with no changes produces byte-identical output.
 In `client.generators`, the path to your copy replaces the built-in name.


### PR DESCRIPTION
## What/Why/How?
Temporary change wording before releasing fix.

## Reference

## Testing

## Screenshots (optional)
<img width="296" height="26" alt="Screenshot 2026-08-26 at 13 12 22" src="https://github.com/user-attachments/assets/6f057c3d-622d-48c8-bc37-ce3a5fd9a472" />

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or API impact.
> 
> **Overview**
> Updates the **Eject** section intro in the customize client generation guide so it points readers to the [`eject-generator`](../commands/eject-generator.md) **command** page instead of using the full `redocly eject-generator <name>` string as the link label.
> 
> This is a temporary documentation wording change ahead of a related fix; other mentions of `redocly eject-generator` elsewhere in the same guide are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c65b42a142756b9b3cc45cc3c83e1cb72e7ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->