### PR TITLE
chore: fix telemetry when npm is unavailable

### DIFF
--- a/.changeset/telemetry-without-npm.md
+++ b/.changeset/telemetry-without-npm.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': patch
+---
+
+Fixed telemetry when `npm` is not available.

--- a/.changeset/telemetry-without-npm.md
+++ b/.changeset/telemetry-without-npm.md
@@ -2,4 +2,4 @@
 '@redocly/cli': patch
 ---
 
-Fixed telemetry when `npm` is not available.
+Fixed an issue where telemetry silently failed to send when `npm` was not available.

--- a/packages/cli/src/utils/__tests__/telemetry.test.ts
+++ b/packages/cli/src/utils/__tests__/telemetry.test.ts
@@ -1,4 +1,5 @@
 import { createConfig } from '@redocly/openapi-core';
+import * as childProcess from 'node:child_process';
 import { it, expect, vi } from 'vitest';
 
 import { RedoclyOAuthClient } from '../../auth/oauth-client.js';
@@ -14,6 +15,10 @@ vi.mock('../otel.js', () => ({ otelTelemetry: { send: mockOtelSend } }));
 vi.mock('../network-check.js');
 vi.mock('../../auth/oauth-client.js');
 vi.mock('../../reunite/api/index.js');
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof childProcess>();
+  return { ...actual, execSync: vi.fn(actual.execSync) };
+});
 
 it('sendTelemetry calls all telemetry functions', async () => {
   vi.mocked(respondWithinMs).mockResolvedValue(true);
@@ -38,5 +43,33 @@ it('sendTelemetry calls all telemetry functions', async () => {
   expect(RedoclyOAuthClient).toHaveBeenCalled();
   expect(getReuniteUrl).toHaveBeenCalled();
   expect(mockMapToCloudEvent).toHaveBeenCalledWith(expect.objectContaining({ env: 'development' }));
+  expect(mockOtelSend).toHaveBeenCalled();
+});
+
+it('sendTelemetry sends the event when npm is not available', async () => {
+  vi.mocked(respondWithinMs).mockResolvedValue(true);
+  vi.mocked(childProcess.execSync).mockImplementation(() => {
+    throw Object.assign(new Error('spawnSync /bin/sh ENOENT'), { code: 'ENOENT' });
+  });
+
+  await sendTelemetry({
+    config: await createConfig({}),
+    argv: { _: ['respect'] } as any,
+    exit_code: 0,
+    execution_time: 1500,
+    spec_version: 'arazzo1',
+    spec_keyword: 'arazzo',
+    spec_full_version: '1.0.1',
+    respect_x_security_auth_types: undefined,
+    respect_source_description_types: undefined,
+    respect_criterion_object_types: undefined,
+    lint_rules_with_errors: undefined,
+    lint_rules_with_warnings: undefined,
+    lint_rules_with_ignored_problems: undefined,
+  });
+
+  expect(mockMapToCloudEvent).toHaveBeenCalledWith(
+    expect.objectContaining({ data: [expect.objectContaining({ npm_version: 'unknown' })] })
+  );
   expect(mockOtelSend).toHaveBeenCalled();
 });

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -104,7 +104,7 @@ export async function sendTelemetry({
         command,
         ...cleanArgs(args, process.argv.slice(2)),
         node_version: process.version,
-        npm_version: execSync('npm -v').toString().replace('\n', ''),
+        npm_version: getNpmVersion(),
         version,
         exit_code,
         execution_time,
@@ -408,6 +408,16 @@ export function cleanArgs(parsedArgs: CommandArgv, rawArgv: string[]) {
   }
 
   return { arguments: JSON.stringify(commandArguments), raw_input: commandInput };
+}
+
+function getNpmVersion(): string {
+  try {
+    return execSync('npm -v', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return 'unknown';
+  }
 }
 
 export const cacheAnonymousId = (anonymousId: string): void => {


### PR DESCRIPTION
## What/Why/How?
Fixed an issue, when telemetry data silently failed when npm is not available.

## Reference

## Testing
Locally

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated telemetry metadata change with fallback behavior; no auth or CLI command logic affected.
> 
> **Overview**
> Telemetry could **fail silently** when building command events because `npm_version` was read with a bare `execSync('npm -v')` that throws if `npm` or the shell is missing.
> 
> The PR routes that through **`getNpmVersion()`**, which runs `npm -v` with suppressed stdin/stderr, trims the output, and returns **`unknown`** on any failure so event assembly and OTEL send still run. Tests mock `child_process.execSync` to simulate `ENOENT` and assert telemetry still maps and sends with `npm_version: 'unknown'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad66f684e27b050619c9e669f033b78ec5c15acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->