### PR TITLE
chore: revert docs changes

### DIFF
--- a/docs/@v2/guides/customize-client-generation.md
+++ b/docs/@v2/guides/customize-client-generation.md
@@ -76,7 +76,7 @@ See the [`baked-setup` example](https://github.com/Redocly/redocly-cli/tree/main
 ## Eject
 
 The quickest method to get a customized generator is
-the [`eject-generator`](../commands/eject-generator.md) command.
+[`redocly eject-generator <name>`](../commands/eject-generator.md).
 The command copies any built-in generator into `./generators/` as its TypeScript source folder — editable source that you own.
 An ejected generator with no changes produces byte-identical output.
 In `client.generators`, the path to your copy replaces the built-in name.


### PR DESCRIPTION
## What/Why/How?
Reverted yesterday docs changes to due fixed in website.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only revert with no runtime or security impact.
> 
> **Overview**
> Reverts a recent wording change in the **Eject** section of `customize-client-generation.md`.
> 
> The intro line again names the full CLI invocation **`redocly eject-generator <name>`** (linked to the command doc) instead of referring generically to the **`eject-generator` command**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80efd1674e0716d039332189e1e407d9531529b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->