### PR TITLE
fix(cli): report production usage data only for released builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  REDOCLY_TELEMETRY: 'off'
+
 jobs:
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -57,6 +60,7 @@ jobs:
             node scripts/post-changeset.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_ENV: production
 
   dockerhub:
     needs: [release]
@@ -113,6 +117,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: BUILD_ENV=production
 
   post-release-smoke-checks:
     needs:
@@ -144,16 +149,18 @@ jobs:
       - name: Test docker image
         continue-on-error: true
         run: |
+          redocly_docker() { docker run --rm -e REDOCLY_TELEMETRY redocly/cli "$@"; }
+
           expected_version="$(cat packages/cli/package.json | jq -r '.version')"
-          actual_version="$(docker run --rm redocly/cli --version)"
+          actual_version="$(redocly_docker --version)"
           if [[ $expected_version == $actual_version  ]]; then
             echo "The version is correct. Actual version: $actual_version"
           else
             echo "The version is incorrect. Expected: $expected_version, actual: $actual_version"
           fi
-          docker run --rm redocly/cli lint https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml
-          docker run --rm redocly/cli bundle https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml --output=bundled.yaml
-          docker run --rm redocly/cli build-docs https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml
+          redocly_docker lint https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml
+          redocly_docker bundle https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml --output=bundled.yaml
+          redocly_docker build-docs https://raw.githubusercontent.com/Rebilly/api-definitions/main/openapi/openapi.yaml
 
   notify:
     needs:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -314,12 +314,13 @@ jobs:
           cd tests/smoke/basic/
 
           # Run commands
-          docker run --rm redocly/cli:latest --version
-          docker run --rm -v $PWD:/spec redocly/cli:latest lint openapi.yaml
-          docker run --rm -v $PWD:/spec redocly/cli:latest bundle openapi.yaml --ext json
-          docker run --rm -v $PWD:/spec redocly/cli:latest build-docs openapi.yaml
-          docker run --rm -v $PWD:/spec redocly/cli:latest split pets.yaml --outDir output/split/petstore && docker run --rm -v $PWD:/spec redocly/cli:latest split museum.yaml --outDir output/split/museum
-          docker run --rm -v $PWD:/spec redocly/cli:latest respect museum-tickets.arazzo.yaml
+          redocly_docker() { docker run --rm -e REDOCLY_TELEMETRY -v "$PWD":/spec redocly/cli:latest "$@"; }
+          redocly_docker --version
+          redocly_docker lint openapi.yaml
+          redocly_docker bundle openapi.yaml --ext json
+          redocly_docker build-docs openapi.yaml
+          redocly_docker split pets.yaml --outDir output/split/petstore && redocly_docker split museum.yaml --outDir output/split/museum
+          redocly_docker respect museum-tickets.arazzo.yaml
 
           # Check for broken styles when building docs (related issue: https://github.com/Redocly/redocly-cli/issues/1073)
           echo "Checking docs for issues..."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:24-alpine
 
+ARG BUILD_ENV
+
 WORKDIR /build
 COPY . .
 RUN apk add --no-cache jq git && \

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -21,7 +21,7 @@ const result = await build({
   keepNames: false,
   metafile: true,
   define: {
-    'process.env.REDOCLY_CLI_BUILD_ENV': '"production"',
+    'process.env.REDOCLY_CLI_BUILD_ENV': JSON.stringify(process.env.BUILD_ENV ?? 'development'),
   },
   // Avoid errors when external dependencies use CJS syntax.
   banner: {


### PR DESCRIPTION
## What/Why/How?

Our own builds and CI runs showed up in usage data as real users. Two fixes:

- Only a real release reports `env: production` now. Snapshots and local builds report `development`.
- Our CI runs no longer send telemetry at all — including the Docker smoke checks, which were sending it even with `REDOCLY_TELEMETRY: off` in the workflow, because containers don't see that variable.

## Reference

Follow-up to #2976.

## Testing

```
npm run compile                      → env:"development"
BUILD_ENV=production npm run compile → env:"production"
```

Verified in Docker: the build arg reaches `RUN`, and `-e REDOCLY_TELEMETRY` forwards the value into containers.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect build-time constants and CI/Docker env wiring for telemetry labeling, not runtime auth or data handling for end users.
> 
> **Overview**
> Stops internal CI and non-release builds from polluting usage telemetry as **production** traffic.
> 
> The CLI esbuild step no longer hardcodes `REDOCLY_CLI_BUILD_ENV` to production; it now bakes in `BUILD_ENV` at compile time, defaulting to **development** when unset. The **release** workflow sets `BUILD_ENV=production` for npm publish, and Docker Hub builds pass `BUILD_ENV=production` via a new Dockerfile `ARG` and `build-args`.
> 
> CI telemetry is tightened: **release** workflow sets workflow-wide `REDOCLY_TELEMETRY: 'off'`, and Docker smoke steps in **release** and **smoke** workflows use a `redocly_docker` helper that forwards `-e REDOCLY_TELEMETRY` into containers (so workflow env vars actually apply inside Docker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ed1c572e6aa5ac3d1e84049ba800386fe13231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->