### PR TITLE
fix: stop mangling the recorded command line and redact the commit author

### DIFF
--- a/.changeset/rotten-toys-call.md
+++ b/.changeset/rotten-toys-call.md
@@ -1,0 +1,6 @@
+---
+'@redocly/cli': patch
+---
+
+Fixed an issue where telemetry recorded a mangled command line when an option value was empty or a single character.
+Telemetry no longer records the `push` commit author.

--- a/.changeset/rotten-toys-call.md
+++ b/.changeset/rotten-toys-call.md
@@ -1,5 +1,0 @@
----
-'@redocly/cli': patch
----
-
-Fixed an issue where telemetry recorded a mangled command line when an option value was empty or a single character.

--- a/.changeset/rotten-toys-call.md
+++ b/.changeset/rotten-toys-call.md
@@ -3,4 +3,3 @@
 ---
 
 Fixed an issue where telemetry recorded a mangled command line when an option value was empty or a single character.
-Telemetry no longer records the `push` commit author.

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -825,6 +825,63 @@ describe('cleanArgs', () => {
       })
     );
   });
+
+  it('should not mangle the raw CLI input when a cleaned argument is an empty string', () => {
+    const rawInput = ['redocly', 'bundle', './fixtures/openapi.yaml', '--output='];
+    const parsedArgs = { apis: ['./fixtures/openapi.yaml'], output: '', o: '' };
+
+    const result = cleanArgs(parsedArgs, rawInput);
+
+    expect(result.raw_input).toEqual('redocly bundle file-yaml --output=');
+    expect(result.arguments).toEqual(JSON.stringify({ apis: ['file-yaml'], output: '', o: '***' }));
+  });
+
+  it('should not mangle the raw CLI input when a cleaned argument is a single character', () => {
+    const rawInput = ['redocly', 'bundle', './fixtures/openapi.yaml', '-o', '-'];
+    const parsedArgs = { apis: ['./fixtures/openapi.yaml'], output: '-', o: '-' };
+
+    const result = cleanArgs(parsedArgs, rawInput);
+
+    expect(result.raw_input).toEqual('redocly bundle file-yaml -o -');
+    expect(result.arguments).toEqual(
+      JSON.stringify({ apis: ['file-yaml'], output: '-', o: '***' })
+    );
+  });
+
+  it('should remove the commit author from parsed args and raw CLI input', () => {
+    const author = 'Jane Doe <jane.doe@example.com>';
+    const rawInput = ['redocly', 'push', './fixtures/openapi.yaml', '--author', author];
+    const parsedArgs = {
+      files: ['./fixtures/openapi.yaml'],
+      organization: 'my-org',
+      o: 'my-org',
+      project: 'my-project',
+      'mount-path': '/docs',
+      branch: 'main',
+      'default-branch': 'main',
+      author,
+      a: author,
+      message: 'Update the docs',
+    };
+
+    const result = cleanArgs(parsedArgs, rawInput);
+
+    expect(result.raw_input).toEqual('redocly push file-yaml --author ***');
+    expect(result.arguments).toEqual(
+      JSON.stringify({
+        files: ['file-yaml'],
+        organization: '***',
+        o: '***',
+        project: 'my-project',
+        'mount-path': '/docs',
+        branch: 'main',
+        'default-branch': 'main',
+        author: '***',
+        a: '***',
+        message: 'Update the docs',
+      })
+    );
+  });
 });
 
 describe('validateFileExtension', () => {

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -321,8 +321,6 @@ function replaceArgs(
 ): string {
   const targetValues = Array.isArray(targets) ? targets : [targets];
   for (const target of targetValues) {
-    // An empty target inserts the replacement between every character, and a single
-    // character such as `-` matches inside every flag.
     if (target.length > 1) {
       commandInput = commandInput.replaceAll(target, replacement);
     }

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -321,7 +321,11 @@ function replaceArgs(
 ): string {
   const targetValues = Array.isArray(targets) ? targets : [targets];
   for (const target of targetValues) {
-    commandInput = commandInput.replaceAll(target, replacement);
+    // An empty target inserts the replacement between every character, and a single
+    // character such as `-` matches inside every flag.
+    if (target.length > 1) {
+      commandInput = commandInput.replaceAll(target, replacement);
+    }
   }
   return commandInput;
 }
@@ -371,6 +375,8 @@ export function cleanArgs(parsedArgs: CommandArgv, rawArgv: string[]) {
     'o',
     'input',
     'i',
+    'author',
+    'a',
     'clientCert',
     'clientKey',
     'caCert',


### PR DESCRIPTION
## What/Why/How?

Two problems in the data that the CLI sends as telemetry.

1. The recorded command line was unreadable when an option value was empty or one character long.
 `redocly bundle openapi.yaml --output=` reached telemetry as `***b***u***n***d***l***e*** ***o***p***e***n***...`.

2. The `push` command sent the commit author.

The fix skips values that are too short to hide, and hides the author.

## Reference

query for validation: 
```sql
WITH
  SpanAttributes['cloudevents.event_data.command.raw_input'] AS raw_input,
  SpanAttributes['cloudevents.event_data.command.version'] AS version,
  SpanAttributes['cloudevents.event_data.command.arguments'] AS args
SELECT
  version,
  count() AS runs,
  any(substring(raw_input, 1, 80)) AS sample,
  any(substring(args, 1, 120)) AS sample_args
FROM default.otel_traces
WHERE ServiceName = 'redocly-cli'
  AND SpanName = 'event.com.redocly.command.ran'
  AND Timestamp >= now() - INTERVAL 30 DAY
  AND startsWith(raw_input, '***')
GROUP BY version
ORDER BY runs DESC

```

## Testing

added unit tests

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry sanitization only; no command execution or auth behavior changes, with regression tests added.
> 
> **Overview**
> Fixes **CLI telemetry** so recorded `raw_input` stays readable and **push commit author** is no longer sent in the clear.
> 
> **`replaceArgs`** now skips `replaceAll` when the value to substitute is **empty or a single character**. That avoids corrupting the command string (e.g. `--output=` or `-o -` turning into runs of `***` on every matching character).
> 
> **`cleanArgs`** treats **`author` / `a`** like other sensitive flags and redacts them in both parsed `arguments` and `raw_input`.
> 
> Unit tests cover empty output, single-character `-` output, and author redaction on `push`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56eae6d4409355370cb98752e3dcc6023de0238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->