### PR TITLE
chore: bump @redocly/config to 0.54.0

### DIFF
--- a/.changeset/tired-geese-press.md
+++ b/.changeset/tired-geese-press.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.54.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,6 +2794,7 @@
       "version": "0.53.1",
       "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.53.1.tgz",
       "integrity": "sha512-aOldTWynKS3ZM6u8WkL72d94QBobITv9X6UECiZykgVjdLiAqV737bPVLGKJYPWf0Ryf3zSHgUYALjCj66BkdA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -2803,6 +2804,7 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
       "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -2817,6 +2819,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
       "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@redocly/mock-server": {
@@ -11124,7 +11127,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.3",
-        "@redocly/config": "^0.53.1",
+        "@redocly/config": "^0.54.0",
         "ajv": "npm:@redocly/ajv@^8.18.3",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -11145,6 +11148,29 @@
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
+      }
+    },
+    "packages/core/node_modules/@redocly/config": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.54.0.tgz",
+      "integrity": "sha512-rJwxdDQY5yES1tYyu6tTljAvQ2ZRu58K7YJm0socZUNFXbu6IhnUTkKcU4cfrsUaAsOb2TOYOJcvmMllKv4w7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "packages/core/node_modules/@redocly/config/node_modules/json-schema-to-ts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "packages/core/node_modules/ajv": {
@@ -11197,6 +11223,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "packages/core/node_modules/ts-algebra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
+      "license": "MIT"
     },
     "packages/respect-core": {
       "name": "@redocly/respect-core",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.3",
-    "@redocly/config": "^0.53.1",
+    "@redocly/config": "^0.54.0",
     "ajv": "npm:@redocly/ajv@^8.18.3",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -20239,6 +20239,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "name": {
         "type": "string",
       },
+      "publicEndpoint": {
+        "type": "boolean",
+      },
     },
     "required": undefined,
   },
@@ -33948,6 +33951,9 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "name": {
         "type": "string",
+      },
+      "publicEndpoint": {
+        "type": "boolean",
       },
     },
     "required": undefined,


### PR DESCRIPTION
## What/Why/How?

bump @redocly/config to 0.54.0

## Reference

## Testing

- update snapshot

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with schema snapshot updates; optional new config field should not break existing configs.
> 
> **Overview**
> Bumps **`@redocly/config`** from **^0.53.1** to **^0.54.0** in `@redocly/openapi-core`, with lockfile updates and a patch changeset.
> 
> The upgrade pulls in an updated Redocly YAML config JSON Schema: metadata/env glob rule objects now allow an optional **`publicEndpoint`** boolean. Snapshot tests for the exported schema were refreshed to match; no other runtime or validation logic changes in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3406718bcea2e91abb621aca490859d0d2628e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->