### PR TITLE
chore: update @redocly/config to 0.55.0

### DIFF
--- a/.changeset/new-peaches-stare.md
+++ b/.changeset/new-peaches-stare.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.55.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11127,7 +11127,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.3",
-        "@redocly/config": "^0.54.0",
+        "@redocly/config": "^0.55.0",
         "ajv": "npm:@redocly/ajv@^8.18.3",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -11151,9 +11151,9 @@
       }
     },
     "packages/core/node_modules/@redocly/config": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.54.0.tgz",
-      "integrity": "sha512-rJwxdDQY5yES1tYyu6tTljAvQ2ZRu58K7YJm0socZUNFXbu6IhnUTkKcU4cfrsUaAsOb2TOYOJcvmMllKv4w7Q==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.55.0.tgz",
+      "integrity": "sha512-PlaCpehzQoe6R9YksDI5gW4mfTA2UfnpCGldXXs7/axeyPdAK/T2UpfsSD9sOedKaq6VF9jtE9qXmnH71CAclg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.3",
-    "@redocly/config": "^0.54.0",
+    "@redocly/config": "^0.55.0",
     "ajv": "npm:@redocly/ajv@^8.18.3",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -2860,7 +2860,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.apis_additionalProperties.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -3437,18 +3436,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     },
     "required": undefined,
   },
-  "rootRedoclyConfigSchema.apis_additionalProperties.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
-      },
-    },
-    "required": undefined,
-  },
   "rootRedoclyConfigSchema.apis_additionalProperties.graphqlRules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
@@ -3597,9 +3584,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {
@@ -5790,7 +5774,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.apis_additionalProperties.theme.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -6367,18 +6350,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     },
     "required": undefined,
   },
-  "rootRedoclyConfigSchema.apis_additionalProperties.theme.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
-      },
-    },
-    "required": undefined,
-  },
   "rootRedoclyConfigSchema.apis_additionalProperties.theme.openapi": {
     "additionalProperties": undefined,
     "description": undefined,
@@ -6487,9 +6458,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {
@@ -11404,7 +11372,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -11981,18 +11948,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     },
     "required": undefined,
   },
-  "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
-      },
-    },
-    "required": undefined,
-  },
   "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.graphqlRules": {
     "additionalProperties": [Function],
     "description": "The rules configuration blocks set up linting rules and their severity. You can configure built-in rules, add configurable rules, and rules from plugins.",
@@ -12141,9 +12096,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {
@@ -14334,7 +14286,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.theme.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -14911,18 +14862,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     },
     "required": undefined,
   },
-  "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.theme.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
-      },
-    },
-    "required": undefined,
-  },
   "rootRedoclyConfigSchema.env_additionalProperties.apis_additionalProperties.theme.openapi": {
     "additionalProperties": undefined,
     "description": undefined,
@@ -15031,9 +14970,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {
@@ -19350,7 +19286,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.env_additionalProperties.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -19923,18 +19858,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {
       "apiId": {
         "type": "string",
-      },
-    },
-    "required": undefined,
-  },
-  "rootRedoclyConfigSchema.env_additionalProperties.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
       },
     },
     "required": undefined,
@@ -20736,9 +20659,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {
@@ -27787,7 +27707,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.env_additionalProperties.theme.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -28360,18 +28279,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {
       "apiId": {
         "type": "string",
-      },
-    },
-    "required": undefined,
-  },
-  "rootRedoclyConfigSchema.env_additionalProperties.theme.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
       },
     },
     "required": undefined,
@@ -28976,9 +28883,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {
@@ -33063,7 +32967,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "showBuiltInScalars": {
         "type": "boolean",
       },
-      "sidebar": "rootRedoclyConfigSchema.graphql.sidebar",
     },
     "required": undefined,
   },
@@ -33636,18 +33539,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "properties": {
       "apiId": {
         "type": "string",
-      },
-    },
-    "required": undefined,
-  },
-  "rootRedoclyConfigSchema.graphql.sidebar": {
-    "additionalProperties": undefined,
-    "description": undefined,
-    "documentationLink": undefined,
-    "items": undefined,
-    "properties": {
-      "hide": {
-        "type": "boolean",
       },
     },
     "required": undefined,
@@ -34449,9 +34340,6 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
         "type": "boolean",
       },
       "hideSecuritySection": {
-        "type": "boolean",
-      },
-      "hideSidebar": {
         "type": "boolean",
       },
       "hideSingleRequestSampleTab": {


### PR DESCRIPTION
## What/Why/How?

update config to v0.55.0

## Reference

## Testing

- update snapshot

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pulls in upstream config schema changes that drop sidebar-related options; projects still using those keys in `redocly.yaml` may see different validation or lint behavior after upgrade.
> 
> **Overview**
> Bumps **`@redocly/openapi-core`**’s dependency on **`@redocly/config`** from **^0.54.0** to **^0.55.0** (including lockfile resolution) and records a patch changeset.
> 
> The **`redocly-yaml`** test snapshots are updated to match the new config schema: **`graphql.sidebar`** (with **`hide`**) is no longer part of the reflected Redocly config shape, and **`hideSidebar`** is removed from the OpenAPI theme sections across root, API, env, and theme nesting paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98b31010e5dcabfc92b5087e3f02bc4ba2f2a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->