### PR TITLE
docs: clarify 101 responses and WebSocket support

### DIFF
--- a/docs/@v1/rules/oas/operation-2xx-response.md
+++ b/docs/@v1/rules/oas/operation-2xx-response.md
@@ -21,6 +21,9 @@ If it doesn't, what is the purpose of the operation?
 Even if there is no response content (204), it can still return a successful response with no content.
 You can greatly improve the developer and user experience of your APIs by making it a standard to provide this information.
 
+An operation with only a `101 Switching Protocols` response fails this rule because 101 is an informational response, not a successful response.
+WebSocket APIs are not supported by OpenAPI; use AsyncAPI to describe them instead.
+
 ## Configuration
 
 | Option           | Type    | Description                                                                               |

--- a/docs/@v2/rules/oas/operation-2xx-response.md
+++ b/docs/@v2/rules/oas/operation-2xx-response.md
@@ -22,6 +22,9 @@ If it doesn't, what is the purpose of the operation?
 Even if there is no response content (204), it can still return a successful response with no content.
 You can greatly improve the developer and user experience of your APIs by making it a standard to provide this information.
 
+An operation with only a `101 Switching Protocols` response fails this rule because 101 is an informational response, not a successful response.
+WebSocket APIs are not supported by OpenAPI; use AsyncAPI to describe them instead.
+
 ## Configuration
 
 | Option           | Type    | Description                                                                               |


### PR DESCRIPTION
## What/Why/How?

We had someone (by misunderstanding) try to describe a websockets connection upgrade using OpenAPI and got flagged by this rule.  So, in this PR I clarify why an operation with only a `101 Switching Protocols` response fails the `operation-2xx-response` rule. The v1 and v2 rule docs now state that 101 is informational rather than successful and that WebSocket APIs should be described with AsyncAPI because OpenAPI does not support them.

## Reference

https://redocly.com/docs/cli/rules/oas/operation-2xx-response

## Testing

- `npx oxfmt --check docs/@v1/rules/oas/operation-2xx-response.md docs/@v2/rules/oas/operation-2xx-response.md`
- Pre-commit lint and formatting hooks passed

## Screenshots (optional)

Not applicable.

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines)
- [x] All new/updated code is covered by tests (documentation-only change)
- [x] Core code changed? - Not applicable
- [x] New package installed? - Not applicable
- [x] Documentation update has been considered

## Security

- [x] The security impact of the change has been considered
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to two markdown rule pages; no runtime or lint rule behavior changes.
> 
> **Overview**
> Updates the **operation-2xx-response** rule documentation for CLI v1 and v2 with guidance that was missing from the API design principles section.
> 
> The docs now explain that an operation whose only declared response is **`101 Switching Protocols`** still fails the rule, because **101 is an informational (1xx) status**, not a successful **2xx** response. They also note that **WebSocket APIs are outside OpenAPI’s scope** and should be described with **AsyncAPI** instead.
> 
> No rule implementation or configuration behavior changes—only user-facing explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f948be0068b4cce47fd660a5a4e10b2bec4043b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->