### PR TITLE
fix: update @faker-js/faker to resolve vulnerability

### DIFF
--- a/.changeset/sharp-candles-smoke.md
+++ b/.changeset/sharp-candles-smoke.md
@@ -1,0 +1,6 @@
+---
+'@redocly/respect-core': patch
+'@redocly/cli': patch
+---
+
+Fixed an issue where `$faker.string.email()` used without options generated addresses at the `undefined.com` domain.

--- a/.changeset/wide-forks-check.md
+++ b/.changeset/wide-forks-check.md
@@ -4,4 +4,3 @@
 ---
 
 Updated `@faker-js/faker` to the `10.6.0` version to resolve the high severity advisory `GHSA-qxc2-j82w-r537`.
-Fixed an issue where `$faker.string.email()` used without options generated addresses at the `undefined.com` domain.

--- a/.changeset/wide-forks-check.md
+++ b/.changeset/wide-forks-check.md
@@ -1,0 +1,7 @@
+---
+'@redocly/respect-core': patch
+'@redocly/cli': patch
+---
+
+Updated `@faker-js/faker` to the `10.6.0` version to resolve the high severity advisory `GHSA-qxc2-j82w-r537`.
+Fixed an issue where `$faker.string.email()` used without options generated addresses at the `undefined.com` domain.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
-        "@faker-js/faker": "^9.9.0",
+        "@faker-js/faker": "^10.6.0",
         "@redocly/mock-server": "^0.10.0",
         "@tanstack/react-query": "^5.0.0",
         "@testing-library/react": "^16.0.0",
@@ -1390,10 +1390,9 @@
       "license": "MIT"
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
-      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
-      "dev": true,
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.6.0.tgz",
+      "integrity": "sha512-3RQHgEtvL1Frl/d1cSreo7qhJ3Gk1OdNUai/CtZ8G+wYeRQnJih3s9xJ9/kgYekPQRdwgh0HXRPqMlzWGwivIQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1402,8 +1401,8 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4486,9 +4485,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.33",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4563,9 +4562,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -4583,11 +4582,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4637,9 +4636,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -5198,9 +5197,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.365",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.365.tgz",
-      "integrity": "sha512-xfip4u1QF1s+URFqpA6N+OeFpDGpN7VJz1f3MO3bVL0QYBjpGiZ5/Of7kugvM+o8TTqmanUlviHN3c8M9vYWCw==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -8336,9 +8335,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10466,9 +10465,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -11235,7 +11234,7 @@
       "version": "2.51.0",
       "license": "MIT",
       "dependencies": {
-        "@faker-js/faker": "^7.6.0",
+        "@faker-js/faker": "^10.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.3",
         "@redocly/openapi-core": "2.51.0",
@@ -11256,16 +11255,6 @@
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
-      }
-    },
-    "packages/respect-core/node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
       }
     },
     "packages/respect-core/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
-    "@faker-js/faker": "^9.9.0",
+    "@faker-js/faker": "^10.6.0",
     "@redocly/mock-server": "^0.10.0",
     "@tanstack/react-query": "^5.0.0",
     "@testing-library/react": "^16.0.0",

--- a/packages/respect-core/package.json
+++ b/packages/respect-core/package.json
@@ -45,7 +45,7 @@
     "typescript": "6.0.2"
   },
   "dependencies": {
-    "@faker-js/faker": "^7.6.0",
+    "@faker-js/faker": "^10.6.0",
     "@noble/hashes": "^1.8.0",
     "@redocly/ajv": "^8.18.3",
     "@redocly/openapi-core": "2.51.0",

--- a/packages/respect-core/src/modules/__tests__/faker.test.ts
+++ b/packages/respect-core/src/modules/__tests__/faker.test.ts
@@ -57,8 +57,20 @@ describe('faker', () => {
     });
 
     it('should return a float', () => {
-      // @ts-expect-error
       expect(faker.number.float()).toBeDefined();
+    });
+
+    it('should span min..min + 99999 when only min is given', () => {
+      const integer = faker.number.integer({ min: 100_000 });
+      expect(integer).toBeGreaterThanOrEqual(100_000);
+      expect(integer).toBeLessThanOrEqual(199_999);
+    });
+
+    it('should round a float to two decimals unless precision is given', () => {
+      const twoDecimals = faker.number.float({ min: 1, max: 2 });
+      expect(twoDecimals).toBe(Number(twoDecimals.toFixed(2)));
+
+      expect(faker.number.float({ min: 1, max: 2, precision: 0.5 }) % 0.5).toBe(0);
     });
   });
 

--- a/packages/respect-core/src/modules/faker.ts
+++ b/packages/respect-core/src/modules/faker.ts
@@ -41,7 +41,7 @@ interface FakeAddress {
 interface FakeNumber {
   integer(options?: Omit<NumberOptions, 'precision'>): number;
 
-  float(options: NumberOptions): number;
+  float(options?: NumberOptions): number;
 }
 
 export interface Faker {
@@ -51,16 +51,21 @@ export interface Faker {
   string: FakeString;
 }
 
+// The defaults faker v7 applied to calls without bounds, kept so that upgrading it
+// doesn't widen the values Arazzo tests send.
+const DEFAULT_RANGE_SIZE = 99999;
+const DEFAULT_FLOAT_PRECISION = 0.01;
+
 export function createFaker(): Faker {
   const fakeString: FakeString = {
     email: ({ provider, domain = 'com' }: { provider?: string; domain?: string } = {}) =>
-      faker.internet.email(undefined, undefined, `${provider}.${domain}`),
-    userName: () => faker.internet.userName(),
-    firstName: () => faker.name.firstName(),
-    lastName: () => faker.name.lastName(),
-    fullName: () => faker.name.fullName(),
-    uuid: () => faker.datatype.uuid(),
-    string: ({ length }: { length?: number } = {}) => faker.datatype.string(length),
+      faker.internet.email(provider ? { provider: `${provider}.${domain}` } : undefined),
+    userName: () => faker.internet.username(),
+    firstName: () => faker.person.firstName(),
+    lastName: () => faker.person.lastName(),
+    fullName: () => faker.person.fullName(),
+    uuid: () => faker.string.uuid(),
+    string: ({ length }: { length?: number } = {}) => faker.string.sample(length),
   };
 
   const fakeDate: FakeDate = {
@@ -69,16 +74,20 @@ export function createFaker(): Faker {
   };
 
   const fakeAddress: FakeAddress = {
-    city: () => faker.address.city(),
-    country: () => faker.address.country(),
-    zipCode: () => faker.address.zipCode(),
-    street: () => faker.address.street(),
+    city: () => faker.location.city(),
+    country: () => faker.location.country(),
+    zipCode: () => faker.location.zipCode(),
+    street: () => faker.location.street(),
   };
 
   const fakeNumber: FakeNumber = {
-    integer: ({ min, max }: Omit<NumberOptions, 'precision'> = {}) =>
-      faker.datatype.number({ min, max, precision: 1 }),
-    float: (options: NumberOptions) => faker.datatype.float(options),
+    integer: ({ min = 0, max = min + DEFAULT_RANGE_SIZE }: Omit<NumberOptions, 'precision'> = {}) =>
+      faker.number.int({ min, max }),
+    float: ({
+      min = 0,
+      max = min + DEFAULT_RANGE_SIZE,
+      precision = DEFAULT_FLOAT_PRECISION,
+    }: NumberOptions = {}) => faker.number.float({ min, max, multipleOf: precision }),
   };
 
   return {


### PR DESCRIPTION
## What/Why/How?

`npm audit` reports a high-severity advisory on `@faker-js/faker`: `helpers.fake` permits arbitrary code execution. The repository declares the package twice:

- root dev dependency: `^9.9.0`
- `@redocly/respect-core` runtime dependency: `^7.6.0`

Our code does not reach the advisory. It never calls `helpers.fake`, and `$faker` expressions reach only the allowlist that `createFaker()` returns. The dependency still ships to `@redocly/respect-core` users, so this PR updates it.

`npm audit fix --force` rewrites `^7.6.0` to `^10.6.0` and breaks the build, because the wrapper uses the v7 API. This PR updates both declarations by hand and rewrites `packages/respect-core/src/modules/faker.ts` for v10:

## Reference

https://github.com/advisories/GHSA-qxc2-j82w-r537

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a runtime dependency shipped with respect-core and changes fake data generation used in `$faker` expressions, though exposure stays limited to the existing allowlisted wrapper API.
> 
> **Overview**
> Upgrades **`@faker-js/faker`** to **10.6.0** in the root dev dependency and **`@redocly/respect-core`** runtime dependency to address high-severity advisory **GHSA-qxc2-j82w-r537**, and drops the nested v7 lock entry so both workspaces share one version.
> 
> **`createFaker()`** in `packages/respect-core/src/modules/faker.ts` is rewritten for faker v10 APIs (`person`, `location`, `string`, `number`, etc.) while keeping the same `$faker` surface for Arazzo. **`$faker.string.email()`** without options no longer builds domains like `undefined.com`—it delegates to faker’s default email when no provider is set. Integer/float helpers keep v7-style default ranges (**0..99999** when bounds are omitted, **0.01** float step) so generated test data does not widen unexpectedly.
> 
> Tests in **`faker.test.ts`** cover the preserved number defaults and optional **`float()`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8547903dcde6fd24b317e4848bfdca7811e34c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->