### PR TITLE
fix: generate-arazzo mangling a remote description URL

### DIFF
--- a/.changeset/generate-arazzo-remote-url.md
+++ b/.changeset/generate-arazzo-remote-url.md
@@ -1,0 +1,6 @@
+---
+'@redocly/cli': patch
+'@redocly/respect-core': patch
+---
+
+Fixed `generate-arazzo` mangling a remote description URL in `sourceDescriptions` (`https://` collapsed to `https:/`) when `--output-file` was provided.

--- a/.changeset/generate-arazzo-remote-url.md
+++ b/.changeset/generate-arazzo-remote-url.md
@@ -3,4 +3,4 @@
 '@redocly/respect-core': patch
 ---
 
-Fixed `generate-arazzo` mangling a remote description URL in `sourceDescriptions` (`https://` collapsed to `https:/`) when `--output-file` was provided.
+Fixed an issue where `generate-arazzo` produced a malformed remote description URL in `sourceDescriptions` (`https://` collapsed to `https:/`) when `--output-file` was provided.

--- a/docs/@v2/commands/generate-arazzo.md
+++ b/docs/@v2/commands/generate-arazzo.md
@@ -87,76 +87,73 @@ npx @redocly/cli@latest generate-arazzo <your-OAS-description-file> --with-ai [-
 
 ## Examples
 
-Run the command: `npx @redocly/cli@latest generate-arazzo 'https://warp-single-sidebar.redocly.app/_spec/apis/index.yaml'`
+Run the command: `npx @redocly/cli@latest generate-arazzo 'https://cafe.redocly.com/_bundle/openapi/cafe.yaml'`
 
 The command generates an `auto-generated.arazzo.yaml` file in the current directory.
 
-The contents of the generated file are:
+The generated file contains one workflow per operation, with the security setup each operation requires.
+A shortened excerpt:
 
 ```yaml {% title="auto-generated.arazzo.yaml" %}
 arazzo: 1.1.0
 info:
-  title: Warp API
+  title: Redocly Cafe
   version: 1.0.0
 sourceDescriptions:
-  - name: warp
+  - name: cafe
     type: openapi
-    url: https://warp-single-sidebar.redocly.app/_spec/apis/index.yaml
+    url: https://cafe.redocly.com/_bundle/openapi/cafe.yaml
 workflows:
-  - workflowId: post-timelines-workflow
+  - workflowId: post-menu-workflow
+    inputs:
+      $ref: '#/components/inputs/OAuth2'
     steps:
-      - stepId: post-timelines-step
-        operationId: $sourceDescriptions.warp.createTimeline
+      - stepId: post-menu-step
+        operationId: $sourceDescriptions.cafe.createMenuItem
+        x-security:
+          - schemeName: OAuth2
+            values:
+              accessToken: $inputs.OAuth2
         successCriteria:
           - condition: $statusCode == 201
-  - workflowId: get-timelines-workflow
+  - workflowId: get-menu-workflow
     steps:
-      - stepId: get-timelines-step
-        operationId: $sourceDescriptions.warp.listTimelines
+      - stepId: get-menu-step
+        operationId: $sourceDescriptions.cafe.listMenuItems
         successCriteria:
           - condition: $statusCode == 200
-  - workflowId: delete-timeline-{timeline_id}-workflow
+  - workflowId: get-revenue-workflow
+    inputs:
+      $ref: '#/components/inputs/ApiKey'
     steps:
-      - stepId: delete-timeline-{timeline_id}-step
-        operationId: $sourceDescriptions.warp.deleteTimeline
-        successCriteria:
-          - condition: $statusCode == 204
-  - workflowId: post-travels-workflow
-    steps:
-      - stepId: post-travels-step
-        operationId: $sourceDescriptions.warp.timeTravel
-        successCriteria:
-          - condition: $statusCode == 200
-  - workflowId: post-items-workflow
-    steps:
-      - stepId: post-items-step
-        operationId: $sourceDescriptions.warp.registerItem
+      - stepId: get-revenue-step
+        operationId: $sourceDescriptions.cafe.getRevenue
+        x-security:
+          - schemeName: ApiKey
+            values:
+              apiKey: $inputs.ApiKey
+          - schemeName: OAuth2
+            values:
+              accessToken: $inputs.OAuth2
         successCriteria:
           - condition: $statusCode == 200
-  - workflowId: post-events-workflow
-    steps:
-      - stepId: post-events-step
-        operationId: $sourceDescriptions.warp.manipulateEvent
-        successCriteria:
-          - condition: $statusCode == 200
-  - workflowId: post-anchors-workflow
-    steps:
-      - stepId: post-anchors-step
-        operationId: $sourceDescriptions.warp.setAnchor
-        successCriteria:
-          - condition: $statusCode == 201
-  - workflowId: post-paradox-checks-workflow
-    steps:
-      - stepId: post-paradox-checks-step
-        operationId: $sourceDescriptions.warp.checkParadox
-        successCriteria:
-          - condition: $statusCode == 200
-  - workflowId: get-monitor-timeline-workflow
-    steps:
-      - stepId: get-monitor-timeline-step
-        operationId: $sourceDescriptions.warp.monitorTimeline
-        successCriteria:
-          - condition: $statusCode == 200
+  # ...one workflow like these for every other operation
+components:
+  inputs:
+    OAuth2:
+      type: object
+      properties:
+        OAuth2:
+          type: string
+          description: OAuth2 authorization for API access.
+          format: password
+    ApiKey:
+      type: object
+      properties:
+        ApiKey:
+          type: string
+          description: API key for internal operations.
+          format: password
 ```
 
 The generated file is not a complete test file and needs to be extended to be functional.

--- a/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-arazzo-description.test.ts
+++ b/packages/respect-core/src/modules/__tests__/arazzo-description-generator/generate-arazzo-description.test.ts
@@ -123,6 +123,25 @@ describe('generateArazzoDescription', () => {
     });
   });
 
+  it('should keep a remote description URL as-is when output file is provided', async () => {
+    vi.mocked(bundleOpenApi).mockResolvedValue(BUNDLED_DESCRIPTION_MOCK);
+
+    const result = await generateArazzoDescription({
+      descriptionPath: 'https://cafe.redocly.com/_bundle/openapi/cafe.yaml',
+      outputFile: './final-test-location/output.yaml',
+      version: '1.0.0',
+      config: await createConfig({}),
+    });
+
+    expect(result.sourceDescriptions).toEqual([
+      {
+        name: 'cafe',
+        type: 'openapi',
+        url: 'https://cafe.redocly.com/_bundle/openapi/cafe.yaml',
+      },
+    ]);
+  });
+
   it('should generate arazzo description with operationId', async () => {
     vi.mocked(bundleOpenApi).mockResolvedValue(BUNDLED_DESCRIPTION_MOCK);
     vi.mocked(getOperationFromDescription).mockReturnValue({

--- a/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
+++ b/packages/respect-core/src/modules/arazzo-description-generator/generate-arazzo-description.ts
@@ -1,3 +1,4 @@
+import { isAbsoluteUrl } from '@redocly/openapi-core';
 import * as path from 'node:path';
 
 import { type GenerateArazzoOptions } from '../../generate.js';
@@ -25,9 +26,12 @@ export async function generateArazzoDescription(opts: GenerateArazzoOptions) {
 
   const { paths: pathsObject, info, security: rootSecurity, components } = document;
   const sourceDescriptionName = resolveDescriptionNameFromPath(descriptionPath);
-  const resolvedDescriptionPath = outputFile
-    ? path.relative(path.dirname(outputFile), path.resolve(descriptionPath))
-    : descriptionPath;
+  // A remote description is referenced as-is: path.relative would mangle the
+  // URL (https:// collapses to https:/).
+  const resolvedDescriptionPath =
+    outputFile && !isAbsoluteUrl(descriptionPath)
+      ? path.relative(path.dirname(outputFile), path.resolve(descriptionPath))
+      : descriptionPath;
   const inputsComponents = components?.securitySchemes
     ? generateSecurityInputsArazzoComponents(components?.securitySchemes)
     : undefined;


### PR DESCRIPTION
## What/Why/How?

Fixed `generate-arazzo` mangling a remote description URL.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [x] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped bug fix in Arazzo path resolution with test and doc updates; no auth, security, or data-handling changes.
> 
> **Overview**
> **Fixes malformed `sourceDescriptions` URLs** when `generate-arazzo` runs with `--output-file`: remote OpenAPI URLs are no longer passed through `path.relative`, which was collapsing `https://` to `https:/`.
> 
> **Behavior change:** with an output file, only **local** description paths are rewritten relative to the output directory; **absolute HTTP(S) URLs** are copied unchanged into the generated Arazzo file.
> 
> Adds a regression test for a remote URL plus `--output-file`, and refreshes the `generate-arazzo` docs example (Cafe API, security/`x-security` excerpt) to match current output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a8782d33782c626d3d28976eb8030613ee1ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->