### PR TITLE
fix(respect): keep step outputs on a same-workflow goto

### DIFF
--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -1,0 +1,6 @@
+---
+'@redocly/respect-core': patch
+'@redocly/cli': patch
+---
+
+Fixed `respect` clearing step outputs when a `goto` action transfers control to a step in the same workflow, which made `$steps` expressions in the target step fail to resolve.

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -204,10 +204,8 @@ export async function runWorkflow({
   if (!fromStepId) {
     ctx.$steps = {};
   } else {
-    const workflowCtx = ctx.$workflows[workflowId];
     for (const stepToReset of workflowSteps) {
       delete ctx.$steps[stepToReset.stepId];
-      if (workflowCtx?.steps) delete workflowCtx.steps[stepToReset.stepId];
     }
   }
   for (const step of workflowSteps) {

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -199,8 +199,9 @@ export async function runWorkflow({
 
   const workflowSteps = workflow.steps.slice(fromStepIndex);
 
-  // clean $steps ctx before running workflow steps
-  ctx.$steps = {};
+  // clean $steps ctx before running workflow steps, unless a goto resumed this
+  // workflow part-way through and the steps it already ran stay addressable
+  if (!fromStepId) ctx.$steps = {};
 
   for (const step of workflowSteps) {
     try {

--- a/packages/respect-core/src/modules/flow-runner/runner.ts
+++ b/packages/respect-core/src/modules/flow-runner/runner.ts
@@ -199,10 +199,17 @@ export async function runWorkflow({
 
   const workflowSteps = workflow.steps.slice(fromStepIndex);
 
-  // clean $steps ctx before running workflow steps, unless a goto resumed this
-  // workflow part-way through and the steps it already ran stay addressable
-  if (!fromStepId) ctx.$steps = {};
-
+  // Reset $steps before running workflow steps.
+  // On resume (goto/retry by stepId), keep earlier step outputs but clear any steps that will be (re)executed.
+  if (!fromStepId) {
+    ctx.$steps = {};
+  } else {
+    const workflowCtx = ctx.$workflows[workflowId];
+    for (const stepToReset of workflowSteps) {
+      delete ctx.$steps[stepToReset.stepId];
+      if (workflowCtx?.steps) delete workflowCtx.steps[stepToReset.stepId];
+    }
+  }
   for (const step of workflowSteps) {
     try {
       const stepResult = await runStep({

--- a/tests/e2e/respect/goto-step-keeps-outputs/__snapshots__/goto-step-keeps-outputs.test.ts.snap
+++ b/tests/e2e/respect/goto-step-keeps-outputs/__snapshots__/goto-step-keeps-outputs.test.ts.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should keep earlier step outputs addressable when a goto action targets a step in the same workflow 1`] = `
+"──────────────────────────────────────────────────────────────────────────────── 
+ 
+  Running workflow goto-step-keeps-outputs.arazzo.yaml / goto-keeps-outputs 
+ 
+  ✓ GET /menu - step list-menu-items 
+    ✓ success criteria check - $statusCode == 200
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+  ✗ GET /menu - step failing-step 
+    ✗ success criteria check - $statusCode == 999
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+  Running failure action goto-cleanup for the step failing-step 
+ 
+  ✓ GET /menu - step cleanup 
+    ✓ success criteria check - $statusCode == 200
+    ✓ success criteria check - $steps.list-menu-items.outputs.menuItems != null
+    ✓ status code check - $statusCode in [200, 400, 500]
+    ✓ content-type check
+    ✓ schema check
+ 
+ 
+
+  Failed tests info:
+
+  Workflow name: goto-keeps-outputs
+ 
+    stepId - failing-step 
+    ✗ success criteria check 
+      Checking simple criteria: {"condition":"$statusCode == 999"}
+       
+  Summary for goto-step-keeps-outputs.arazzo.yaml
+  
+  Workflows: 1 failed, 1 total
+  Steps: 2 passed, 1 failed, 3 total
+  Checks: 12 passed, 1 failed, 13 total
+  Time: <test>ms 
+ 
+ 
+┌─────────────────────────────────────────────────────────────────────────────┬────────────┬─────────┬─────────┬──────────┐
+│ Filename                                                                    │ Workflows  │ Passed  │ Failed  │ Warnings │
+├─────────────────────────────────────────────────────────────────────────────┼────────────┼─────────┼─────────┼──────────┤
+│ x goto-step-keeps-outputs.arazzo.yaml                                       │ 1          │ 0       │ 1       │ -        │
+└─────────────────────────────────────────────────────────────────────────────┴────────────┴─────────┴─────────┴──────────┘
+ 
+
+ Tests exited with error 
+
+"
+`;

--- a/tests/e2e/respect/goto-step-keeps-outputs/goto-step-keeps-outputs.arazzo.yaml
+++ b/tests/e2e/respect/goto-step-keeps-outputs/goto-step-keeps-outputs.arazzo.yaml
@@ -1,0 +1,35 @@
+arazzo: 1.0.1
+info:
+  title: Goto step keeps earlier outputs
+  description: A goto action targeting a step in the same workflow keeps earlier step outputs addressable.
+  version: 1.0.0
+
+sourceDescriptions:
+  - name: cafe-api
+    type: openapi
+    url: https://cafe.redocly.com/_bundle/openapi/cafe.yaml
+
+workflows:
+  - workflowId: goto-keeps-outputs
+    steps:
+      - stepId: list-menu-items
+        operationId: $sourceDescriptions.cafe-api.listMenuItems
+        outputs:
+          menuItems: $response.body
+        successCriteria:
+          - condition: $statusCode == 200
+
+      - stepId: failing-step
+        operationId: $sourceDescriptions.cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 999
+        onFailure:
+          - name: goto-cleanup
+            type: goto
+            stepId: cleanup
+
+      - stepId: cleanup
+        operationId: $sourceDescriptions.cafe-api.listMenuItems
+        successCriteria:
+          - condition: $statusCode == 200
+          - condition: $steps.list-menu-items.outputs.menuItems != null

--- a/tests/e2e/respect/goto-step-keeps-outputs/goto-step-keeps-outputs.test.ts
+++ b/tests/e2e/respect/goto-step-keeps-outputs/goto-step-keeps-outputs.test.ts
@@ -1,0 +1,16 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getCommandOutput, getParams } from '../../helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// The cleanup step reached by the goto reads an output of a step that ran before it
+test('should keep earlier step outputs addressable when a goto action targets a step in the same workflow', () => {
+  const indexEntryPoint = join(process.cwd(), 'packages/cli/lib/index.js');
+  const fixturesPath = join(__dirname, 'goto-step-keeps-outputs.arazzo.yaml');
+  const args = getParams(indexEntryPoint, ['respect', fixturesPath]);
+
+  const result = getCommandOutput(args);
+  expect(result).toMatchSnapshot();
+}, 60_000);


### PR DESCRIPTION
## What/Why/How?
> [!NOTE]
> This was heavily assisted by Anthropic's Opus 5. I'm submitting it by hand, having done my due diligence on it. If I've missed something obvious, just say and I'll sort it out.

`runWorkflow` clears `ctx.$steps` on entry. A `goto` targeting a `stepId` re-enters `runWorkflow` with `fromStepId`, so outputs of steps that already ran are discarded:

```yaml
- stepId: create-group
  operationId: $sourceDescriptions.api.createGroup
  outputs:
    groupId: $response.body#/id

- stepId: represent-group
  operationId: $sourceDescriptions.api.updateGroupRepresentation
  successCriteria:
    - condition: $statusCode == 200
  onFailure:
    - name: cleanup
      type: goto
      stepId: delete-group

- stepId: delete-group
  operationId: $sourceDescriptions.api.deleteGroup
  parameters:
    - name: groupId
      in: path
      value: $steps.create-group.outputs.groupId
```

When `represent-group` fails, the goto fires and `delete-group` errors:

```
Error in resolving runtime expression '$steps.create-group.outputs.groupId'.
```

The Arazzo specification describes a `stepId` goto as "a one-way transfer of workflow control" to a step "within the current workflow", and separately requires tools to treat runtime expression output references such as `$steps.stepId.outputs.field` as implicit dependencies and to ensure the referenced step completes before the referencing step executes.

Neither statement discards step context, so clearing it on re-entry was never spec behaviour. `ctx.$steps` is now cleared only when `fromStepId` is absent. A `goto` or `retry` that names a `workflowId` still goes through `resolveWorkflowContext` and still gets a clean `$steps` namespace.

## Reference

No existing issue. #2735 and #2796 add action `parameters`, which the specification limits to actions referencing a `workflowId`, so they do not reach the `stepId` case.

https://github.com/OAI/Arazzo-Specification/blob/main/versions/1.1.0.md#failure-action-object

## Testing

`tests/e2e/respect/goto-step-keeps-outputs` runs the CLI against an Arazzo document where a failing step routes `onFailure: goto` to a later step that reads an earlier step's output. It fails on `main` with the error above and passes with this change.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared workflow execution state (`ctx.$steps`) for goto/retry paths; behavior is narrower and spec-aligned but could affect workflows that accidentally relied on full clears on re-entry.
> 
> **Overview**
> Fixes **respect** workflow execution so an `onFailure` (or similar) **goto** to another step in the **same workflow** no longer wipes outputs from steps that already completed.
> 
> `runWorkflow` used to always reset `ctx.$steps` before running steps. Re-entry via `fromStepId` (same-workflow goto) therefore dropped earlier step outputs and broke expressions like `$steps.list-menu-items.outputs.menuItems` in the target step. It now clears `$steps` only on a normal workflow start; on goto it removes entries only for the steps about to be re-run (from the target onward), leaving prior step outputs intact. Goto/retry to another **workflow** still gets a fresh `$steps` namespace via existing context resolution.
> 
> Adds an e2e Arazzo fixture and snapshot test (`goto-step-keeps-outputs`) that asserts the cleanup step can read an earlier step’s output after a goto.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38eb0c5d31fefe91e2dd3124c09bc2828980385d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->