### PR TITLE
fix: update fast-uri to 3.1.7 to resolve advisories

### DIFF
--- a/.changeset/cute-berries-love.md
+++ b/.changeset/cute-berries-love.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': patch
+---
+
+Updated `fast-uri` to the `3.1.7` version to resolve advisories.

--- a/.changeset/cute-berries-love.md
+++ b/.changeset/cute-berries-love.md
@@ -2,4 +2,4 @@
 '@redocly/cli': patch
 ---
 
-Updated `fast-uri` to the `3.1.7` version to resolve advisories.
+Updated `fast-uri` to the `3.1.7` version to resolve `CVE-2026-75931`, `CVE-2026-75975`, `CVE-2026-75899`, and `CVE-2026-76172`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5762,9 +5762,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What/Why/How?

Four high-severity advisories for `fast-uri` were published on 2026-09-02. All four affect `>= 3.x, < 3.1.6`, and the lockfile pinned `3.1.5`:

| Advisory | Summary |
|---|---|
| `GHSA-5jgf-p345-68v8` | Host confusion via skipped IDN canonicalization on scheme-relative references |
| `GHSA-f65p-4m7j-42xc` | Server-side request forgery via malformed IPv6 normalization |
| `GHSA-fph4-wmhf-6fwf` | Server-side request forgery via repeated hostname percent-decoding |
| `GHSA-jqff-g426-hqxp` | Host confusion via percent-encoded scheme normalization |

`npm audit fix` updated the lockfile entry to `3.1.7`. This PR changes only `package-lock.json`. No declared dependency range changes.

## Reference

- https://github.com/advisories/GHSA-5jgf-p345-68v8
- https://github.com/advisories/GHSA-f65p-4m7j-42xc
- https://github.com/advisories/GHSA-fph4-wmhf-6fwf
- https://github.com/advisories/GHSA-jqff-g426-hqxp

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency upgrade with no application code changes; reduces URI-parsing security risk rather than introducing new behavior.
> 
> **Overview**
> Bumps the **transitive** `fast-uri` lockfile resolution from **3.1.5** to **3.1.7** so installs pick up patched releases. No direct `package.json` range changes—only `package-lock.json` and a **@redocly/cli** patch changeset noting the CVE fixes (`CVE-2026-75931`, `CVE-2026-75975`, `CVE-2026-75899`, `CVE-2026-76172`).
> 
> This addresses four high-severity advisories on `fast-uri` 3.x before 3.1.6 (host confusion via IDN/scheme handling and SSRF via IPv6 and hostname decoding), which matter wherever the CLI resolves or normalizes URIs through that dependency chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec84a41dc9372ff1bd74e607ce12710e5aa2ad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->