### PR TITLE
fix(core): keep webpackIgnore inside dynamic import for plugin loading

### DIFF
--- a/.changeset/plugin-loading-bundled-consumers.md
+++ b/.changeset/plugin-loading-bundled-consumers.md
@@ -3,4 +3,4 @@
 '@redocly/cli': patch
 ---
 
-Fixed plugin loading breaking in consumers that bundle `@redocly/openapi-core` with webpack or rspack. TypeScript's `rewriteRelativeImportExtensions` wrapped the dynamic `import()` in `loadPluginModule` in a helper call, hiding the `webpackIgnore` magic comment from bundlers and causing them to rewrite the import into a broken require.
+Fixed plugin loading breaking in consumers that bundle `@redocly/openapi-core` with webpack or rspack.

--- a/.changeset/plugin-loading-bundled-consumers.md
+++ b/.changeset/plugin-loading-bundled-consumers.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed plugin loading breaking in consumers that bundle `@redocly/openapi-core` with webpack or rspack. TypeScript's `rewriteRelativeImportExtensions` wrapped the dynamic `import()` in `loadPluginModule` in a helper call, hiding the `webpackIgnore` magic comment from bundlers and causing them to rewrite the import into a broken require.

--- a/packages/core/src/config/__tests__/plugins-cache.test.ts
+++ b/packages/core/src/config/__tests__/plugins-cache.test.ts
@@ -1,3 +1,7 @@
+// Bundlers only honor `webpackIgnore` directly inside `import(...)`; TS's
+// `rewriteRelativeImportExtensions` wraps the argument in a helper call that hides it,
+// breaking plugin loading in webpack/rspack consumers. This pins the compiled shape.
+
 import * as fs from 'node:fs';
 import module from 'node:module';
 import path from 'node:path';
@@ -85,11 +89,8 @@ describe('plugins-cache', () => {
     });
   });
 
-  describe('compiled output', () => {
+  describe('loadPluginModule (lib/config/plugins-cache.js)', () => {
     it('should keep webpackIgnore directly inside the dynamic import call', () => {
-      // Bundlers only honor `webpackIgnore` when it sits directly inside `import(...)`.
-      // TS's `rewriteRelativeImportExtensions` wraps the argument in a helper call,
-      // which hides the comment from webpack/rspack and breaks plugin loading in bundled consumers.
       const compiledPath = path.join(__dirname, '../../../lib/config/plugins-cache.js');
       const compiled = fs.readFileSync(compiledPath, 'utf-8');
 

--- a/packages/core/src/config/__tests__/plugins-cache.test.ts
+++ b/packages/core/src/config/__tests__/plugins-cache.test.ts
@@ -84,4 +84,16 @@ describe('plugins-cache', () => {
       expect(getPluginCacheVersion()).toBe(before + 2);
     });
   });
+
+  describe('compiled output', () => {
+    it('should keep webpackIgnore directly inside the dynamic import call', () => {
+      // Bundlers only honor `webpackIgnore` when it sits directly inside `import(...)`.
+      // TS's `rewriteRelativeImportExtensions` wraps the argument in a helper call,
+      // which hides the comment from webpack/rspack and breaks plugin loading in bundled consumers.
+      const compiledPath = path.join(__dirname, '../../../lib/config/plugins-cache.js');
+      const compiled = fs.readFileSync(compiledPath, 'utf-8');
+
+      expect(compiled).toContain('import(/* webpackIgnore: true */ pluginUrl.href)');
+    });
+  });
 });

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    // Off: it wraps loadPluginModule's dynamic import() in a runtime helper that hides
+    // the webpackIgnore comment from bundlers and breaks plugin loading. Every relative
+    // import here already carries its own .js extension, so it rewrites nothing anyway.
+    "rewriteRelativeImportExtensions": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["lib", "**/__tests__", "**/*.test.ts"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    // Off: it wraps loadPluginModule's dynamic import() in a runtime helper that hides
-    // the webpackIgnore comment from bundlers and breaks plugin loading. Every relative
-    // import here already carries its own .js extension, so it rewrites nothing anyway.
     "rewriteRelativeImportExtensions": false
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## What/Why/How?

Since 2.48.0, `loadPluginModule` fails to load plugins in apps that bundle `@redocly/openapi-core` with webpack or rspack (for example Redocly Reunite). The compiled output changed from a plain `import(/* webpackIgnore: true */ pluginUrl.href)` to `import(__rewriteRelativeImportExtension(/* webpackIgnore: true */ pluginUrl.href))`, because TypeScript's `rewriteRelativeImportExtensions` wraps dynamic imports whose specifier isn't a string literal. Bundlers only honor `webpackIgnore` when it's directly inside `import(...)`, so once it's wrapped they emit a "Critical dependency" warning and rewrite the import into a require that throws `Cannot find module` at runtime.

`rewriteRelativeImportExtensions` doesn't do anything useful here: `packages/core` already writes `.js` extensions on every relative import, and the only dynamic import in the package always resolves to an absolute `file://` URL, which the helper never rewrites anyway. Turning it off for `packages/core` restores the original compiled shape without touching anything the option was actually needed for.

## Reference

Fixes #3089

## Testing

Confirmed the compiled output is wrapped on `main` and unwrapped after this change (`npm run compile`, inspect `packages/core/lib/config/plugins-cache.js`). Added a test that reads the compiled file and asserts the import stays unwrapped, so a future TS/tsconfig change can't reintroduce this silently. Ran the existing `plugins-cache` tests (which load real cjs/esm plugin fixtures through `loadPluginModule`) to confirm plugin loading still works at runtime, plus the full unit suite, typecheck, and lint.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/tsconfig and compile-output guard only; runtime plugin-loading behavior is unchanged aside from fixing bundled consumers.
> 
> **Overview**
> **Restores plugin loading** when apps bundle `@redocly/openapi-core` with webpack or rspack (e.g. since 2.48.0). TypeScript’s `rewriteRelativeImportExtensions` was wrapping `loadPluginModule`’s dynamic `import(/* webpackIgnore: true */ …)` in a helper, so bundlers ignored the comment and broke runtime plugin resolution.
> 
> **`packages/core/tsconfig.json`** now sets `rewriteRelativeImportExtensions: false` so compiled `plugins-cache.js` keeps a plain dynamic import. A **regression test** reads the built file and asserts that shape. Patch **changeset** for `@redocly/openapi-core` and `@redocly/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa9dbdc6c2ddc83ff2d6dd6c0db6cd1445bf809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->