### PR TITLE
chore: update test setup and the contributing guide

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.head_ref == 'changeset-release/main'
         run: |
           cd tests/performance/
-          cat package.json | jq ".dependencies = $(cat package.json | jq ._enhancedDependencies)" > package.json
+          cat package.json | jq ".dependencies = $(cat package.json | jq ._historicalVersions)" > package.json
           cat package.json
 
       - name: Prepare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -461,4 +461,5 @@ To release a new version, switch to the `v1` branch and follow the steps describ
 
 ### Handle a broken release
 
-If a release pipeline failed or didn't start after the release PR was merged into main (for example, if GitHub Actions was down), the new package version will be published to the NPM registry with the next successful merge into main. However, that merge should not be another release PR, otherwise it would swallow the original version.
+If a release pipeline failed or didn't start after the release PR was merged into `main` (for example, if GitHub Actions was down),
+you **must** merge a PR **without changesets** into `main` to trigger the release process again otherwise the release will be lost.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -458,3 +458,7 @@ The released version can be installed with `npm install @redocly/cli@snapshot`.
 Redocly CLI v1 is currently in archive mode, but still can receive bug fixes.
 
 To release a new version, switch to the `v1` branch and follow the steps described in the Contribution guide (the `CONTRIBUTING.md` file).
+
+### Handle a broken release
+
+If a release pipeline failed or didn't start after the release PR was merged into main (for example, if GitHub Actions was down), the new package version will be published to the NPM registry with the next successful merge into main. However, that merge should not be another release PR, otherwise it would swallow the original version.

--- a/docs/@v2/commands/scorecard-classic.md
+++ b/docs/@v2/commands/scorecard-classic.md
@@ -6,7 +6,7 @@ The `scorecard-classic` command evaluates your API descriptions against quality 
 Use this command to validate API quality and track compliance with organizational governance standards across multiple severity levels.
 
 {% admonition type="info" name="Note" %}
-The `scorecard-classic` command requires a scorecard configuration in your Redocly project. You can configure this in your project settings or by providing a `--project-url` flag. Learn more about [configuring scorecards](https://redocly.com/docs/realm/config/scorecard).
+The `scorecard-classic` command requires a scorecard configuration in your Redocly project. You can configure this in your project settings or by providing a `--project-url` flag. Learn more about [configuring scorecards](https://redocly.com/docs/realm/config/scorecard-classic).
 {% /admonition %}
 
 ## Usage

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -4,16 +4,16 @@ Automated benchmark testing that compares the performance of **Redocly CLI** ver
 
 ## Adding a version after a release
 
-After releasing a new version, add it to `_enhancedDependencies` in [package.json](./package.json) for historical reference; it is benchmarked only on opt-in runs (see [Which versions get benchmarked](#which-versions-get-benchmarked)).
+After releasing a new version, add it to `_historicalVersions` in [package.json](./package.json) for historical reference; it is benchmarked only on opt-in runs (see [Which versions get benchmarked](#which-versions-get-benchmarked)).
 
 ## Which versions get benchmarked
 
 Two version sets live in [package.json](./package.json):
 
 - `dependencies` — benchmarked on **every** run. Kept minimal (`cli-latest` and `cli-next`) so regular PRs get a fast latest-vs-next comparison.
-- `_enhancedDependencies` — the full historical matrix, benchmarked only on opt-in runs.
+- `_historicalVersions` — the full historical matrix, benchmarked only on opt-in runs.
 
-The [performance workflow](../../.github/workflows/performance.yaml) promotes `_enhancedDependencies` into `dependencies` (overwriting it) only on the release PR (`changeset-release/main`). This keeps the deep-dive across many versions off the normal PR path while leaving it a single label away.
+The [performance workflow](../../.github/workflows/performance.yaml) promotes `_historicalVersions` into `dependencies` (overwriting it) only on the release PR (`changeset-release/main`). This keeps the deep-dive across many versions off the normal PR path while leaving it a single label away.
 
 ## Scripts
 

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -12,7 +12,7 @@
     "test:check-config": "REDOCLY_SUPPRESS_UPDATE_NOTICE=true hyperfine --warmup 2 'node node_modules/cli-latest/bin/cli.js check-config --config=api-definitions/redocly.yaml --lint-config=warn' 'node node_modules/cli-next/bin/cli.js check-config --config=api-definitions/redocly.yaml --lint-config=warn'",
     "test": "npm run test:bundle && npm run test:lint && npm run test:check-config"
   },
-  "_enhancedDependencies": {
+  "_historicalVersions": {
     "cli-2.0.0": "npm:@redocly/cli@2.0.0",
     "cli-2.13.0": "npm:@redocly/cli@2.13.0",
     "cli-2.14.2": "npm:@redocly/cli@2.14.2",
@@ -23,6 +23,7 @@
     "cli-2.34.0": "npm:@redocly/cli@2.34.0",
     "cli-2.45.0": "npm:@redocly/cli@2.45.0",
     "cli-2.46.0": "npm:@redocly/cli@2.46.0",
+    "cli-2.51.1": "npm:@redocly/cli@2.51.1",
     "cli-latest": "npm:@redocly/cli@latest",
     "cli-next": "file:../../redocly-cli.tgz"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,9 +21,9 @@ const configExtension: { [key: string]: ViteUserConfig } = {
           'packages/cli/src/utils/assert-node-version.ts',
         ],
         thresholds: {
-          lines: 77,
+          lines: 78,
           functions: 81,
-          statements: 77,
+          statements: 78,
           branches: 71,
         },
       },


### PR DESCRIPTION
## What/Why/How?
- Updated the contribution guide
- Added new version to perf. benchmark (https://github.com/Redocly/redocly-cli/pull/3077)


## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [ ] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, benchmark metadata, and CI threshold tweaks with no runtime or security-sensitive code changes.
> 
> **Overview**
> **Contributor and release ops:** Adds a **Handle a broken release** section to `CONTRIBUTING.md` explaining that if the release pipeline fails after merging the release PR, maintainers must merge a **changeset-free** PR into `main` to re-trigger publishing so the release is not lost.
> 
> **Performance benchmarks:** Renames `_enhancedDependencies` to `_historicalVersions` in `tests/performance/package.json`, its README, and the performance GitHub workflow jq step. Adds **CLI 2.51.1** to the historical version matrix for opt-in release-branch benchmarks.
> 
> **Docs:** Fixes the `scorecard-classic` command doc link to point at `scorecard-classic` configuration docs instead of `scorecard`.
> 
> **CI:** Raises Vitest Istanbul **lines** and **statements** coverage thresholds from **77%** to **78%**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a706c69061624682f7e42c71078cf4d28fe7b2c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->