### PR TITLE
feat: export push entries

### DIFF
--- a/.changeset/cli-api-entry-point.md
+++ b/.changeset/cli-api-entry-point.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': minor
+---
+
+Added the `@redocly/cli/api` entry point, which exports the `push` and `pushStatus` functions and their TypeScript types for use from Node.js.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,14 @@
     "openapi": "bin/cli.js"
   },
   "type": "module",
+  "exports": {
+    "./api": {
+      "types": "./lib/api.d.ts",
+      "default": "./lib/api.js"
+    },
+    "./bin/cli.js": "./bin/cli.js",
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": ">=22.12.0 || >=20.19.0 <21.0.0",
     "npm": ">=10"

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -2,6 +2,7 @@ import { build } from 'esbuild';
 import { cpSync, existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -9,7 +10,7 @@ rmSync(path.join(packageDir, 'lib'), { recursive: true, force: true });
 
 const result = await build({
   absWorkingDir: packageDir,
-  entryPoints: ['src/index.ts'],
+  entryPoints: ['src/index.ts', 'src/api.ts'],
   outdir: 'lib',
   chunkNames: 'chunks/[hash]',
   bundle: true,
@@ -26,12 +27,12 @@ const result = await build({
   // Avoid errors when external dependencies use CJS syntax.
   banner: {
     js: [
-      "import { createRequire as __createRequire } from 'node:module';",
-      "import { fileURLToPath as __fileURLToPath } from 'node:url';",
-      "import { dirname as __pathDirname } from 'node:path';",
-      'const require = __createRequire(import.meta.url);',
-      'var __filename = __fileURLToPath(import.meta.url);',
-      'var __dirname = __pathDirname(__filename);',
+      "import { createRequire as __redoclyCliCreateRequire } from 'node:module';",
+      "import { fileURLToPath as __redoclyCliFileURLToPath } from 'node:url';",
+      "import { dirname as __redoclyCliPathDirname } from 'node:path';",
+      'const require = __redoclyCliCreateRequire(import.meta.url);',
+      'var __filename = __redoclyCliFileURLToPath(import.meta.url);',
+      'var __dirname = __redoclyCliPathDirname(__filename);',
     ].join('\n'),
   },
   logLevel: 'info',
@@ -43,6 +44,8 @@ if (entryChunkInputs.some((inputPath) => inputPath.includes('node_modules/redoc'
     'redoc leaked into lib/index.js — check for stray static imports in build-docs commands'
   );
 }
+
+emitDeclarations(['src/api.ts', 'src/reunite/api/types.ts']);
 
 const allInputs = Object.values(result.metafile.outputs).flatMap((chunk) =>
   Object.keys(chunk.inputs)
@@ -98,6 +101,46 @@ cpSync(
   path.join(packageDir, 'lib', 'eject-assets'),
   { recursive: true }
 );
+
+// Emits the declarations for the public `@redocly/cli/api` entry. `rootDir` and `outDir`
+// from the package tsconfig map each source path to its output path.
+function emitDeclarations(sourcePaths) {
+  const configPath = path.join(packageDir, 'tsconfig.json');
+  const config = ts.getParsedCommandLineOfConfigFile(configPath, {}, ts.sys);
+  const program = ts.createProgram({
+    rootNames: sourcePaths.map((sourcePath) => path.join(packageDir, sourcePath)),
+    options: {
+      ...config.options,
+      declaration: true,
+      emitDeclarationOnly: true,
+      declarationMap: false,
+      composite: false,
+      incremental: false,
+    },
+  });
+
+  for (const sourcePath of sourcePaths) {
+    const { diagnostics } = program.emit(
+      program.getSourceFile(path.join(packageDir, sourcePath)),
+      writeDeclaration
+    );
+
+    if (diagnostics.length) {
+      throw new Error(ts.formatDiagnostics(diagnostics, ts.createCompilerHost({})));
+    }
+  }
+}
+
+function writeDeclaration(outputPath, text) {
+  const packageImport = text.match(/from ['"](?!\.)([^'"]+)['"]/);
+  if (packageImport) {
+    throw new Error(
+      `${outputPath} imports '${packageImport[1]}' — the published package ships no dependencies, so a public type cannot come from one`
+    );
+  }
+
+  ts.sys.writeFile(outputPath, text);
+}
 
 function findLicenseText(pkgRoot) {
   for (const filename of ['LICENSE', 'LICENSE.md', 'LICENSE.txt', 'LICENCE', 'LICENCE.md']) {

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -122,24 +122,22 @@ function emitDeclarations(sourcePaths) {
   for (const sourcePath of sourcePaths) {
     const { diagnostics } = program.emit(
       program.getSourceFile(path.join(packageDir, sourcePath)),
-      writeDeclaration
+      (outputPath, text) => {
+        const packageImport = text.match(/from ['"](?!\.)([^'"]+)['"]/);
+        if (packageImport) {
+          throw new Error(
+            `${outputPath} imports '${packageImport[1]}' — the published package ships no dependencies, so a public type cannot come from one`
+          );
+        }
+
+        ts.sys.writeFile(outputPath, text);
+      }
     );
 
     if (diagnostics.length) {
       throw new Error(ts.formatDiagnostics(diagnostics, ts.createCompilerHost({})));
     }
   }
-}
-
-function writeDeclaration(outputPath, text) {
-  const packageImport = text.match(/from ['"](?!\.)([^'"]+)['"]/);
-  if (packageImport) {
-    throw new Error(
-      `${outputPath} imports '${packageImport[1]}' — the published package ships no dependencies, so a public type cannot come from one`
-    );
-  }
-
-  ts.sys.writeFile(outputPath, text);
 }
 
 function findLicenseText(pkgRoot) {

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -8,13 +8,9 @@ const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '.
 
 rmSync(path.join(packageDir, 'lib'), { recursive: true, force: true });
 
-const result = await build({
+const sharedOptions = {
   absWorkingDir: packageDir,
-  entryPoints: ['src/index.ts', 'src/api.ts'],
-  outdir: 'lib',
-  chunkNames: 'chunks/[hash]',
   bundle: true,
-  splitting: true,
   platform: 'node',
   format: 'esm',
   target: 'node20.19',
@@ -36,19 +32,41 @@ const result = await build({
     ].join('\n'),
   },
   logLevel: 'info',
+};
+
+const cliBuild = await build({
+  ...sharedOptions,
+  entryPoints: ['src/index.ts'],
+  outdir: 'lib',
+  chunkNames: 'chunks/[hash]',
+  splitting: true,
 });
 
-const entryChunkInputs = Object.keys(result.metafile.outputs['lib/index.js']?.inputs ?? {});
-if (entryChunkInputs.some((inputPath) => inputPath.includes('node_modules/redoc'))) {
-  throw new Error(
-    'redoc leaked into lib/index.js — check for stray static imports in build-docs commands'
-  );
+// The `@redocly/cli/api` entry is bundled on its own. Sharing chunks with the CLI splits
+// its startup graph into more files, which costs a few milliseconds on every command.
+const apiBuild = await build({
+  ...sharedOptions,
+  entryPoints: ['src/api.ts'],
+  outfile: 'lib/api.js',
+  splitting: false,
+});
+
+for (const [entryPath, metafile] of [
+  ['lib/index.js', cliBuild.metafile],
+  ['lib/api.js', apiBuild.metafile],
+]) {
+  const entryInputs = Object.keys(metafile.outputs[entryPath]?.inputs ?? {});
+  if (entryInputs.some((inputPath) => inputPath.includes('node_modules/redoc'))) {
+    throw new Error(
+      `redoc leaked into ${entryPath} — check for stray static imports in build-docs commands`
+    );
+  }
 }
 
 emitDeclarations(['src/api.ts', 'src/reunite/api/types.ts']);
 
-const allInputs = Object.values(result.metafile.outputs).flatMap((chunk) =>
-  Object.keys(chunk.inputs)
+const allInputs = [cliBuild, apiBuild].flatMap((buildResult) =>
+  Object.values(buildResult.metafile.outputs).flatMap((chunk) => Object.keys(chunk.inputs))
 );
 
 const seenPkgRoots = new Set();

--- a/packages/cli/scripts/prepare-publish-dir.mjs
+++ b/packages/cli/scripts/prepare-publish-dir.mjs
@@ -36,6 +36,7 @@ const publishPackageJson = {
   license: packageJson.license,
   type: packageJson.type,
   bin: packageJson.bin,
+  exports: packageJson.exports,
   repository: packageJson.repository,
   homepage: packageJson.homepage,
   keywords: packageJson.keywords,

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,0 +1,29 @@
+import type {
+  PushOptions,
+  PushResult,
+  PushStatusOptions,
+  PushStatusSummary,
+} from './reunite/api/types.js';
+import { handlePushStatus } from './reunite/commands/push-status.js';
+import { handlePush } from './reunite/commands/push.js';
+
+export type {
+  CommitStatus,
+  DeploymentStatus,
+  DeploymentStatusResponse,
+  PushOptions,
+  PushResponse,
+  PushResult,
+  PushStatusBase,
+  PushStatusOptions,
+  PushStatusSummary,
+  ScorecardItem,
+} from './reunite/api/types.js';
+
+export function push(options: PushOptions): Promise<PushResult | undefined> {
+  return handlePush({ argv: options });
+}
+
+export function pushStatus(options: PushStatusOptions): Promise<PushStatusSummary> {
+  return handlePushStatus({ argv: options });
+}

--- a/packages/cli/src/reunite/api/api-client.ts
+++ b/packages/cli/src/reunite/api/api-client.ts
@@ -5,17 +5,60 @@ import type { Readable } from 'node:stream';
 import { DEFAULT_FETCH_TIMEOUT } from '../../utils/constants.js';
 import fetchWithTimeout, { type FetchWithTimeoutOptions } from '../../utils/fetch-with-timeout.js';
 import { version } from '../../utils/package.js';
-import type {
-  ListRemotesResponse,
-  ProjectSourceResponse,
-  PushResponse,
-  UpsertRemoteResponse,
-} from './types.js';
+import type { PushResponse } from './types.js';
 
 interface BaseApiClient {
   request(url: string, options: FetchWithTimeoutOptions): Promise<Response>;
 }
 type CommandOption = 'push' | 'push-status';
+
+type ProjectSourceResponse = {
+  branchName: string;
+  contentPath: string;
+  isInternal: boolean;
+};
+
+type UpsertRemoteResponse = {
+  id: string;
+  type: 'CICD';
+  mountPath: string;
+  mountBranchName: string;
+  organizationId: string;
+  projectId: string;
+};
+
+type ListRemotesResponse = {
+  object: 'list';
+  page: {
+    endCursor: string;
+    startCursor: string;
+    haxNextPage: boolean;
+    hasPrevPage: boolean;
+    limit: number;
+    total: number;
+  };
+  items: Remote[];
+};
+
+type Remote = {
+  mountPath: string;
+  type: string;
+  autoSync: boolean;
+  autoMerge: boolean;
+  createdAt: string;
+  updatedAt: string;
+  providerType: string;
+  namespaceId: string;
+  repositoryId: string;
+  projectId: string;
+  mountBranchName: string;
+  contentPath: string;
+  credentialId: string;
+  branchName: string;
+  contentType: string;
+  id: string;
+};
+
 export type SunsetWarning = { sunsetDate: Date; isSunsetExpired: boolean };
 export type SunsetWarningsBuffer = SunsetWarning[];
 

--- a/packages/cli/src/reunite/api/types.ts
+++ b/packages/cli/src/reunite/api/types.ts
@@ -1,50 +1,3 @@
-export type ProjectSourceResponse = {
-  branchName: string;
-  contentPath: string;
-  isInternal: boolean;
-};
-
-export type UpsertRemoteResponse = {
-  id: string;
-  type: 'CICD';
-  mountPath: string;
-  mountBranchName: string;
-  organizationId: string;
-  projectId: string;
-};
-
-export type ListRemotesResponse = {
-  object: 'list';
-  page: {
-    endCursor: string;
-    startCursor: string;
-    haxNextPage: boolean;
-    hasPrevPage: boolean;
-    limit: number;
-    total: number;
-  };
-  items: Remote[];
-};
-
-export type Remote = {
-  mountPath: string;
-  type: string;
-  autoSync: boolean;
-  autoMerge: boolean;
-  createdAt: string;
-  updatedAt: string;
-  providerType: string;
-  namespaceId: string;
-  repositoryId: string;
-  projectId: string;
-  mountBranchName: string;
-  contentPath: string;
-  credentialId: string;
-  branchName: string;
-  contentType: string;
-  id: string;
-};
-
 export type PushResponse = {
   id: string;
   remoteId: string;
@@ -67,12 +20,7 @@ export type PushResponse = {
       email: string;
       image: string | null;
     };
-    statuses: Array<{
-      name: string;
-      description: string;
-      status: 'pending' | 'running' | 'success' | 'failed';
-      url: string | null;
-    }>;
+    statuses: CommitStatus[];
   };
   remote: {
     commits: {
@@ -91,7 +39,7 @@ export type DeploymentStatusResponse = {
   scorecard: ScorecardItem[];
 };
 
-export type PushStatusResponse = {
+type PushStatusResponse = {
   preview: DeploymentStatusResponse;
   production: DeploymentStatusResponse;
 };
@@ -106,3 +54,52 @@ export type ScorecardItem = {
 export type PushStatusBase = 'pending' | 'success' | 'running' | 'failed';
 
 export type DeploymentStatus = 'skipped' | PushStatusBase;
+
+export type CommitStatus = {
+  name: string;
+  description: string;
+  status: PushStatusBase;
+  url: string | null;
+};
+
+export type PushOptions = {
+  files: string[];
+  organization: string;
+  project: string;
+  'mount-path': string;
+  branch: string;
+  author: string;
+  message: string;
+  'commit-sha'?: string;
+  'commit-url'?: string;
+  namespace?: string;
+  repository?: string;
+  'created-at'?: string;
+  'default-branch': string;
+  domain?: string;
+  'wait-for-deployment'?: boolean;
+  'max-execution-time'?: number; // in seconds
+  'continue-on-deploy-failures'?: boolean;
+  verbose?: boolean;
+};
+
+export type PushResult = { pushId: string };
+
+export type PushStatusOptions = {
+  organization: string;
+  project: string;
+  pushId: string;
+  domain?: string;
+  wait?: boolean;
+  'max-execution-time'?: number; // in seconds
+  'retry-interval'?: number; // in seconds
+  'start-time'?: number; // in milliseconds
+  'continue-on-deploy-failures'?: boolean;
+  onRetry?: (lastSummary: PushStatusSummary) => void;
+};
+
+export type PushStatusSummary = {
+  preview: DeploymentStatusResponse;
+  production: DeploymentStatusResponse | null;
+  commit: PushResponse['commit'];
+};

--- a/packages/cli/src/reunite/commands/__tests__/push-status.test.ts
+++ b/packages/cli/src/reunite/commands/__tests__/push-status.test.ts
@@ -23,8 +23,6 @@ const remotes = {
 };
 
 describe('handlePushStatus()', () => {
-  const mockConfig = { apis: {} } as any;
-
   const commitStub: PushResponse['commit'] = {
     message: 'test-commit-message',
     branchName: 'test-branch-name',
@@ -110,8 +108,6 @@ describe('handlePushStatus()', () => {
         project: 'test-project',
         pushId: 'test-push-id',
       },
-      config: mockConfig,
-      version: 'cli-version',
     });
     expect(process.stdout.write).toHaveBeenCalledTimes(1);
     expect(process.stdout.write).toHaveBeenCalledWith(
@@ -130,8 +126,6 @@ describe('handlePushStatus()', () => {
         project: 'test-project',
         pushId: 'test-push-id',
       },
-      config: mockConfig,
-      version: 'cli-version',
     });
     expect(process.stdout.write).toHaveBeenCalledTimes(2);
     expect(process.stdout.write).toHaveBeenCalledWith(
@@ -163,8 +157,6 @@ describe('handlePushStatus()', () => {
           project: 'test-project',
           pushId: 'test-push-id',
         },
-        config: mockConfig,
-        version: 'cli-version',
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [Error: ❌ Preview deploy fail.
@@ -204,8 +196,6 @@ describe('handlePushStatus()', () => {
         project: 'test-project',
         pushId: 'test-push-id',
       },
-      config: mockConfig,
-      version: 'cli-version',
     });
     expect(process.stdout.write).toHaveBeenCalledTimes(4);
     expect(process.stdout.write).toHaveBeenCalledWith(
@@ -241,8 +231,6 @@ describe('handlePushStatus()', () => {
         pushId: 'test-push-id',
         wait: true,
       },
-      config: mockConfig,
-      version: 'cli-version',
     });
 
     expect(process.stderr.write).toHaveBeenCalledWith(
@@ -262,8 +250,6 @@ describe('handlePushStatus()', () => {
           project: 'test-project',
           pushId: 'test-push-id',
         },
-        config: mockConfig,
-        version: 'cli-version',
       });
 
       expect(result).toEqual({
@@ -290,8 +276,6 @@ describe('handlePushStatus()', () => {
           project: 'test-project',
           pushId: 'test-push-id',
         },
-        config: mockConfig,
-        version: 'cli-version',
       });
 
       expect(result).toEqual({
@@ -357,8 +341,6 @@ describe('handlePushStatus()', () => {
           'retry-interval': 0.5, // 500 ms
           wait: true,
         },
-        config: mockConfig,
-        version: 'cli-version',
       });
 
       expect(result).toEqual({
@@ -431,8 +413,6 @@ describe('handlePushStatus()', () => {
           'retry-interval': 0.5, // 500 ms
           wait: true,
         },
-        config: mockConfig,
-        version: 'cli-version',
       });
 
       expect(result).toEqual({
@@ -472,8 +452,6 @@ describe('handlePushStatus()', () => {
             pushId: 'test-push-id',
             'continue-on-deploy-failures': false,
           },
-          config: mockConfig,
-          version: 'cli-version',
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         [Error: ❌ Preview deploy fail.
@@ -503,8 +481,6 @@ describe('handlePushStatus()', () => {
             pushId: 'test-push-id',
             'continue-on-deploy-failures': true,
           },
-          config: mockConfig,
-          version: 'cli-version',
         })
       ).resolves.toStrictEqual({
         preview: {
@@ -563,8 +539,6 @@ describe('handlePushStatus()', () => {
           'retry-interval': 0.5, // 500 ms
           onRetry: onRetrySpy,
         },
-        config: mockConfig,
-        version: 'cli-version',
       });
 
       expect(onRetrySpy).toBeCalledTimes(2);
@@ -636,8 +610,6 @@ describe('handlePushStatus()', () => {
             'max-execution-time': 1, // seconds
             wait: true,
           },
-          config: mockConfig,
-          version: 'cli-version',
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         [Error: ✗ Failed to get push status. Reason: Timeout exceeded.

--- a/packages/cli/src/reunite/commands/__tests__/push.test.ts
+++ b/packages/cli/src/reunite/commands/__tests__/push.test.ts
@@ -3,7 +3,6 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { type MockInstance } from 'vitest';
 
-import { version } from '../../../utils/package.js';
 import { ReuniteApi, ReuniteApiError } from '../../api/index.js';
 import { handlePush } from '../push.js';
 
@@ -65,7 +64,6 @@ describe('handlePush()', () => {
   });
 
   it('should upload files', async () => {
-    const mockConfig = { apis: {} } as any;
     process.env.REDOCLY_AUTHORIZATION = 'test-api-key';
 
     fsStatSyncSpy.mockReturnValueOnce({
@@ -96,8 +94,6 @@ describe('handlePush()', () => {
         files: ['test-file'],
         'max-execution-time': 10,
       },
-      config: mockConfig,
-      version,
     });
 
     expect(remotes.getDefaultBranch).toHaveBeenCalledWith('test-org', 'test-project');
@@ -135,7 +131,6 @@ describe('handlePush()', () => {
   });
 
   it('should return push id', async () => {
-    const mockConfig = { apis: {} } as any;
     process.env.REDOCLY_AUTHORIZATION = 'test-api-key';
 
     fsStatSyncSpy.mockReturnValueOnce({
@@ -166,15 +161,12 @@ describe('handlePush()', () => {
         files: ['test-file'],
         'max-execution-time': 10,
       },
-      config: mockConfig,
-      version,
     });
 
     expect(result).toEqual({ pushId: 'test-id' });
   });
 
   it('should collect files from directory and preserve file structure', async () => {
-    const mockConfig = { apis: {} } as any;
     process.env.REDOCLY_AUTHORIZATION = 'test-api-key';
 
     /*
@@ -218,8 +210,6 @@ describe('handlePush()', () => {
         files: ['test-folder'],
         'max-execution-time': 10,
       },
-      config: mockConfig,
-      version,
     });
 
     expect(remotes.push).toHaveBeenCalledWith(
@@ -245,7 +235,6 @@ describe('handlePush()', () => {
   });
 
   it('should not upload files if no files passed', async () => {
-    const mockConfig = { apis: {} } as any;
     process.env.REDOCLY_AUTHORIZATION = 'test-api-key';
 
     await handlePush({
@@ -261,8 +250,6 @@ describe('handlePush()', () => {
         files: [],
         'max-execution-time': 10,
       },
-      config: mockConfig,
-      version,
     });
 
     expect(remotes.getDefaultBranch).not.toHaveBeenCalled();
@@ -271,7 +258,6 @@ describe('handlePush()', () => {
   });
 
   it('should get domain from env if not passed', async () => {
-    const mockConfig = { organization: 'test-org-from-config', apis: {} } as any;
     process.env.REDOCLY_AUTHORIZATION = 'test-api-key';
     process.env.REDOCLY_DOMAIN = 'test-domain-from-env';
 
@@ -297,8 +283,6 @@ describe('handlePush()', () => {
         'max-execution-time': 10,
         organization: 'redocly-test',
       },
-      config: mockConfig,
-      version,
     });
 
     expect(ReuniteApi).toBeCalledWith({
@@ -309,7 +293,6 @@ describe('handlePush()', () => {
   });
 
   it('should print error message', async () => {
-    const mockConfig = { apis: {} } as any;
     process.env.REDOCLY_AUTHORIZATION = 'test-api-key';
 
     remotes.push.mockRestore();
@@ -344,8 +327,6 @@ describe('handlePush()', () => {
           files: ['test-file'],
           'max-execution-time': 10,
         },
-        config: mockConfig,
-        version,
       })
     ).rejects.toThrow('✗ File upload failed. Reason: Deprecated.');
   });

--- a/packages/cli/src/reunite/commands/push-status.ts
+++ b/packages/cli/src/reunite/commands/push-status.ts
@@ -8,8 +8,9 @@ import type { CommandArgs } from '../../wrapper.js';
 import { ReuniteApi, getApiKeys, getDomain } from '../api/index.js';
 import type {
   DeploymentStatus,
-  DeploymentStatusResponse,
   PushResponse,
+  PushStatusOptions,
+  PushStatusSummary,
   ScorecardItem,
 } from '../api/types.js';
 import { DeploymentError } from '../utils.js';
@@ -17,29 +18,13 @@ import { handleReuniteError, retryUntilConditionMet } from './utils.js';
 
 const RETRY_INTERVAL_MS = 5000; // 5 sec
 
-export type PushStatusArgv = {
-  organization: string;
-  project: string;
-  pushId: string;
-  domain?: string;
+export type PushStatusArgv = PushStatusOptions & {
   format?: Extract<OutputFormat, 'stylish'>;
-  wait?: boolean;
-  'max-execution-time'?: number; // in seconds
-  'retry-interval'?: number; // in seconds
-  'start-time'?: number; // in milliseconds
-  'continue-on-deploy-failures'?: boolean;
-  onRetry?: (lasSummary: PushStatusSummary) => void;
 } & VerifyConfigOptions;
-
-export interface PushStatusSummary {
-  preview: DeploymentStatusResponse;
-  production: DeploymentStatusResponse | null;
-  commit: PushResponse['commit'];
-}
 
 export async function handlePushStatus({
   argv,
-}: CommandArgs<PushStatusArgv>): Promise<PushStatusSummary | void> {
+}: Pick<CommandArgs<PushStatusArgv>, 'argv'>): Promise<PushStatusSummary> {
   const startedAt = performance.now();
   const spinner = new Spinner();
 

--- a/packages/cli/src/reunite/commands/push.ts
+++ b/packages/cli/src/reunite/commands/push.ts
@@ -6,31 +6,13 @@ import * as path from 'node:path';
 import type { VerifyConfigOptions } from '../../types.js';
 import { exitWithError } from '../../utils/error.js';
 import { printExecutionTime } from '../../utils/miscellaneous.js';
-import { version } from '../../utils/package.js';
 import type { CommandArgs } from '../../wrapper.js';
 import { ReuniteApi, getDomain, getApiKeys } from '../api/index.js';
+import type { PushOptions, PushResult } from '../api/types.js';
 import { handlePushStatus } from './push-status.js';
 import { handleReuniteError } from './utils.js';
 
-export type PushArgv = {
-  files: string[];
-  organization: string;
-  project: string;
-  'mount-path': string;
-  branch: string;
-  author: string;
-  message: string;
-  'commit-sha'?: string;
-  'commit-url'?: string;
-  namespace?: string;
-  repository?: string;
-  'created-at'?: string;
-  'default-branch': string;
-  domain?: string;
-  'wait-for-deployment'?: boolean;
-  'max-execution-time'?: number;
-  'continue-on-deploy-failures'?: boolean;
-  verbose?: boolean;
+export type PushArgv = PushOptions & {
   format?: Extract<OutputFormat, 'stylish'>;
 } & VerifyConfigOptions;
 
@@ -38,8 +20,7 @@ type FileToUpload = { name: string; path: string };
 
 export async function handlePush({
   argv,
-  config,
-}: CommandArgs<PushArgv>): Promise<{ pushId: string } | void> {
+}: Pick<CommandArgs<PushArgv>, 'argv'>): Promise<PushResult | undefined> {
   const startedAt = performance.now(); // for printing execution time
   const startTime = Date.now(); // for push-status command
 
@@ -67,7 +48,8 @@ export async function handlePush({
     const commandName = 'push' as const;
 
     if (!filesToUpload.length) {
-      return printExecutionTime(commandName, startedAt, `No files to upload`);
+      printExecutionTime(commandName, startedAt, `No files to upload`);
+      return;
     }
 
     const client = new ReuniteApi({ domain, apiKey, command: commandName });
@@ -125,8 +107,6 @@ export async function handlePush({
           'start-time': startTime,
           'continue-on-deploy-failures': argv['continue-on-deploy-failures'],
         },
-        config,
-        version,
       });
     }
     if (verbose) {

--- a/packages/cli/src/reunite/commands/utils.ts
+++ b/packages/cli/src/reunite/commands/utils.ts
@@ -58,7 +58,7 @@ export async function retryUntilConditionMet<T>({
 export function handleReuniteError(
   message: string,
   error: ReuniteApiError | DeploymentError | Error
-) {
+): never {
   if (error instanceof DeploymentError) {
     return exitWithError(error.message);
   }


### PR DESCRIPTION
## What/Why/How?
Exported the command and types from the bundled cli.

- Refactored types, moved exported types to the `types.ts` file
- Added entry points to the `tsconfig`
- Added generation of the `*.d.ts` files


## Reference

- Closes #3087
- Redocly/reunite-push-action#138

## Testing
Locally with CLI installed to testing repo

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes Reunite push/status as a supported API and changes handler signatures; behavior still hinges on `REDOCLY_AUTHORIZATION` / domain env vars and the same deployment error paths as the CLI.
> 
> **Overview**
> Adds a **programmatic entry point** at `@redocly/cli/api` with `push` and `pushStatus`, plus exported TypeScript types for Reunite push flows. Consumers can drive the same upload and deployment-status behavior as the CLI without shelling out.
> 
> **Build and publish:** `package.json` defines `./api` exports; the build bundles `src/api.ts` as a second esbuild entry and emits `.d.ts` via the TypeScript compiler, with a guard that blocks public declarations from referencing non-relative (dependency) imports. Published `.publish` package.json now includes `exports`. Esbuild banner helpers are renamed to reduce global name clashes when multiple bundles load.
> 
> **Refactor for a stable public surface:** `PushOptions`, `PushResult`, `PushStatusOptions`, and `PushStatusSummary` live in `reunite/api/types.ts`; internal Reunite client response shapes move into `api-client.ts`. `handlePush` / `handlePushStatus` accept only `argv` (no `config` / `version`), and tests are updated accordingly. `handlePushStatus` is typed to always return `PushStatusSummary`; empty-file push returns `undefined` after logging instead of exiting via the timing helper return path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3373421435ef0a28627b5b7fbe479879143b8075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->