### PR TITLE
chore: update changelog for v1

### DIFF
--- a/docs/@v1/changelog.md
+++ b/docs/@v1/changelog.md
@@ -7,6 +7,13 @@ toc:
 
 <!-- do-not-remove -->
 
+## 1.34.20 (2026-09-09)
+
+### Patch Changes
+
+- Updated `js-yaml` to `4.3.2`, `undici` to `6.28.0`, `redoc` to `2.5.3`, `styled-components` to `6.5.3`, and the OpenTelemetry packages to `2.11.0`.
+- Updated @redocly/openapi-core to v1.34.20.
+
 ## 1.34.19 (2026-08-10)
 
 ### Patch Changes


### PR DESCRIPTION
## What/Why/How?

Update changelog for v1

## Reference

- Redocly/redocly-cli#3099 — the 1.34.20 release

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no runtime or CLI behavior changes in this diff.
> 
> **Overview**
> Documents **Redocly CLI v1.34.20** (2026-09-09) at the top of `docs/@v1/changelog.md`.
> 
> The new **Patch Changes** entry records dependency bumps (`js-yaml` 4.3.2, `undici` 6.28.0, `redoc` 2.5.3, `styled-components` 6.5.3, OpenTelemetry 2.11.0) and alignment with **@redocly/openapi-core** v1.34.20. No application code changes in this PR—only the changelog for release #3099.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0e54dbcf25faf980b3f03892ba9dcf66a5bbd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->