### PR TITLE
feat: add introspect-mcp command

### DIFF
--- a/.changeset/wild-donuts-brew.md
+++ b/.changeset/wild-donuts-brew.md
@@ -1,0 +1,5 @@
+---
+'@redocly/cli': minor
+---
+
+Added an experimental `introspect-mcp` command that introspects a running MCP server over Streamable HTTP and records its tools, prompts, resources, and capabilities in the `x-mcp` extension of an OpenAPI description, creating the file or updating it in place.

--- a/.changeset/wild-donuts-brew.md
+++ b/.changeset/wild-donuts-brew.md
@@ -4,4 +4,3 @@
 
 Added an experimental `introspect-mcp` command that analyzes a running MCP server and records its tools, prompts, resources, and capabilities.
 `introspect-mcp` records its findings in the `x-mcp` extension of an OpenAPI description.
-The command connects over Streamable HTTP (with a fallback to the legacy HTTP+SSE transport) or starts a local stdio server with `--command`, and `--check` verifies the description is still in sync with the server, for CI.

--- a/.changeset/wild-donuts-brew.md
+++ b/.changeset/wild-donuts-brew.md
@@ -2,5 +2,6 @@
 '@redocly/cli': minor
 ---
 
-Added an experimental `introspect-mcp` command that introspects a running MCP server and records its tools, prompts, resources, and capabilities in the `x-mcp` extension of an OpenAPI description, creating the file or updating it in place.
+Added an experimental `introspect-mcp` command that analyzes a running MCP server and records its tools, prompts, resources, and capabilities.
+`introspect-mcp` records its findings in the `x-mcp` extension of an OpenAPI description.
 The command connects over Streamable HTTP (with a fallback to the legacy HTTP+SSE transport) or starts a local stdio server with `--command`, and `--check` verifies the description is still in sync with the server, for CI.

--- a/.changeset/wild-donuts-brew.md
+++ b/.changeset/wild-donuts-brew.md
@@ -2,4 +2,5 @@
 '@redocly/cli': minor
 ---
 
-Added an experimental `introspect-mcp` command that introspects a running MCP server over Streamable HTTP and records its tools, prompts, resources, and capabilities in the `x-mcp` extension of an OpenAPI description, creating the file or updating it in place.
+Added an experimental `introspect-mcp` command that introspects a running MCP server and records its tools, prompts, resources, and capabilities in the `x-mcp` extension of an OpenAPI description, creating the file or updating it in place.
+The command connects over Streamable HTTP (with a fallback to the legacy HTTP+SSE transport) or starts a local stdio server with `--command`, and `--check` verifies the description is still in sync with the server, for CI.

--- a/.claude/skills/redocly-cli/SKILL.md
+++ b/.claude/skills/redocly-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: redocly-cli
-description: Redocly CLI for OpenAPI, AsyncAPI, Arazzo, and Overlay descriptions. Use when the user wants to lint, bundle, split, or join an API description, apply decorators, build or preview API docs, test a live API with respect or Arazzo, capture traffic or check drift, get stats or a score, generate a TypeScript client, push to Reunite, or find the node type a rule or plugin should target.
+description: Redocly CLI for OpenAPI, AsyncAPI, Arazzo, and Overlay descriptions. Use when the user wants to lint, bundle, split, or join an API description, apply decorators, build or preview API docs, test a live API with respect or Arazzo, capture traffic or check drift, get stats or a score, generate a TypeScript client, document an MCP server in an OpenAPI description, push to Reunite, or find the node type a rule or plugin should target.
 ---
 
 # Redocly CLI usage
@@ -29,6 +29,7 @@ Install: `npm i @redocly/cli@latest`, or run without installing: `npx @redocly/c
 | -------------------- | ------------------------------------------------------------------------------------- | --------------------- |
 | `lint`               | Validate an API description against the configured rules                              | API authoring         |
 | `split`              | Break a single-file description into a multi-file structure                           | API authoring         |
+| `introspect-mcp`     | Record a live MCP server's tools, prompts, and resources in `x-mcp` [experimental]    | API authoring         |
 | `build-docs`         | Render an API description to a zero-dependency HTML page (Redoc)                      | Docs rendering        |
 | `preview`            | Local preview of a Redocly project (Realm, Reef, Revel)                               | Docs rendering        |
 | `bundle`             | Resolve all `$ref`s into a single self-contained file and apply decorators            | CI and delivery       |

--- a/docs/@v2/commands/index.md
+++ b/docs/@v2/commands/index.md
@@ -8,6 +8,7 @@ API authoring commands:
 
 - [`lint`](lint.md) Lint an API description.
 - [`split`](split.md) Split an API description into a multi-file structure.
+- [`introspect-mcp`](introspect-mcp.md) Introspect an MCP server and record its capabilities in the `x-mcp` extension of an OpenAPI description [experimental feature].
 
 Docs rendering commands:
 

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -25,8 +25,8 @@ If the output file doesn't exist, the command creates a minimal OpenAPI 3.1 desc
 Review and complete the `info` section afterward.
 If the file exists, the command updates it in place:
 
-- The server URL is appended to `servers` unless it's already listed.
-  Stdio servers have no URL, so `servers` stays untouched.
+- The MCP server URL is appended to `x-mcp.servers` unless it's already listed.
+  The root `servers` list (the API's base URLs) stays untouched, and stdio servers have no URL to record.
 - The `x-mcp` lists are replaced with what the server reports.
   Renamed or removed entries don't linger.
 - Documentation-only annotations that the MCP protocol doesn't carry are preserved by entry name: `tags` and `security` on tools, prompts, and resources, and `example` on prompt arguments.

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -31,7 +31,9 @@ If the file exists, the command updates it in place:
 Everything else in the description stays untouched.
 You can keep documenting the API around the generated `x-mcp` section.
 
-With `--check`, the command writes nothing: it compares the file with what an introspection run would produce, reports the added, removed, and changed entries, and exits with code `1` when the file is out of date — made for CI.
+With `--check`, the command only compares the file with what an introspection run would produce without writing anything.
+It reports the added, removed, and changed entries, and exits with code `1` when the file is out of date.
+This flag is useful for CI.
 
 ## Usage
 

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -3,7 +3,8 @@
 The `introspect-mcp` command analyzes a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
 The command connects to the server, lists its tools, prompts, and resources together with the server capabilities and the negotiated protocol version.
 Then the command writes this information into the description file.
-[Redocly Realm](https://redocly.com/docs/realm) renders the `x-mcp` extension as MCP documentation alongside the rest of the API reference, so the recorded tools, prompts, and resources become reader-facing docs.
+[Redocly Realm](https://redocly.com/docs/realm) renders the `x-mcp` extension as MCP documentation alongside the rest of the API reference.
+The recorded tools, prompts, and resources become reader-facing docs.
 
 {% admonition type="warning" name="Experimental" %}
 This is an experimental feature.

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -3,6 +3,7 @@
 The `introspect-mcp` command analyzes a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
 The command connects to the server, lists its tools, prompts, and resources together with the server capabilities and the negotiated protocol version.
 Then the command writes this information into the description file.
+[Redocly Realm](https://redocly.com/docs/realm) renders the `x-mcp` extension as MCP documentation alongside the rest of the API reference, so the recorded tools, prompts, and resources become reader-facing docs.
 
 {% admonition type="warning" name="Experimental" %}
 This is an experimental feature.
@@ -100,4 +101,5 @@ Run the command without --check to update it.
 
 ## Resources
 
-- [The `x-mcp` extension reference](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) describes every field the command writes.
+- [The `x-mcp` extension reference](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) describes every field the command writes and shows how the rendered MCP docs look.
+- [Redocly Realm](https://redocly.com/docs/realm) renders an OpenAPI description with `x-mcp` as MCP documentation - use the [`preview`](./preview.md) command to see it locally.

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -93,7 +93,6 @@ redocly introspect-mcp https://example.com/mcp --output api/openapi.yaml --check
 
 ```text
 api/openapi.yaml is out of date with the MCP server:
-
   - tools - added: orders/cancel; changed: orders/create
   - protocolVersion - 2024-11-05 -> 2025-11-25
 

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -1,0 +1,60 @@
+# `introspect-mcp`
+
+The `introspect-mcp` command introspects a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
+The command connects to the server over Streamable HTTP, lists its tools, prompts, and resources, and writes them — together with the server capabilities and the negotiated protocol version — into the description file.
+
+{% admonition type="warning" name="Experimental" %}
+This is an experimental feature.
+Its behavior, command, flags, and output may change in future releases.
+{% /admonition %}
+
+## How it works
+
+If the output file doesn't exist, the command creates a minimal OpenAPI 3.1 description scaffolded from the server's implementation info and instructions — review and complete the `info` section afterward.
+If the file exists, the command updates it in place:
+
+- The server URL is appended to `servers` unless it's already listed.
+- The `x-mcp` lists are replaced with what the server reports now, so renamed or removed entries don't linger.
+- Documentation-only annotations that the MCP protocol doesn't carry are preserved by entry name: `tags` and `security` on tools, prompts, and resources, and `example` on prompt arguments.
+
+Everything else in the description stays untouched, so you can keep documenting the API around the generated `x-mcp` section.
+
+## Usage
+
+```bash
+redocly introspect-mcp <server-url>
+redocly introspect-mcp <server-url> --output <file>
+redocly introspect-mcp <server-url> -H "Authorization: Bearer <token>"
+```
+
+## Options
+
+| Option       | Type     | Description                                                                                                          |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| server-url   | string   | **REQUIRED.** URL of the MCP server (Streamable HTTP endpoint).                                                      |
+| --output, -o | string   | OpenAPI description file to create or update. Default value is `openapi.yaml`. A `.json` file is written as JSON.    |
+| --header, -H | [string] | Header sent with every request to the MCP server, in `"Name: value"` format. Repeat the option for multiple headers. |
+| --config     | string   | Specify path to the [configuration file](../configuration/index.md).                                                 |
+| --help       | boolean  | Display help.                                                                                                        |
+| --version    | boolean  | Display version number.                                                                                              |
+
+## Examples
+
+### Document an MCP server in an OpenAPI description
+
+The same command creates the file on the first run and refreshes it afterward,
+keeping the `tags`, `security`, and prompt argument `example` annotations you added by hand:
+
+```bash
+redocly introspect-mcp https://example.com/mcp --output api/openapi.yaml
+```
+
+### Introspect a server that requires authentication
+
+```bash
+redocly introspect-mcp https://example.com/mcp -H "Authorization: Bearer $MCP_TOKEN"
+```
+
+## Related resources
+
+- [The `x-mcp` extension reference](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) describes every field the command writes.

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -1,6 +1,6 @@
 # `introspect-mcp`
 
-The `introspect-mcp` command introspects a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
+The `introspect-mcp` command analyzes a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
 The command connects to the server, lists its tools, prompts, and resources together with the server capabilities and the negotiated protocol version.
 Then the command writes this information into the description file.
 

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -50,16 +50,16 @@ redocly introspect-mcp <server-url> --output <file> --check
 
 ## Options
 
-| Option       | Type     | Description                                                                                                                                        |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| server-url   | string   | URL of the MCP server (Streamable HTTP, with a fallback to the legacy HTTP+SSE transport). Provide either a server URL or `--command`.             |
-| --command    | string   | Command that starts a local MCP server to introspect over stdio, for example `"npx -y my-mcp-server"`. Provide either a server URL or this option. |
-| --output, -o | string   | OpenAPI description file to create or update. Default value is `openapi.yaml`. A `.json` file is written as JSON.                                  |
-| --header, -H | [string] | Header sent with every request to the MCP server, in `"Name: value"` format. Repeat the option for multiple headers. Only applies to a server URL. |
-| --check      | boolean  | Verify the description is up to date with the MCP server instead of writing: report the differences and exit with code `1` when it is not.         |
-| --config     | string   | Specify path to the [configuration file](../configuration/index.md).                                                                               |
-| --help       | boolean  | Display help.                                                                                                                                      |
-| --version    | boolean  | Display version number.                                                                                                                            |
+| Option       | Type     | Description                                                                                                                                                                             |
+| ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| server-url   | string   | URL of the MCP server (Streamable HTTP, with a fallback to the legacy HTTP+SSE transport). Provide either a server URL or `--command`.                                                  |
+| --command    | string   | Command that starts a local MCP server to introspect over stdio, for example `"npx -y my-mcp-server"`. Quote arguments that contain spaces. Provide either a server URL or this option. |
+| --output, -o | string   | OpenAPI description file to create or update. Default value is `openapi.yaml`. A `.json` file is written as JSON.                                                                       |
+| --header, -H | [string] | Header sent with every request to the MCP server, in `"Name: value"` format. Repeat the option for multiple headers. Only applies to a server URL.                                      |
+| --check      | boolean  | Verify the description is up to date with the MCP server instead of writing: report the differences and exit with code `1` when it is not.                                              |
+| --config     | string   | Specify path to the [configuration file](../configuration/index.md).                                                                                                                    |
+| --help       | boolean  | Display help.                                                                                                                                                                           |
+| --version    | boolean  | Display version number.                                                                                                                                                                 |
 
 ## Examples
 

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -1,7 +1,7 @@
 # `introspect-mcp`
 
 The `introspect-mcp` command introspects a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
-The command connects to the server over Streamable HTTP, lists its tools, prompts, and resources, and writes them — together with the server capabilities and the negotiated protocol version — into the description file.
+The command connects to the server, lists its tools, prompts, and resources, and writes them — together with the server capabilities and the negotiated protocol version — into the description file.
 
 {% admonition type="warning" name="Experimental" %}
 This is an experimental feature.
@@ -10,14 +10,21 @@ Its behavior, command, flags, and output may change in future releases.
 
 ## How it works
 
+The command reaches the MCP server in one of two ways:
+
+- **A server URL** connects over Streamable HTTP, and automatically falls back to the legacy HTTP+SSE transport when the server doesn't support Streamable HTTP.
+- **`--command`** starts a local MCP server process and talks to it over stdio — the way most published MCP servers run, for example `npx -y my-mcp-server`. The process inherits your environment, so servers that read API keys from environment variables work as they do in your shell.
+
 If the output file doesn't exist, the command creates a minimal OpenAPI 3.1 description scaffolded from the server's implementation info and instructions — review and complete the `info` section afterward.
 If the file exists, the command updates it in place:
 
-- The server URL is appended to `servers` unless it's already listed.
+- The server URL is appended to `servers` unless it's already listed (stdio servers have no URL, so `servers` stays untouched).
 - The `x-mcp` lists are replaced with what the server reports now, so renamed or removed entries don't linger.
 - Documentation-only annotations that the MCP protocol doesn't carry are preserved by entry name: `tags` and `security` on tools, prompts, and resources, and `example` on prompt arguments.
 
 Everything else in the description stays untouched, so you can keep documenting the API around the generated `x-mcp` section.
+
+With `--check`, the command writes nothing: it compares the file with what an introspection run would produce, reports the added, removed, and changed entries, and exits with code `1` when the file is out of date — made for CI.
 
 ## Usage
 
@@ -25,18 +32,22 @@ Everything else in the description stays untouched, so you can keep documenting 
 redocly introspect-mcp <server-url>
 redocly introspect-mcp <server-url> --output <file>
 redocly introspect-mcp <server-url> -H "Authorization: Bearer <token>"
+redocly introspect-mcp --command "npx -y my-mcp-server" --output <file>
+redocly introspect-mcp <server-url> --output <file> --check
 ```
 
 ## Options
 
-| Option       | Type     | Description                                                                                                          |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------- |
-| server-url   | string   | **REQUIRED.** URL of the MCP server (Streamable HTTP endpoint).                                                      |
-| --output, -o | string   | OpenAPI description file to create or update. Default value is `openapi.yaml`. A `.json` file is written as JSON.    |
-| --header, -H | [string] | Header sent with every request to the MCP server, in `"Name: value"` format. Repeat the option for multiple headers. |
-| --config     | string   | Specify path to the [configuration file](../configuration/index.md).                                                 |
-| --help       | boolean  | Display help.                                                                                                        |
-| --version    | boolean  | Display version number.                                                                                              |
+| Option       | Type     | Description                                                                                                                                        |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| server-url   | string   | URL of the MCP server (Streamable HTTP, with a fallback to the legacy HTTP+SSE transport). Provide either a server URL or `--command`.             |
+| --command    | string   | Command that starts a local MCP server to introspect over stdio, for example `"npx -y my-mcp-server"`. Provide either a server URL or this option. |
+| --output, -o | string   | OpenAPI description file to create or update. Default value is `openapi.yaml`. A `.json` file is written as JSON.                                  |
+| --header, -H | [string] | Header sent with every request to the MCP server, in `"Name: value"` format. Repeat the option for multiple headers. Only applies to a server URL. |
+| --check      | boolean  | Verify the description is up to date with the MCP server instead of writing: report the differences and exit with code `1` when it is not.         |
+| --config     | string   | Specify path to the [configuration file](../configuration/index.md).                                                                               |
+| --help       | boolean  | Display help.                                                                                                                                      |
+| --version    | boolean  | Display version number.                                                                                                                            |
 
 ## Examples
 
@@ -49,10 +60,33 @@ keeping the `tags`, `security`, and prompt argument `example` annotations you ad
 redocly introspect-mcp https://example.com/mcp --output api/openapi.yaml
 ```
 
+### Document a local stdio server
+
+```bash
+redocly introspect-mcp --command "npx -y my-mcp-server" --output api/openapi.yaml
+```
+
 ### Introspect a server that requires authentication
 
 ```bash
 redocly introspect-mcp https://example.com/mcp -H "Authorization: Bearer $MCP_TOKEN"
+```
+
+### Fail CI when the description is stale
+
+`--check` compares the file with the live server without writing, and reports what drifted:
+
+```bash
+redocly introspect-mcp https://example.com/mcp --output api/openapi.yaml --check
+```
+
+```text
+api/openapi.yaml is out of date with the MCP server:
+
+  - tools - added: orders/cancel; changed: orders/create
+  - protocolVersion - 2024-11-05 -> 2025-11-25
+
+Run the command without --check to update it.
 ```
 
 ## Related resources

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -12,17 +12,24 @@ Its behavior, command, flags, and output may change in future releases.
 
 The command reaches the MCP server in one of two ways:
 
-- **A server URL** connects over Streamable HTTP, and automatically falls back to the legacy HTTP+SSE transport when the server doesn't support Streamable HTTP.
-- **`--command`** starts a local MCP server process and talks to it over stdio — the way most published MCP servers run, for example `npx -y my-mcp-server`. The process inherits your environment, so servers that read API keys from environment variables work as they do in your shell.
+- A server URL connects over Streamable HTTP, and automatically falls back to the legacy HTTP+SSE transport when the server doesn't support Streamable HTTP.
+- `--command` starts a local MCP server process and talks to it over stdio.
+  Most published MCP servers run this way, for example `npx -y my-mcp-server`.
+  The process inherits your environment.
+  Servers that read API keys from environment variables work as they do in your shell.
 
-If the output file doesn't exist, the command creates a minimal OpenAPI 3.1 description scaffolded from the server's implementation info and instructions — review and complete the `info` section afterward.
+If the output file doesn't exist, the command creates a minimal OpenAPI 3.1 description scaffolded from the server's implementation info and instructions.
+Review and complete the `info` section afterward.
 If the file exists, the command updates it in place:
 
-- The server URL is appended to `servers` unless it's already listed (stdio servers have no URL, so `servers` stays untouched).
-- The `x-mcp` lists are replaced with what the server reports now, so renamed or removed entries don't linger.
+- The server URL is appended to `servers` unless it's already listed.
+  Stdio servers have no URL, so `servers` stays untouched.
+- The `x-mcp` lists are replaced with what the server reports.
+  Renamed or removed entries don't linger.
 - Documentation-only annotations that the MCP protocol doesn't carry are preserved by entry name: `tags` and `security` on tools, prompts, and resources, and `example` on prompt arguments.
 
-Everything else in the description stays untouched, so you can keep documenting the API around the generated `x-mcp` section.
+Everything else in the description stays untouched.
+You can keep documenting the API around the generated `x-mcp` section.
 
 With `--check`, the command writes nothing: it compares the file with what an introspection run would produce, reports the added, removed, and changed entries, and exits with code `1` when the file is out of date — made for CI.
 
@@ -53,8 +60,7 @@ redocly introspect-mcp <server-url> --output <file> --check
 
 ### Document an MCP server in an OpenAPI description
 
-The same command creates the file on the first run and refreshes it afterward,
-keeping the `tags`, `security`, and prompt argument `example` annotations you added by hand:
+The same command creates the file on the first run and refreshes it afterward, keeping the `tags`, `security`, and prompt argument `example` annotations you added by hand:
 
 ```bash
 redocly introspect-mcp https://example.com/mcp --output api/openapi.yaml
@@ -89,6 +95,6 @@ api/openapi.yaml is out of date with the MCP server:
 Run the command without --check to update it.
 ```
 
-## Related resources
+## Resources
 
 - [The `x-mcp` extension reference](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) describes every field the command writes.

--- a/docs/@v2/commands/introspect-mcp.md
+++ b/docs/@v2/commands/introspect-mcp.md
@@ -1,7 +1,8 @@
 # `introspect-mcp`
 
 The `introspect-mcp` command introspects a running MCP (Model Context Protocol) server and records what it found in the [`x-mcp` extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description.
-The command connects to the server, lists its tools, prompts, and resources, and writes them — together with the server capabilities and the negotiated protocol version — into the description file.
+The command connects to the server, lists its tools, prompts, and resources together with the server capabilities and the negotiated protocol version.
+Then the command writes this information into the description file.
 
 {% admonition type="warning" name="Experimental" %}
 This is an experimental feature.

--- a/docs/@v2/v2.sidebars.yaml
+++ b/docs/@v2/v2.sidebars.yaml
@@ -36,6 +36,8 @@
           page: commands/logout.md
         - label: inspect-node-types
           page: commands/inspect-node-types.md
+        - label: introspect-mcp
+          page: commands/introspect-mcp.md
         - label: preview
           page: commands/preview.md
         - label: proxy

--- a/package-lock.json
+++ b/package-lock.json
@@ -2973,6 +2973,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/@redocly/mock-server/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@redocly/mock-server/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,6 +1405,19 @@
         "npm": ">=10"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1741,6 +1754,47 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -4312,6 +4366,51 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -4539,6 +4638,62 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
@@ -4616,6 +4771,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-me-maybe": {
@@ -4890,6 +5076,30 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4907,6 +5117,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
@@ -4918,6 +5138,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/create-require": {
@@ -5096,6 +5334,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5196,6 +5444,28 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.420",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
@@ -5208,6 +5478,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -5248,6 +5528,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-escape-html": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/es-escape-html/-/es-escape-html-0.1.1.tgz",
@@ -5264,6 +5564,19 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -5323,6 +5636,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5670,11 +5990,44 @@
         "url": "https://github.com/eta-dev/eta?sponsor=1"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -5684,6 +6037,70 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -5860,6 +6277,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5902,6 +6341,26 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -5930,6 +6389,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/functional-red-black-tree": {
@@ -5969,6 +6438,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -6053,6 +6561,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6098,6 +6619,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/header-range-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/header-range-parser/-/header-range-parser-1.1.3.tgz",
@@ -6126,6 +6673,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -6145,6 +6702,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -6256,6 +6834,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6391,6 +6986,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-subdir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
@@ -6457,6 +7059,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-levenshtein": {
@@ -6641,6 +7253,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-server": {
       "version": "1.0.0-beta.3",
@@ -7667,6 +8286,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
@@ -7805,6 +8434,33 @@
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7959,6 +8615,33 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-function": {
@@ -8459,6 +9142,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -8469,6 +9165,29 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/onetime": {
       "version": "7.0.0",
@@ -8723,6 +9442,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -8847,6 +9576,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pluralize": {
@@ -8992,6 +9731,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9000,6 +9763,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -9021,6 +9801,53 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -9419,6 +10246,34 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9497,12 +10352,66 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -9584,6 +10493,82 @@
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -10105,6 +11090,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -10260,6 +11255,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -10454,6 +11482,16 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
@@ -10550,6 +11588,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -10910,6 +11958,13 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -11040,6 +12095,16 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -11059,6 +12124,7 @@
         "redocly": "bin/cli.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
         "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/sdk-trace-node": "2.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "^22.15.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitest/coverage-istanbul": "^4.1.8",
+        "@vitest/coverage-istanbul": "^4.1.11",
         "eslint-plugin-sonarjs": "^4.2.0",
         "husky": "^9.1.7",
         "jsdom": "^27.2.0",
@@ -40,7 +40,7 @@
         "typescript": "6.0.2",
         "typescript7": "npm:typescript@7.0.2",
         "valibot": "^1.4.2",
-        "vitest": "^4.1.8",
+        "vitest": "^4.1.11",
         "zod": "^4.0.0"
       },
       "engines": {
@@ -773,40 +773,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -1822,25 +1788,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -2138,13 +2085,13 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.149.0.tgz",
+      "integrity": "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==",
       "dev": true,
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
@@ -3086,10 +3033,27 @@
       "resolved": "packages/respect-core",
       "link": true
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.8.tgz",
+      "integrity": "sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.8.tgz",
+      "integrity": "sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ==",
       "cpu": [
         "arm64"
       ],
@@ -3104,9 +3068,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.8.tgz",
+      "integrity": "sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA==",
       "cpu": [
         "arm64"
       ],
@@ -3121,9 +3085,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.8.tgz",
+      "integrity": "sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA==",
       "cpu": [
         "x64"
       ],
@@ -3138,9 +3102,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.8.tgz",
+      "integrity": "sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ==",
       "cpu": [
         "x64"
       ],
@@ -3155,9 +3119,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.8.tgz",
+      "integrity": "sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q==",
       "cpu": [
         "arm"
       ],
@@ -3172,13 +3136,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.8.tgz",
+      "integrity": "sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3189,13 +3156,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.8.tgz",
+      "integrity": "sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3206,13 +3176,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.8.tgz",
+      "integrity": "sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3223,13 +3196,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.8.tgz",
+      "integrity": "sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3240,13 +3216,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.8.tgz",
+      "integrity": "sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3257,13 +3236,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.8.tgz",
+      "integrity": "sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3274,9 +3256,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.8.tgz",
+      "integrity": "sha512-637Ke4kWSy6rp9cxQ9gMOXlxPgIw/c1beASV4M//3+9I4uwBVOOl74G+e3zyU3u19U7RkRl/HuewixZ/Z6+Rjg==",
       "cpu": [
         "arm64"
       ],
@@ -3290,29 +3272,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.8.tgz",
+      "integrity": "sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A==",
       "cpu": [
         "arm64"
       ],
@@ -3327,9 +3290,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.8.tgz",
+      "integrity": "sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng==",
       "cpu": [
         "x64"
       ],
@@ -3725,17 +3688,6 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -4256,9 +4208,9 @@
       }
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.8.tgz",
-      "integrity": "sha512-/h514nMZMKI6foh21mVgO1zlCH6pdDamwKMbla1uLU2GMxTlfp0PQMxovWozmzQdCIQYZ2XXEzg2zNZom2zAOg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.11.tgz",
+      "integrity": "sha512-pK9LJtOS534bmUwdwLpGD9qL52DeqVWSInrXFMNqrvWLbbAhuIPAlRup3UbsjFOMqCC/p3MmmX7uXV7ZTkcFfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4277,20 +4229,20 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.8"
+        "vitest": "4.1.11"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -4298,10 +4250,37 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4312,13 +4291,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4326,14 +4305,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4342,9 +4321,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4352,13 +4331,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5559,9 +5538,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6030,9 +6009,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7085,9 +7064,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -7395,9 +7374,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -7411,23 +7390,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -7446,9 +7425,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -7467,9 +7446,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -7488,9 +7467,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -7509,9 +7488,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -7530,13 +7509,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7551,13 +7533,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7572,13 +7557,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7593,13 +7581,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7614,9 +7605,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -7635,9 +7626,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -9156,15 +9147,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -9610,9 +9604,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -9630,7 +9624,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9920,9 +9914,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10013,9 +10007,9 @@
       "license": "MIT"
     },
     "node_modules/redoc/node_modules/@redocly/openapi-core": {
-      "version": "1.34.19",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz",
-      "integrity": "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==",
+      "version": "1.34.20",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.20.tgz",
+      "integrity": "sha512-ypeBZ/6BKXR9+7/TtbKhbl4UgD7raHhPS12oknlKno2A8+lnFkxIwiE/Aklu6L2cd/ioH+fCWuMxi9/p3EyAPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10024,7 +10018,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.3.1",
+        "js-yaml": "4.3.2",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -10213,13 +10207,13 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.8.tgz",
+      "integrity": "sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.149.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -10229,21 +10223,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm-eabi": "1.2.8",
+        "@rolldown/binding-android-arm64": "1.2.8",
+        "@rolldown/binding-darwin-arm64": "1.2.8",
+        "@rolldown/binding-darwin-x64": "1.2.8",
+        "@rolldown/binding-freebsd-x64": "1.2.8",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.8",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.8",
+        "@rolldown/binding-linux-arm64-musl": "1.2.8",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.8",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.8",
+        "@rolldown/binding-linux-x64-gnu": "1.2.8",
+        "@rolldown/binding-linux-x64-musl": "1.2.8",
+        "@rolldown/binding-openharmony-arm64": "1.2.8",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.8",
+        "@rolldown/binding-win32-x64-msvc": "1.2.8"
       }
     },
     "node_modules/router": {
@@ -10754,9 +10748,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10991,9 +10985,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11036,9 +11030,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11049,9 +11043,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11202,14 +11196,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -11630,147 +11616,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+    "node_modules/vite": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.3.0.tgz",
+      "integrity": "sha512-lhZBVvEHefgE+HQZC9O7EBJgCU/nVzFNl7vkS4RE0APtWLP02/8QVIkQtzBxPquh7lq5/78NHipTj7ODQ6XuyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.8",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.7",
+        "postcss": "^8.5.28",
+        "rolldown": "~1.2.6",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -11787,7 +11643,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.7.1",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -11836,6 +11692,122 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/node": "^22.15.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitest/coverage-istanbul": "^4.1.8",
+    "@vitest/coverage-istanbul": "^4.1.11",
     "eslint-plugin-sonarjs": "^4.2.0",
     "husky": "^9.1.7",
     "jsdom": "^27.2.0",
@@ -81,8 +81,11 @@
     "typescript": "6.0.2",
     "typescript7": "npm:typescript@7.0.2",
     "valibot": "^1.4.2",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.11",
     "zod": "^4.0.0"
+  },
+  "overrides": {
+    "js-yaml@4": "4.3.2"
   },
   "lint-staged": {
     "**/*.{ts,js,yaml,yml,json,md}": [

--- a/package.json
+++ b/package.json
@@ -84,9 +84,6 @@
     "vitest": "^4.1.11",
     "zod": "^4.0.0"
   },
-  "overrides": {
-    "js-yaml@4": "4.3.2"
-  },
   "lint-staged": {
     "**/*.{ts,js,yaml,yml,json,md}": [
       "npm run lint",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "Roman Hotsiy <roman@redocly.com> (https://redocly.com/)"
   ],
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-trace-node": "2.8.0",

--- a/packages/cli/src/commands/introspect-mcp/__tests__/fixtures/stdio-mcp-server.mjs
+++ b/packages/cli/src/commands/introspect-mcp/__tests__/fixtures/stdio-mcp-server.mjs
@@ -1,0 +1,18 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server(
+  { name: 'stdio-cafe-mcp', version: '1.2.3' },
+  { capabilities: { tools: {} }, instructions: 'Manage cafe orders over stdio.' }
+);
+server.setRequestHandler(ListToolsRequestSchema, () => ({
+  tools: [
+    {
+      name: 'menu/get',
+      description: 'Get the menu.',
+      inputSchema: { type: 'object' },
+    },
+  ],
+}));
+await server.connect(new StdioServerTransport());

--- a/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
+++ b/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
@@ -7,12 +7,12 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { parseYaml } from '@redocly/openapi-core';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { type AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { outdent } from 'outdent';
 
 import { AbortFlowError } from '../../../utils/error.js';
@@ -266,10 +266,16 @@ describe('handleIntrospectMcp', () => {
       'stdio-mcp-server.mjs'
     );
     const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    // Launching through a wrapper under a path with a space proves that quoted
+    // --command arguments stay together.
+    const wrapperDir = join(outputDir, 'server files');
+    mkdirSync(wrapperDir);
+    const wrapperPath = join(wrapperDir, 'start-server.mjs');
+    writeFileSync(wrapperPath, `import ${JSON.stringify(pathToFileURL(fixturePath).href)};\n`);
     // The `generated` folder doesn't exist yet - the command creates it.
     const outputFile = join(outputDir, 'generated', 'openapi.yaml');
     try {
-      await runIntrospectMcp({ command: `node ${fixturePath}`, output: outputFile });
+      await runIntrospectMcp({ command: `node "${wrapperPath}"`, output: outputFile });
 
       expect(readFileSync(outputFile, 'utf-8')).toMatchInlineSnapshot(`
         "openapi: 3.1.0

--- a/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
+++ b/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
@@ -1,17 +1,21 @@
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   ListPromptsRequestSchema,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { parseYaml } from '@redocly/openapi-core';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { type AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { outdent } from 'outdent';
 
+import { AbortFlowError } from '../../../utils/error.js';
 import type { CommandArgs } from '../../../wrapper.js';
 import { handleIntrospectMcp, type IntrospectMcpCommandArgv } from '../index.js';
 
@@ -44,6 +48,29 @@ const MENU_RESOURCE = {
   mimeType: 'application/json',
 };
 
+function buildMcpServer() {
+  const mcpServer = new McpServer(
+    { name: 'cafe-mcp', version: '3.2.1' },
+    {
+      capabilities: { tools: {}, prompts: {}, resources: {} },
+      instructions: 'Manage the cafe menu and orders.',
+    }
+  );
+  // Tools are served in two pages to exercise cursor pagination.
+  mcpServer.setRequestHandler(ListToolsRequestSchema, (listRequest) =>
+    listRequest.params?.cursor === 'page-2'
+      ? { tools: [LIST_MENU_TOOL] }
+      : { tools: [CREATE_ORDER_TOOL], nextCursor: 'page-2' }
+  );
+  mcpServer.setRequestHandler(ListPromptsRequestSchema, () => ({
+    prompts: [DAILY_SPECIAL_PROMPT],
+  }));
+  mcpServer.setRequestHandler(ListResourcesRequestSchema, () => ({
+    resources: [MENU_RESOURCE],
+  }));
+  return mcpServer;
+}
+
 let httpServer: HttpServer;
 let serverUrl: string;
 let lastAuthHeader: string | string[] | undefined;
@@ -52,25 +79,7 @@ let lastAuthHeader: string | string[] | undefined;
 beforeAll(async () => {
   httpServer = createServer(async (request, response) => {
     lastAuthHeader = request.headers['x-cafe-auth'] ?? lastAuthHeader;
-    const mcpServer = new McpServer(
-      { name: 'cafe-mcp', version: '3.2.1' },
-      {
-        capabilities: { tools: {}, prompts: {}, resources: {} },
-        instructions: 'Manage the cafe menu and orders.',
-      }
-    );
-    // Tools are served in two pages to exercise cursor pagination.
-    mcpServer.setRequestHandler(ListToolsRequestSchema, (listRequest) =>
-      listRequest.params?.cursor === 'page-2'
-        ? { tools: [LIST_MENU_TOOL] }
-        : { tools: [CREATE_ORDER_TOOL], nextCursor: 'page-2' }
-    );
-    mcpServer.setRequestHandler(ListPromptsRequestSchema, () => ({
-      prompts: [DAILY_SPECIAL_PROMPT],
-    }));
-    mcpServer.setRequestHandler(ListResourcesRequestSchema, () => ({
-      resources: [MENU_RESOURCE],
-    }));
+    const mcpServer = buildMcpServer();
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
       enableJsonResponse: true,
@@ -90,9 +99,9 @@ afterAll(async () => {
   await new Promise((resolve) => httpServer.close(resolve));
 });
 
-function runIntrospectMcp(outputFile: string, header?: string[]) {
+function runIntrospectMcp(argv: Partial<IntrospectMcpCommandArgv> & { output: string }) {
   return handleIntrospectMcp({
-    argv: { 'server-url': serverUrl, output: outputFile, header },
+    argv: { check: false, ...argv },
     version: '0.0.0',
   } as CommandArgs<IntrospectMcpCommandArgv>);
 }
@@ -102,7 +111,11 @@ describe('handleIntrospectMcp', () => {
     const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
     const outputFile = join(outputDir, 'openapi.yaml');
     try {
-      await runIntrospectMcp(outputFile, ['X-Cafe-Auth: secret-token']);
+      await runIntrospectMcp({
+        'server-url': serverUrl,
+        output: outputFile,
+        header: ['X-Cafe-Auth: secret-token'],
+      });
 
       expect(lastAuthHeader).toBe('secret-token');
       const written = readFileSync(outputFile, 'utf-8').replaceAll(serverUrl, '<server-url>');
@@ -188,7 +201,7 @@ describe('handleIntrospectMcp', () => {
       'utf-8'
     );
     try {
-      await runIntrospectMcp(outputFile);
+      await runIntrospectMcp({ 'server-url': serverUrl, output: outputFile });
 
       const written = readFileSync(outputFile, 'utf-8').replaceAll(serverUrl, '<server-url>');
       expect(written).toMatchInlineSnapshot(`
@@ -242,6 +255,97 @@ describe('handleIntrospectMcp', () => {
       `);
     } finally {
       rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('introspects a local stdio server started with --command', async () => {
+    const fixturePath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'stdio-mcp-server.mjs'
+    );
+    const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    const outputFile = join(outputDir, 'openapi.yaml');
+    try {
+      await runIntrospectMcp({ command: `node ${fixturePath}`, output: outputFile });
+
+      expect(readFileSync(outputFile, 'utf-8')).toMatchInlineSnapshot(`
+        "openapi: 3.1.0
+        info:
+          title: stdio-cafe-mcp
+          description: Manage cafe orders over stdio.
+          version: 1.2.3
+        paths: {}
+        x-mcp:
+          protocolVersion: '2025-11-25'
+          capabilities:
+            tools: {}
+          tools:
+            - name: menu/get
+              description: Get the menu.
+              inputSchema:
+                type: object
+        "
+      `);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--check passes on an up-to-date description and fails on a stale one, writing nothing', async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    const outputFile = join(outputDir, 'openapi.yaml');
+    try {
+      await runIntrospectMcp({ 'server-url': serverUrl, output: outputFile });
+      const upToDate = readFileSync(outputFile, 'utf-8');
+
+      await runIntrospectMcp({ 'server-url': serverUrl, output: outputFile, check: true });
+      expect(readFileSync(outputFile, 'utf-8')).toBe(upToDate);
+
+      const stale = upToDate.replace('description: Create an order.', 'description: A stale one.');
+      writeFileSync(outputFile, stale, 'utf-8');
+      await expect(
+        runIntrospectMcp({ 'server-url': serverUrl, output: outputFile, check: true })
+      ).rejects.toThrow(AbortFlowError);
+      expect(readFileSync(outputFile, 'utf-8')).toBe(stale);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the legacy HTTP+SSE transport when streamable HTTP is not supported', async () => {
+    const sseTransports = new Map<string, SSEServerTransport>();
+    const sseHttpServer = createServer(async (request, response) => {
+      const requestUrl = new URL(request.url ?? '/', 'http://localhost');
+      if (request.method === 'GET' && requestUrl.pathname === '/sse') {
+        const transport = new SSEServerTransport('/messages', response);
+        sseTransports.set(transport.sessionId, transport);
+        await buildMcpServer().connect(transport);
+      } else if (request.method === 'POST' && requestUrl.pathname === '/messages') {
+        const transport = sseTransports.get(requestUrl.searchParams.get('sessionId') ?? '');
+        await transport?.handlePostMessage(request, response);
+      } else {
+        response.writeHead(405).end();
+      }
+    });
+    await new Promise<void>((resolve) => sseHttpServer.listen(0, '127.0.0.1', resolve));
+    const sseServerUrl = `http://127.0.0.1:${(sseHttpServer.address() as AddressInfo).port}/sse`;
+    const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    const outputFile = join(outputDir, 'openapi.yaml');
+    try {
+      await runIntrospectMcp({ 'server-url': sseServerUrl, output: outputFile });
+
+      const document = parseYaml(readFileSync(outputFile, 'utf-8')) as Record<string, any>;
+      expect(document.servers).toEqual([{ url: sseServerUrl }]);
+      expect(document['x-mcp'].tools.map((tool: { name: string }) => tool.name)).toEqual([
+        'orders/create',
+        'menu/list',
+      ]);
+      expect(document['x-mcp'].protocolVersion).toBeDefined();
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+      await Promise.all([...sseTransports.values()].map((transport) => transport.close()));
+      await new Promise((resolve) => sseHttpServer.close(resolve));
     }
   });
 });

--- a/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
+++ b/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
@@ -1,0 +1,247 @@
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server as HttpServer } from 'node:http';
+import { type AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { outdent } from 'outdent';
+
+import type { CommandArgs } from '../../../wrapper.js';
+import { handleIntrospectMcp, type IntrospectMcpCommandArgv } from '../index.js';
+
+const CREATE_ORDER_TOOL = {
+  name: 'orders/create',
+  description: 'Create an order.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: { customerName: { type: 'string' } },
+    required: ['customerName'],
+  },
+};
+
+const LIST_MENU_TOOL = {
+  name: 'menu/list',
+  description: 'List the menu items.',
+  inputSchema: { type: 'object' as const },
+};
+
+const DAILY_SPECIAL_PROMPT = {
+  name: 'daily-special',
+  description: 'Suggest a daily special.',
+  arguments: [{ name: 'category', description: 'Menu category.', required: true }],
+};
+
+const MENU_RESOURCE = {
+  name: 'menu',
+  uri: 'cafe://menu',
+  description: 'The current menu.',
+  mimeType: 'application/json',
+};
+
+let httpServer: HttpServer;
+let serverUrl: string;
+let lastAuthHeader: string | string[] | undefined;
+
+// A stateless Streamable HTTP MCP server: every request gets a fresh server and transport.
+beforeAll(async () => {
+  httpServer = createServer(async (request, response) => {
+    lastAuthHeader = request.headers['x-cafe-auth'] ?? lastAuthHeader;
+    const mcpServer = new McpServer(
+      { name: 'cafe-mcp', version: '3.2.1' },
+      {
+        capabilities: { tools: {}, prompts: {}, resources: {} },
+        instructions: 'Manage the cafe menu and orders.',
+      }
+    );
+    // Tools are served in two pages to exercise cursor pagination.
+    mcpServer.setRequestHandler(ListToolsRequestSchema, (listRequest) =>
+      listRequest.params?.cursor === 'page-2'
+        ? { tools: [LIST_MENU_TOOL] }
+        : { tools: [CREATE_ORDER_TOOL], nextCursor: 'page-2' }
+    );
+    mcpServer.setRequestHandler(ListPromptsRequestSchema, () => ({
+      prompts: [DAILY_SPECIAL_PROMPT],
+    }));
+    mcpServer.setRequestHandler(ListResourcesRequestSchema, () => ({
+      resources: [MENU_RESOURCE],
+    }));
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    response.on('close', () => {
+      transport.close();
+      mcpServer.close();
+    });
+    await mcpServer.connect(transport);
+    await transport.handleRequest(request, response);
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  serverUrl = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => httpServer.close(resolve));
+});
+
+function runIntrospectMcp(outputFile: string, header?: string[]) {
+  return handleIntrospectMcp({
+    argv: { 'server-url': serverUrl, output: outputFile, header },
+    version: '0.0.0',
+  } as CommandArgs<IntrospectMcpCommandArgv>);
+}
+
+describe('handleIntrospectMcp', () => {
+  it('creates an OpenAPI description with the x-mcp extension from a live MCP server', async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    const outputFile = join(outputDir, 'openapi.yaml');
+    try {
+      await runIntrospectMcp(outputFile, ['X-Cafe-Auth: secret-token']);
+
+      expect(lastAuthHeader).toBe('secret-token');
+      const written = readFileSync(outputFile, 'utf-8').replaceAll(serverUrl, '<server-url>');
+      expect(written).toMatchInlineSnapshot(`
+        "openapi: 3.1.0
+        info:
+          title: cafe-mcp
+          description: Manage the cafe menu and orders.
+          version: 3.2.1
+        paths: {}
+        servers:
+          - url: <server-url>
+        x-mcp:
+          protocolVersion: '2025-11-25'
+          capabilities:
+            prompts: {}
+            resources: {}
+            tools: {}
+          tools:
+            - name: orders/create
+              description: Create an order.
+              inputSchema:
+                type: object
+                properties:
+                  customerName:
+                    type: string
+                required:
+                  - customerName
+            - name: menu/list
+              description: List the menu items.
+              inputSchema:
+                type: object
+          prompts:
+            - name: daily-special
+              description: Suggest a daily special.
+              arguments:
+                - name: category
+                  description: Menu category.
+                  required: true
+          resources:
+            - name: menu
+              uri: cafe://menu
+              description: The current menu.
+              mimeType: application/json
+        "
+      `);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes an existing description, preserving tags, security, and argument examples', async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    const outputFile = join(outputDir, 'openapi.yaml');
+    writeFileSync(
+      outputFile,
+      outdent`
+        openapi: 3.1.0
+        info:
+          title: Cafe API
+          version: 2.0.0
+        servers:
+          - url: https://api.cafe.example.com
+        paths: {}
+        x-mcp:
+          protocolVersion: 2024-11-05
+          tools:
+            - name: orders/create
+              description: A stale description.
+              tags:
+                - Orders
+              security:
+                - OAuth2:
+                    - orders:write
+            - name: removed/tool
+              description: No longer reported by the server.
+          prompts:
+            - name: daily-special
+              arguments:
+                - name: category
+                  example: beverage
+      ` + '\n',
+      'utf-8'
+    );
+    try {
+      await runIntrospectMcp(outputFile);
+
+      const written = readFileSync(outputFile, 'utf-8').replaceAll(serverUrl, '<server-url>');
+      expect(written).toMatchInlineSnapshot(`
+        "openapi: 3.1.0
+        info:
+          title: Cafe API
+          version: 2.0.0
+        servers:
+          - url: https://api.cafe.example.com
+          - url: <server-url>
+        paths: {}
+        x-mcp:
+          protocolVersion: '2025-11-25'
+          tools:
+            - name: orders/create
+              description: Create an order.
+              inputSchema:
+                type: object
+                properties:
+                  customerName:
+                    type: string
+                required:
+                  - customerName
+              tags:
+                - Orders
+              security:
+                - OAuth2:
+                    - orders:write
+            - name: menu/list
+              description: List the menu items.
+              inputSchema:
+                type: object
+          prompts:
+            - name: daily-special
+              description: Suggest a daily special.
+              arguments:
+                - name: category
+                  description: Menu category.
+                  required: true
+                  example: beverage
+          capabilities:
+            prompts: {}
+            resources: {}
+            tools: {}
+          resources:
+            - name: menu
+              uri: cafe://menu
+              description: The current menu.
+              mimeType: application/json
+        "
+      `);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
+++ b/packages/cli/src/commands/introspect-mcp/__tests__/index.test.ts
@@ -126,10 +126,10 @@ describe('handleIntrospectMcp', () => {
           description: Manage the cafe menu and orders.
           version: 3.2.1
         paths: {}
-        servers:
-          - url: <server-url>
         x-mcp:
           protocolVersion: '2025-11-25'
+          servers:
+            - url: <server-url>
           capabilities:
             prompts: {}
             resources: {}
@@ -211,7 +211,6 @@ describe('handleIntrospectMcp', () => {
           version: 2.0.0
         servers:
           - url: https://api.cafe.example.com
-          - url: <server-url>
         paths: {}
         x-mcp:
           protocolVersion: '2025-11-25'
@@ -242,6 +241,8 @@ describe('handleIntrospectMcp', () => {
                   description: Menu category.
                   required: true
                   example: beverage
+          servers:
+            - url: <server-url>
           capabilities:
             prompts: {}
             resources: {}
@@ -265,7 +266,8 @@ describe('handleIntrospectMcp', () => {
       'stdio-mcp-server.mjs'
     );
     const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
-    const outputFile = join(outputDir, 'openapi.yaml');
+    // The `generated` folder doesn't exist yet - the command creates it.
+    const outputFile = join(outputDir, 'generated', 'openapi.yaml');
     try {
       await runIntrospectMcp({ command: `node ${fixturePath}`, output: outputFile });
 
@@ -313,6 +315,82 @@ describe('handleIntrospectMcp', () => {
     }
   });
 
+  it('clears lists the server no longer reports, and --check flags them as stale', async () => {
+    const emptyToolsServer = createServer(async (request, response) => {
+      const mcpServer = new McpServer(
+        { name: 'cafe-mcp', version: '3.2.1' },
+        { capabilities: { tools: {} } }
+      );
+      mcpServer.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      response.on('close', () => {
+        transport.close();
+        mcpServer.close();
+      });
+      await mcpServer.connect(transport);
+      await transport.handleRequest(request, response);
+    });
+    await new Promise<void>((resolve) => emptyToolsServer.listen(0, '127.0.0.1', resolve));
+    const emptyToolsServerUrl = `http://127.0.0.1:${
+      (emptyToolsServer.address() as AddressInfo).port
+    }/mcp`;
+    const outputDir = mkdtempSync(join(tmpdir(), 'introspect-mcp-'));
+    const outputFile = join(outputDir, 'openapi.yaml');
+    writeFileSync(
+      outputFile,
+      outdent`
+        openapi: 3.1.0
+        info:
+          title: Cafe API
+          version: 2.0.0
+        servers:
+          - url: ${emptyToolsServerUrl}
+        paths: {}
+        x-mcp:
+          tools:
+            - name: removed/tool
+              description: No longer reported by the server.
+          prompts:
+            - name: removed-prompt
+      ` + '\n',
+      'utf-8'
+    );
+    try {
+      await expect(
+        runIntrospectMcp({ 'server-url': emptyToolsServerUrl, output: outputFile, check: true })
+      ).rejects.toThrow(AbortFlowError);
+
+      await runIntrospectMcp({ 'server-url': emptyToolsServerUrl, output: outputFile });
+      const written = readFileSync(outputFile, 'utf-8').replaceAll(
+        emptyToolsServerUrl,
+        '<server-url>'
+      );
+      expect(written).toMatchInlineSnapshot(`
+        "openapi: 3.1.0
+        info:
+          title: Cafe API
+          version: 2.0.0
+        servers:
+          - url: <server-url>
+        paths: {}
+        x-mcp:
+          tools: []
+          protocolVersion: '2025-11-25'
+          servers:
+            - url: <server-url>
+          capabilities:
+            tools: {}
+        "
+      `);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+      await new Promise((resolve) => emptyToolsServer.close(resolve));
+    }
+  });
+
   it('falls back to the legacy HTTP+SSE transport when streamable HTTP is not supported', async () => {
     const sseTransports = new Map<string, SSEServerTransport>();
     const sseHttpServer = createServer(async (request, response) => {
@@ -336,7 +414,8 @@ describe('handleIntrospectMcp', () => {
       await runIntrospectMcp({ 'server-url': sseServerUrl, output: outputFile });
 
       const document = parseYaml(readFileSync(outputFile, 'utf-8')) as Record<string, any>;
-      expect(document.servers).toEqual([{ url: sseServerUrl }]);
+      expect(document['x-mcp'].servers).toEqual([{ url: sseServerUrl }]);
+      expect(document.servers).toBeUndefined();
       expect(document['x-mcp'].tools.map((tool: { name: string }) => tool.name)).toEqual([
         'orders/create',
         'menu/list',

--- a/packages/cli/src/commands/introspect-mcp/check.ts
+++ b/packages/cli/src/commands/introspect-mcp/check.ts
@@ -1,0 +1,73 @@
+import { isPlainObject } from '@redocly/openapi-core';
+import { isDeepStrictEqual } from 'node:util';
+
+import { entriesByName } from './update-description.js';
+
+function namedListChanges(existingEntries: unknown, updatedEntries: unknown): string | undefined {
+  const existingByName = entriesByName(existingEntries);
+  const updatedByName = entriesByName(updatedEntries);
+  const added = [...updatedByName.keys()].filter((name) => !existingByName.has(name));
+  const removed = [...existingByName.keys()].filter((name) => !updatedByName.has(name));
+  const changed = [...updatedByName.keys()].filter(
+    (name) =>
+      existingByName.has(name) &&
+      !isDeepStrictEqual(existingByName.get(name), updatedByName.get(name))
+  );
+
+  const parts: string[] = [];
+  if (added.length > 0) {
+    parts.push(`added: ${added.join(', ')}`);
+  }
+  if (removed.length > 0) {
+    parts.push(`removed: ${removed.join(', ')}`);
+  }
+  if (changed.length > 0) {
+    parts.push(`changed: ${changed.join(', ')}`);
+  }
+  return parts.length > 0 ? parts.join('; ') : undefined;
+}
+
+/**
+ * Compare the document on disk with what an introspection run would write and describe the
+ * differences, one line per change. An empty result means the document is up to date.
+ */
+export function describeXMcpChanges(
+  existingDocument: Record<string, unknown>,
+  updatedDocument: Record<string, unknown>
+): string[] {
+  if (isDeepStrictEqual(existingDocument, updatedDocument)) {
+    return [];
+  }
+
+  const existingXMcp: Record<string, unknown> = isPlainObject(existingDocument['x-mcp'])
+    ? existingDocument['x-mcp']
+    : {};
+  const updatedXMcp: Record<string, unknown> = isPlainObject(updatedDocument['x-mcp'])
+    ? updatedDocument['x-mcp']
+    : {};
+
+  const changes: string[] = [];
+  for (const listName of ['tools', 'prompts', 'resources'] as const) {
+    const listChanges = namedListChanges(existingXMcp[listName], updatedXMcp[listName]);
+    if (listChanges) {
+      changes.push(`${listName} - ${listChanges}`);
+    }
+  }
+  if (!isDeepStrictEqual(existingXMcp.protocolVersion, updatedXMcp.protocolVersion)) {
+    changes.push(
+      `protocolVersion - ${existingXMcp.protocolVersion ?? 'not set'} -> ${
+        updatedXMcp.protocolVersion
+      }`
+    );
+  }
+  if (!isDeepStrictEqual(existingXMcp.capabilities, updatedXMcp.capabilities)) {
+    changes.push('capabilities changed');
+  }
+  if (!isDeepStrictEqual(existingDocument.servers, updatedDocument.servers)) {
+    changes.push('servers - the MCP server URL is not listed');
+  }
+  if (changes.length === 0) {
+    changes.push('x-mcp changed');
+  }
+  return changes;
+}

--- a/packages/cli/src/commands/introspect-mcp/check.ts
+++ b/packages/cli/src/commands/introspect-mcp/check.ts
@@ -63,7 +63,7 @@ export function describeXMcpChanges(
   if (!isDeepStrictEqual(existingXMcp.capabilities, updatedXMcp.capabilities)) {
     changes.push('capabilities changed');
   }
-  if (!isDeepStrictEqual(existingDocument.servers, updatedDocument.servers)) {
+  if (!isDeepStrictEqual(existingXMcp.servers, updatedXMcp.servers)) {
     changes.push('servers - the MCP server URL is not listed');
   }
   if (changes.length === 0) {

--- a/packages/cli/src/commands/introspect-mcp/index.ts
+++ b/packages/cli/src/commands/introspect-mcp/index.ts
@@ -1,6 +1,7 @@
 import { isPlainObject, logger, parseYaml, stringifyYaml } from '@redocly/openapi-core';
 import { blue, gray, yellow } from 'colorette';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 import { AbortFlowError, exitWithError } from '../../utils/error.js';
 import { type CommandArgs } from '../../wrapper.js';
@@ -115,6 +116,7 @@ export async function handleIntrospectMcp({
   const content = outputFile.endsWith('.json')
     ? JSON.stringify(openapiDocument, null, 2) + '\n'
     : stringifyYaml(openapiDocument);
+  mkdirSync(dirname(outputFile), { recursive: true });
   writeFileSync(outputFile, content);
 
   logger.info(

--- a/packages/cli/src/commands/introspect-mcp/index.ts
+++ b/packages/cli/src/commands/introspect-mcp/index.ts
@@ -2,15 +2,18 @@ import { isPlainObject, logger, parseYaml, stringifyYaml } from '@redocly/openap
 import { blue, gray, yellow } from 'colorette';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-import { exitWithError } from '../../utils/error.js';
+import { AbortFlowError, exitWithError } from '../../utils/error.js';
 import { type CommandArgs } from '../../wrapper.js';
-import { introspectMcpServer } from './introspect.js';
+import { describeXMcpChanges } from './check.js';
+import { introspectMcpServer, type McpTarget } from './introspect.js';
 import { updateDescription } from './update-description.js';
 
 export type IntrospectMcpCommandArgv = {
-  'server-url': string;
+  'server-url'?: string;
+  command?: string;
   output: string;
   header?: string[];
+  check: boolean;
   config?: string;
 };
 
@@ -31,21 +34,38 @@ function parseHeaders(rawHeaders: string[] = []): Record<string, string> {
   return headers;
 }
 
+function resolveTarget(argv: IntrospectMcpCommandArgv): McpTarget {
+  if (argv.command) {
+    const [command, ...args] = argv.command.trim().split(/\s+/);
+    if (!command) {
+      exitWithError('The --command option cannot be empty.');
+    }
+    return { kind: 'stdio', command, args };
+  }
+  let url: URL;
+  try {
+    url = new URL(argv['server-url'] ?? '');
+  } catch {
+    exitWithError(`Invalid MCP server URL: ${argv['server-url']}.`);
+  }
+  return { kind: 'http', url, headers: parseHeaders(argv.header) };
+}
+
 export async function handleIntrospectMcp({
   argv,
   version,
 }: CommandArgs<IntrospectMcpCommandArgv>) {
-  let serverUrl: URL;
-  try {
-    serverUrl = new URL(argv['server-url']);
-  } catch {
-    exitWithError(`Invalid MCP server URL: ${argv['server-url']}.`);
-  }
-  const headers = parseHeaders(argv.header);
+  const target = resolveTarget(argv);
   const outputFile = argv.output;
 
-  logger.info(gray(`\n  Connecting to the MCP server at ${serverUrl.href}... \n`));
-  const snapshot = await introspectMcpServer({ serverUrl, headers, version });
+  logger.info(
+    gray(
+      `\n  Connecting to the MCP server at ${
+        target.kind === 'http' ? target.url.href : argv.command
+      }... \n`
+    )
+  );
+  const snapshot = await introspectMcpServer(target, version);
 
   const isNewDocument = !existsSync(outputFile);
   let existingDocument: Record<string, unknown> | undefined;
@@ -64,7 +84,33 @@ export async function handleIntrospectMcp({
     existingDocument = document;
   }
 
-  const openapiDocument = updateDescription(existingDocument, snapshot, argv['server-url']);
+  const serverUrl = target.kind === 'http' ? argv['server-url'] : undefined;
+
+  if (argv.check) {
+    if (!existingDocument) {
+      exitWithError(
+        `Cannot check ${outputFile} - the file does not exist. Run the command without --check to create it.`
+      );
+    }
+    const updatedDocument = updateDescription(
+      structuredClone(existingDocument),
+      snapshot,
+      serverUrl
+    );
+    const changes = describeXMcpChanges(existingDocument, updatedDocument);
+    if (changes.length === 0) {
+      logger.info('\n' + blue(`${yellow(outputFile)} is up to date with the MCP server.`) + '\n');
+      return;
+    }
+    logger.error(`\n${outputFile} is out of date with the MCP server:\n`);
+    for (const change of changes) {
+      logger.error(`  - ${change}\n`);
+    }
+    logger.error('\nRun the command without --check to update it.\n');
+    throw new AbortFlowError();
+  }
+
+  const openapiDocument = updateDescription(existingDocument, snapshot, serverUrl);
 
   const content = outputFile.endsWith('.json')
     ? JSON.stringify(openapiDocument, null, 2) + '\n'

--- a/packages/cli/src/commands/introspect-mcp/index.ts
+++ b/packages/cli/src/commands/introspect-mcp/index.ts
@@ -1,0 +1,87 @@
+import { isPlainObject, logger, parseYaml, stringifyYaml } from '@redocly/openapi-core';
+import { blue, gray, yellow } from 'colorette';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+import { exitWithError } from '../../utils/error.js';
+import { type CommandArgs } from '../../wrapper.js';
+import { introspectMcpServer } from './introspect.js';
+import { updateDescription } from './update-description.js';
+
+export type IntrospectMcpCommandArgv = {
+  'server-url': string;
+  output: string;
+  header?: string[];
+  config?: string;
+};
+
+function parseHeaders(rawHeaders: string[] = []): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const rawHeader of rawHeaders) {
+    const separatorIndex = rawHeader.indexOf(':');
+    if (separatorIndex === -1) {
+      exitWithError(`Invalid header "${rawHeader}". Use the "Name: value" format.`);
+    }
+    const name = rawHeader.slice(0, separatorIndex).trim();
+    const value = rawHeader.slice(separatorIndex + 1).trim();
+    if (!name || !value) {
+      exitWithError(`Invalid header "${rawHeader}". Use the "Name: value" format.`);
+    }
+    headers[name] = value;
+  }
+  return headers;
+}
+
+export async function handleIntrospectMcp({
+  argv,
+  version,
+}: CommandArgs<IntrospectMcpCommandArgv>) {
+  let serverUrl: URL;
+  try {
+    serverUrl = new URL(argv['server-url']);
+  } catch {
+    exitWithError(`Invalid MCP server URL: ${argv['server-url']}.`);
+  }
+  const headers = parseHeaders(argv.header);
+  const outputFile = argv.output;
+
+  logger.info(gray(`\n  Connecting to the MCP server at ${serverUrl.href}... \n`));
+  const snapshot = await introspectMcpServer({ serverUrl, headers, version });
+
+  const isNewDocument = !existsSync(outputFile);
+  let existingDocument: Record<string, unknown> | undefined;
+  if (!isNewDocument) {
+    let document: unknown;
+    try {
+      document = parseYaml(readFileSync(outputFile, 'utf-8'));
+    } catch (error) {
+      exitWithError(
+        `Failed to parse ${outputFile}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    if (!isPlainObject(document)) {
+      exitWithError(`Expected ${outputFile} to contain an OpenAPI description object.`);
+    }
+    existingDocument = document;
+  }
+
+  const openapiDocument = updateDescription(existingDocument, snapshot, argv['server-url']);
+
+  const content = outputFile.endsWith('.json')
+    ? JSON.stringify(openapiDocument, null, 2) + '\n'
+    : stringifyYaml(openapiDocument);
+  writeFileSync(outputFile, content);
+
+  logger.info(
+    `Recorded ${snapshot.tools.length} tool(s), ${snapshot.prompts.length} prompt(s), and ${snapshot.resources.length} resource(s).\n`
+  );
+  logger.info(
+    '\n' +
+      blue(
+        `${isNewDocument ? 'Created' : 'Updated'} ${yellow(outputFile)} with the MCP server capabilities in the x-mcp extension.`
+      ) +
+      '\n'
+  );
+  if (isNewDocument) {
+    logger.warn(`The info section of ${outputFile} is scaffolded - review and complete it.\n`);
+  }
+}

--- a/packages/cli/src/commands/introspect-mcp/index.ts
+++ b/packages/cli/src/commands/introspect-mcp/index.ts
@@ -35,9 +35,45 @@ function parseHeaders(rawHeaders: string[] = []): Record<string, string> {
   return headers;
 }
 
+// Split a command line on whitespace, keeping segments in single or double quotes together,
+// so paths and arguments with spaces survive. The command is spawned directly - no shell.
+function splitCommand(rawCommand: string): string[] {
+  const commandParts: string[] = [];
+  let currentPart = '';
+  let openQuote: '"' | "'" | undefined;
+  let partStarted = false;
+  for (const character of rawCommand) {
+    if (openQuote) {
+      if (character === openQuote) {
+        openQuote = undefined;
+      } else {
+        currentPart += character;
+      }
+    } else if (character === '"' || character === "'") {
+      openQuote = character;
+      partStarted = true;
+    } else if (/\s/.test(character)) {
+      if (partStarted || currentPart) {
+        commandParts.push(currentPart);
+        currentPart = '';
+        partStarted = false;
+      }
+    } else {
+      currentPart += character;
+    }
+  }
+  if (openQuote) {
+    exitWithError(`Unclosed ${openQuote} quote in --command.`);
+  }
+  if (partStarted || currentPart) {
+    commandParts.push(currentPart);
+  }
+  return commandParts;
+}
+
 function resolveTarget(argv: IntrospectMcpCommandArgv): McpTarget {
   if (argv.command) {
-    const [command, ...args] = argv.command.trim().split(/\s+/);
+    const [command, ...args] = splitCommand(argv.command);
     if (!command) {
       exitWithError('The --command option cannot be empty.');
     }

--- a/packages/cli/src/commands/introspect-mcp/introspect.ts
+++ b/packages/cli/src/commands/introspect-mcp/introspect.ts
@@ -1,5 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type {
   Implementation,
   Prompt,
@@ -7,8 +10,14 @@ import type {
   ServerCapabilities,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '@redocly/openapi-core';
+import { gray } from 'colorette';
 
 import { exitWithError } from '../../utils/error.js';
+
+export type McpTarget =
+  | { kind: 'http'; url: URL; headers: Record<string, string> }
+  | { kind: 'stdio'; command: string; args: string[] };
 
 export type McpServerSnapshot = {
   protocolVersion?: string;
@@ -33,27 +42,88 @@ async function collectAllPages<Item>(
   return items;
 }
 
-export async function introspectMcpServer({
-  serverUrl,
-  headers,
-  version,
-}: {
-  serverUrl: URL;
-  headers: Record<string, string>;
-  version: string;
-}): Promise<McpServerSnapshot> {
-  const mcpClient = new Client({ name: 'redocly-cli', version });
-  const transport = new StreamableHTTPClientTransport(serverUrl, { requestInit: { headers } });
+// Only the Streamable HTTP transport exposes the negotiated protocol version itself,
+// but the client reports it to any transport that listens - so listen on all of them.
+function captureProtocolVersion(transport: Transport): () => string | undefined {
+  let negotiatedVersion: string | undefined;
+  const originalSetProtocolVersion = transport.setProtocolVersion?.bind(transport);
+  transport.setProtocolVersion = (protocolVersion: string) => {
+    negotiatedVersion = protocolVersion;
+    originalSetProtocolVersion?.(protocolVersion);
+  };
+  return () => negotiatedVersion;
+}
 
-  try {
-    await mcpClient.connect(transport);
-  } catch (error) {
-    exitWithError(
-      `Failed to connect to the MCP server at ${serverUrl.href}: ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
+// The spawned server inherits the full environment, like running the command in the same
+// shell would - stdio servers commonly read their API keys from environment variables.
+function inheritedEnvironment(): Record<string, string> {
+  const environment: Record<string, string> = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      environment[name] = value;
+    }
   }
+  return environment;
+}
+
+function targetLabel(target: McpTarget): string {
+  return target.kind === 'http'
+    ? target.url.href
+    : `"${[target.command, ...target.args].join(' ')}"`;
+}
+
+async function connectClient(
+  target: McpTarget,
+  version: string
+): Promise<{ mcpClient: Client; getProtocolVersion: () => string | undefined }> {
+  // For HTTP, try Streamable HTTP first and fall back to the legacy HTTP+SSE transport,
+  // as the MCP specification recommends for clients supporting both.
+  const transportAttempts: (() => Transport)[] =
+    target.kind === 'stdio'
+      ? [
+          () =>
+            new StdioClientTransport({
+              command: target.command,
+              args: target.args,
+              env: inheritedEnvironment(),
+            }),
+        ]
+      : [
+          () =>
+            new StreamableHTTPClientTransport(target.url, {
+              requestInit: { headers: target.headers },
+            }),
+          () => new SSEClientTransport(target.url, { requestInit: { headers: target.headers } }),
+        ];
+
+  let firstError: unknown;
+  for (const [attemptIndex, createTransport] of transportAttempts.entries()) {
+    if (attemptIndex > 0) {
+      logger.info(gray('  Retrying with the legacy HTTP+SSE transport... \n'));
+    }
+    const transport = createTransport();
+    const getProtocolVersion = captureProtocolVersion(transport);
+    const mcpClient = new Client({ name: 'redocly-cli', version });
+    try {
+      await mcpClient.connect(transport);
+      return { mcpClient, getProtocolVersion };
+    } catch (error) {
+      firstError ??= error;
+      await mcpClient.close().catch(() => undefined);
+    }
+  }
+  exitWithError(
+    `Failed to connect to the MCP server at ${targetLabel(target)}: ${
+      firstError instanceof Error ? firstError.message : String(firstError)
+    }`
+  );
+}
+
+export async function introspectMcpServer(
+  target: McpTarget,
+  version: string
+): Promise<McpServerSnapshot> {
+  const { mcpClient, getProtocolVersion } = await connectClient(target, version);
 
   try {
     const capabilities = mcpClient.getServerCapabilities();
@@ -77,7 +147,7 @@ export async function introspectMcpServer({
       : [];
 
     return {
-      protocolVersion: transport.protocolVersion,
+      protocolVersion: getProtocolVersion(),
       capabilities,
       serverInfo: mcpClient.getServerVersion(),
       instructions: mcpClient.getInstructions(),

--- a/packages/cli/src/commands/introspect-mcp/introspect.ts
+++ b/packages/cli/src/commands/introspect-mcp/introspect.ts
@@ -1,0 +1,91 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {
+  Implementation,
+  Prompt,
+  Resource,
+  ServerCapabilities,
+  Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { exitWithError } from '../../utils/error.js';
+
+export type McpServerSnapshot = {
+  protocolVersion?: string;
+  capabilities?: ServerCapabilities;
+  serverInfo?: Implementation;
+  instructions?: string;
+  tools: Tool[];
+  prompts: Prompt[];
+  resources: Resource[];
+};
+
+async function collectAllPages<Item>(
+  listPage: (cursor: string | undefined) => Promise<{ items: Item[]; nextCursor?: string }>
+): Promise<Item[]> {
+  const items: Item[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await listPage(cursor);
+    items.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return items;
+}
+
+export async function introspectMcpServer({
+  serverUrl,
+  headers,
+  version,
+}: {
+  serverUrl: URL;
+  headers: Record<string, string>;
+  version: string;
+}): Promise<McpServerSnapshot> {
+  const mcpClient = new Client({ name: 'redocly-cli', version });
+  const transport = new StreamableHTTPClientTransport(serverUrl, { requestInit: { headers } });
+
+  try {
+    await mcpClient.connect(transport);
+  } catch (error) {
+    exitWithError(
+      `Failed to connect to the MCP server at ${serverUrl.href}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  try {
+    const capabilities = mcpClient.getServerCapabilities();
+    const tools = capabilities?.tools
+      ? await collectAllPages(async (cursor) => {
+          const page = await mcpClient.listTools({ cursor });
+          return { items: page.tools, nextCursor: page.nextCursor };
+        })
+      : [];
+    const prompts = capabilities?.prompts
+      ? await collectAllPages(async (cursor) => {
+          const page = await mcpClient.listPrompts({ cursor });
+          return { items: page.prompts, nextCursor: page.nextCursor };
+        })
+      : [];
+    const resources = capabilities?.resources
+      ? await collectAllPages(async (cursor) => {
+          const page = await mcpClient.listResources({ cursor });
+          return { items: page.resources, nextCursor: page.nextCursor };
+        })
+      : [];
+
+    return {
+      protocolVersion: transport.protocolVersion,
+      capabilities,
+      serverInfo: mcpClient.getServerVersion(),
+      instructions: mcpClient.getInstructions(),
+      tools,
+      prompts,
+      resources,
+    };
+  } finally {
+    await mcpClient.close();
+  }
+}

--- a/packages/cli/src/commands/introspect-mcp/update-description.ts
+++ b/packages/cli/src/commands/introspect-mcp/update-description.ts
@@ -1,0 +1,104 @@
+import type { Prompt } from '@modelcontextprotocol/sdk/types.js';
+import { isPlainObject } from '@redocly/openapi-core';
+
+import type { McpServerSnapshot } from './introspect.js';
+
+function entriesByName(entries: unknown): Map<unknown, Record<string, unknown>> {
+  const byName = new Map<unknown, Record<string, unknown>>();
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    if (isPlainObject(entry)) {
+      byName.set(entry.name, entry);
+    }
+  }
+  return byName;
+}
+
+/**
+ * The `x-mcp` extension lets authors annotate server-reported entries with fields the MCP
+ * protocol doesn't carry (`tags` and `security`, plus `example` on prompt arguments).
+ * A refresh replaces each list with what the server reports now and carries those
+ * annotations over by entry name.
+ */
+function preserveDocFields<Entry extends { name: string }>(
+  freshEntries: Entry[],
+  existingEntries: unknown,
+  docFields: string[]
+): (Entry & Record<string, unknown>)[] {
+  const existingByName = entriesByName(existingEntries);
+  return freshEntries.map((freshEntry) => {
+    const existingEntry = existingByName.get(freshEntry.name);
+    const annotations: Record<string, unknown> = {};
+    for (const docField of docFields) {
+      if (existingEntry && existingEntry[docField] !== undefined) {
+        annotations[docField] = existingEntry[docField];
+      }
+    }
+    return { ...freshEntry, ...annotations };
+  });
+}
+
+function mergePrompts(freshPrompts: Prompt[], existingPrompts: unknown) {
+  const existingByName = entriesByName(existingPrompts);
+  return preserveDocFields(freshPrompts, existingPrompts, ['tags', 'security']).map((prompt) => {
+    if (!prompt.arguments) {
+      return prompt;
+    }
+    const existingArguments = existingByName.get(prompt.name)?.arguments;
+    return {
+      ...prompt,
+      arguments: preserveDocFields(prompt.arguments, existingArguments, ['example']),
+    };
+  });
+}
+
+/**
+ * Record the snapshot in the document's `x-mcp` extension and `servers`, scaffolding a
+ * minimal OpenAPI description from the server info when there is no existing document.
+ */
+export function updateDescription(
+  existingDocument: Record<string, unknown> | undefined,
+  snapshot: McpServerSnapshot,
+  serverUrl: string
+): Record<string, unknown> {
+  const document: Record<string, unknown> = existingDocument ?? {
+    openapi: '3.1.0',
+    info: {
+      title: snapshot.serverInfo?.title || snapshot.serverInfo?.name || 'MCP API',
+      ...(snapshot.instructions ? { description: snapshot.instructions } : {}),
+      version: snapshot.serverInfo?.version || '1.0.0',
+    },
+    paths: {},
+  };
+
+  const servers = Array.isArray(document.servers) ? document.servers : [];
+  if (!servers.some((server) => isPlainObject(server) && server.url === serverUrl)) {
+    servers.push({ url: serverUrl });
+  }
+  document.servers = servers;
+
+  const existingXMcp: Record<string, unknown> = isPlainObject(document['x-mcp'])
+    ? document['x-mcp']
+    : {};
+  const xMcp: Record<string, unknown> = { ...existingXMcp };
+  if (snapshot.protocolVersion) {
+    xMcp.protocolVersion = snapshot.protocolVersion;
+  }
+  if (snapshot.capabilities) {
+    xMcp.capabilities = snapshot.capabilities;
+  }
+  if (snapshot.tools.length > 0) {
+    xMcp.tools = preserveDocFields(snapshot.tools, existingXMcp.tools, ['tags', 'security']);
+  }
+  if (snapshot.prompts.length > 0) {
+    xMcp.prompts = mergePrompts(snapshot.prompts, existingXMcp.prompts);
+  }
+  if (snapshot.resources.length > 0) {
+    xMcp.resources = preserveDocFields(snapshot.resources, existingXMcp.resources, [
+      'tags',
+      'security',
+    ]);
+  }
+  document['x-mcp'] = xMcp;
+
+  return document;
+}

--- a/packages/cli/src/commands/introspect-mcp/update-description.ts
+++ b/packages/cli/src/commands/introspect-mcp/update-description.ts
@@ -3,7 +3,7 @@ import { isPlainObject } from '@redocly/openapi-core';
 
 import type { McpServerSnapshot } from './introspect.js';
 
-function entriesByName(entries: unknown): Map<unknown, Record<string, unknown>> {
+export function entriesByName(entries: unknown): Map<unknown, Record<string, unknown>> {
   const byName = new Map<unknown, Record<string, unknown>>();
   for (const entry of Array.isArray(entries) ? entries : []) {
     if (isPlainObject(entry)) {
@@ -58,7 +58,7 @@ function mergePrompts(freshPrompts: Prompt[], existingPrompts: unknown) {
 export function updateDescription(
   existingDocument: Record<string, unknown> | undefined,
   snapshot: McpServerSnapshot,
-  serverUrl: string
+  serverUrl: string | undefined
 ): Record<string, unknown> {
   const document: Record<string, unknown> = existingDocument ?? {
     openapi: '3.1.0',
@@ -70,11 +70,14 @@ export function updateDescription(
     paths: {},
   };
 
-  const servers = Array.isArray(document.servers) ? document.servers : [];
-  if (!servers.some((server) => isPlainObject(server) && server.url === serverUrl)) {
-    servers.push({ url: serverUrl });
+  // A stdio server has no URL to record, so `servers` stays untouched.
+  if (serverUrl) {
+    const servers = Array.isArray(document.servers) ? document.servers : [];
+    if (!servers.some((server) => isPlainObject(server) && server.url === serverUrl)) {
+      servers.push({ url: serverUrl });
+    }
+    document.servers = servers;
   }
-  document.servers = servers;
 
   const existingXMcp: Record<string, unknown> = isPlainObject(document['x-mcp'])
     ? document['x-mcp']

--- a/packages/cli/src/commands/introspect-mcp/update-description.ts
+++ b/packages/cli/src/commands/introspect-mcp/update-description.ts
@@ -52,8 +52,8 @@ function mergePrompts(freshPrompts: Prompt[], existingPrompts: unknown) {
 }
 
 /**
- * Record the snapshot in the document's `x-mcp` extension and `servers`, scaffolding a
- * minimal OpenAPI description from the server info when there is no existing document.
+ * Record the snapshot in the document's `x-mcp` extension, scaffolding a minimal OpenAPI
+ * description from the server info when there is no existing document.
  */
 export function updateDescription(
   existingDocument: Record<string, unknown> | undefined,
@@ -70,15 +70,6 @@ export function updateDescription(
     paths: {},
   };
 
-  // A stdio server has no URL to record, so `servers` stays untouched.
-  if (serverUrl) {
-    const servers = Array.isArray(document.servers) ? document.servers : [];
-    if (!servers.some((server) => isPlainObject(server) && server.url === serverUrl)) {
-      servers.push({ url: serverUrl });
-    }
-    document.servers = servers;
-  }
-
   const existingXMcp: Record<string, unknown> = isPlainObject(document['x-mcp'])
     ? document['x-mcp']
     : {};
@@ -86,20 +77,37 @@ export function updateDescription(
   if (snapshot.protocolVersion) {
     xMcp.protocolVersion = snapshot.protocolVersion;
   }
+  // The MCP endpoint belongs in `x-mcp.servers` - the root `servers` list the REST base URLs.
+  // A stdio server has no URL to record.
+  if (serverUrl) {
+    const mcpServers = Array.isArray(xMcp.servers) ? xMcp.servers : [];
+    if (!mcpServers.some((server) => isPlainObject(server) && server.url === serverUrl)) {
+      mcpServers.push({ url: serverUrl });
+    }
+    xMcp.servers = mcpServers;
+  }
   if (snapshot.capabilities) {
     xMcp.capabilities = snapshot.capabilities;
   }
-  if (snapshot.tools.length > 0) {
+  // Each list mirrors the server: a declared capability is recorded even when its list is
+  // empty, and the list of an undeclared capability is dropped, so stale entries don't linger.
+  if (snapshot.capabilities?.tools) {
     xMcp.tools = preserveDocFields(snapshot.tools, existingXMcp.tools, ['tags', 'security']);
+  } else {
+    delete xMcp.tools;
   }
-  if (snapshot.prompts.length > 0) {
+  if (snapshot.capabilities?.prompts) {
     xMcp.prompts = mergePrompts(snapshot.prompts, existingXMcp.prompts);
+  } else {
+    delete xMcp.prompts;
   }
-  if (snapshot.resources.length > 0) {
+  if (snapshot.capabilities?.resources) {
     xMcp.resources = preserveDocFields(snapshot.resources, existingXMcp.resources, [
       'tags',
       'security',
     ]);
+  } else {
+    delete xMcp.resources;
   }
   document['x-mcp'] = xMcp;
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1161,17 +1161,23 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
-    'introspect-mcp <server-url>',
+    'introspect-mcp [server-url]',
     'Introspect a running MCP server and record its capabilities in the x-mcp extension of an OpenAPI description [experimental].',
     (yargs) =>
       yargs
         .env('REDOCLY_CLI_INTROSPECT_MCP')
         .positional('server-url', {
-          describe: 'URL of the MCP server (Streamable HTTP endpoint).',
+          describe:
+            'URL of the MCP server (Streamable HTTP, with a fallback to the legacy HTTP+SSE transport). Alternative to --command.',
           type: 'string',
-          demandOption: true,
         })
         .option({
+          command: {
+            describe:
+              'Command that starts a local MCP server to introspect over stdio, for example "npx -y my-mcp-server". Alternative to a server URL.',
+            type: 'string',
+            requiresArg: true,
+          },
           output: {
             alias: 'o',
             describe: 'OpenAPI description file to create or update.',
@@ -1185,7 +1191,22 @@ yargs(hideBin(process.argv))
             array: true,
             type: 'string',
           },
+          check: {
+            describe:
+              'Verify the description is up to date with the MCP server instead of writing: report the differences and exit with an error when it is not.',
+            type: 'boolean',
+            default: false,
+          },
           config: { describe: 'Path to the config file.', type: 'string' },
+        })
+        .check((argv) => {
+          if (Boolean(argv['server-url']) === Boolean(argv.command)) {
+            throw new Error('Provide either an MCP server URL or --command, not both.');
+          }
+          if (argv.command && argv.header) {
+            throw new Error('The --header option only applies to an MCP server URL.');
+          }
+          return true;
         }),
     async (argv) => {
       const { handleIntrospectMcp } = await import('./commands/introspect-mcp/index.js');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from './commands/generate-client.js';
 import { type GenerateSpecArgv } from './commands/generate-spec/index.js';
 import { handleInspectNodeTypes } from './commands/inspect-node-types.js';
+import type { IntrospectMcpCommandArgv } from './commands/introspect-mcp/index.js';
 import { handleJoin } from './commands/join/index.js';
 import { handleLint } from './commands/lint.js';
 import { PRODUCT_PLANS } from './commands/preview-project/constants.js';
@@ -1157,6 +1158,38 @@ yargs(hideBin(process.argv))
     async (argv) => {
       const { handleGenerateSpec } = await import('./commands/generate-spec/index.js');
       commandWrapper(handleGenerateSpec)(argv as Arguments<GenerateSpecArgv>);
+    }
+  )
+  .command(
+    'introspect-mcp <server-url>',
+    'Introspect a running MCP server and record its capabilities in the x-mcp extension of an OpenAPI description [experimental].',
+    (yargs) =>
+      yargs
+        .env('REDOCLY_CLI_INTROSPECT_MCP')
+        .positional('server-url', {
+          describe: 'URL of the MCP server (Streamable HTTP endpoint).',
+          type: 'string',
+          demandOption: true,
+        })
+        .option({
+          output: {
+            alias: 'o',
+            describe: 'OpenAPI description file to create or update.',
+            type: 'string',
+            default: 'openapi.yaml',
+          },
+          header: {
+            alias: 'H',
+            describe:
+              'Header sent with every request to the MCP server, in "Name: value" format. Repeat the option for multiple headers.',
+            array: true,
+            type: 'string',
+          },
+          config: { describe: 'Path to the config file.', type: 'string' },
+        }),
+    async (argv) => {
+      const { handleIntrospectMcp } = await import('./commands/introspect-mcp/index.js');
+      commandWrapper(handleIntrospectMcp)(argv as Arguments<IntrospectMcpCommandArgv>);
     }
   )
   .command(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1174,7 +1174,7 @@ yargs(hideBin(process.argv))
         .option({
           command: {
             describe:
-              'Command that starts a local MCP server to introspect over stdio, for example "npx -y my-mcp-server". Alternative to a server URL.',
+              'Command that starts a local MCP server to introspect over stdio, for example "npx -y my-mcp-server". Quote arguments that contain spaces. Alternative to a server URL.',
             type: 'string',
             requiresArg: true,
           },

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -8,6 +8,7 @@ import type { EjectGeneratorCommandArgv } from './commands/eject-generator.js';
 import type { EjectArgv } from './commands/eject.js';
 import type { GenerateArazzoCommandArgv } from './commands/generate-arazzo/index.js';
 import type { InspectNodeTypesArgv } from './commands/inspect-node-types.js';
+import type { IntrospectMcpCommandArgv } from './commands/introspect-mcp/index.js';
 import type { JoinArgv } from './commands/join/types.js';
 import type { LintArgv } from './commands/lint.js';
 import type { PreviewProjectArgv } from './commands/preview-project/types.js';
@@ -50,7 +51,8 @@ export type CommandArgv =
   | DriftArgv
   | ProxyArgv
   | GenerateArazzoCommandArgv
-  | EjectGeneratorCommandArgv;
+  | EjectGeneratorCommandArgv
+  | IntrospectMcpCommandArgv;
 
 export type VerifyConfigOptions = {
   config?: string;


### PR DESCRIPTION
## What/Why/How?

Added an experimental `introspect-mcp` command.
The `introspect-mcp` command introspects a running MCP (Model Context Protocol) server and records what it found in the [x-mcp extension](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-mcp) of an OpenAPI description. The command connects to the server, lists its tools, prompts, and resources, and writes them — together with the server capabilities and the negotiated protocol version — into the description file.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The command runs user-supplied `--command` processes, calls remote MCP endpoints, and mutates OpenAPI files; behavior is new and marked experimental but covered by tests.
> 
> **Overview**
> Adds an **experimental** `introspect-mcp` command that connects to a live MCP server and writes or refreshes the **`x-mcp`** block on an OpenAPI description (tools, prompts, resources, capabilities, protocol version). Targets are either an HTTP URL (Streamable HTTP with HTTP+SSE fallback, optional `-H` headers) or **`--command`** for a local stdio server with quoted argument parsing and inherited env.
> 
> When the output file is missing, the command scaffolds a minimal OpenAPI 3.1 file from server metadata; otherwise it updates **`x-mcp` in place**, appends HTTP URLs to **`x-mcp.servers`** without touching root **`servers`**, replaces server-reported lists, and keeps hand-authored **`tags`**, **`security`**, and prompt-argument **`example`** by name. **`--check`** diffs against a live introspection run for CI without writing.
> 
> Ships with **`@modelcontextprotocol/sdk`**, integration tests (including SSE fallback and stdio), v2 docs/sidebar/changeset, and a minor devDependency bump (vitest 4.1.11) in the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1bff227605f4b8506cc371ad2be7b3d3e71f803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->