### PR TITLE
docs: mention the redocly-lint-rules skill

### DIFF
--- a/.claude/rules/walker-visitors-nodes.md
+++ b/.claude/rules/walker-visitors-nodes.md
@@ -58,7 +58,7 @@ The factory types live in `visitors.ts`, one set per spec flavor: `Oas3Rule`, `O
 State that spans nodes lives in the factory scope, so it is fresh for every document walk.
 Collect in `enter` hooks and report in `leave`, often `Root.leave`, when every `$ref` is resolved.
 
-When you author a rule, read the `redocly-lint-rules` skill first.
+When you author a rule, read the [`redocly-lint-rules` skill](../skills/redocly-lint-rules/SKILL.md) first.
 Its plugin section covers pitfalls that apply to built-in rules too: raw versus resolved children, the context fields, and how to prove a rule with a violating and a conforming fixture.
 
 ```ts

--- a/docs/@v1/guides/migrate-from-spectral.md
+++ b/docs/@v1/guides/migrate-from-spectral.md
@@ -1,7 +1,8 @@
 # Migrate to Redocly from Spectral
 
 [Spectral](https://stoplight.io/open-source/spectral) offers similar linting capabilities to Redocly CLI and the rest of the Redocly tools.
-This guide lays out the differences so you can switch tools if you want to.
+Redocly CLI and the rest of the Redocly toolchain cover the same linting ground as [Spectral](https://stoplight.io/open-source/spectral), and go further.
+This guide compares both tools so you can decide whether switching makes sense for your team.
 
 The first step is to [install Redocly CLI](../installation.md).
 
@@ -128,7 +129,7 @@ Included here is an attempt to map the simliar-but-not-identical naming of rules
 ### Configurable and extensible rules
 
 If the built-in rules don't meet your requirements, don't worry!
-Redocly allows you to build any rule to meet your needs, using [configurable rules](../rules/configurable-rules.md).
+With Redocly you can use [configurable rules](../rules/configurable-rules.md) to build any rule to suit your needs. 
 Declare which elements of the OpenAPI description should comply with the rule, and then define the criteria that it should be checked against.
 
 Build up the rulesets that work for your organization's API standards.

--- a/docs/@v1/guides/migrate-from-spectral.md
+++ b/docs/@v1/guides/migrate-from-spectral.md
@@ -129,7 +129,7 @@ Included here is an attempt to map the simliar-but-not-identical naming of rules
 ### Configurable and extensible rules
 
 If the built-in rules don't meet your requirements, don't worry!
-With Redocly you can use [configurable rules](../rules/configurable-rules.md) to build any rule to suit your needs. 
+With Redocly you can use [configurable rules](../rules/configurable-rules.md) to build any rule to suit your needs.
 Declare which elements of the OpenAPI description should comply with the rule, and then define the criteria that it should be checked against.
 
 Build up the rulesets that work for your organization's API standards.

--- a/docs/@v1/guides/migrate-from-spectral.md
+++ b/docs/@v1/guides/migrate-from-spectral.md
@@ -1,6 +1,7 @@
 # Migrate to Redocly from Spectral
 
-[Spectral](https://stoplight.io/open-source/spectral) offers similar linting capabilities to Redocly CLI and the rest of the Redocly tools. This guide lays out the differences so you can switch tools if you want to.
+[Spectral](https://stoplight.io/open-source/spectral) offers similar linting capabilities to Redocly CLI and the rest of the Redocly tools.
+This guide lays out the differences so you can switch tools if you want to.
 
 The first step is to [install Redocly CLI](../installation.md).
 
@@ -126,9 +127,12 @@ Included here is an attempt to map the simliar-but-not-identical naming of rules
 
 ### Configurable and extensible rules
 
-If the built-in rules don't meet your requirements, don't worry! Redocly allows you to build any rule to meet your needs, using [configurable rules](../rules/configurable-rules.md). Declare which elements of the OpenAPI description should comply with the rule, and then define the criteria that it should be checked against.
+If the built-in rules don't meet your requirements, don't worry!
+Redocly allows you to build any rule to meet your needs, using [configurable rules](../rules/configurable-rules.md).
+Declare which elements of the OpenAPI description should comply with the rule, and then define the criteria that it should be checked against.
 
-Build up the rulesets that work for your organization's API standards. These can be:
+Build up the rulesets that work for your organization's API standards.
+These can be:
 
 - using existing Redocly rulesets
 - defining your own rulesets from built-in, configurable and/or custom rules
@@ -136,7 +140,8 @@ Build up the rulesets that work for your organization's API standards. These can
 - adding per-API additions or exceptions as required
 - using an ignore file to overlook existing/historic incompatibilities while still enforcing rules for changed elements
 
-For some advanced use cases, the configurable rules can't cover all possibilities. If that happens, Redocly supports [adding rules in custom plugins](../custom-plugins/custom-rules.md) so that you can use JavaScript to express any specialist rules you need.
+For some advanced use cases, the configurable rules can't cover all possibilities.
+If that happens, Redocly supports [adding rules in custom plugins](../custom-plugins/custom-rules.md) so that you can use JavaScript to express any specialist rules you need.
 
 ## Explore tool functionality
 

--- a/docs/@v2/commands/inspect-node-types.md
+++ b/docs/@v2/commands/inspect-node-types.md
@@ -16,6 +16,8 @@ Node types are the vocabulary of [configurable rules](../rules/configurable-rule
 - a plugin rule declares a visitor for a node type
 
 Use `inspect-node-types` to find the right type name for the part of your description you want to check.
+The `redocly-lint-rules` agent skill runs this command for you when an AI coding assistant writes a rule.
+Install the skill with `npx skills add https://redocly.com`.
 
 A node has a type only because of the path the linter took to reach it, so the command always walks the whole description from its root.
 Nodes in referenced files appear at their own pointers, in their own files.

--- a/docs/@v2/custom-plugins/custom-rules.md
+++ b/docs/@v2/custom-plugins/custom-rules.md
@@ -16,6 +16,8 @@ To find the exact type of a place in your API description, either:
 
 - Run the [`inspect-node-types` command](../commands/inspect-node-types.md) with a pointer to that place.
 - Hover over it in the [Redocly OpenAPI VS Code extension](https://redocly.com/docs/redocly-openapi/) to see the same type hints.
+- Ask an AI coding assistant that has the `redocly-lint-rules` agent skill (`npx skills add https://redocly.com`).
+  The skill looks up the type, writes the visitor, and tests it against a violating and a conforming fixture.
 
 To keep the plugin code manageable, each rule can go in its own file. This example is in `plugins/rules/opid-not-test.js`:
 

--- a/docs/@v2/guides/configure-rules.md
+++ b/docs/@v2/guides/configure-rules.md
@@ -148,3 +148,5 @@ Especially when you are working on improving your APIs or API descriptions, sett
 
 - Check out the detailed reference documentation for the [built-in rules](../rules/built-in-rules.md) and [configurable rules](../rules/configurable-rules.md).
 - If nothing there meets your needs, you can create your own rules by creating [custom plugins](../custom-plugins/index.md) with JavaScript.
+- If you work with an AI coding assistant, install the `redocly-lint-rules` agent skill with `npx skills add https://redocly.com`.
+  It turns a check written in plain language into a configurable rule or a custom plugin.

--- a/docs/@v2/guides/migrate-from-spectral.md
+++ b/docs/@v2/guides/migrate-from-spectral.md
@@ -165,6 +165,13 @@ Build up the rulesets that work for your organization's API standards. These can
 
 For some advanced use cases, the configurable rules can't cover all possibilities. If that happens, Redocly supports [adding rules in custom plugins](../custom-plugins/custom-rules.md) so that you can use JavaScript to express any specialist rules you need.
 
+If you work with an AI coding assistant, install the `redocly-lint-rules` agent skill.
+It turns a Spectral rule into a Redocly one, and it verifies the result against your API description.
+
+```bash
+npx skills add https://redocly.com
+```
+
 ## Explore tool functionality
 
 Redocly CLI supports multiple Redocly products and functions, so go ahead and [read more about Redocly CLI](../index.md).

--- a/docs/@v2/guides/migrate-from-spectral.md
+++ b/docs/@v2/guides/migrate-from-spectral.md
@@ -1,6 +1,6 @@
 # Migrate to Redocly from Spectral
 
-[Spectral](https://stoplight.io/open-source/spectral) offers similar linting capabilities to Redocly CLI and the rest of the Redocly tools. This guide lays out the differences so you can switch tools if you want to.
+Redocly CLI and the rest of the Redocly toolchain cover the same linting ground as [Spectral](https://stoplight.io/open-source/spectral) — and go further. This guide compares both tools so you can decide whether switching makes sense for your team.
 
 The first step is to [install Redocly CLI](../installation.md).
 

--- a/docs/@v2/rules.md
+++ b/docs/@v2/rules.md
@@ -12,6 +12,9 @@ Redocly uses rules to describe all the different aspects of API behavior that we
 - **Configurable rules** allow powerful describing of API standards without needing to write code. Create a configurable rule, choose which parts of the API description it applies to, and what the criteria for success are. The linting tool does the rest. With plenty of examples, the [configurable rules](./rules/configurable-rules.md) helps you to describe your API standards easily and well.
 - **Custom code rules** if none of the above exactly fits your needs, then a [custom code plugin](./custom-plugins/index.md) is an extensible way to bring some custom JavaScript to build on Redocly's existing features.
 
+If you work with an AI coding assistant, the `redocly-lint-rules` agent skill picks the right level for a check written in plain language and writes the rule for you.
+Install it with `npx skills add https://redocly.com`.
+
 ## Rulesets
 
 Rulesets are groups of rules that are applied together, and APIs can be checked against as many rulesets as needed during linting. To get you started, there are some built-in rulesets:

--- a/docs/@v2/rules/configurable-rules.md
+++ b/docs/@v2/rules/configurable-rules.md
@@ -673,6 +673,8 @@ To find the exact type of a place in your API description, either:
 
 - Run the [`inspect-node-types` command](../commands/inspect-node-types.md) with a pointer to that place.
 - Hover over it in the [Redocly OpenAPI VS Code extension](https://redocly.com/docs/redocly-openapi/) to see the same type hints.
+- Ask an AI coding assistant that has the `redocly-lint-rules` agent skill (`npx skills add https://redocly.com`).
+  The skill looks up the type and writes the configurable rule for you.
 
 ### `any` example
 


### PR DESCRIPTION
## What/Why/How?

Added mentions of the `redocly-lint-rules` skill to the docs.
 
## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [ ] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or lint behavior impact.
> 
> **Overview**
> Documentation now points readers and agent authors at the **`redocly-lint-rules`** skill (`npx skills add https://redocly.com`) wherever they learn how to write or migrate rules.
> 
> **v2 docs** add the skill as an option alongside `inspect-node-types` and the VS Code extension in configurable rules and custom plugins, note that the skill runs `inspect-node-types` automatically, and include it in **Next steps** on configure-rules, the rules overview, and Spectral migration (including converting Spectral rules with verification).
> 
> **v1 Spectral migration** gets refreshed intro and paragraph breaks only (no skill block in that diff).
> 
> **`.claude/rules/walker-visitors-nodes.md`** turns the plain skill name into a link to `../skills/redocly-lint-rules/SKILL.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53c2520a24474ded4291f1df625bc6c08d8e70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->