### PR TITLE
docs: add info about boolean values should be false

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ Naming and reuse:
 
 - If the rule enforces a specification requirement, prefix its name with `spec-` and add it to the spec ruleset in `packages/core/src/config/spec.ts`.
 - If the same concept already exists for another spec flavor, reuse that rule name so it stays discoverable across specs.
+- Boolean options default to `false`.
+  Name each of them according to what makes `true`, so that adding them never alters the existing behavior.
 - Prefer real rule code over assertion-based (`redocly.yaml`) rules when contributing to the core rule set.
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,9 @@ The SRI value also appears in [e2e test snapshots](#e2e-tests) — update those 
 
 There are three ways of providing arguments to the CLI: environment variables, command line arguments, and a Redocly configuration file.
 
+Boolean arguments and options default to `false`, so a missing value and an explicit `false` behave the same.
+Name each of them according to what makes `true`, so that adding them never alters the existing behavior.
+
 #### Environment variables
 
 Environment variables should be used to provide some arguments that are common for all the commands.


### PR DESCRIPTION
## What/Why/How?
Added to contribution guide and for agents info about our convention that boolean default values should be false.

## Reference
Discussion: https://redoc-ly.slack.com/archives/C02UHE7EL3E/p1788882091999789?thread_ts=1788877659.206849&cid=C02UHE7EL3E

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, CLI, or configuration behavior changes.
> 
> **Overview**
> Documents the project convention that **boolean CLI/config/rule options default to `false`**, with missing and explicit `false` treated the same, and that option names should describe what **`true`** enables so new flags stay backward compatible.
> 
> The same guidance is added in **`AGENTS.md`** (built-in rule naming) and **`CONTRIBUTING.md`** (**Arguments usage**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcdf1ce32d5d1adc7f53389736756e851ca0a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->