### PR TITLE
chore: update redocly config to v0.56.0

### DIFF
--- a/.changeset/olive-times-build.md
+++ b/.changeset/olive-times-build.md
@@ -1,0 +1,5 @@
+---
+'@redocly/openapi-core': patch
+---
+
+Updated @redocly/config to v0.56.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12187,7 +12187,7 @@
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.3",
-        "@redocly/config": "^0.55.0",
+        "@redocly/config": "^0.56.0",
         "ajv": "npm:@redocly/ajv@^8.18.3",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -12211,9 +12211,9 @@
       }
     },
     "packages/core/node_modules/@redocly/config": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.55.0.tgz",
-      "integrity": "sha512-PlaCpehzQoe6R9YksDI5gW4mfTA2UfnpCGldXXs7/axeyPdAK/T2UpfsSD9sOedKaq6VF9jtE9qXmnH71CAclg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.56.0.tgz",
+      "integrity": "sha512-sGEC13BWOSKgFEHSPmFmTHpRt+zfNOc4+5+COe3Z4TD37glshCzM8qaeX7fIddGf6akRSs1tz3j+2FZVEQtCWw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@redocly/ajv": "^8.18.3",
-    "@redocly/config": "^0.55.0",
+    "@redocly/config": "^0.56.0",
     "ajv": "npm:@redocly/ajv@^8.18.3",
     "ajv-formats": "^3.0.1",
     "colorette": "^1.2.0",

--- a/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/redocly-yaml.test.ts.snap
@@ -637,6 +637,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       "preprocessors": "Preprocessors",
       "products": "rootRedoclyConfigSchema.products",
       "rbac": "rootRedoclyConfigSchema.rbac",
+      "recheck": "rootRedoclyConfigSchema.recheck",
       "redirects": "Redirects",
       "removeAttribution": {
         "type": "boolean",
@@ -2096,6 +2097,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "products": "rootRedoclyConfigSchema.products",
       "rbac": "rootRedoclyConfigSchema.rbac",
+      "recheck": "rootRedoclyConfigSchema.recheck",
       "redirects": "Redirects",
       "removeAttribution": {
         "type": "boolean",
@@ -10607,6 +10609,7 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
       },
       "products": "rootRedoclyConfigSchema.env_additionalProperties.products",
       "rbac": "rootRedoclyConfigSchema.env_additionalProperties.rbac",
+      "recheck": "rootRedoclyConfigSchema.env_additionalProperties.recheck",
       "redirects": "Redirects",
       "removeAttribution": {
         "type": "boolean",
@@ -23462,6 +23465,294 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "apiDescriptions": "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions",
+      "baseline": {
+        "minLength": 1,
+        "type": "string",
+      },
+      "excludes": {
+        "items": {
+          "minLength": 1,
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "markdoc": [Function],
+      "rules": "rootRedoclyConfigSchema.env_additionalProperties.recheck.rules",
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "rules": "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions.rules",
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions.rules": {
+    "additionalProperties": [Function],
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions.rules_additionalProperties_1": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "appliesTo": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "assertions": {
+        "type": "object",
+      },
+      "description": {
+        "type": "string",
+      },
+      "exceptions": "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions.rules_additionalProperties_1.exceptions",
+      "excludes": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fix": {
+        "type": "boolean",
+      },
+      "link": {
+        "type": "string",
+      },
+      "message": {
+        "minLength": 1,
+        "type": "string",
+      },
+      "scope": [Function],
+      "severity": {
+        "enum": [
+          "off",
+          "info",
+          "warn",
+          "error",
+        ],
+        "type": "string",
+      },
+      "tags": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.apiDescriptions.rules_additionalProperties_1.exceptions": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "files": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "lines": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "extend": "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend",
+      "schema": [Function],
+    },
+    "required": [
+      "schema",
+    ],
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "tags": "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags",
+      "tagsFile": {
+        "minLength": 1,
+        "type": "string",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags": {
+    "additionalProperties": "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags_additionalProperties",
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags_additionalProperties": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "attributes": "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags_additionalProperties.attributes",
+      "selfClosing": {
+        "type": "boolean",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags_additionalProperties.attributes": {
+    "additionalProperties": "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags_additionalProperties.attributes_additionalProperties",
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.markdoc_1.extend.tags_additionalProperties.attributes_additionalProperties": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "default": [Function],
+      "dynamic": {
+        "type": "boolean",
+      },
+      "enum": {
+        "items": {
+          "type": "string",
+        },
+        "minItems": 1,
+        "type": "array",
+      },
+      "required": {
+        "type": "boolean",
+      },
+      "type": {
+        "enum": [
+          "string",
+          "number",
+          "boolean",
+        ],
+        "type": "string",
+      },
+    },
+    "required": [
+      "type",
+    ],
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.rules": {
+    "additionalProperties": [Function],
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.rules_additionalProperties_1": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "appliesTo": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "assertions": {
+        "type": "object",
+      },
+      "description": {
+        "type": "string",
+      },
+      "exceptions": "rootRedoclyConfigSchema.env_additionalProperties.recheck.rules_additionalProperties_1.exceptions",
+      "excludes": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fix": {
+        "type": "boolean",
+      },
+      "link": {
+        "type": "string",
+      },
+      "message": {
+        "minLength": 1,
+        "type": "string",
+      },
+      "scope": [Function],
+      "severity": {
+        "enum": [
+          "off",
+          "info",
+          "warn",
+          "error",
+        ],
+        "type": "string",
+      },
+      "tags": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.env_additionalProperties.recheck.rules_additionalProperties_1.exceptions": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "files": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "lines": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
     "required": undefined,
   },
   "rootRedoclyConfigSchema.env_additionalProperties.responseHeaders": {
@@ -37143,6 +37434,294 @@ exports[`createConfigTypes > matches snapshot for the default config schema 1`] 
     "documentationLink": undefined,
     "items": undefined,
     "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "apiDescriptions": "rootRedoclyConfigSchema.recheck.apiDescriptions",
+      "baseline": {
+        "minLength": 1,
+        "type": "string",
+      },
+      "excludes": {
+        "items": {
+          "minLength": 1,
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "markdoc": [Function],
+      "rules": "rootRedoclyConfigSchema.recheck.rules",
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.apiDescriptions": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "rules": "rootRedoclyConfigSchema.recheck.apiDescriptions.rules",
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.apiDescriptions.rules": {
+    "additionalProperties": [Function],
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.apiDescriptions.rules_additionalProperties_1": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "appliesTo": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "assertions": {
+        "type": "object",
+      },
+      "description": {
+        "type": "string",
+      },
+      "exceptions": "rootRedoclyConfigSchema.recheck.apiDescriptions.rules_additionalProperties_1.exceptions",
+      "excludes": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fix": {
+        "type": "boolean",
+      },
+      "link": {
+        "type": "string",
+      },
+      "message": {
+        "minLength": 1,
+        "type": "string",
+      },
+      "scope": [Function],
+      "severity": {
+        "enum": [
+          "off",
+          "info",
+          "warn",
+          "error",
+        ],
+        "type": "string",
+      },
+      "tags": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.apiDescriptions.rules_additionalProperties_1.exceptions": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "files": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "lines": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.markdoc_1": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "extend": "rootRedoclyConfigSchema.recheck.markdoc_1.extend",
+      "schema": [Function],
+    },
+    "required": [
+      "schema",
+    ],
+  },
+  "rootRedoclyConfigSchema.recheck.markdoc_1.extend": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "tags": "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags",
+      "tagsFile": {
+        "minLength": 1,
+        "type": "string",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags": {
+    "additionalProperties": "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags_additionalProperties",
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags_additionalProperties": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "attributes": "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags_additionalProperties.attributes",
+      "selfClosing": {
+        "type": "boolean",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags_additionalProperties.attributes": {
+    "additionalProperties": "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags_additionalProperties.attributes_additionalProperties",
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.markdoc_1.extend.tags_additionalProperties.attributes_additionalProperties": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "default": [Function],
+      "dynamic": {
+        "type": "boolean",
+      },
+      "enum": {
+        "items": {
+          "type": "string",
+        },
+        "minItems": 1,
+        "type": "array",
+      },
+      "required": {
+        "type": "boolean",
+      },
+      "type": {
+        "enum": [
+          "string",
+          "number",
+          "boolean",
+        ],
+        "type": "string",
+      },
+    },
+    "required": [
+      "type",
+    ],
+  },
+  "rootRedoclyConfigSchema.recheck.rules": {
+    "additionalProperties": [Function],
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {},
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.rules_additionalProperties_1": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "appliesTo": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "assertions": {
+        "type": "object",
+      },
+      "description": {
+        "type": "string",
+      },
+      "exceptions": "rootRedoclyConfigSchema.recheck.rules_additionalProperties_1.exceptions",
+      "excludes": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fix": {
+        "type": "boolean",
+      },
+      "link": {
+        "type": "string",
+      },
+      "message": {
+        "minLength": 1,
+        "type": "string",
+      },
+      "scope": [Function],
+      "severity": {
+        "enum": [
+          "off",
+          "info",
+          "warn",
+          "error",
+        ],
+        "type": "string",
+      },
+      "tags": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "required": undefined,
+  },
+  "rootRedoclyConfigSchema.recheck.rules_additionalProperties_1.exceptions": {
+    "additionalProperties": undefined,
+    "description": undefined,
+    "documentationLink": undefined,
+    "items": undefined,
+    "properties": {
+      "files": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "lines": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
     "required": undefined,
   },
   "rootRedoclyConfigSchema.responseHeaders": {


### PR DESCRIPTION
## What/Why/How?

Updated redocly/config to v0.56.0.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch with regenerated schema snapshots; no core logic changes beyond accepting the new optional `recheck` config shape from upstream.
> 
> **Overview**
> Bumps **`@redocly/config`** from **^0.55.0** to **^0.56.0** in `@redocly/openapi-core`, with lockfile and a patch changeset.
> 
> The upgrade pulls in an updated **`redocly.yaml` schema** that now includes a top-level **`recheck`** section (and the same under per-env overrides). Snapshot tests for the config schema reflect that block—**baseline**, **excludes**, **rules**, **apiDescriptions**, and **markdoc**—so CLI validation/typing stays aligned with the new config package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783562cd98472bd7168054ed0eefa904022a8e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->