### PR TITLE
fix: false positives for required inside not

### DIFF
--- a/.changeset/no-required-schema-properties-undefined-not.md
+++ b/.changeset/no-required-schema-properties-undefined-not.md
@@ -1,0 +1,6 @@
+---
+'@redocly/openapi-core': patch
+'@redocly/cli': patch
+---
+
+Fixed an issue where the `no-required-schema-properties-undefined` rule incorrectly reported properties required inside a `not` subschema as undefined.

--- a/packages/core/src/rules/common/__tests__/no-required-schema-properties-undefined.test.ts
+++ b/packages/core/src/rules/common/__tests__/no-required-schema-properties-undefined.test.ts
@@ -1245,4 +1245,86 @@ describe('no-required-schema-properties-undefined', () => {
       ]
     `);
   });
+
+  it('should not report when required inside not is defined in the enclosing schema', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        paths: {}
+        components:
+          schemas:
+            Contact:
+              type: object
+              properties:
+                email:
+                  type: string
+                phone:
+                  type: string
+              not:
+                required:
+                  - email
+                  - phone
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-required-schema-properties-undefined': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`[]`);
+  });
+
+  it('should report when required inside not is undefined in the enclosing schema', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        paths: {}
+        components:
+          schemas:
+            Contact:
+              type: object
+              properties:
+                email:
+                  type: string
+              not:
+                required:
+                  - emial
+      `,
+      'foobar.yaml'
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: await createConfig({ rules: { 'no-required-schema-properties-undefined': 'error' } }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      [
+        {
+          "location": [
+            {
+              "pointer": "#/components/schemas/Contact/not/required/0",
+              "reportOnKey": false,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "Required property 'emial' is not defined.",
+          "reference": "https://redocly.com/docs/cli/rules/common/no-required-schema-properties-undefined",
+          "ruleId": "no-required-schema-properties-undefined",
+          "severity": "error",
+          "suggest": [],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/src/rules/common/no-required-schema-properties-undefined.ts
+++ b/packages/core/src/rules/common/no-required-schema-properties-undefined.ts
@@ -67,7 +67,8 @@ export const NoRequiredSchemaPropertiesUndefined:
           return !!(
             parent.allOf?.some(matchesChild) ||
             parent.anyOf?.some(matchesChild) ||
-            parent.oneOf?.some(matchesChild)
+            parent.oneOf?.some(matchesChild) ||
+            (parent.not && matchesChild(parent.not))
           );
         };
 

--- a/packages/core/src/rules/utils.ts
+++ b/packages/core/src/rules/utils.ts
@@ -25,7 +25,7 @@ import { type AjvValidator } from './ajv.js';
 export type AnySchema =
   | Oas3Schema
   | Oas3_1Schema
-  | (Oas2Schema & { anyOf?: undefined; oneOf?: undefined });
+  | (Oas2Schema & { anyOf?: undefined; oneOf?: undefined; not?: undefined });
 
 export const resolveSchema = <T extends NonUndefined>(
   schemaOrRef: Referenced<T> | undefined,


### PR DESCRIPTION
## What/Why/How?

Fixed an issue where the `no-required-schema-properties-undefined` rule incorrectly reported properties required inside a `not` subschema as undefined. `required` under `not` asserts that a property is absent, so the names it lists belong to the enclosing schema and there is nothing to declare in a sibling `properties`. The rule walked up to the enclosing schema only through `allOf`, `anyOf` and `oneOf`, so it now treats `not` the same way. A name that is undefined in the enclosing schema is still reported, so typos are still caught.

## Reference

Closes: https://github.com/Redocly/redocly-cli/issues/3104

## Testing

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [x] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [ ] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule behavior change with targeted tests; no runtime API or security impact.
> 
> **Overview**
> Fixes **false positives** in the `no-required-schema-properties-undefined` lint rule when `required` appears under a schema’s **`not`** keyword.
> 
> The rule now treats a subschema inside **`not`** like composition children under `allOf` / `anyOf` / `oneOf`, so it resolves required property names against the **enclosing** object schema (where `properties` are declared). Valid patterns such as forbidding both `email` and `phone` via `not.required` no longer error when those fields exist on the parent. **Typos** in `not.required` are still reported when the name is missing from the enclosing schema.
> 
> Adds regression tests and a patch **changeset** for `@redocly/openapi-core` and `@redocly/cli`. The shared `AnySchema` type is updated so OAS2 typings explicitly exclude `not`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f34cff2089a2db72c7be28ed944ab9a7f54971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->