### PR TITLE
chore(deps): bump @redocly/mock-server to 0.11.0-next.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "@faker-js/faker": "^10.6.0",
-        "@redocly/mock-server": "^0.10.0",
+        "@redocly/mock-server": "0.11.0-next.2",
         "@tanstack/react-query": "^5.0.0",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^22.15.3",
@@ -2791,9 +2791,9 @@
       "link": true
     },
     "node_modules/@redocly/config": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.53.1.tgz",
-      "integrity": "sha512-aOldTWynKS3ZM6u8WkL72d94QBobITv9X6UECiZykgVjdLiAqV737bPVLGKJYPWf0Ryf3zSHgUYALjCj66BkdA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.55.0.tgz",
+      "integrity": "sha512-PlaCpehzQoe6R9YksDI5gW4mfTA2UfnpCGldXXs7/axeyPdAK/T2UpfsSD9sOedKaq6VF9jtE9qXmnH71CAclg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2823,19 +2823,19 @@
       "license": "MIT"
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0.tgz",
-      "integrity": "sha512-162k659ADkMva40DJ7MdLZ3ic4ohWr2gkIw9hdEk6KxWKP1zfnbTmZGLiSC1DSFDWKctRmFWJ/7Tj8hqtsSbJg==",
+      "version": "0.11.0-next.2",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.11.0-next.2.tgz",
+      "integrity": "sha512-1MhFHUARxRoMMtzvm4DFHWfw80OqzBL+Kcd3KLfL3V5gTZ9ieoQnKDjgQ/xbaKB/OYj4fbPo5Oo084imPbKfJQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
-        "@redocly/openapi-core": "2.45.0",
+        "@redocly/openapi-core": "2.51.2",
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
-        "js-yaml": "4.3.1",
-        "openapi-sampler": "^1.7.2",
+        "js-yaml": "4.3.2",
+        "openapi-sampler": "^1.7.5",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
         "ts-node": "10.9.2",
@@ -2860,15 +2860,15 @@
       }
     },
     "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.45.0.tgz",
-      "integrity": "sha512-a8NsUpiE4M3sfNEI+BuEHNqslcn19nE2AP1mw5hvDnEsnJRDCgPk+Sy1zyQCCnmiisk9vy+XlVzFXPraPrAW4g==",
+      "version": "2.51.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.51.2.tgz",
+      "integrity": "sha512-NHdbowBOGXFYMiVEAXUGFahKiMypRhuiq0tVeTb7AxXmoi/w/kbwbRzdyDobY9Og6j+gTWiSqzoCx3vlGoVVYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.53.1",
-        "ajv": "npm:@redocly/ajv@8.18.1",
+        "@redocly/ajv": "^8.18.3",
+        "@redocly/config": "^0.55.0",
+        "ajv": "npm:@redocly/ajv@^8.18.3",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "graphql": "^16.14.1",
@@ -2902,9 +2902,9 @@
     },
     "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
-      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "dev": true,
       "funding": [
         {
@@ -2973,33 +2973,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@redocly/mock-server/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9223,9 +9200,9 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.4.tgz",
-      "integrity": "sha512-CKS/rd5ucPCuEDbJnjGDXZTsuGWcmv53aCmQx7soZlPEONUGN4af0/dY5+THRFZraSEjeA78nlfzdFswC/N5SA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.5.tgz",
+      "integrity": "sha512-zpnod1EYNkMP3xg18bhMknvzdaxz5ePUyHakO/7zwEIq/Y8T0SsliS9a+YXCWQCvn+5LfE//UtDVoUULcKdVAQ==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@faker-js/faker": "^10.6.0",
-    "@redocly/mock-server": "^0.10.0",
+    "@redocly/mock-server": "0.11.0-next.2",
     "@tanstack/react-query": "^5.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^22.15.3",


### PR DESCRIPTION
## What/Why/How?

Pinned `@redocly/mock-server` to `0.11.0-next.2`. This version can be changed to 0.11.0 after 15th Sep or later

## Reference

https://github.com/advisories/GHSA-2883-xcg3-v3hh

## Testing

`npm audit` — 0 vulnerabilities.

## Screenshots (optional)

## Check yourself

- [x] This PR follows the [contributing guide](https://github.com/Redocly/redocly-cli/blob/main/CONTRIBUTING.md#pull-request-guidelines) <!-- required 🔒 -->
- [ ] All new/updated code is covered by tests
- [ ] Core code changed? - Tested with other Redocly products (internal contributions only)
- [x] New package installed? - Tested in different environments (browser/node)
- [x] Documentation update has been considered <!-- required 🔒 -->

## Security

- [x] The security impact of the change has been considered <!-- required 🔒 -->
- [x] Code follows company security practices and guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency bump for a known advisory; no production code paths changed.
> 
> **Overview**
> **Pins the dev dependency `@redocly/mock-server` from `^0.10.0` to `0.11.0-next.2`** to address [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh). The lockfile refresh pulls in updated transitive packages under that tree (e.g. `js-yaml` 4.3.2, `@redocly/openapi-core` 2.51.2, `openapi-sampler` 1.7.5). The PR description notes this pre-release pin can move to `0.11.0` after mid-September.
> 
> No runtime or CLI source changes—only `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2caa3b470e61fe71ca77c12437dd9c6b5ebe2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->